### PR TITLE
default identityRoles to empty array instead of nil, fixes #142

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -1,3 +1,12 @@
+# Release 0.15.2
+
+* What's New:
+
+
+* Bug Fixes:
+  * [#142](https://github.com/openziti/ziti/issues/142) - fix CLI ca create not defaulting identity roles
+
+
 # Release 0.15.1
 
 * What's New:

--- a/ziti/cmd/ziti/cmd/edge_controller/create_ca.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/create_ca.go
@@ -90,7 +90,7 @@ func newCreateCaCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.C
 	cmd.Flags().BoolVarP(&options.authEnabled, "auth", "e", false, "Whether the CA can be used for authentication or not")
 	cmd.Flags().BoolVarP(&options.ottCaEnrollment, "ottca", "o", false, "Whether the CA can be used for one-time-token CA enrollment")
 	cmd.Flags().BoolVarP(&options.autoCaEnrollment, "autoca", "u", false, "Whether the CA can be used for auto CA enrollment")
-	cmd.Flags().StringSliceVarP(&options.identityRoles, "role-attributes", "a", nil, "A csv string of role attributes enrolling identities receive")
+	cmd.Flags().StringSliceVarP(&options.identityRoles, "role-attributes", "a", []string{}, "A csv string of role attributes enrolling identities receive")
 
 	return cmd
 }


### PR DESCRIPTION
Works for 
- no `-a` at all 
- `-a=""`
- `-a "one,two,three"`