### PR TITLE
Add fractional seconds (milliseconds) to logrus.JSONFormatter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Release 0.18.3
+
+## What's New
+
+* JSON logging now emits timestamps that include fractional seconds. Timestamps remain in RFC3339 format.
+
 # Release 0.18.2
 
 ## What's New

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## What's New
 
-* JSON logging now emits timestamps that include fractional seconds. Timestamps remain in RFC3339 format.
+* Ziti executables that use JSON logging now emit timestamps that include fractional seconds. Timestamps remain in 
+  the RFC3339 format.
 
 # Release 0.18.2
 

--- a/test/sdk-echo-server/sdk-echo-server.go
+++ b/test/sdk-echo-server/sdk-echo-server.go
@@ -52,7 +52,7 @@ var root = &cobra.Command{
 		case "pfxlog":
 			logrus.SetFormatter(pfxlog.NewFormatterStartingToday())
 		case "json":
-			logrus.SetFormatter(&logrus.JSONFormatter{})
+			logrus.SetFormatter(&logrus.JSONFormatter{TimestampFormat: "2006-01-02T15:04:05.000Z"})
 		case "text":
 			logrus.SetFormatter(&logrus.TextFormatter{})
 		default:

--- a/test/zapp-fortio-grpc-server/zapp-fortio-grpc-server.go
+++ b/test/zapp-fortio-grpc-server/zapp-fortio-grpc-server.go
@@ -58,7 +58,7 @@ var root = &cobra.Command{
 		case "pfxlog":
 			logrus.SetFormatter(pfxlog.NewFormatterStartingToday())
 		case "json":
-			logrus.SetFormatter(&logrus.JSONFormatter{})
+			logrus.SetFormatter(&logrus.JSONFormatter{TimestampFormat: "2006-01-02T15:04:05.000Z"})
 		case "text":
 			logrus.SetFormatter(&logrus.TextFormatter{})
 		default:

--- a/ziti-controller/subcmd/root.go
+++ b/ziti-controller/subcmd/root.go
@@ -46,7 +46,7 @@ var root = &cobra.Command{
 		case "pfxlog":
 			logrus.SetFormatter(pfxlog.NewFormatterStartingToday())
 		case "json":
-			logrus.SetFormatter(&logrus.JSONFormatter{})
+			logrus.SetFormatter(&logrus.JSONFormatter{TimestampFormat: "2006-01-02T15:04:05.000Z"})
 		case "text":
 			logrus.SetFormatter(&logrus.TextFormatter{})
 		default:

--- a/ziti-probe/subcmd/root.go
+++ b/ziti-probe/subcmd/root.go
@@ -43,7 +43,7 @@ var root = &cobra.Command{
 		case "pfxlog":
 			logrus.SetFormatter(pfxlog.NewFormatterStartingToday())
 		case "json":
-			logrus.SetFormatter(&logrus.JSONFormatter{})
+			logrus.SetFormatter(&logrus.JSONFormatter{TimestampFormat: "2006-01-02T15:04:05.000Z"})
 		case "text":
 			logrus.SetFormatter(&logrus.TextFormatter{})
 		default:

--- a/ziti-router/subcmd/root.go
+++ b/ziti-router/subcmd/root.go
@@ -42,7 +42,7 @@ var root = &cobra.Command{
 		case "pfxlog":
 			logrus.SetFormatter(pfxlog.NewFormatterStartingToday())
 		case "json":
-			logrus.SetFormatter(&logrus.JSONFormatter{})
+			logrus.SetFormatter(&logrus.JSONFormatter{TimestampFormat: "2006-01-02T15:04:05.000Z"})
 		case "text":
 			logrus.SetFormatter(&logrus.TextFormatter{})
 		default:

--- a/ziti-tunnel/cmd/ziti-tunnel/subcmd/root.go
+++ b/ziti-tunnel/cmd/ziti-tunnel/subcmd/root.go
@@ -78,7 +78,7 @@ func rootPreRun(cmd *cobra.Command, _ []string) {
 	case "pfxlog":
 		logrus.SetFormatter(pfxlog.NewFormatterStartingToday())
 	case "json":
-		logrus.SetFormatter(&logrus.JSONFormatter{})
+		logrus.SetFormatter(&logrus.JSONFormatter{TimestampFormat: "2006-01-02T15:04:05.000Z"})
 	case "text":
 		logrus.SetFormatter(&logrus.TextFormatter{})
 	default:


### PR DESCRIPTION
Adjust the timestamps emitted by the JSON log format to include fractional seconds.