### PR TITLE
Make timeout used by CLI's internal REST client configurable via cmd line arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
   * IDs generated for entities in the Edge no longer use underscores and instead use periods to avoid issues when used as a common name in CSRs
   * [edge#424](https://github.com/openziti/edge/issues/424) Authenticated, non-admin, clients can query service terminators
   * [sdk-golang#112](https://github.com/openziti/sdk-golang/issues/112) Process checks for Windows are case-insensitive
+  * [ziti#245](https://github.com/openziti/ziti/issues/245) Make timeout used by CLI's internal REST client configurable via cmd line arg
+
+    All `ziti edge controller` subcommands now support the `--timeout=n` flag which controls the internal REST-client timeout used when communicating with the Controller. The timeout resolution is in seconds.  If this flag is not specified, the default is `5`.  Prior to this release, the the REST-client timeout was always `2`.  You now have the opportunity to increase the timeout if necessary (e.g. if large amounts of data are being queried).
+
+    All `ziti edge controller` subcommands now support the `--verbose` flag which will cause internal REST-client to emit debugging information concerning HTTP headers, status, raw json response data, and more.  You now have the opportunity to see much more information, which could be valuable during trouble-shooting.
 
 # Release 0.17.4
 ## Breaking Changes

--- a/ziti/cmd/ziti/cmd/common.go
+++ b/ziti/cmd/ziti/cmd/common.go
@@ -17,10 +17,10 @@
 package cmd
 
 import (
+	"fmt"
 	cmdutil "github.com/openziti/ziti/ziti/cmd/ziti/cmd/factory"
 	"github.com/openziti/ziti/ziti/cmd/ziti/cmd/table"
 	"github.com/openziti/ziti/ziti/cmd/ziti/internal/log"
-	"fmt"
 	"github.com/spf13/cobra"
 	"io"
 	"os"
@@ -38,6 +38,7 @@ type CommonOptions struct {
 	Verbose        bool
 	Staging        bool
 	ConfigIdentity string
+	Timeout        int
 }
 
 type ServerFlags struct {
@@ -72,6 +73,7 @@ func (options *CommonOptions) addCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&options.Verbose, "verbose", "", false, "Enable verbose logging")
 	cmd.Flags().BoolVarP(&options.Staging, "staging", "", false, "Install/Upgrade components from the ziti-staging repo")
 	cmd.Flags().StringVarP(&options.ConfigIdentity, "configIdentity", "i", "", "Which configIdentity to use")
+	cmd.Flags().IntVarP(&options.Timeout, "timeout", "t", 5, "Timeout for REST operations (specified in seconds)")
 	options.Cmd = cmd
 }
 

--- a/ziti/cmd/ziti/cmd/common/options.go
+++ b/ziti/cmd/ziti/cmd/common/options.go
@@ -33,4 +33,5 @@ type CommonOptions struct {
 	Verbose        bool
 	Staging        bool
 	ConfigIdentity string
+	Timeout        int
 }

--- a/ziti/cmd/ziti/cmd/edge_controller/common.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/common.go
@@ -23,8 +23,8 @@ import (
 	"strings"
 )
 
-func mapNameToID(entityType string, val string) (string, error) {
-	list, _, err := filterEntitiesOfType(entityType, fmt.Sprintf("id=\"%s\"", val), false, nil)
+func mapNameToID(entityType string, val string, o commonOptions) (string, error) {
+	list, _, err := filterEntitiesOfType(entityType, fmt.Sprintf("id=\"%s\"", val), false, nil, o.Timeout, o.Verbose)
 	if err != nil {
 		return "", err
 	}
@@ -33,7 +33,7 @@ func mapNameToID(entityType string, val string) (string, error) {
 		return val, nil
 	}
 
-	list, _, err = filterEntitiesOfType(entityType, fmt.Sprintf("name=\"%s\"", val), false, nil)
+	list, _, err = filterEntitiesOfType(entityType, fmt.Sprintf("name=\"%s\"", val), false, nil, o.Timeout, o.Verbose)
 	if err != nil {
 		return "", err
 	}
@@ -54,8 +54,8 @@ func mapNameToID(entityType string, val string) (string, error) {
 	return entityId, nil
 }
 
-func mapIdToName(entityType string, val string) (string, error) {
-	list, _, err := filterEntitiesOfType(entityType, fmt.Sprintf(`id="%s"`, val), false, nil)
+func mapIdToName(entityType string, val string, o commonOptions) (string, error) {
+	list, _, err := filterEntitiesOfType(entityType, fmt.Sprintf(`id="%s"`, val), false, nil, o.Timeout, o.Verbose)
 	if err != nil {
 		return "", err
 	}
@@ -69,7 +69,7 @@ func mapIdToName(entityType string, val string) (string, error) {
 	return name, nil
 }
 
-func mapNamesToIDs(entityType string, list ...string) ([]string, error) {
+func mapNamesToIDs(entityType string, o commonOptions, list ...string) ([]string, error) {
 	var result []string
 	for _, val := range list {
 		if strings.HasPrefix(val, "id") {
@@ -81,7 +81,7 @@ func mapNamesToIDs(entityType string, list ...string) ([]string, error) {
 				name := strings.TrimPrefix(val, "name:")
 				query = fmt.Sprintf(`name="%s"`, name)
 			}
-			list, _, err := filterEntitiesOfType(entityType, query, false, nil)
+			list, _, err := filterEntitiesOfType(entityType, query, false, nil, o.Timeout, o.Verbose)
 			if err != nil {
 				return nil, err
 			}
@@ -103,10 +103,10 @@ func mapNamesToIDs(entityType string, list ...string) ([]string, error) {
 	return result, nil
 }
 
-func mapIdentityNameToID(nameOrId string) (string, error) {
-	return mapNameToID("identities", nameOrId)
+func mapIdentityNameToID(nameOrId string, o commonOptions) (string, error) {
+	return mapNameToID("identities", nameOrId, o)
 }
 
-func mapCaNameToID(nameOrId string) (string, error) {
-	return mapNameToID("cas", nameOrId)
+func mapCaNameToID(nameOrId string, o commonOptions) (string, error) {
+	return mapNameToID("cas", nameOrId, o)
 }

--- a/ziti/cmd/ziti/cmd/edge_controller/create.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/create.go
@@ -56,5 +56,5 @@ func newCreateCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Com
 
 // createEntityOfType create an entity of the given type on the Ziti Edge Controller
 func createEntityOfType(entityType string, body string, options *commonOptions) (*gabs.Container, error) {
-	return util.EdgeControllerCreate(entityType, body, options.Out, options.OutputJSONResponse)
+	return util.EdgeControllerCreate(entityType, body, options.Out, options.OutputJSONResponse, options.Timeout, options.Verbose)
 }

--- a/ziti/cmd/ziti/cmd/edge_controller/create_authenticator_updb.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/create_authenticator_updb.go
@@ -20,8 +20,8 @@ import (
 	"errors"
 	"fmt"
 	"github.com/Jeffail/gabs"
-	"github.com/openziti/ziti/ziti/cmd/ziti/cmd/helpers"
 	"github.com/openziti/foundation/util/term"
+	"github.com/openziti/ziti/ziti/cmd/ziti/cmd/helpers"
 	"github.com/spf13/cobra"
 )
 
@@ -78,7 +78,7 @@ func runCreateIdentityPassword(idType string, options *createAuthenticatorUpdb) 
 		return errors.New("an identity must be specified")
 	}
 
-	id, err := mapIdentityNameToID(options.idOrName)
+	id, err := mapIdentityNameToID(options.idOrName, options.commonOptions)
 
 	if err != nil {
 		return err

--- a/ziti/cmd/ziti/cmd/edge_controller/create_config.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/create_config.go
@@ -95,7 +95,7 @@ func runCreateConfig(o *createConfigOptions) error {
 		return errors.Errorf("unable to parse data as json: %v", err)
 	}
 
-	configTypeId, err := mapNameToID("config-types", o.Args[1])
+	configTypeId, err := mapNameToID("config-types", o.Args[1], o.commonOptions)
 	if err != nil {
 		return err
 	}

--- a/ziti/cmd/ziti/cmd/edge_controller/create_edge_router.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/create_edge_router.go
@@ -96,7 +96,7 @@ func runCreateEdgeRouter(o *createEdgeRouterOptions) error {
 }
 
 func getEdgeRouterJwt(o *createEdgeRouterOptions, id string) error {
-	newRouter, err := DetailEntityOfType("edge-routers", id, o.OutputJSONResponse, o.Out)
+	newRouter, err := DetailEntityOfType("edge-routers", id, o.OutputJSONResponse, o.Out, o.commonOptions.Timeout, o.commonOptions.Verbose)
 	if err != nil {
 		return err
 	}

--- a/ziti/cmd/ziti/cmd/edge_controller/create_edge_router_policy.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/create_edge_router_policy.go
@@ -68,12 +68,12 @@ func newCreateEdgeRouterPolicyCmd(f cmdutil.Factory, out io.Writer, errOut io.Wr
 
 // runCreateEdgeRouterPolicy create a new edgeRouterPolicy on the Ziti Edge Controller
 func runCreateEdgeRouterPolicy(o *createEdgeRouterPolicyOptions) error {
-	edgeRouterRoles, err := convertNamesToIds(o.edgeRouterRoles, "edge-routers")
+	edgeRouterRoles, err := convertNamesToIds(o.edgeRouterRoles, "edge-routers", o.commonOptions)
 	if err != nil {
 		return err
 	}
 
-	identityRoles, err := convertNamesToIds(o.identityRoles, "identities")
+	identityRoles, err := convertNamesToIds(o.identityRoles, "identities", o.commonOptions)
 	if err != nil {
 		return err
 	}

--- a/ziti/cmd/ziti/cmd/edge_controller/create_identity.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/create_identity.go
@@ -114,16 +114,16 @@ func runCreateIdentity(idType string, o *createIdentityOptions) error {
 	}
 
 	if o.jwtOutputFile != "" {
-		if err := getIdentityJwt(o, id); err != nil {
+		if err := getIdentityJwt(o, id, o.commonOptions.Timeout, o.commonOptions.Verbose); err != nil {
 			return err
 		}
 	}
 	return err
 }
 
-func getIdentityJwt(o *createIdentityOptions, id string) error {
+func getIdentityJwt(o *createIdentityOptions, id string, timeout int, verbose bool) error {
 
-	newIdentity, err := DetailEntityOfType("identities", id, o.OutputJSONResponse, o.Out)
+	newIdentity, err := DetailEntityOfType("identities", id, o.OutputJSONResponse, o.Out, timeout, verbose)
 	if err != nil {
 		return err
 	}

--- a/ziti/cmd/ziti/cmd/edge_controller/create_service.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/create_service.go
@@ -78,7 +78,7 @@ func newCreateServiceCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *co
 
 // runCreateService implements the command to create a service
 func runCreateService(o *createServiceOptions) (err error) {
-	configs, err := mapNamesToIDs("configs", o.configs...)
+	configs, err := mapNamesToIDs("configs", o.commonOptions, o.configs...)
 	if err != nil {
 		return err
 	}

--- a/ziti/cmd/ziti/cmd/edge_controller/create_service_edge_router_policy.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/create_service_edge_router_policy.go
@@ -68,12 +68,12 @@ func newCreateServiceEdgeRouterPolicyCmd(f cmdutil.Factory, out io.Writer, errOu
 
 // runCreateServiceEdgeRouterPolicy create a new edgeRouterPolicy on the Ziti Edge Controller
 func runCreateServiceEdgeRouterPolicy(o *createServiceEdgeRouterPolicyOptions) error {
-	edgeRouterRoles, err := convertNamesToIds(o.edgeRouterRoles, "edge-routers")
+	edgeRouterRoles, err := convertNamesToIds(o.edgeRouterRoles, "edge-routers", o.commonOptions)
 	if err != nil {
 		return err
 	}
 
-	serviceRoles, err := convertNamesToIds(o.serviceRoles, "services")
+	serviceRoles, err := convertNamesToIds(o.serviceRoles, "services", o.commonOptions)
 	if err != nil {
 		return err
 	}

--- a/ziti/cmd/ziti/cmd/edge_controller/create_service_policy.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/create_service_policy.go
@@ -78,17 +78,17 @@ func runCreateServicePolicy(o *createServicePolicyOptions) error {
 		return errors.Errorf("Invalid policy type '%v'. Valid values: [Bind, Dial]", policyType)
 	}
 
-	serviceRoles, err := convertNamesToIds(o.serviceRoles, "services")
+	serviceRoles, err := convertNamesToIds(o.serviceRoles, "services", o.commonOptions)
 	if err != nil {
 		return err
 	}
 
-	identityRoles, err := convertNamesToIds(o.identityRoles, "identities")
+	identityRoles, err := convertNamesToIds(o.identityRoles, "identities", o.commonOptions)
 	if err != nil {
 		return err
 	}
 
-	postureCheckRoles, err := convertNamesToIds(o.postureCheckRoles, "postureChecks")
+	postureCheckRoles, err := convertNamesToIds(o.postureCheckRoles, "postureChecks", o.commonOptions)
 	if err != nil {
 		return err
 	}
@@ -118,12 +118,12 @@ func runCreateServicePolicy(o *createServicePolicyOptions) error {
 	return err
 }
 
-func convertNamesToIds(roles []string, entityType string) ([]string, error) {
+func convertNamesToIds(roles []string, entityType string, o commonOptions) ([]string, error) {
 	var result []string
 	for _, val := range roles {
 		if strings.HasPrefix(val, "@") {
 			idOrName := strings.TrimPrefix(val, "@")
-			id, err := mapNameToID(entityType, idOrName)
+			id, err := mapNameToID(entityType, idOrName, o)
 			if err != nil {
 				return nil, err
 			}

--- a/ziti/cmd/ziti/cmd/edge_controller/create_terminator.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/create_terminator.go
@@ -77,12 +77,12 @@ func newCreateTerminatorCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) 
 // runCreateTerminator implements the command to create a Terminator
 func runCreateTerminator(o *createTerminatorOptions) (err error) {
 	entityData := gabs.New()
-	service, err := mapNameToID("services", o.Args[0])
+	service, err := mapNameToID("services", o.Args[0], o.commonOptions)
 	if err != nil {
 		return err
 	}
 
-	router, err := mapNameToID("edge-routers", o.Args[1])
+	router, err := mapNameToID("edge-routers", o.Args[1], o.commonOptions)
 	if err != nil {
 		router = o.Args[1] // might be a pure fabric router, id might not be UUID
 	}

--- a/ziti/cmd/ziti/cmd/edge_controller/db_check_integrity.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/db_check_integrity.go
@@ -51,9 +51,9 @@ func runCheckIntegrityDb(o *dbCheckIntegrityOptions) error {
 	var body *gabs.Container
 
 	if o.fix {
-		body, err = util.EdgeControllerUpdate("database/fix-data-integrity", "", o.Out, http.MethodPost, o.OutputJSONRequest, o.OutputJSONResponse)
+		body, err = util.EdgeControllerUpdate("database/fix-data-integrity", "", o.Out, http.MethodPost, o.OutputJSONRequest, o.OutputJSONResponse, o.commonOptions.Timeout, o.commonOptions.Verbose)
 	} else {
-		body, err = util.EdgeControllerList("database/check-data-integrity", nil, o.OutputJSONResponse, o.Out)
+		body, err = util.EdgeControllerList("database/check-data-integrity", nil, o.OutputJSONResponse, o.Out, o.commonOptions.Timeout, o.commonOptions.Verbose)
 	}
 
 	if err != nil {

--- a/ziti/cmd/ziti/cmd/edge_controller/db_snapshot.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/db_snapshot.go
@@ -58,6 +58,6 @@ func newDbSnapshotCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra
 }
 
 func runSnapshotDb(o *dbSnapshotOptions) error {
-	_, err := util.EdgeControllerUpdate("database/snapshot", "", o.Out, http.MethodPost, false, false)
+	_, err := util.EdgeControllerUpdate("database/snapshot", "", o.Out, http.MethodPost, false, false, o.commonOptions.Timeout, o.commonOptions.Verbose)
 	return err
 }

--- a/ziti/cmd/ziti/cmd/edge_controller/delete.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/delete.go
@@ -98,13 +98,13 @@ func runDeleteEntityOfType(o *commonOptions, entityType string) error {
 	var err error
 	ids := []string{o.Args[0]}
 	if entityType != "terminators" && entityType != "api-sessions" && entityType != "sessions" {
-		ids, err = mapNamesToIDs(entityType, o.Args[0])
+		ids, err = mapNamesToIDs(entityType, *o, o.Args[0])
 	}
 	if err != nil {
 		return err
 	}
 	for _, id := range ids {
-		_, err := util.EdgeControllerDelete(entityType, id, o.Out, o.OutputJSONResponse)
+		_, err := util.EdgeControllerDelete(entityType, id, o.Out, o.OutputJSONResponse, o.Timeout, o.Verbose)
 		if err != nil {
 			return err
 		}
@@ -120,5 +120,5 @@ func getPlural(entityType string) string {
 }
 
 func deleteEntityOfType(entityType string, id string, options *commonOptions) (*gabs.Container, error) {
-	return util.EdgeControllerDelete(entityType, id, options.Out, options.OutputJSONResponse)
+	return util.EdgeControllerDelete(entityType, id, options.Out, options.OutputJSONResponse, options.Timeout, options.Verbose)
 }

--- a/ziti/cmd/ziti/cmd/edge_controller/delete_authenticator_updb.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/delete_authenticator_updb.go
@@ -53,7 +53,7 @@ func newDeleteAuthenticatorUpdb(idType string, options *commonOptions) *cobra.Co
 
 func runDeleteUpdb(idOrName string, options *deleteUpdbOptions) error {
 
-	id, err := mapIdentityNameToID(idOrName)
+	id, err := mapIdentityNameToID(idOrName, options.commonOptions)
 
 	if err != nil {
 		return err

--- a/ziti/cmd/ziti/cmd/edge_controller/detail.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/detail.go
@@ -22,8 +22,8 @@ import (
 	"io"
 )
 
-func DetailEntityOfType(entityType, entityId string, logJSON bool, out io.Writer) (*gabs.Container, error) {
-	jsonParsed, err := util.EdgeControllerDetailEntity(entityType, entityId, logJSON, out)
+func DetailEntityOfType(entityType, entityId string, logJSON bool, out io.Writer, timeout int, verbose bool) (*gabs.Container, error) {
+	jsonParsed, err := util.EdgeControllerDetailEntity(entityType, entityId, logJSON, out, timeout, verbose)
 
 	if err != nil {
 		return nil, err

--- a/ziti/cmd/ziti/cmd/edge_controller/list.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/list.go
@@ -307,18 +307,18 @@ func listEntitiesWithOptions(entityType string, options *commonOptions) ([]*gabs
 		params.Add("filter", options.Args[0])
 	}
 
-	return listEntitiesOfType(entityType, params, options.OutputJSONResponse, options.Out)
+	return listEntitiesOfType(entityType, params, options.OutputJSONResponse, options.Out, options.Timeout, options.Verbose)
 }
 
-func filterEntitiesOfType(entityType string, filter string, logJSON bool, out io.Writer) ([]*gabs.Container, *paging, error) {
+func filterEntitiesOfType(entityType string, filter string, logJSON bool, out io.Writer, timeout int, verbose bool) ([]*gabs.Container, *paging, error) {
 	params := url.Values{}
 	params.Add("filter", filter)
-	return listEntitiesOfType(entityType, params, logJSON, out)
+	return listEntitiesOfType(entityType, params, logJSON, out, timeout, verbose)
 }
 
 // listEntitiesOfType queries the Ziti Controller for entities of the given type
-func listEntitiesOfType(entityType string, params url.Values, logJSON bool, out io.Writer) ([]*gabs.Container, *paging, error) {
-	jsonParsed, err := util.EdgeControllerList(entityType, params, logJSON, out)
+func listEntitiesOfType(entityType string, params url.Values, logJSON bool, out io.Writer, timeout int, verbose bool) ([]*gabs.Container, *paging, error) {
+	jsonParsed, err := util.EdgeControllerList(entityType, params, logJSON, out, timeout, verbose)
 
 	if err != nil {
 		return nil, nil, err
@@ -357,7 +357,7 @@ func getPaging(c *gabs.Container) *paging {
 
 // listEntitiesOfType queries the Ziti Controller for entities of the given type
 func filterSubEntitiesOfType(entityType, subType, entityId, filter string, o *commonOptions) ([]*gabs.Container, *paging, error) {
-	jsonParsed, err := util.EdgeControllerListSubEntities(entityType, subType, entityId, filter, o.OutputJSONResponse, o.Out)
+	jsonParsed, err := util.EdgeControllerListSubEntities(entityType, subType, entityId, filter, o.OutputJSONResponse, o.Out, o.Timeout, o.Verbose)
 
 	if err != nil {
 		return nil, nil, err
@@ -381,7 +381,7 @@ func runListEdgeRouters(roleFilters []string, roleSemantic string, options *comm
 	if roleSemantic != "" {
 		params.Add("roleSemantic", roleSemantic)
 	}
-	children, paging, err := listEntitiesOfType("edge-routers", params, options.OutputJSONResponse, options.Out)
+	children, paging, err := listEntitiesOfType("edge-routers", params, options.OutputJSONResponse, options.Out, options.Timeout, options.Verbose)
 	if err != nil {
 		return err
 	}
@@ -424,12 +424,12 @@ func outputEdgeRouterPolicies(o *commonOptions, children []*gabs.Container, pagi
 		id, _ := entity.Path("id").Data().(string)
 		name, _ := entity.Path("name").Data().(string)
 
-		identityRoles, err := mapRoleIdsToNames(entity, "identityRoles", "identities")
+		identityRoles, err := mapRoleIdsToNames(entity, "identityRoles", "identities", *o)
 		if err != nil {
 			return err
 		}
 
-		edgeRouterRoles, err := mapRoleIdsToNames(entity, "edgeRouterRoles", "edge-routers")
+		edgeRouterRoles, err := mapRoleIdsToNames(entity, "edgeRouterRoles", "edge-routers", *o)
 		if err != nil {
 			return err
 		}
@@ -488,7 +488,7 @@ func runListServices(asIdentity string, configTypes []string, roleFilters []stri
 	if len(configTypes) == 1 && strings.EqualFold("all", configTypes[0]) {
 		params.Add("configTypes", "all")
 	} else {
-		if configTypes, err := mapNamesToIDs("config-types", configTypes...); err != nil {
+		if configTypes, err := mapNamesToIDs("config-types", *options, configTypes...); err != nil {
 			return err
 		} else {
 			for _, configType := range configTypes {
@@ -502,7 +502,7 @@ func runListServices(asIdentity string, configTypes []string, roleFilters []stri
 	if roleSemantic != "" {
 		params.Add("roleSemantic", roleSemantic)
 	}
-	children, pagingInfo, err := listEntitiesOfType("services", params, options.OutputJSONResponse, options.Out)
+	children, pagingInfo, err := listEntitiesOfType("services", params, options.OutputJSONResponse, options.Out, options.Timeout, options.Verbose)
 	if err != nil {
 		return err
 	}
@@ -537,9 +537,9 @@ func outputServiceConfigs(o *commonOptions, children []*gabs.Container, pagingIn
 
 	for _, entity := range children {
 		service, _ := entity.Path("service").Data().(string)
-		serviceName, _ := mapIdToName("services", service)
+		serviceName, _ := mapIdToName("services", service, *o)
 		config, _ := entity.Path("config").Data().(string)
-		configName, _ := mapIdToName("configs", config)
+		configName, _ := mapIdToName("configs", config, *o)
 		_, err := fmt.Fprintf(o.Out, "service: %v    config: %v\n", serviceName, configName)
 		if err != nil {
 			return err
@@ -565,11 +565,11 @@ func outputServiceEdgeRouterPolicies(o *commonOptions, children []*gabs.Containe
 	for _, entity := range children {
 		id, _ := entity.Path("id").Data().(string)
 		name, _ := entity.Path("name").Data().(string)
-		edgeRouterRoles, err := mapRoleIdsToNames(entity, "edgeRouterRoles", "edge-routers")
+		edgeRouterRoles, err := mapRoleIdsToNames(entity, "edgeRouterRoles", "edge-routers", *o)
 		if err != nil {
 			return err
 		}
-		serviceRoles, err := mapRoleIdsToNames(entity, "serviceRoles", "services")
+		serviceRoles, err := mapRoleIdsToNames(entity, "serviceRoles", "services", *o)
 		if err != nil {
 			return err
 		}
@@ -600,16 +600,16 @@ func outputServicePolicies(o *commonOptions, children []*gabs.Container, pagingI
 		name, _ := entity.Path("name").Data().(string)
 		policyType, _ := entity.Path("type").Data().(string)
 
-		identityRoles, err := mapRoleIdsToNames(entity, "identityRoles", "identities")
+		identityRoles, err := mapRoleIdsToNames(entity, "identityRoles", "identities", *o)
 		if err != nil {
 			return err
 		}
 
-		serviceRoles, err := mapRoleIdsToNames(entity, "serviceRoles", "services")
+		serviceRoles, err := mapRoleIdsToNames(entity, "serviceRoles", "services", *o)
 		if err != nil {
 			return err
 		}
-		postureCheckRoles, err := mapRoleIdsToNames(entity, "postureCheckRoles", "posture-checks")
+		postureCheckRoles, err := mapRoleIdsToNames(entity, "postureCheckRoles", "posture-checks", *o)
 		if err != nil {
 			return err
 		}
@@ -623,7 +623,7 @@ func outputServicePolicies(o *commonOptions, children []*gabs.Container, pagingI
 	return nil
 }
 
-func mapRoleIdsToNames(c *gabs.Container, path string, entityType string) ([]string, error) {
+func mapRoleIdsToNames(c *gabs.Container, path string, entityType string, o commonOptions) ([]string, error) {
 	jsonValues := c.Path(path).Data()
 	if jsonValues == nil {
 		return nil, nil
@@ -636,7 +636,7 @@ func mapRoleIdsToNames(c *gabs.Container, path string, entityType string) ([]str
 		str := val.(string)
 		if strings.HasPrefix(str, "@") {
 			id := strings.TrimPrefix(str, "@")
-			name, err := mapIdToName(entityType, id)
+			name, err := mapIdToName(entityType, id, o)
 			if err != nil {
 				return nil, err
 			}
@@ -660,7 +660,7 @@ func runListIdentities(roleFilters []string, roleSemantic string, options *commo
 	if roleSemantic != "" {
 		params.Add("roleSemantic", roleSemantic)
 	}
-	children, pagingInfo, err := listEntitiesOfType("identities", params, options.OutputJSONResponse, options.Out)
+	children, pagingInfo, err := listEntitiesOfType("identities", params, options.OutputJSONResponse, options.Out, options.Timeout, options.Verbose)
 	if err != nil {
 		return err
 	}
@@ -935,7 +935,7 @@ func runListRoleAttributes(entityType string, o *commonOptions) error {
 
 func runListChilden(parentType, childType string, o *commonOptions, outputF outputFunction) error {
 	idOrName := o.Args[0]
-	parentId, err := mapNameToID(parentType, idOrName)
+	parentId, err := mapNameToID(parentType, idOrName, *o)
 	if err != nil {
 		return err
 	}

--- a/ziti/cmd/ziti/cmd/edge_controller/login.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/login.go
@@ -95,7 +95,7 @@ func (o *loginOptions) Run() error {
 
 	body := container.String()
 
-	jsonParsed, err := util.EdgeControllerLogin(host, o.Cert, body, o.Out, o.OutputJSONResponse)
+	jsonParsed, err := util.EdgeControllerLogin(host, o.Cert, body, o.Out, o.OutputJSONResponse, o.commonOptions.Timeout, o.commonOptions.Verbose)
 
 	if err != nil {
 		return err

--- a/ziti/cmd/ziti/cmd/edge_controller/policy_advisor.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/policy_advisor.go
@@ -110,12 +110,12 @@ func newPolicyAdvisorServicesCmd(f cmdutil.Factory, out io.Writer, errOut io.Wri
 // runIdentitiesPolicyAdvisor create a new policyAdvisor on the Ziti Edge Controller
 func runIdentitiesPolicyAdvisor(o *policyAdvisorOptions) error {
 	if len(o.Args) > 0 {
-		identityId, err := mapNameToID("identities", o.Args[0])
+		identityId, err := mapNameToID("identities", o.Args[0], o.commonOptions)
 		if err != nil {
 			return err
 		}
 		if len(o.Args) > 1 {
-			serviceId, err := mapNameToID("services", o.Args[1])
+			serviceId, err := mapNameToID("services", o.Args[1], o.commonOptions)
 			if err != nil {
 				return err
 			}
@@ -140,13 +140,13 @@ func runIdentitiesPolicyAdvisor(o *policyAdvisorOptions) error {
 // runServicesPolicyAdvisor create a new policyAdvisor on the Ziti Edge Controller
 func runServicesPolicyAdvisor(o *policyAdvisorOptions) error {
 	if len(o.Args) > 0 {
-		serviceId, err := mapNameToID("services", o.Args[0])
+		serviceId, err := mapNameToID("services", o.Args[0], o.commonOptions)
 		if err != nil {
 			return err
 		}
 
 		if len(o.Args) > 1 {
-			identityId, err := mapNameToID("identities", o.Args[1])
+			identityId, err := mapNameToID("identities", o.Args[1], o.commonOptions)
 			if err != nil {
 				return err
 			}
@@ -206,7 +206,7 @@ func runPolicyAdvisorForIdentities(o *policyAdvisorOptions) error {
 	done := false
 	for !done {
 		filter := fmt.Sprintf(`true skip %v limit 2`, skip)
-		children, _, err := filterEntitiesOfType("identities", filter, false, o.Out)
+		children, _, err := filterEntitiesOfType("identities", filter, false, o.Out, o.commonOptions.Timeout, o.commonOptions.Verbose)
 		if err != nil {
 			panic(err)
 		}
@@ -236,7 +236,7 @@ func runPolicyAdvisorForServices(o *policyAdvisorOptions) error {
 	done := false
 	for !done {
 		filter := fmt.Sprintf(`true skip %v limit 2`, skip)
-		children, _, err := filterEntitiesOfType("services", filter, false, o.Out)
+		children, _, err := filterEntitiesOfType("services", filter, false, o.Out, o.commonOptions.Timeout, o.commonOptions.Verbose)
 		if err != nil {
 			panic(err)
 		}
@@ -285,7 +285,7 @@ func runPolicyAdvisorForIdentity(identityId string, o *policyAdvisorOptions) err
 	}
 
 	if skip == 0 {
-		identityName, err := mapIdToName("identities", identityId)
+		identityName, err := mapIdToName("identities", identityId, o.commonOptions)
 		if err != nil {
 			return err
 		}
@@ -320,7 +320,7 @@ func runPolicyAdvisorForService(serviceId string, o *policyAdvisorOptions) error
 	}
 
 	if skip == 0 {
-		serviceName, err := mapIdToName("services", serviceId)
+		serviceName, err := mapIdToName("services", serviceId, o.commonOptions)
 		if err != nil {
 			return err
 		}
@@ -332,7 +332,7 @@ func runPolicyAdvisorForService(serviceId string, o *policyAdvisorOptions) error
 }
 
 func runPolicyAdvisorForIdentityAndService(identityId, serviceId string, o *policyAdvisorOptions) error {
-	result, err := util.EdgeControllerList("identities/"+identityId+"/policy-advice/"+serviceId, nil, o.OutputJSONResponse, o.Out)
+	result, err := util.EdgeControllerList("identities/"+identityId+"/policy-advice/"+serviceId, nil, o.OutputJSONResponse, o.Out, o.commonOptions.Timeout, o.commonOptions.Verbose)
 	if err != nil || o.OutputJSONResponse {
 		return err
 	}

--- a/ziti/cmd/ziti/cmd/edge_controller/root.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/root.go
@@ -45,6 +45,8 @@ type commonOptions struct {
 func (options *commonOptions) AddCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&options.OutputJSONResponse, "output-json", "j", false, "Output the full JSON response from the Ziti Edge Controller")
 	cmd.Flags().BoolVar(&options.OutputJSONRequest, "output-request-json", false, "Output the full JSON request to the Ziti Edge Controller")
+	cmd.Flags().IntVarP(&options.Timeout, "timeout", "", 5, "Timeout for REST operations (specified in seconds)")
+	cmd.Flags().BoolVarP(&options.Verbose, "verbose", "", false, "Enable verbose logging")
 }
 
 // newCmdEdgeController creates a command object for the "edge controller" command

--- a/ziti/cmd/ziti/cmd/edge_controller/update.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/update.go
@@ -72,9 +72,9 @@ func deleteEntityOfTypeWithBody(entityType string, body string, options *commonO
 
 // updateEntityOfType updates an entity of the given type on the Ziti Edge Controller
 func updateEntityOfType(entityType string, body string, options *commonOptions, method string) (*gabs.Container, error) {
-	return util.EdgeControllerUpdate(entityType, body, options.Out, method, options.OutputJSONRequest, options.OutputJSONResponse)
+	return util.EdgeControllerUpdate(entityType, body, options.Out, method, options.OutputJSONRequest, options.OutputJSONResponse, options.Timeout, options.Verbose)
 }
 
 func doRequest(entityType string, options *commonOptions, doRequest func(request *resty.Request, url string) (*resty.Response, error)) (*gabs.Container, error) {
-	return util.EdgeControllerRequest(entityType, options.Out, options.OutputJSONResponse, doRequest)
+	return util.EdgeControllerRequest(entityType, options.Out, options.OutputJSONResponse, options.Timeout, options.Verbose, doRequest)
 }

--- a/ziti/cmd/ziti/cmd/edge_controller/update_authenticator_updb.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/update_authenticator_updb.go
@@ -100,7 +100,7 @@ func updateSelfPassword(current string, new string, options commonOptions) error
 	setJSONValue(passwordData, current, "currentPassword")
 	setJSONValue(passwordData, new, "password")
 
-	respEnvelope, err := util.EdgeControllerList("current-identity/authenticators", map[string][]string{"filter": {`method="updb"`}}, options.OutputJSONResponse, options.Out)
+	respEnvelope, err := util.EdgeControllerList("current-identity/authenticators", map[string][]string{"filter": {`method="updb"`}}, options.OutputJSONResponse, options.Out, options.Timeout, options.Verbose)
 
 	if err != nil {
 		return err
@@ -128,7 +128,7 @@ func updateSelfPassword(current string, new string, options commonOptions) error
 }
 
 func setIdentityPassword(identity, password string, options commonOptions) error {
-	id, err := mapIdentityNameToID(identity)
+	id, err := mapIdentityNameToID(identity, options)
 
 	if err != nil {
 		return err

--- a/ziti/cmd/ziti/cmd/edge_controller/update_ca.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/update_ca.go
@@ -108,7 +108,7 @@ func runUpdateCa(options updateCaOptions) error {
 		return runVerifyCa(options)
 	}
 
-	id, err := mapCaNameToID(options.nameOrId)
+	id, err := mapCaNameToID(options.nameOrId, options.commonOptions)
 
 	if err != nil {
 		return err
@@ -132,7 +132,7 @@ func runUpdateCa(options updateCaOptions) error {
 }
 
 func runVerifyCa(options updateCaOptions) error {
-	id, err := mapCaNameToID(options.nameOrId)
+	id, err := mapCaNameToID(options.nameOrId, options.commonOptions)
 
 	if err != nil {
 		return err

--- a/ziti/cmd/ziti/cmd/edge_controller/update_config.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/update_config.go
@@ -72,7 +72,7 @@ func newUpdateConfigCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cob
 
 // runUpdateConfig update a new config on the Ziti Edge Controller
 func runUpdateConfig(o *updateConfigOptions) error {
-	id, err := mapNameToID("configs", o.Args[0])
+	id, err := mapNameToID("configs", o.Args[0], o.commonOptions)
 	if err != nil {
 		return err
 	}

--- a/ziti/cmd/ziti/cmd/edge_controller/update_edge_router.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/update_edge_router.go
@@ -68,7 +68,7 @@ func newUpdateEdgeRouterCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) 
 
 // runUpdateEdgeRouter update a new edgeRouter on the Ziti Edge Controller
 func runUpdateEdgeRouter(o *updateEdgeRouterOptions) error {
-	id, err := mapNameToID("edge-routers", o.Args[0])
+	id, err := mapNameToID("edge-routers", o.Args[0], o.commonOptions)
 	if err != nil {
 		return err
 	}

--- a/ziti/cmd/ziti/cmd/edge_controller/update_edge_router_policy.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/update_edge_router_policy.go
@@ -68,17 +68,17 @@ func newUpdateEdgeRouterPolicyCmd(f cmdutil.Factory, out io.Writer, errOut io.Wr
 }
 
 func runUpdateEdgeRouterPolicy(o *updateEdgeRouterPolicyOptions) error {
-	id, err := mapNameToID("edge-router-policies", o.Args[0])
+	id, err := mapNameToID("edge-router-policies", o.Args[0], o.commonOptions)
 	if err != nil {
 		return err
 	}
 
-	edgeRouterRoles, err := convertNamesToIds(o.edgeRouterRoles, "edge-routers")
+	edgeRouterRoles, err := convertNamesToIds(o.edgeRouterRoles, "edge-routers", o.commonOptions)
 	if err != nil {
 		return err
 	}
 
-	identityRoles, err := convertNamesToIds(o.identityRoles, "identities")
+	identityRoles, err := convertNamesToIds(o.identityRoles, "identities", o.commonOptions)
 	if err != nil {
 		return err
 	}

--- a/ziti/cmd/ziti/cmd/edge_controller/update_identity.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/update_identity.go
@@ -68,7 +68,7 @@ func newUpdateIdentityCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *c
 
 // runUpdateIdentity update a new identity on the Ziti Edge Controller
 func runUpdateIdentity(o *updateIdentityOptions) error {
-	id, err := mapNameToID("identities", o.Args[0])
+	id, err := mapNameToID("identities", o.Args[0], o.commonOptions)
 	if err != nil {
 		return err
 	}

--- a/ziti/cmd/ziti/cmd/edge_controller/update_identity_configs.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/update_identity_configs.go
@@ -63,17 +63,17 @@ func newUpdateIdentityConfigsCmd(f cmdutil.Factory, out io.Writer, errOut io.Wri
 
 // runupdateIdentityConfigs update a new identity on the Ziti Edge Controller
 func runupdateIdentityConfigs(o *updateIdentityConfigsOptions) error {
-	id, err := mapNameToID("identities", o.Args[0])
+	id, err := mapNameToID("identities", o.Args[0], o.commonOptions)
 	if err != nil {
 		return err
 	}
 
-	serviceId, err := mapNameToID("services", o.Args[1])
+	serviceId, err := mapNameToID("services", o.Args[1], o.commonOptions)
 	if err != nil {
 		return err
 	}
 
-	configId, err := mapNameToID("configs", o.Args[2])
+	configId, err := mapNameToID("configs", o.Args[2], o.commonOptions)
 	if err != nil {
 		return err
 	}

--- a/ziti/cmd/ziti/cmd/edge_controller/update_posture_check.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/update_posture_check.go
@@ -109,7 +109,7 @@ func newUpdatePostureCheckMacCmd(f cmdutil.Factory, out io.Writer, errOut io.Wri
 
 // runUpdatePostureCheckMac update a new identity on the Ziti Edge Controller
 func runUpdatePostureCheckMac(o *updatePostureCheckMacOptions) error {
-	id, err := mapNameToID("posture-checks", o.Args[0])
+	id, err := mapNameToID("posture-checks", o.Args[0], o.commonOptions)
 	if err != nil {
 		return err
 	}
@@ -177,7 +177,7 @@ func newUpdatePostureCheckDomainCmd(f cmdutil.Factory, out io.Writer, errOut io.
 
 // runUpdatePostureCheckDomain update a new identity on the Ziti Edge Controller
 func runUpdatePostureCheckDomain(o *updatePostureCheckDomainOptions) error {
-	id, err := mapNameToID("posture-checks", o.Args[0])
+	id, err := mapNameToID("posture-checks", o.Args[0], o.commonOptions)
 	if err != nil {
 		return err
 	}
@@ -256,7 +256,7 @@ func newUpdatePostureCheckProcessCmd(f cmdutil.Factory, out io.Writer, errOut io
 
 // runUpdatePostureCheckProcess update a new identity on the Ziti Edge Controller
 func runUpdatePostureCheckProcess(o *updatePostureCheckProcessOptions) error {
-	id, err := mapNameToID("posture-checks", o.Args[0])
+	id, err := mapNameToID("posture-checks", o.Args[0], o.commonOptions)
 	if err != nil {
 		return err
 	}
@@ -358,7 +358,7 @@ func newUpdatePostureCheckOsCmd(f cmdutil.Factory, out io.Writer, errOut io.Writ
 
 // runUpdatePostureCheckOs update a new identity on the Ziti Edge Controller
 func runUpdatePostureCheckOs(o *updatePostureCheckOsOptions) error {
-	id, err := mapNameToID("posture-checks", o.Args[0])
+	id, err := mapNameToID("posture-checks", o.Args[0], o.commonOptions)
 	if err != nil {
 		return err
 	}

--- a/ziti/cmd/ziti/cmd/edge_controller/update_service.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/update_service.go
@@ -73,7 +73,7 @@ func newUpdateServiceCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *co
 
 // runUpdateService update a new service on the Ziti Edge Controller
 func runUpdateService(o *updateServiceOptions) error {
-	id, err := mapNameToID("services", o.Args[0])
+	id, err := mapNameToID("services", o.Args[0], o.commonOptions)
 	if err != nil {
 		return err
 	}

--- a/ziti/cmd/ziti/cmd/edge_controller/update_service_edge_router_policy.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/update_service_edge_router_policy.go
@@ -68,17 +68,17 @@ func newUpdateServiceEdgeRouterPolicyCmd(f cmdutil.Factory, out io.Writer, errOu
 }
 
 func runUpdateServiceEdgeRouterPolicy(o *updateServiceEdgeRouterPolicyOptions) error {
-	id, err := mapNameToID("service-edge-router-policies", o.Args[0])
+	id, err := mapNameToID("service-edge-router-policies", o.Args[0], o.commonOptions)
 	if err != nil {
 		return err
 	}
 
-	edgeRouterRoles, err := convertNamesToIds(o.edgeRouterRoles, "edge-routers")
+	edgeRouterRoles, err := convertNamesToIds(o.edgeRouterRoles, "edge-routers", o.commonOptions)
 	if err != nil {
 		return err
 	}
 
-	serviceRoles, err := convertNamesToIds(o.serviceRoles, "services")
+	serviceRoles, err := convertNamesToIds(o.serviceRoles, "services", o.commonOptions)
 	if err != nil {
 		return err
 	}

--- a/ziti/cmd/ziti/cmd/edge_controller/update_service_policy.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/update_service_policy.go
@@ -70,22 +70,22 @@ func newUpdateServicePolicyCmd(f cmdutil.Factory, out io.Writer, errOut io.Write
 }
 
 func runUpdateServicePolicy(o *updateServicePolicyOptions) error {
-	id, err := mapNameToID("service-policies", o.Args[0])
+	id, err := mapNameToID("service-policies", o.Args[0], o.commonOptions)
 	if err != nil {
 		return err
 	}
 
-	serviceRoles, err := convertNamesToIds(o.serviceRoles, "services")
+	serviceRoles, err := convertNamesToIds(o.serviceRoles, "services", o.commonOptions)
 	if err != nil {
 		return err
 	}
 
-	identityRoles, err := convertNamesToIds(o.identityRoles, "identities")
+	identityRoles, err := convertNamesToIds(o.identityRoles, "identities", o.commonOptions)
 	if err != nil {
 		return err
 	}
 
-	postureCheckRoles, err := convertNamesToIds(o.postureCheckRoles, "posture-checks")
+	postureCheckRoles, err := convertNamesToIds(o.postureCheckRoles, "posture-checks", o.commonOptions)
 	if err != nil {
 		return err
 	}

--- a/ziti/cmd/ziti/cmd/edge_controller/update_terminator.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/update_terminator.go
@@ -79,7 +79,7 @@ func newUpdateTerminatorCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) 
 func runUpdateTerminator(o *updateTerminatorOptions) (err error) {
 	entityData := gabs.New()
 
-	router, err := mapNameToID("edge-routers", o.router)
+	router, err := mapNameToID("edge-routers", o.router, o.commonOptions)
 	if err != nil {
 		router = o.router // might be a pure fabric router, id might not be UUID
 	}

--- a/ziti/cmd/ziti/cmd/edge_controller/verify.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/verify.go
@@ -44,5 +44,5 @@ func newVerifyCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Com
 
 // createEntityOfType create an entity of the given type on the Ziti Edge Controller
 func verifyEntityOfType(entityType, body, id string, options *commonOptions) error {
-	return util.EdgeControllerVerify(entityType, id, body, options.Out, options.OutputJSONResponse)
+	return util.EdgeControllerVerify(entityType, id, body, options.Out, options.OutputJSONResponse, options.Timeout, options.Verbose)
 }

--- a/ziti/cmd/ziti/cmd/edge_controller/verify_ca.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/verify_ca.go
@@ -135,14 +135,14 @@ func newVerifyCaCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.C
 
 func runValidateCa(options *verifyCaOptions) error {
 	var err error
-	options.caId, err = mapCaNameToID(options.caNameOrId)
+	options.caId, err = mapCaNameToID(options.caNameOrId, options.commonOptions)
 
 	if err != nil {
 		return err
 	}
 
 	if options.isGenerateCert {
-		jsonContainer, err := util.EdgeControllerRequest("cas/"+options.caId, options.Out, options.OutputJSONResponse, func(request *resty.Request, url string) (*resty.Response, error) { return request.Get(url) })
+		jsonContainer, err := util.EdgeControllerRequest("cas/"+options.caId, options.Out, options.OutputJSONResponse, options.commonOptions.Timeout, options.commonOptions.Verbose, func(request *resty.Request, url string) (*resty.Response, error) { return request.Get(url) })
 
 		if err != nil {
 			return fmt.Errorf("could not request ca [%s] (%v}", options.caId, err)
@@ -161,7 +161,7 @@ func runValidateCa(options *verifyCaOptions) error {
 		}
 	}
 
-	return util.EdgeControllerVerify("cas", options.caId, string(options.certPemBytes), options.Out, options.OutputJSONResponse)
+	return util.EdgeControllerVerify("cas", options.caId, string(options.certPemBytes), options.Out, options.OutputJSONResponse, options.commonOptions.Timeout, options.commonOptions.Verbose)
 }
 
 func generateCert(options *verifyCaOptions, token string) ([]byte, crypto.Signer, error) {

--- a/ziti/cmd/ziti/cmd/edge_controller/version.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/version.go
@@ -59,7 +59,7 @@ func newVersionCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Co
 
 // Run implements this command
 func (o *versionOptions) Run() error {
-	jsonParsed, err := util.EdgeControllerList("version", nil, o.OutputJSONResponse, o.Out)
+	jsonParsed, err := util.EdgeControllerList("version", nil, o.OutputJSONResponse, o.Out, o.commonOptions.Timeout, o.commonOptions.Verbose)
 	if err != nil {
 		return err
 	}

--- a/ziti/cmd/ziti/util/rest.go
+++ b/ziti/cmd/ziti/util/rest.go
@@ -534,7 +534,7 @@ func Unzip(src, dest string) error {
 }
 
 // EdgeControllerLogin will authenticate to the given Edge Controller
-func EdgeControllerLogin(url string, cert string, authentication string, out io.Writer, logJSON bool) (*gabs.Container, error) {
+func EdgeControllerLogin(url string, cert string, authentication string, out io.Writer, logJSON bool, timeout int, verbose bool) (*gabs.Container, error) {
 	client := newClient()
 
 	if cert != "" {
@@ -542,6 +542,8 @@ func EdgeControllerLogin(url string, cert string, authentication string, out io.
 	}
 
 	resp, err := client.
+		SetTimeout(time.Duration(time.Duration(timeout)*time.Second)).
+		SetDebug(verbose).
 		R().
 		SetQueryParam("method", "password").
 		SetHeader("Content-Type", "application/json").
@@ -581,7 +583,7 @@ func outputJson(out io.Writer, data []byte) {
 	}
 }
 
-func EdgeControllerDetailEntity(entityType, entityId string, logJSON bool, out io.Writer) (*gabs.Container, error) {
+func EdgeControllerDetailEntity(entityType, entityId string, logJSON bool, out io.Writer, timeout int, verbose bool) (*gabs.Container, error) {
 	session := &Session{}
 	if err := session.Load(); err != nil {
 		return nil, err
@@ -595,7 +597,10 @@ func EdgeControllerDetailEntity(entityType, entityId string, logJSON bool, out i
 
 	queryUrl := session.GetBaseUrl() + "/" + path.Join(entityType, entityId)
 
-	resp, err := client.R().
+	resp, err := client.
+		SetTimeout(time.Duration(time.Duration(timeout)*time.Second)).
+		SetDebug(verbose).
+		R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader(constants.ZitiSession, session.GetToken()).
 		Get(queryUrl)
@@ -623,16 +628,16 @@ func EdgeControllerDetailEntity(entityType, entityId string, logJSON bool, out i
 }
 
 // EdgeControllerListSubEntities will list entities of the given type in the given Edge Controller
-func EdgeControllerListSubEntities(entityType, subType, entityId string, filter string, logJSON bool, out io.Writer) (*gabs.Container, error) {
+func EdgeControllerListSubEntities(entityType, subType, entityId string, filter string, logJSON bool, out io.Writer, timeout int, verbose bool) (*gabs.Container, error) {
 	params := url.Values{}
 	if filter != "" {
 		params.Add("filter", filter)
 	}
-	return EdgeControllerList(entityType+"/"+entityId+"/"+subType, params, logJSON, out)
+	return EdgeControllerList(entityType+"/"+entityId+"/"+subType, params, logJSON, out, timeout, verbose)
 }
 
 // EdgeControllerList will list entities of the given type in the given Edge Controller
-func EdgeControllerList(path string, params url.Values, logJSON bool, out io.Writer) (*gabs.Container, error) {
+func EdgeControllerList(path string, params url.Values, logJSON bool, out io.Writer, timeout int, verbose bool) (*gabs.Container, error) {
 	session := &Session{}
 	if err := session.Load(); err != nil {
 		return nil, err
@@ -651,6 +656,8 @@ func EdgeControllerList(path string, params url.Values, logJSON bool, out io.Wri
 	}
 
 	resp, err := client.
+		SetTimeout(time.Duration(time.Duration(timeout)*time.Second)).
+		SetDebug(verbose).
 		R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader(constants.ZitiSession, session.GetToken()).
@@ -679,7 +686,7 @@ func EdgeControllerList(path string, params url.Values, logJSON bool, out io.Wri
 }
 
 // EdgeControllerCreate will create entities of the given type in the given Edge Controller
-func EdgeControllerCreate(entityType string, body string, out io.Writer, logJSON bool) (*gabs.Container, error) {
+func EdgeControllerCreate(entityType string, body string, out io.Writer, logJSON bool, timeout int, verbose bool) (*gabs.Container, error) {
 	session := &Session{}
 	if err := session.Load(); err != nil {
 		return nil, err
@@ -691,6 +698,8 @@ func EdgeControllerCreate(entityType string, body string, out io.Writer, logJSON
 		client.SetRootCertificate(session.Cert)
 	}
 	resp, err := client.
+		SetTimeout(time.Duration(time.Duration(timeout)*time.Second)).
+		SetDebug(verbose).
 		R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader(constants.ZitiSession, session.Token).
@@ -720,7 +729,7 @@ func EdgeControllerCreate(entityType string, body string, out io.Writer, logJSON
 }
 
 // EdgeControllerDelete will delete entities of the given type in the given Edge Controller
-func EdgeControllerDelete(entityType string, id string, out io.Writer, logJSON bool) (*gabs.Container, error) {
+func EdgeControllerDelete(entityType string, id string, out io.Writer, logJSON bool, timeout int, verbose bool) (*gabs.Container, error) {
 	session := &Session{}
 	if err := session.Load(); err != nil {
 		return nil, err
@@ -735,6 +744,8 @@ func EdgeControllerDelete(entityType string, id string, out io.Writer, logJSON b
 	fullUrl := session.Host + "/" + entityPath
 
 	resp, err := client.
+		SetTimeout(time.Duration(time.Duration(timeout)*time.Second)).
+		SetDebug(verbose).
 		R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader(constants.ZitiSession, session.Token).
@@ -763,7 +774,7 @@ func EdgeControllerDelete(entityType string, id string, out io.Writer, logJSON b
 }
 
 // EdgeControllerUpdate will update entities of the given type in the given Edge Controller
-func EdgeControllerUpdate(entityType string, body string, out io.Writer, method string, logRequestJson, logResponseJSON bool) (*gabs.Container, error) {
+func EdgeControllerUpdate(entityType string, body string, out io.Writer, method string, logRequestJson, logResponseJSON bool, timeout int, verbose bool) (*gabs.Container, error) {
 	session := &Session{}
 	if err := session.Load(); err != nil {
 		return nil, err
@@ -781,6 +792,8 @@ func EdgeControllerUpdate(entityType string, body string, out io.Writer, method 
 	}
 
 	resp, err := client.
+		SetTimeout(time.Duration(time.Duration(timeout)*time.Second)).
+		SetDebug(verbose).
 		R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader(constants.ZitiSession, session.Token).
@@ -814,7 +827,7 @@ func EdgeControllerUpdate(entityType string, body string, out io.Writer, method 
 }
 
 // EdgeControllerVerify will create entities of the given type in the given Edge Controller
-func EdgeControllerVerify(entityType, id, body string, out io.Writer, logJSON bool) error {
+func EdgeControllerVerify(entityType, id, body string, out io.Writer, logJSON bool, timeout int, verbose bool) error {
 	session := &Session{}
 	if err := session.Load(); err != nil {
 		return err
@@ -826,6 +839,8 @@ func EdgeControllerVerify(entityType, id, body string, out io.Writer, logJSON bo
 		client.SetRootCertificate(session.Cert)
 	}
 	resp, err := client.
+		SetTimeout(time.Duration(time.Duration(timeout)*time.Second)).
+		SetDebug(verbose).
 		R().
 		SetHeader("Content-Type", "text/plain").
 		SetHeader(constants.ZitiSession, session.Token).
@@ -848,7 +863,7 @@ func EdgeControllerVerify(entityType, id, body string, out io.Writer, logJSON bo
 	return nil
 }
 
-func EdgeControllerRequest(entityType string, out io.Writer, logJSON bool, doRequest func(*resty.Request, string) (*resty.Response, error)) (*gabs.Container, error) {
+func EdgeControllerRequest(entityType string, out io.Writer, logJSON bool, timeout int, verbose bool, doRequest func(*resty.Request, string) (*resty.Response, error)) (*gabs.Container, error) {
 	session := &Session{}
 	if err := session.Load(); err != nil {
 		return nil, err
@@ -861,6 +876,8 @@ func EdgeControllerRequest(entityType string, out io.Writer, logJSON bool, doReq
 	}
 
 	request := client.
+		SetTimeout(time.Duration(time.Duration(timeout)*time.Second)).
+		SetDebug(verbose).
 		R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader(constants.ZitiSession, session.Token)


### PR DESCRIPTION
adds `--timeout=n` and `--verbose` flags to all `ziti edge controller` subcmds.