### PR TITLE
rename edge controller commonOptions to edgeOptions

### DIFF
--- a/ziti/cmd/ziti/cmd/edge_controller/common.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/common.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 )
 
-func mapNameToID(entityType string, val string, o commonOptions) (string, error) {
+func mapNameToID(entityType string, val string, o edgeOptions) (string, error) {
 	list, _, err := filterEntitiesOfType(entityType, fmt.Sprintf("id=\"%s\"", val), false, nil, o.Timeout, o.Verbose)
 	if err != nil {
 		return "", err
@@ -54,7 +54,7 @@ func mapNameToID(entityType string, val string, o commonOptions) (string, error)
 	return entityId, nil
 }
 
-func mapIdToName(entityType string, val string, o commonOptions) (string, error) {
+func mapIdToName(entityType string, val string, o edgeOptions) (string, error) {
 	list, _, err := filterEntitiesOfType(entityType, fmt.Sprintf(`id="%s"`, val), false, nil, o.Timeout, o.Verbose)
 	if err != nil {
 		return "", err
@@ -69,7 +69,7 @@ func mapIdToName(entityType string, val string, o commonOptions) (string, error)
 	return name, nil
 }
 
-func mapNamesToIDs(entityType string, o commonOptions, list ...string) ([]string, error) {
+func mapNamesToIDs(entityType string, o edgeOptions, list ...string) ([]string, error) {
 	var result []string
 	for _, val := range list {
 		if strings.HasPrefix(val, "id") {
@@ -103,10 +103,10 @@ func mapNamesToIDs(entityType string, o commonOptions, list ...string) ([]string
 	return result, nil
 }
 
-func mapIdentityNameToID(nameOrId string, o commonOptions) (string, error) {
+func mapIdentityNameToID(nameOrId string, o edgeOptions) (string, error) {
 	return mapNameToID("identities", nameOrId, o)
 }
 
-func mapCaNameToID(nameOrId string, o commonOptions) (string, error) {
+func mapCaNameToID(nameOrId string, o edgeOptions) (string, error) {
 	return mapNameToID("cas", nameOrId, o)
 }

--- a/ziti/cmd/ziti/cmd/edge_controller/create.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/create.go
@@ -55,6 +55,6 @@ func newCreateCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Com
 }
 
 // createEntityOfType create an entity of the given type on the Ziti Edge Controller
-func createEntityOfType(entityType string, body string, options *commonOptions) (*gabs.Container, error) {
+func createEntityOfType(entityType string, body string, options *edgeOptions) (*gabs.Container, error) {
 	return util.EdgeControllerCreate(entityType, body, options.Out, options.OutputJSONResponse, options.Timeout, options.Verbose)
 }

--- a/ziti/cmd/ziti/cmd/edge_controller/create_authenticator.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/create_authenticator.go
@@ -25,7 +25,7 @@ import (
 
 // newCreateAuthenticatorCmd creates the 'edge controller create authenticator' command
 func newCreateAuthenticatorCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
-	options := commonOptions{
+	options := edgeOptions{
 		CommonOptions:      common.CommonOptions{Factory: f, Out: out, Err: errOut},
 		OutputJSONResponse: false,
 	}

--- a/ziti/cmd/ziti/cmd/edge_controller/create_authenticator_updb.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/create_authenticator_updb.go
@@ -26,14 +26,14 @@ import (
 )
 
 type createAuthenticatorUpdb struct {
-	commonOptions
+	edgeOptions
 	idOrName string
 	password string
 	username string
 }
 
-func newCreateAuthenticatorUpdb(idType string, options commonOptions) *cobra.Command {
-	updbOptions := &createAuthenticatorUpdb{commonOptions: options}
+func newCreateAuthenticatorUpdb(idType string, options edgeOptions) *cobra.Command {
+	updbOptions := &createAuthenticatorUpdb{edgeOptions: options}
 
 	cmd := &cobra.Command{
 		Use:     idType + " <identityIdOrName> <username> [<password>]",
@@ -78,7 +78,7 @@ func runCreateIdentityPassword(idType string, options *createAuthenticatorUpdb) 
 		return errors.New("an identity must be specified")
 	}
 
-	id, err := mapIdentityNameToID(options.idOrName, options.commonOptions)
+	id, err := mapIdentityNameToID(options.idOrName, options.edgeOptions)
 
 	if err != nil {
 		return err
@@ -94,7 +94,7 @@ func runCreateIdentityPassword(idType string, options *createAuthenticatorUpdb) 
 	setJSONValue(passwordData, options.password, "password")
 	setJSONValue(passwordData, options.username, "username")
 
-	if _, err = createEntityOfType(fmt.Sprintf("identities/%s/updb", id), passwordData.String(), &options.commonOptions); err != nil {
+	if _, err = createEntityOfType(fmt.Sprintf("identities/%s/updb", id), passwordData.String(), &options.edgeOptions); err != nil {
 		return err
 	}
 	return nil

--- a/ziti/cmd/ziti/cmd/edge_controller/create_ca.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/create_ca.go
@@ -28,7 +28,7 @@ import (
 )
 
 type createCaOptions struct {
-	commonOptions
+	edgeOptions
 	tags             map[string]string
 	name             string
 	caPath           string
@@ -42,7 +42,7 @@ type createCaOptions struct {
 // newCreateCaCmd creates the 'edge controller create ca local' command for the given entity type
 func newCreateCaCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &createCaOptions{
-		commonOptions: commonOptions{
+		edgeOptions: edgeOptions{
 			CommonOptions: common.CommonOptions{
 				Factory: f,
 				Out:     out,
@@ -104,7 +104,7 @@ func runCreateCa(options *createCaOptions) (err error) {
 	setJSONValue(data, string(options.caPemBytes), "certPem")
 	setJSONValue(data, options.identityRoles, "identityRoles")
 
-	result, err := createEntityOfType("cas", data.String(), &options.commonOptions)
+	result, err := createEntityOfType("cas", data.String(), &options.edgeOptions)
 
 	if err != nil {
 		panic(err)

--- a/ziti/cmd/ziti/cmd/edge_controller/create_config.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/create_config.go
@@ -32,14 +32,14 @@ import (
 )
 
 type createConfigOptions struct {
-	commonOptions
+	edgeOptions
 	jsonFile string
 }
 
 // newCreateConfigCmd creates the 'edge controller create service-policy' command
 func newCreateConfigCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &createConfigOptions{
-		commonOptions: commonOptions{
+		edgeOptions: edgeOptions{
 			CommonOptions: common.CommonOptions{Factory: f, Out: out, Err: errOut},
 		},
 	}
@@ -95,7 +95,7 @@ func runCreateConfig(o *createConfigOptions) error {
 		return errors.Errorf("unable to parse data as json: %v", err)
 	}
 
-	configTypeId, err := mapNameToID("config-types", o.Args[1], o.commonOptions)
+	configTypeId, err := mapNameToID("config-types", o.Args[1], o.edgeOptions)
 	if err != nil {
 		return err
 	}
@@ -104,7 +104,7 @@ func runCreateConfig(o *createConfigOptions) error {
 	setJSONValue(entityData, o.Args[0], "name")
 	setJSONValue(entityData, configTypeId, "configTypeId")
 	setJSONValue(entityData, dataMap, "data")
-	result, err := createEntityOfType("configs", entityData.String(), &o.commonOptions)
+	result, err := createEntityOfType("configs", entityData.String(), &o.edgeOptions)
 
 	if err != nil {
 		panic(err)

--- a/ziti/cmd/ziti/cmd/edge_controller/create_config_type.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/create_config_type.go
@@ -32,14 +32,14 @@ import (
 )
 
 type createConfigTypeOptions struct {
-	commonOptions
+	edgeOptions
 	schemaFile string
 }
 
 // newCreateConfigTypeCmd creates the 'edge controller create service-policy' command
 func newCreateConfigTypeCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &createConfigTypeOptions{
-		commonOptions: commonOptions{
+		edgeOptions: edgeOptions{
 			CommonOptions: common.CommonOptions{Factory: f, Out: out, Err: errOut},
 		},
 	}
@@ -101,7 +101,7 @@ func runCreateConfigType(o *createConfigTypeOptions) error {
 		setJSONValue(entityData, schemaMap, "schema")
 	}
 
-	result, err := createEntityOfType("config-types", entityData.String(), &o.commonOptions)
+	result, err := createEntityOfType("config-types", entityData.String(), &o.edgeOptions)
 
 	if err != nil {
 		panic(err)

--- a/ziti/cmd/ziti/cmd/edge_controller/create_edge_router.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/create_edge_router.go
@@ -29,14 +29,14 @@ import (
 )
 
 type createEdgeRouterOptions struct {
-	commonOptions
+	edgeOptions
 	roleAttributes []string
 	jwtOutputFile  string
 }
 
 func newCreateEdgeRouterCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &createEdgeRouterOptions{
-		commonOptions: commonOptions{
+		edgeOptions: edgeOptions{
 			CommonOptions: common.CommonOptions{Factory: f, Out: out, Err: errOut},
 		},
 	}
@@ -71,7 +71,7 @@ func runCreateEdgeRouter(o *createEdgeRouterOptions) error {
 	setJSONValue(routerData, o.Args[0], "name")
 	setJSONValue(routerData, o.roleAttributes, "roleAttributes")
 
-	result, err := createEntityOfType("edge-routers", routerData.String(), &o.commonOptions)
+	result, err := createEntityOfType("edge-routers", routerData.String(), &o.edgeOptions)
 
 	if err != nil {
 		return err
@@ -96,7 +96,7 @@ func runCreateEdgeRouter(o *createEdgeRouterOptions) error {
 }
 
 func getEdgeRouterJwt(o *createEdgeRouterOptions, id string) error {
-	newRouter, err := DetailEntityOfType("edge-routers", id, o.OutputJSONResponse, o.Out, o.commonOptions.Timeout, o.commonOptions.Verbose)
+	newRouter, err := DetailEntityOfType("edge-routers", id, o.OutputJSONResponse, o.Out, o.edgeOptions.Timeout, o.edgeOptions.Verbose)
 	if err != nil {
 		return err
 	}

--- a/ziti/cmd/ziti/cmd/edge_controller/create_edge_router_policy.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/create_edge_router_policy.go
@@ -28,7 +28,7 @@ import (
 )
 
 type createEdgeRouterPolicyOptions struct {
-	commonOptions
+	edgeOptions
 	edgeRouterRoles []string
 	identityRoles   []string
 	semantic        string
@@ -37,7 +37,7 @@ type createEdgeRouterPolicyOptions struct {
 // newCreateEdgeRouterPolicyCmd creates the 'edge controller create edge-router-policy' command
 func newCreateEdgeRouterPolicyCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &createEdgeRouterPolicyOptions{
-		commonOptions: commonOptions{
+		edgeOptions: edgeOptions{
 			CommonOptions: common.CommonOptions{Factory: f, Out: out, Err: errOut},
 		},
 	}
@@ -68,12 +68,12 @@ func newCreateEdgeRouterPolicyCmd(f cmdutil.Factory, out io.Writer, errOut io.Wr
 
 // runCreateEdgeRouterPolicy create a new edgeRouterPolicy on the Ziti Edge Controller
 func runCreateEdgeRouterPolicy(o *createEdgeRouterPolicyOptions) error {
-	edgeRouterRoles, err := convertNamesToIds(o.edgeRouterRoles, "edge-routers", o.commonOptions)
+	edgeRouterRoles, err := convertNamesToIds(o.edgeRouterRoles, "edge-routers", o.edgeOptions)
 	if err != nil {
 		return err
 	}
 
-	identityRoles, err := convertNamesToIds(o.identityRoles, "identities", o.commonOptions)
+	identityRoles, err := convertNamesToIds(o.identityRoles, "identities", o.edgeOptions)
 	if err != nil {
 		return err
 	}
@@ -86,7 +86,7 @@ func runCreateEdgeRouterPolicy(o *createEdgeRouterPolicyOptions) error {
 		setJSONValue(entityData, o.semantic, "semantic")
 	}
 
-	result, err := createEntityOfType("edge-router-policies", entityData.String(), &o.commonOptions)
+	result, err := createEntityOfType("edge-router-policies", entityData.String(), &o.edgeOptions)
 
 	if err != nil {
 		panic(err)

--- a/ziti/cmd/ziti/cmd/edge_controller/create_identity.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/create_identity.go
@@ -31,7 +31,7 @@ import (
 )
 
 type createIdentityOptions struct {
-	commonOptions
+	edgeOptions
 	isAdmin                  bool
 	roleAttributes           []string
 	jwtOutputFile            string
@@ -44,7 +44,7 @@ type createIdentityOptions struct {
 func newCreateIdentityCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	newOptions := func() *createIdentityOptions {
 		return &createIdentityOptions{
-			commonOptions: commonOptions{
+			edgeOptions: edgeOptions{
 				CommonOptions: common.CommonOptions{Factory: f, Out: out, Err: errOut},
 			},
 		}
@@ -111,7 +111,7 @@ func runCreateIdentity(idType string, o *createIdentityOptions) error {
 	}
 	setJSONValue(entityData, o.defaultHostingCost, "defaultHostingCost")
 
-	result, err := createEntityOfType("identities", entityData.String(), &o.commonOptions)
+	result, err := createEntityOfType("identities", entityData.String(), &o.edgeOptions)
 
 	if err != nil {
 		panic(err)
@@ -124,7 +124,7 @@ func runCreateIdentity(idType string, o *createIdentityOptions) error {
 	}
 
 	if o.jwtOutputFile != "" {
-		if err := getIdentityJwt(o, id, o.commonOptions.Timeout, o.commonOptions.Verbose); err != nil {
+		if err := getIdentityJwt(o, id, o.edgeOptions.Timeout, o.edgeOptions.Verbose); err != nil {
 			return err
 		}
 	}

--- a/ziti/cmd/ziti/cmd/edge_controller/create_posture_check.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/create_posture_check.go
@@ -43,7 +43,7 @@ func newCreatePostureCheckCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer
 }
 
 type createPostureCheckOptions struct {
-	commonOptions
+	edgeOptions
 	name           string
 	tags           map[string]string
 	roleAttributes []string
@@ -82,7 +82,7 @@ func (options *createPostureCheckOptions) addPostureFlags(cmd *cobra.Command) {
 func newCreatePostureCheckMacCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &createPostureCheckMacOptions{
 		createPostureCheckOptions: createPostureCheckOptions{
-			commonOptions: commonOptions{
+			edgeOptions: edgeOptions{
 				CommonOptions: common.CommonOptions{
 					Factory: f,
 					Out:     out,
@@ -122,7 +122,7 @@ func newCreatePostureCheckMacCmd(f cmdutil.Factory, out io.Writer, errOut io.Wri
 func newCreatePostureCheckDomainCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &createPostureCheckDomainOptions{
 		createPostureCheckOptions: createPostureCheckOptions{
-			commonOptions: commonOptions{
+			edgeOptions: edgeOptions{
 				CommonOptions: common.CommonOptions{
 					Factory: f,
 					Out:     out,
@@ -162,7 +162,7 @@ func newCreatePostureCheckDomainCmd(f cmdutil.Factory, out io.Writer, errOut io.
 func newCreatePostureCheckProcessCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &createPostureCheckProcessOptions{
 		createPostureCheckOptions: createPostureCheckOptions{
-			commonOptions: commonOptions{
+			edgeOptions: edgeOptions{
 				CommonOptions: common.CommonOptions{
 					Factory: f,
 					Out:     out,
@@ -311,7 +311,7 @@ func runCreatePostureCheckProcess(o *createPostureCheckProcessOptions) error {
 		setJSONValue(entityData, cleanSigner, "process", "signerFingerprint")
 	}
 
-	result, err := createEntityOfType("posture-checks", entityData.String(), &o.commonOptions)
+	result, err := createEntityOfType("posture-checks", entityData.String(), &o.edgeOptions)
 
 	if err != nil {
 		panic(err)
@@ -372,7 +372,7 @@ func runCreatePostureCheckMac(o *createPostureCheckMacOptions) (err error) {
 
 	setJSONValue(entityData, addresses, "macAddresses")
 
-	result, err := createEntityOfType("posture-checks", entityData.String(), &o.commonOptions)
+	result, err := createEntityOfType("posture-checks", entityData.String(), &o.edgeOptions)
 
 	if err != nil {
 		panic(err)
@@ -418,7 +418,7 @@ func runCreatePostureCheckDomain(o *createPostureCheckDomainOptions) (err error)
 
 	setJSONValue(entityData, domains, "domains")
 
-	result, err := createEntityOfType("posture-checks", entityData.String(), &o.commonOptions)
+	result, err := createEntityOfType("posture-checks", entityData.String(), &o.edgeOptions)
 
 	if err != nil {
 		panic(err)
@@ -437,7 +437,7 @@ func newCreatePostureCheckOsCmd(f cmdutil.Factory, out io.Writer, errOut io.Writ
 
 	options := &createPostureCheckOsOptions{
 		createPostureCheckOptions: createPostureCheckOptions{
-			commonOptions: commonOptions{
+			edgeOptions: edgeOptions{
 				CommonOptions: common.CommonOptions{
 					Factory: f,
 					Out:     out,
@@ -493,7 +493,7 @@ func runCreatePostureCheckOs(o *createPostureCheckOsOptions) error {
 	setPostureCheckEntityValues(entityData, &o.createPostureCheckOptions, PostureCheckTypeOS)
 	setJSONValue(entityData, osSpecs, "operatingSystems")
 
-	result, err := createEntityOfType("posture-checks", entityData.String(), &o.commonOptions)
+	result, err := createEntityOfType("posture-checks", entityData.String(), &o.edgeOptions)
 
 	if err != nil {
 		panic(err)

--- a/ziti/cmd/ziti/cmd/edge_controller/create_service.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/create_service.go
@@ -27,7 +27,7 @@ import (
 )
 
 type createServiceOptions struct {
-	commonOptions
+	edgeOptions
 	terminatorStrategy string
 	tags               map[string]string
 	roleAttributes     []string
@@ -39,7 +39,7 @@ type createServiceOptions struct {
 // newCreateServiceCmd creates the 'edge controller create service local' command for the given entity type
 func newCreateServiceCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &createServiceOptions{
-		commonOptions: commonOptions{
+		edgeOptions: edgeOptions{
 			CommonOptions: common.CommonOptions{
 				Factory: f,
 				Out:     out,
@@ -78,7 +78,7 @@ func newCreateServiceCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *co
 
 // runCreateService implements the command to create a service
 func runCreateService(o *createServiceOptions) (err error) {
-	configs, err := mapNamesToIDs("configs", o.commonOptions, o.configs...)
+	configs, err := mapNamesToIDs("configs", o.edgeOptions, o.configs...)
 	if err != nil {
 		return err
 	}
@@ -95,7 +95,7 @@ func runCreateService(o *createServiceOptions) (err error) {
 	setJSONValue(entityData, configs, "configs")
 	setJSONValue(entityData, o.tags, "tags")
 
-	result, err := createEntityOfType("services", entityData.String(), &o.commonOptions)
+	result, err := createEntityOfType("services", entityData.String(), &o.edgeOptions)
 
 	if err != nil {
 		panic(err)

--- a/ziti/cmd/ziti/cmd/edge_controller/create_service_edge_router_policy.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/create_service_edge_router_policy.go
@@ -28,7 +28,7 @@ import (
 )
 
 type createServiceEdgeRouterPolicyOptions struct {
-	commonOptions
+	edgeOptions
 	edgeRouterRoles []string
 	serviceRoles    []string
 	semantic        string
@@ -37,7 +37,7 @@ type createServiceEdgeRouterPolicyOptions struct {
 // newCreateServiceEdgeRouterPolicyCmd creates the 'edge controller create service-edge-router-policy' command
 func newCreateServiceEdgeRouterPolicyCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &createServiceEdgeRouterPolicyOptions{
-		commonOptions: commonOptions{
+		edgeOptions: edgeOptions{
 			CommonOptions: common.CommonOptions{Factory: f, Out: out, Err: errOut},
 		},
 	}
@@ -68,12 +68,12 @@ func newCreateServiceEdgeRouterPolicyCmd(f cmdutil.Factory, out io.Writer, errOu
 
 // runCreateServiceEdgeRouterPolicy create a new edgeRouterPolicy on the Ziti Edge Controller
 func runCreateServiceEdgeRouterPolicy(o *createServiceEdgeRouterPolicyOptions) error {
-	edgeRouterRoles, err := convertNamesToIds(o.edgeRouterRoles, "edge-routers", o.commonOptions)
+	edgeRouterRoles, err := convertNamesToIds(o.edgeRouterRoles, "edge-routers", o.edgeOptions)
 	if err != nil {
 		return err
 	}
 
-	serviceRoles, err := convertNamesToIds(o.serviceRoles, "services", o.commonOptions)
+	serviceRoles, err := convertNamesToIds(o.serviceRoles, "services", o.edgeOptions)
 	if err != nil {
 		return err
 	}
@@ -85,7 +85,7 @@ func runCreateServiceEdgeRouterPolicy(o *createServiceEdgeRouterPolicyOptions) e
 		setJSONValue(entityData, o.semantic, "semantic")
 	}
 
-	result, err := createEntityOfType("service-edge-router-policies", entityData.String(), &o.commonOptions)
+	result, err := createEntityOfType("service-edge-router-policies", entityData.String(), &o.edgeOptions)
 
 	if err != nil {
 		panic(err)

--- a/ziti/cmd/ziti/cmd/edge_controller/create_service_policy.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/create_service_policy.go
@@ -31,7 +31,7 @@ import (
 )
 
 type createServicePolicyOptions struct {
-	commonOptions
+	edgeOptions
 	serviceRoles      []string
 	identityRoles     []string
 	postureCheckRoles []string
@@ -41,7 +41,7 @@ type createServicePolicyOptions struct {
 // newCreateServicePolicyCmd creates the 'edge controller create service-policy' command
 func newCreateServicePolicyCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &createServicePolicyOptions{
-		commonOptions: commonOptions{
+		edgeOptions: edgeOptions{
 			CommonOptions: common.CommonOptions{Factory: f, Out: out, Err: errOut},
 		},
 	}
@@ -78,17 +78,17 @@ func runCreateServicePolicy(o *createServicePolicyOptions) error {
 		return errors.Errorf("Invalid policy type '%v'. Valid values: [Bind, Dial]", policyType)
 	}
 
-	serviceRoles, err := convertNamesToIds(o.serviceRoles, "services", o.commonOptions)
+	serviceRoles, err := convertNamesToIds(o.serviceRoles, "services", o.edgeOptions)
 	if err != nil {
 		return err
 	}
 
-	identityRoles, err := convertNamesToIds(o.identityRoles, "identities", o.commonOptions)
+	identityRoles, err := convertNamesToIds(o.identityRoles, "identities", o.edgeOptions)
 	if err != nil {
 		return err
 	}
 
-	postureCheckRoles, err := convertNamesToIds(o.postureCheckRoles, "postureChecks", o.commonOptions)
+	postureCheckRoles, err := convertNamesToIds(o.postureCheckRoles, "postureChecks", o.edgeOptions)
 	if err != nil {
 		return err
 	}
@@ -103,7 +103,7 @@ func runCreateServicePolicy(o *createServicePolicyOptions) error {
 	if o.semantic != "" {
 		setJSONValue(entityData, o.semantic, "semantic")
 	}
-	result, err := createEntityOfType("service-policies", entityData.String(), &o.commonOptions)
+	result, err := createEntityOfType("service-policies", entityData.String(), &o.edgeOptions)
 
 	if err != nil {
 		panic(err)
@@ -118,7 +118,7 @@ func runCreateServicePolicy(o *createServicePolicyOptions) error {
 	return err
 }
 
-func convertNamesToIds(roles []string, entityType string, o commonOptions) ([]string, error) {
+func convertNamesToIds(roles []string, entityType string, o edgeOptions) ([]string, error) {
 	var result []string
 	for _, val := range roles {
 		if strings.HasPrefix(val, "@") {

--- a/ziti/cmd/ziti/cmd/edge_controller/create_terminator.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/create_terminator.go
@@ -30,7 +30,7 @@ import (
 )
 
 type createTerminatorOptions struct {
-	commonOptions
+	edgeOptions
 	binding    string
 	cost       int32
 	precedence string
@@ -40,7 +40,7 @@ type createTerminatorOptions struct {
 // newCreateTerminatorCmd creates the 'edge controller create Terminator local' command for the given entity type
 func newCreateTerminatorCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &createTerminatorOptions{
-		commonOptions: commonOptions{
+		edgeOptions: edgeOptions{
 			CommonOptions: common.CommonOptions{
 				Factory: f,
 				Out:     out,
@@ -77,12 +77,12 @@ func newCreateTerminatorCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) 
 // runCreateTerminator implements the command to create a Terminator
 func runCreateTerminator(o *createTerminatorOptions) (err error) {
 	entityData := gabs.New()
-	service, err := mapNameToID("services", o.Args[0], o.commonOptions)
+	service, err := mapNameToID("services", o.Args[0], o.edgeOptions)
 	if err != nil {
 		return err
 	}
 
-	router, err := mapNameToID("edge-routers", o.Args[1], o.commonOptions)
+	router, err := mapNameToID("edge-routers", o.Args[1], o.edgeOptions)
 	if err != nil {
 		router = o.Args[1] // might be a pure fabric router, id might not be UUID
 	}
@@ -112,7 +112,7 @@ func runCreateTerminator(o *createTerminatorOptions) (err error) {
 		setJSONValue(entityData, o.precedence, "precedence")
 	}
 
-	result, err := createEntityOfType("terminators", entityData.String(), &o.commonOptions)
+	result, err := createEntityOfType("terminators", entityData.String(), &o.edgeOptions)
 
 	if err != nil {
 		panic(err)

--- a/ziti/cmd/ziti/cmd/edge_controller/db_check_integrity.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/db_check_integrity.go
@@ -14,13 +14,13 @@ import (
 )
 
 type dbCheckIntegrityOptions struct {
-	commonOptions
+	edgeOptions
 	fix bool
 }
 
 func newDbCheckIntegrityCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &dbCheckIntegrityOptions{
-		commonOptions: commonOptions{
+		edgeOptions: edgeOptions{
 			CommonOptions: common.CommonOptions{Factory: f, Out: out, Err: errOut},
 		},
 	}
@@ -54,7 +54,7 @@ func runCheckIntegrityDb(o *dbCheckIntegrityOptions) error {
 		target = "database/check-data-integrity"
 	}
 
-	if _, err := util.EdgeControllerUpdate(target, "", o.Out, http.MethodPost, o.OutputJSONRequest, o.OutputJSONResponse, o.commonOptions.Timeout, o.commonOptions.Verbose); err != nil {
+	if _, err := util.EdgeControllerUpdate(target, "", o.Out, http.MethodPost, o.OutputJSONRequest, o.OutputJSONResponse, o.edgeOptions.Timeout, o.edgeOptions.Verbose); err != nil {
 		return err
 	}
 
@@ -64,7 +64,7 @@ func runCheckIntegrityDb(o *dbCheckIntegrityOptions) error {
 
 func newDbCheckIntegrityStatusCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &dbCheckIntegrityOptions{
-		commonOptions: commonOptions{
+		edgeOptions: edgeOptions{
 			CommonOptions: common.CommonOptions{Factory: f, Out: out, Err: errOut},
 		},
 	}
@@ -90,7 +90,7 @@ func newDbCheckIntegrityStatusCmd(f cmdutil.Factory, out io.Writer, errOut io.Wr
 }
 
 func runCheckIntegrityStatus(o *dbCheckIntegrityOptions) error {
-	body, err := util.EdgeControllerList("database/data-integrity-results", nil, o.OutputJSONResponse, o.Out, o.commonOptions.Timeout, o.commonOptions.Verbose)
+	body, err := util.EdgeControllerList("database/data-integrity-results", nil, o.OutputJSONResponse, o.Out, o.edgeOptions.Timeout, o.edgeOptions.Verbose)
 	if err != nil {
 		return err
 	}

--- a/ziti/cmd/ziti/cmd/edge_controller/db_snapshot.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/db_snapshot.go
@@ -27,12 +27,12 @@ import (
 )
 
 type dbSnapshotOptions struct {
-	commonOptions
+	edgeOptions
 }
 
 func newDbSnapshotCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &dbSnapshotOptions{
-		commonOptions: commonOptions{
+		edgeOptions: edgeOptions{
 			CommonOptions: common.CommonOptions{Factory: f, Out: out, Err: errOut},
 		},
 	}
@@ -58,6 +58,6 @@ func newDbSnapshotCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra
 }
 
 func runSnapshotDb(o *dbSnapshotOptions) error {
-	_, err := util.EdgeControllerUpdate("database/snapshot", "", o.Out, http.MethodPost, false, false, o.commonOptions.Timeout, o.commonOptions.Verbose)
+	_, err := util.EdgeControllerUpdate("database/snapshot", "", o.Out, http.MethodPost, false, false, o.edgeOptions.Timeout, o.edgeOptions.Verbose)
 	return err
 }

--- a/ziti/cmd/ziti/cmd/edge_controller/delete.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/delete.go
@@ -40,8 +40,8 @@ func newDeleteCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Com
 		},
 	}
 
-	newOptions := func() *commonOptions {
-		return &commonOptions{
+	newOptions := func() *edgeOptions {
+		return &edgeOptions{
 			CommonOptions: common.CommonOptions{
 				Factory: f,
 				Out:     out,
@@ -68,10 +68,10 @@ func newDeleteCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Com
 	return cmd
 }
 
-type deleteCmdRunner func(*commonOptions, string) error
+type deleteCmdRunner func(*edgeOptions, string) error
 
 // newDeleteCmdForEntityType creates the delete command for the given entity type
-func newDeleteCmdForEntityType(entityType string, command deleteCmdRunner, options *commonOptions) *cobra.Command {
+func newDeleteCmdForEntityType(entityType string, command deleteCmdRunner, options *edgeOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   entityType + " <id>",
 		Short: "deletes entity of type " + entityType + " managed by the Ziti Edge Controller",
@@ -94,7 +94,7 @@ func newDeleteCmdForEntityType(entityType string, command deleteCmdRunner, optio
 }
 
 // runDeleteEntityOfType implements the commands to delete various entity types
-func runDeleteEntityOfType(o *commonOptions, entityType string) error {
+func runDeleteEntityOfType(o *edgeOptions, entityType string) error {
 	var err error
 	ids := []string{o.Args[0]}
 	if entityType != "terminators" && entityType != "api-sessions" && entityType != "sessions" {
@@ -119,6 +119,6 @@ func getPlural(entityType string) string {
 	return entityType + "s"
 }
 
-func deleteEntityOfType(entityType string, id string, options *commonOptions) (*gabs.Container, error) {
+func deleteEntityOfType(entityType string, id string, options *edgeOptions) (*gabs.Container, error) {
 	return util.EdgeControllerDelete(entityType, id, options.Out, options.OutputJSONResponse, options.Timeout, options.Verbose)
 }

--- a/ziti/cmd/ziti/cmd/edge_controller/delete_authenticator.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/delete_authenticator.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newDeleteAuthenticatorCmd(idType string, options *commonOptions) *cobra.Command {
+func newDeleteAuthenticatorCmd(idType string, options *edgeOptions) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:        idType,

--- a/ziti/cmd/ziti/cmd/edge_controller/delete_authenticator_updb.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/delete_authenticator_updb.go
@@ -23,12 +23,12 @@ import (
 import cmdhelper "github.com/openziti/ziti/ziti/cmd/ziti/cmd/helpers"
 
 type deleteUpdbOptions struct {
-	commonOptions
+	edgeOptions
 }
 
-func newDeleteAuthenticatorUpdb(idType string, options *commonOptions) *cobra.Command {
+func newDeleteAuthenticatorUpdb(idType string, options *edgeOptions) *cobra.Command {
 	updbOptions := deleteUpdbOptions{
-		commonOptions: *options,
+		edgeOptions: *options,
 	}
 
 	cmd := &cobra.Command{
@@ -53,12 +53,12 @@ func newDeleteAuthenticatorUpdb(idType string, options *commonOptions) *cobra.Co
 
 func runDeleteUpdb(idOrName string, options *deleteUpdbOptions) error {
 
-	id, err := mapIdentityNameToID(idOrName, options.commonOptions)
+	id, err := mapIdentityNameToID(idOrName, options.edgeOptions)
 
 	if err != nil {
 		return err
 	}
-	_, err = deleteEntityOfType(fmt.Sprintf("identities/%s/updb/password", id), "", &options.commonOptions)
+	_, err = deleteEntityOfType(fmt.Sprintf("identities/%s/updb/password", id), "", &options.edgeOptions)
 
 	if err != nil {
 		return err

--- a/ziti/cmd/ziti/cmd/edge_controller/list.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/list.go
@@ -46,8 +46,8 @@ func newListCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Comma
 		},
 	}
 
-	newOptions := func() *commonOptions {
-		return &commonOptions{
+	newOptions := func() *edgeOptions {
+		return &edgeOptions{
 			CommonOptions: common.CommonOptions{
 				Factory: f,
 				Out:     out,
@@ -133,7 +133,7 @@ type paging struct {
 	errorz.ErrorHolderImpl
 }
 
-func (p *paging) output(o *commonOptions) {
+func (p *paging) output(o *edgeOptions) {
 	if p.HasError() {
 		_, _ = fmt.Fprintf(o.Out, "unable to retrieve paging information: %v\n", p.Err)
 	} else if p.count == 0 {
@@ -148,9 +148,9 @@ func (p *paging) output(o *commonOptions) {
 	}
 }
 
-type listCommandRunner func(*commonOptions) error
+type listCommandRunner func(*edgeOptions) error
 
-type outputFunction func(o *commonOptions, children []*gabs.Container, pagingInfo *paging) error
+type outputFunction func(o *edgeOptions, children []*gabs.Container, pagingInfo *paging) error
 
 func newEntityListRootCmd(entityType string) *cobra.Command {
 	desc := fmt.Sprintf("list entities related to a %v instance managed by the Ziti Edge Controller", entityType)
@@ -166,7 +166,7 @@ func newEntityListRootCmd(entityType string) *cobra.Command {
 }
 
 // newListCmdForEntityType creates the list command for the given entity type
-func newListCmdForEntityType(entityType string, command listCommandRunner, options *commonOptions) *cobra.Command {
+func newListCmdForEntityType(entityType string, command listCommandRunner, options *edgeOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   entityType + " <filter>?",
 		Short: "lists " + entityType + " managed by the Ziti Edge Controller",
@@ -189,7 +189,7 @@ func newListCmdForEntityType(entityType string, command listCommandRunner, optio
 }
 
 // newListServicesCmd creates the list command for the given entity type
-func newListServicesCmd(options *commonOptions) *cobra.Command {
+func newListServicesCmd(options *edgeOptions) *cobra.Command {
 	var asIdentity string
 	var configTypes []string
 	var roleFilters []string
@@ -221,7 +221,7 @@ func newListServicesCmd(options *commonOptions) *cobra.Command {
 }
 
 // newListEdgeRoutersCmd creates the list command for the given entity type
-func newListEdgeRoutersCmd(options *commonOptions) *cobra.Command {
+func newListEdgeRoutersCmd(options *edgeOptions) *cobra.Command {
 	var roleFilters []string
 	var roleSemantic string
 
@@ -249,7 +249,7 @@ func newListEdgeRoutersCmd(options *commonOptions) *cobra.Command {
 }
 
 // newListEdgeRoutersCmd creates the list command for the given entity type
-func newListIdentitiesCmd(options *commonOptions) *cobra.Command {
+func newListIdentitiesCmd(options *edgeOptions) *cobra.Command {
 	var roleFilters []string
 	var roleSemantic string
 
@@ -277,7 +277,7 @@ func newListIdentitiesCmd(options *commonOptions) *cobra.Command {
 }
 
 // newSubListCmdForEntityType creates the list command for the given entity type
-func newSubListCmdForEntityType(entityType string, subType string, outputF outputFunction, options *commonOptions) *cobra.Command {
+func newSubListCmdForEntityType(entityType string, subType string, outputF outputFunction, options *edgeOptions) *cobra.Command {
 	desc := fmt.Sprintf("lists %v related to a %v instanced managed by the Ziti Edge Controller", subType, entityType)
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("%v <id or name>", subType),
@@ -301,7 +301,7 @@ func newSubListCmdForEntityType(entityType string, subType string, outputF outpu
 }
 
 // listEntitiesOfType queries the Ziti Controller for entities of the given type
-func listEntitiesWithOptions(entityType string, options *commonOptions) ([]*gabs.Container, *paging, error) {
+func listEntitiesWithOptions(entityType string, options *edgeOptions) ([]*gabs.Container, *paging, error) {
 	params := url.Values{}
 	if len(options.Args) > 0 {
 		params.Add("filter", options.Args[0])
@@ -356,7 +356,7 @@ func getPaging(c *gabs.Container) *paging {
 }
 
 // listEntitiesOfType queries the Ziti Controller for entities of the given type
-func filterSubEntitiesOfType(entityType, subType, entityId, filter string, o *commonOptions) ([]*gabs.Container, *paging, error) {
+func filterSubEntitiesOfType(entityType, subType, entityId, filter string, o *edgeOptions) ([]*gabs.Container, *paging, error) {
 	jsonParsed, err := util.EdgeControllerListSubEntities(entityType, subType, entityId, filter, o.OutputJSONResponse, o.Out, o.Timeout, o.Verbose)
 
 	if err != nil {
@@ -370,7 +370,7 @@ func filterSubEntitiesOfType(entityType, subType, entityId, filter string, o *co
 	return children, getPaging(jsonParsed), err
 }
 
-func runListEdgeRouters(roleFilters []string, roleSemantic string, options *commonOptions) error {
+func runListEdgeRouters(roleFilters []string, roleSemantic string, options *edgeOptions) error {
 	params := url.Values{}
 	if len(options.Args) > 0 {
 		params.Add("filter", options.Args[0])
@@ -389,7 +389,7 @@ func runListEdgeRouters(roleFilters []string, roleSemantic string, options *comm
 	return outputEdgeRouters(options, children, paging)
 }
 
-func outputEdgeRouters(o *commonOptions, children []*gabs.Container, pagingInfo *paging) error {
+func outputEdgeRouters(o *edgeOptions, children []*gabs.Container, pagingInfo *paging) error {
 	if o.OutputJSONResponse {
 		return nil
 	}
@@ -407,7 +407,7 @@ func outputEdgeRouters(o *commonOptions, children []*gabs.Container, pagingInfo 
 	return nil
 }
 
-func runListEdgeRouterPolicies(o *commonOptions) error {
+func runListEdgeRouterPolicies(o *edgeOptions) error {
 	children, paging, err := listEntitiesWithOptions("edge-router-policies", o)
 	if err != nil {
 		return err
@@ -415,7 +415,7 @@ func runListEdgeRouterPolicies(o *commonOptions) error {
 	return outputEdgeRouterPolicies(o, children, paging)
 }
 
-func outputEdgeRouterPolicies(o *commonOptions, children []*gabs.Container, pagingInfo *paging) error {
+func outputEdgeRouterPolicies(o *edgeOptions, children []*gabs.Container, pagingInfo *paging) error {
 	if o.OutputJSONResponse {
 		return nil
 	}
@@ -443,7 +443,7 @@ func outputEdgeRouterPolicies(o *commonOptions, children []*gabs.Container, pagi
 	return nil
 }
 
-func runListTerminators(o *commonOptions) error {
+func runListTerminators(o *edgeOptions) error {
 	children, pagingInfo, err := listEntitiesWithOptions("terminators", o)
 	if err != nil {
 		return err
@@ -451,7 +451,7 @@ func runListTerminators(o *commonOptions) error {
 	return outputTerminators(o, children, pagingInfo)
 }
 
-func outputTerminators(o *commonOptions, children []*gabs.Container, pagingInfo *paging) error {
+func outputTerminators(o *edgeOptions, children []*gabs.Container, pagingInfo *paging) error {
 	if o.OutputJSONResponse {
 		return nil
 	}
@@ -476,7 +476,7 @@ func outputTerminators(o *commonOptions, children []*gabs.Container, pagingInfo 
 	return nil
 }
 
-func runListServices(asIdentity string, configTypes []string, roleFilters []string, roleSemantic string, options *commonOptions) error {
+func runListServices(asIdentity string, configTypes []string, roleFilters []string, roleSemantic string, options *edgeOptions) error {
 	params := url.Values{}
 	if len(options.Args) > 0 {
 		params.Add("filter", options.Args[0])
@@ -509,7 +509,7 @@ func runListServices(asIdentity string, configTypes []string, roleFilters []stri
 	return outputServices(options, children, pagingInfo)
 }
 
-func outputServices(o *commonOptions, children []*gabs.Container, pagingInfo *paging) error {
+func outputServices(o *edgeOptions, children []*gabs.Container, pagingInfo *paging) error {
 	if o.OutputJSONResponse {
 		return nil
 	}
@@ -530,7 +530,7 @@ func outputServices(o *commonOptions, children []*gabs.Container, pagingInfo *pa
 	return nil
 }
 
-func outputServiceConfigs(o *commonOptions, children []*gabs.Container, pagingInfo *paging) error {
+func outputServiceConfigs(o *edgeOptions, children []*gabs.Container, pagingInfo *paging) error {
 	if o.OutputJSONResponse {
 		return nil
 	}
@@ -549,7 +549,7 @@ func outputServiceConfigs(o *commonOptions, children []*gabs.Container, pagingIn
 	return nil
 }
 
-func runListServiceEdgeRouterPolices(o *commonOptions) error {
+func runListServiceEdgeRouterPolices(o *edgeOptions) error {
 	children, pagingInfo, err := listEntitiesWithOptions("service-edge-router-policies", o)
 	if err != nil {
 		return err
@@ -557,7 +557,7 @@ func runListServiceEdgeRouterPolices(o *commonOptions) error {
 	return outputServiceEdgeRouterPolicies(o, children, pagingInfo)
 }
 
-func outputServiceEdgeRouterPolicies(o *commonOptions, children []*gabs.Container, pagingInfo *paging) error {
+func outputServiceEdgeRouterPolicies(o *edgeOptions, children []*gabs.Container, pagingInfo *paging) error {
 	if o.OutputJSONResponse {
 		return nil
 	}
@@ -582,7 +582,7 @@ func outputServiceEdgeRouterPolicies(o *commonOptions, children []*gabs.Containe
 	return nil
 }
 
-func runListServicePolices(o *commonOptions) error {
+func runListServicePolices(o *edgeOptions) error {
 	children, pagingInfo, err := listEntitiesWithOptions("service-policies", o)
 	if err != nil {
 		return err
@@ -590,7 +590,7 @@ func runListServicePolices(o *commonOptions) error {
 	return outputServicePolicies(o, children, pagingInfo)
 }
 
-func outputServicePolicies(o *commonOptions, children []*gabs.Container, pagingInfo *paging) error {
+func outputServicePolicies(o *edgeOptions, children []*gabs.Container, pagingInfo *paging) error {
 	if o.OutputJSONResponse {
 		return nil
 	}
@@ -623,7 +623,7 @@ func outputServicePolicies(o *commonOptions, children []*gabs.Container, pagingI
 	return nil
 }
 
-func mapRoleIdsToNames(c *gabs.Container, path string, entityType string, o commonOptions) ([]string, error) {
+func mapRoleIdsToNames(c *gabs.Container, path string, entityType string, o edgeOptions) ([]string, error) {
 	jsonValues := c.Path(path).Data()
 	if jsonValues == nil {
 		return nil, nil
@@ -649,7 +649,7 @@ func mapRoleIdsToNames(c *gabs.Container, path string, entityType string, o comm
 }
 
 // runListIdentities implements the command to list identities
-func runListIdentities(roleFilters []string, roleSemantic string, options *commonOptions) error {
+func runListIdentities(roleFilters []string, roleSemantic string, options *edgeOptions) error {
 	params := url.Values{}
 	if len(options.Args) > 0 {
 		params.Add("filter", options.Args[0])
@@ -668,7 +668,7 @@ func runListIdentities(roleFilters []string, roleSemantic string, options *commo
 }
 
 // outputIdentities implements the command to list identities
-func outputIdentities(o *commonOptions, children []*gabs.Container, pagingInfo *paging) error {
+func outputIdentities(o *edgeOptions, children []*gabs.Container, pagingInfo *paging) error {
 	if o.OutputJSONResponse {
 		return nil
 	}
@@ -687,7 +687,7 @@ func outputIdentities(o *commonOptions, children []*gabs.Container, pagingInfo *
 	return nil
 }
 
-func outputPostureCheck(o *commonOptions, entity *gabs.Container) error {
+func outputPostureCheck(o *edgeOptions, entity *gabs.Container) error {
 	id, _ := entity.Path("id").Data().(string)
 	typeId, _ := entity.Path("typeId").Data().(string)
 	name, _ := entity.Path("name").Data().(string)
@@ -745,7 +745,7 @@ func outputPostureCheck(o *commonOptions, entity *gabs.Container) error {
 	return nil
 }
 
-func outputPostureChecks(o *commonOptions, children []*gabs.Container, pagingInfo *paging) error {
+func outputPostureChecks(o *edgeOptions, children []*gabs.Container, pagingInfo *paging) error {
 	if o.OutputJSONResponse {
 		return nil
 	}
@@ -760,7 +760,7 @@ func outputPostureChecks(o *commonOptions, children []*gabs.Container, pagingInf
 	return nil
 }
 
-func runListCAs(o *commonOptions) error {
+func runListCAs(o *edgeOptions) error {
 	children, pagingInfo, err := listEntitiesWithOptions("cas", o)
 	if err != nil {
 		return err
@@ -782,7 +782,7 @@ func runListCAs(o *commonOptions) error {
 	return nil
 }
 
-func runListConfigTypes(o *commonOptions) error {
+func runListConfigTypes(o *edgeOptions) error {
 	children, pagingInfo, err := listEntitiesWithOptions("config-types", o)
 	if err != nil {
 		return err
@@ -803,7 +803,7 @@ func runListConfigTypes(o *commonOptions) error {
 	return nil
 }
 
-func runListConfigs(o *commonOptions) error {
+func runListConfigs(o *edgeOptions) error {
 	children, pagingInfo, err := listEntitiesWithOptions("configs", o)
 	if err != nil {
 		return err
@@ -811,7 +811,7 @@ func runListConfigs(o *commonOptions) error {
 	return outputConfigs(o, children, pagingInfo)
 }
 
-func outputConfigs(o *commonOptions, children []*gabs.Container, pagingInfo *paging) error {
+func outputConfigs(o *edgeOptions, children []*gabs.Container, pagingInfo *paging) error {
 	if o.OutputJSONResponse {
 		return nil
 	}
@@ -833,7 +833,7 @@ func outputConfigs(o *commonOptions, children []*gabs.Container, pagingInfo *pag
 	return nil
 }
 
-func runListApiSessions(o *commonOptions) error {
+func runListApiSessions(o *edgeOptions) error {
 	children, pagingInfo, err := listEntitiesWithOptions("api-sessions", o)
 	if err != nil {
 		return err
@@ -855,7 +855,7 @@ func runListApiSessions(o *commonOptions) error {
 	return err
 }
 
-func runListSessions(o *commonOptions) error {
+func runListSessions(o *edgeOptions) error {
 	children, pagingInfo, err := listEntitiesWithOptions("sessions", o)
 
 	if err != nil {
@@ -879,7 +879,7 @@ func runListSessions(o *commonOptions) error {
 	return err
 }
 
-func runListTransitRouters(o *commonOptions) error {
+func runListTransitRouters(o *edgeOptions) error {
 	children, pagingInfo, err := listEntitiesWithOptions("transit-routers", o)
 
 	if err != nil {
@@ -901,19 +901,19 @@ func runListTransitRouters(o *commonOptions) error {
 	return err
 }
 
-func runListEdgeRouterRoleAttributes(o *commonOptions) error {
+func runListEdgeRouterRoleAttributes(o *edgeOptions) error {
 	return runListRoleAttributes("edge-router", o)
 }
 
-func runListIdentityRoleAttributes(o *commonOptions) error {
+func runListIdentityRoleAttributes(o *edgeOptions) error {
 	return runListRoleAttributes("identity", o)
 }
 
-func runListServiceRoleAttributes(o *commonOptions) error {
+func runListServiceRoleAttributes(o *edgeOptions) error {
 	return runListRoleAttributes("service", o)
 }
 
-func runListRoleAttributes(entityType string, o *commonOptions) error {
+func runListRoleAttributes(entityType string, o *edgeOptions) error {
 	children, pagingInfo, err := listEntitiesWithOptions(entityType+"-role-attributes", o)
 
 	if err != nil {
@@ -933,7 +933,7 @@ func runListRoleAttributes(entityType string, o *commonOptions) error {
 	return err
 }
 
-func runListChilden(parentType, childType string, o *commonOptions, outputF outputFunction) error {
+func runListChilden(parentType, childType string, o *edgeOptions, outputF outputFunction) error {
 	idOrName := o.Args[0]
 	parentId, err := mapNameToID(parentType, idOrName, *o)
 	if err != nil {
@@ -957,7 +957,7 @@ func runListChilden(parentType, childType string, o *commonOptions, outputF outp
 	return outputF(o, children, pagingInfo)
 }
 
-func runListPostureChecks(o *commonOptions) error {
+func runListPostureChecks(o *edgeOptions) error {
 	children, pagingInfo, err := listEntitiesWithOptions("posture-checks", o)
 
 	if err != nil {
@@ -985,7 +985,7 @@ func containerArrayToString(containers []*gabs.Container, limit int) string {
 	return strings.Join(values, ",")
 }
 
-func runListPostureCheckTypes(o *commonOptions) error {
+func runListPostureCheckTypes(o *edgeOptions) error {
 	children, pagingInfo, err := listEntitiesWithOptions("posture-check-types", o)
 
 	if err != nil {

--- a/ziti/cmd/ziti/cmd/edge_controller/login.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/login.go
@@ -32,7 +32,7 @@ import (
 
 // loginOptions are the flags for login commands
 type loginOptions struct {
-	commonOptions
+	edgeOptions
 	Username string
 	Password string
 	Cert     string
@@ -41,7 +41,7 @@ type loginOptions struct {
 // newLoginCmd creates the command
 func newLoginCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &loginOptions{
-		commonOptions: commonOptions{
+		edgeOptions: edgeOptions{
 			CommonOptions: common.CommonOptions{Factory: f, Out: out, Err: errOut},
 		},
 	}
@@ -95,7 +95,7 @@ func (o *loginOptions) Run() error {
 
 	body := container.String()
 
-	jsonParsed, err := util.EdgeControllerLogin(host, o.Cert, body, o.Out, o.OutputJSONResponse, o.commonOptions.Timeout, o.commonOptions.Verbose)
+	jsonParsed, err := util.EdgeControllerLogin(host, o.Cert, body, o.Out, o.OutputJSONResponse, o.edgeOptions.Timeout, o.edgeOptions.Verbose)
 
 	if err != nil {
 		return err

--- a/ziti/cmd/ziti/cmd/edge_controller/policy_advisor.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/policy_advisor.go
@@ -45,14 +45,14 @@ func newPolicyAdivsorCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *co
 }
 
 type policyAdvisorOptions struct {
-	commonOptions
+	edgeOptions
 	quiet bool
 }
 
 // newPolicyAdvisorIdentitiesCmd creates the 'edge controller policy-advisor identities' command
 func newPolicyAdvisorIdentitiesCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &policyAdvisorOptions{
-		commonOptions: commonOptions{
+		edgeOptions: edgeOptions{
 			CommonOptions: common.CommonOptions{Factory: f, Out: out, Err: errOut},
 		},
 	}
@@ -81,7 +81,7 @@ func newPolicyAdvisorIdentitiesCmd(f cmdutil.Factory, out io.Writer, errOut io.W
 // newPolicyAdvisorServicesCmd creates the 'edge controller policy-advisor services' command
 func newPolicyAdvisorServicesCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &policyAdvisorOptions{
-		commonOptions: commonOptions{
+		edgeOptions: edgeOptions{
 			CommonOptions: common.CommonOptions{Factory: f, Out: out, Err: errOut},
 		},
 	}
@@ -110,12 +110,12 @@ func newPolicyAdvisorServicesCmd(f cmdutil.Factory, out io.Writer, errOut io.Wri
 // runIdentitiesPolicyAdvisor create a new policyAdvisor on the Ziti Edge Controller
 func runIdentitiesPolicyAdvisor(o *policyAdvisorOptions) error {
 	if len(o.Args) > 0 {
-		identityId, err := mapNameToID("identities", o.Args[0], o.commonOptions)
+		identityId, err := mapNameToID("identities", o.Args[0], o.edgeOptions)
 		if err != nil {
 			return err
 		}
 		if len(o.Args) > 1 {
-			serviceId, err := mapNameToID("services", o.Args[1], o.commonOptions)
+			serviceId, err := mapNameToID("services", o.Args[1], o.edgeOptions)
 			if err != nil {
 				return err
 			}
@@ -140,13 +140,13 @@ func runIdentitiesPolicyAdvisor(o *policyAdvisorOptions) error {
 // runServicesPolicyAdvisor create a new policyAdvisor on the Ziti Edge Controller
 func runServicesPolicyAdvisor(o *policyAdvisorOptions) error {
 	if len(o.Args) > 0 {
-		serviceId, err := mapNameToID("services", o.Args[0], o.commonOptions)
+		serviceId, err := mapNameToID("services", o.Args[0], o.edgeOptions)
 		if err != nil {
 			return err
 		}
 
 		if len(o.Args) > 1 {
-			identityId, err := mapNameToID("identities", o.Args[1], o.commonOptions)
+			identityId, err := mapNameToID("identities", o.Args[1], o.edgeOptions)
 			if err != nil {
 				return err
 			}
@@ -206,7 +206,7 @@ func runPolicyAdvisorForIdentities(o *policyAdvisorOptions) error {
 	done := false
 	for !done {
 		filter := fmt.Sprintf(`true skip %v limit 2`, skip)
-		children, _, err := filterEntitiesOfType("identities", filter, false, o.Out, o.commonOptions.Timeout, o.commonOptions.Verbose)
+		children, _, err := filterEntitiesOfType("identities", filter, false, o.Out, o.edgeOptions.Timeout, o.edgeOptions.Verbose)
 		if err != nil {
 			panic(err)
 		}
@@ -236,7 +236,7 @@ func runPolicyAdvisorForServices(o *policyAdvisorOptions) error {
 	done := false
 	for !done {
 		filter := fmt.Sprintf(`true skip %v limit 2`, skip)
-		children, _, err := filterEntitiesOfType("services", filter, false, o.Out, o.commonOptions.Timeout, o.commonOptions.Verbose)
+		children, _, err := filterEntitiesOfType("services", filter, false, o.Out, o.edgeOptions.Timeout, o.edgeOptions.Verbose)
 		if err != nil {
 			panic(err)
 		}
@@ -267,7 +267,7 @@ func runPolicyAdvisorForIdentity(identityId string, o *policyAdvisorOptions) err
 	for !done {
 		filter := "true limit 2"
 		filter = fmt.Sprintf(`true skip %v limit 2`, skip)
-		children, _, err := filterSubEntitiesOfType("identities", "services", identityId, filter, &o.commonOptions)
+		children, _, err := filterSubEntitiesOfType("identities", "services", identityId, filter, &o.edgeOptions)
 		if err != nil {
 			panic(err)
 		}
@@ -285,7 +285,7 @@ func runPolicyAdvisorForIdentity(identityId string, o *policyAdvisorOptions) err
 	}
 
 	if skip == 0 {
-		identityName, err := mapIdToName("identities", identityId, o.commonOptions)
+		identityName, err := mapIdToName("identities", identityId, o.edgeOptions)
 		if err != nil {
 			return err
 		}
@@ -302,7 +302,7 @@ func runPolicyAdvisorForService(serviceId string, o *policyAdvisorOptions) error
 	for !done {
 		filter := "true limit 2"
 		filter = fmt.Sprintf(`true skip %v limit 2`, skip)
-		children, _, err := filterSubEntitiesOfType("services", "identities", serviceId, filter, &o.commonOptions)
+		children, _, err := filterSubEntitiesOfType("services", "identities", serviceId, filter, &o.edgeOptions)
 		if err != nil {
 			return err
 		}
@@ -320,7 +320,7 @@ func runPolicyAdvisorForService(serviceId string, o *policyAdvisorOptions) error
 	}
 
 	if skip == 0 {
-		serviceName, err := mapIdToName("services", serviceId, o.commonOptions)
+		serviceName, err := mapIdToName("services", serviceId, o.edgeOptions)
 		if err != nil {
 			return err
 		}
@@ -332,7 +332,7 @@ func runPolicyAdvisorForService(serviceId string, o *policyAdvisorOptions) error
 }
 
 func runPolicyAdvisorForIdentityAndService(identityId, serviceId string, o *policyAdvisorOptions) error {
-	result, err := util.EdgeControllerList("identities/"+identityId+"/policy-advice/"+serviceId, nil, o.OutputJSONResponse, o.Out, o.commonOptions.Timeout, o.commonOptions.Verbose)
+	result, err := util.EdgeControllerList("identities/"+identityId+"/policy-advice/"+serviceId, nil, o.OutputJSONResponse, o.Out, o.edgeOptions.Timeout, o.edgeOptions.Verbose)
 	if err != nil || o.OutputJSONResponse {
 		return err
 	}

--- a/ziti/cmd/ziti/cmd/edge_controller/root.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/root.go
@@ -35,14 +35,14 @@ func NewCmdEdge(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Comma
 	return cmd
 }
 
-// commonOptions are common options for edge controller commands
-type commonOptions struct {
+// edgeOptions are common options for edge controller commands
+type edgeOptions struct {
 	common.CommonOptions
 	OutputJSONRequest  bool
 	OutputJSONResponse bool
 }
 
-func (options *commonOptions) AddCommonFlags(cmd *cobra.Command) {
+func (options *edgeOptions) AddCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&options.OutputJSONResponse, "output-json", "j", false, "Output the full JSON response from the Ziti Edge Controller")
 	cmd.Flags().BoolVar(&options.OutputJSONRequest, "output-request-json", false, "Output the full JSON request to the Ziti Edge Controller")
 	cmd.Flags().IntVarP(&options.Timeout, "timeout", "", 5, "Timeout for REST operations (specified in seconds)")

--- a/ziti/cmd/ziti/cmd/edge_controller/update.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/update.go
@@ -54,27 +54,27 @@ func newUpdateCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Com
 	return cmd
 }
 
-func putEntityOfType(entityType string, body string, options *commonOptions) (*gabs.Container, error) {
+func putEntityOfType(entityType string, body string, options *edgeOptions) (*gabs.Container, error) {
 	return updateEntityOfType(entityType, body, options, resty.MethodPut)
 }
 
-func patchEntityOfType(entityType string, body string, options *commonOptions) (*gabs.Container, error) {
+func patchEntityOfType(entityType string, body string, options *edgeOptions) (*gabs.Container, error) {
 	return updateEntityOfType(entityType, body, options, resty.MethodPatch)
 }
 
-func postEntityOfType(entityType string, body string, options *commonOptions) (*gabs.Container, error) {
+func postEntityOfType(entityType string, body string, options *edgeOptions) (*gabs.Container, error) {
 	return updateEntityOfType(entityType, body, options, resty.MethodPost)
 }
 
-func deleteEntityOfTypeWithBody(entityType string, body string, options *commonOptions) (*gabs.Container, error) {
+func deleteEntityOfTypeWithBody(entityType string, body string, options *edgeOptions) (*gabs.Container, error) {
 	return updateEntityOfType(entityType, body, options, resty.MethodDelete)
 }
 
 // updateEntityOfType updates an entity of the given type on the Ziti Edge Controller
-func updateEntityOfType(entityType string, body string, options *commonOptions, method string) (*gabs.Container, error) {
+func updateEntityOfType(entityType string, body string, options *edgeOptions, method string) (*gabs.Container, error) {
 	return util.EdgeControllerUpdate(entityType, body, options.Out, method, options.OutputJSONRequest, options.OutputJSONResponse, options.Timeout, options.Verbose)
 }
 
-func doRequest(entityType string, options *commonOptions, doRequest func(request *resty.Request, url string) (*resty.Response, error)) (*gabs.Container, error) {
+func doRequest(entityType string, options *edgeOptions, doRequest func(request *resty.Request, url string) (*resty.Response, error)) (*gabs.Container, error) {
 	return util.EdgeControllerRequest(entityType, options.Out, options.OutputJSONResponse, options.Timeout, options.Verbose, doRequest)
 }

--- a/ziti/cmd/ziti/cmd/edge_controller/update_authenticator.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/update_authenticator.go
@@ -25,7 +25,7 @@ import (
 
 // newUpdateAuthenticatorCmd creates the 'edge controller update authenticator' command
 func newUpdateAuthenticatorCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
-	options := commonOptions{
+	options := edgeOptions{
 		CommonOptions:      common.CommonOptions{Factory: f, Out: out, Err: errOut},
 		OutputJSONResponse: false,
 	}

--- a/ziti/cmd/ziti/cmd/edge_controller/update_authenticator_updb.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/update_authenticator_updb.go
@@ -27,7 +27,7 @@ import (
 import cmdhelper "github.com/openziti/ziti/ziti/cmd/ziti/cmd/helpers"
 
 type updateUpdbOptions struct {
-	commonOptions
+	edgeOptions
 	identity         string
 	newPassword      string
 	currentPassword  string
@@ -35,9 +35,9 @@ type updateUpdbOptions struct {
 	self             bool
 }
 
-func newUpdateAuthenticatorUpdb(idType string, options commonOptions) *cobra.Command {
+func newUpdateAuthenticatorUpdb(idType string, options edgeOptions) *cobra.Command {
 	updbOptions := updateUpdbOptions{
-		commonOptions: options,
+		edgeOptions: options,
 	}
 	cmd := &cobra.Command{
 		Use:   idType + " (-i <identityIdOrName> -p <newPassword>) | (-c <currentPassword> -n <newPassword>)",
@@ -72,17 +72,17 @@ func runUpdateUpdbPassword(idType string, options *updateUpdbOptions) error {
 	}
 
 	if options.identity != "" {
-		return setIdentityPassword(options.identity, options.identityPassword, options.commonOptions)
+		return setIdentityPassword(options.identity, options.identityPassword, options.edgeOptions)
 	}
 
 	if options.self {
-		return updateSelfPassword(options.currentPassword, options.newPassword, options.commonOptions)
+		return updateSelfPassword(options.currentPassword, options.newPassword, options.edgeOptions)
 	}
 
 	return errors.New("invalid arguments, requires --self or --identity, see help for details")
 }
 
-func updateSelfPassword(current string, new string, options commonOptions) error {
+func updateSelfPassword(current string, new string, options edgeOptions) error {
 	var err error
 	if current == "" {
 		if current, err = term.PromptPassword("Enter your current password: ", false); err != nil {
@@ -127,7 +127,7 @@ func updateSelfPassword(current string, new string, options commonOptions) error
 	return nil
 }
 
-func setIdentityPassword(identity, password string, options commonOptions) error {
+func setIdentityPassword(identity, password string, options edgeOptions) error {
 	id, err := mapIdentityNameToID(identity, options)
 
 	if err != nil {

--- a/ziti/cmd/ziti/cmd/edge_controller/update_ca.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/update_ca.go
@@ -29,7 +29,7 @@ import (
 )
 
 type updateCaOptions struct {
-	commonOptions
+	edgeOptions
 	verify           bool
 	verifyCertPath   string
 	verifyCertBytes  []byte
@@ -43,7 +43,7 @@ type updateCaOptions struct {
 // newUpdateAuthenticatorCmd creates the 'edge controller update authenticator' command
 func newUpdateCaCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := updateCaOptions{
-		commonOptions: commonOptions{
+		edgeOptions: edgeOptions{
 			CommonOptions:      common.CommonOptions{Factory: f, Out: out, Err: errOut},
 			OutputJSONResponse: false,
 		},
@@ -108,7 +108,7 @@ func runUpdateCa(options updateCaOptions) error {
 		return runVerifyCa(options)
 	}
 
-	id, err := mapCaNameToID(options.nameOrId, options.commonOptions)
+	id, err := mapCaNameToID(options.nameOrId, options.edgeOptions)
 
 	if err != nil {
 		return err
@@ -122,7 +122,7 @@ func runUpdateCa(options updateCaOptions) error {
 	setJSONValue(data, options.authEnabled, "isAuthEnabled")
 	setJSONValue(data, tags, "tags")
 
-	_, err = putEntityOfType("cas/"+id, data.String(), &options.commonOptions)
+	_, err = putEntityOfType("cas/"+id, data.String(), &options.edgeOptions)
 
 	if err != nil {
 		return err
@@ -132,13 +132,13 @@ func runUpdateCa(options updateCaOptions) error {
 }
 
 func runVerifyCa(options updateCaOptions) error {
-	id, err := mapCaNameToID(options.nameOrId, options.commonOptions)
+	id, err := mapCaNameToID(options.nameOrId, options.edgeOptions)
 
 	if err != nil {
 		return err
 	}
 
-	_, err = doRequest("cas/"+id+"/verify", &options.commonOptions, func(request *resty.Request, url string) (response *resty.Response, e error) {
+	_, err = doRequest("cas/"+id+"/verify", &options.edgeOptions, func(request *resty.Request, url string) (response *resty.Response, e error) {
 		return request.SetHeader("Content-Type", "text/plain").
 			SetBody(string(options.verifyCertBytes)).
 			Post(url)

--- a/ziti/cmd/ziti/cmd/edge_controller/update_config.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/update_config.go
@@ -32,7 +32,7 @@ import (
 )
 
 type updateConfigOptions struct {
-	commonOptions
+	edgeOptions
 	name     string
 	data     string
 	jsonFile string
@@ -41,7 +41,7 @@ type updateConfigOptions struct {
 // newUpdateConfigCmd updates the 'edge controller update service-policy' command
 func newUpdateConfigCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &updateConfigOptions{
-		commonOptions: commonOptions{
+		edgeOptions: edgeOptions{
 			CommonOptions: common.CommonOptions{Factory: f, Out: out, Err: errOut},
 		},
 	}
@@ -72,7 +72,7 @@ func newUpdateConfigCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cob
 
 // runUpdateConfig update a new config on the Ziti Edge Controller
 func runUpdateConfig(o *updateConfigOptions) error {
-	id, err := mapNameToID("configs", o.Args[0], o.commonOptions)
+	id, err := mapNameToID("configs", o.Args[0], o.edgeOptions)
 	if err != nil {
 		return err
 	}
@@ -115,7 +115,7 @@ func runUpdateConfig(o *updateConfigOptions) error {
 		return errors.New("no change specified. must specify at least one attribute to change")
 	}
 
-	_, err = patchEntityOfType(fmt.Sprintf("configs/%v", id), entityData.String(), &o.commonOptions)
+	_, err = patchEntityOfType(fmt.Sprintf("configs/%v", id), entityData.String(), &o.edgeOptions)
 
 	if err != nil {
 		panic(err)

--- a/ziti/cmd/ziti/cmd/edge_controller/update_edge_router.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/update_edge_router.go
@@ -30,14 +30,14 @@ import (
 )
 
 type updateEdgeRouterOptions struct {
-	commonOptions
+	edgeOptions
 	name           string
 	roleAttributes []string
 }
 
 func newUpdateEdgeRouterCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &updateEdgeRouterOptions{
-		commonOptions: commonOptions{
+		edgeOptions: edgeOptions{
 			CommonOptions: common.CommonOptions{Factory: f, Out: out, Err: errOut},
 		},
 	}
@@ -68,7 +68,7 @@ func newUpdateEdgeRouterCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) 
 
 // runUpdateEdgeRouter update a new edgeRouter on the Ziti Edge Controller
 func runUpdateEdgeRouter(o *updateEdgeRouterOptions) error {
-	id, err := mapNameToID("edge-routers", o.Args[0], o.commonOptions)
+	id, err := mapNameToID("edge-routers", o.Args[0], o.edgeOptions)
 	if err != nil {
 		return err
 	}
@@ -89,6 +89,6 @@ func runUpdateEdgeRouter(o *updateEdgeRouterOptions) error {
 		return errors.New("no change specified. must specify at least one attribute to change")
 	}
 
-	_, err = patchEntityOfType(fmt.Sprintf("edge-routers/%v", id), entityData.String(), &o.commonOptions)
+	_, err = patchEntityOfType(fmt.Sprintf("edge-routers/%v", id), entityData.String(), &o.edgeOptions)
 	return err
 }

--- a/ziti/cmd/ziti/cmd/edge_controller/update_edge_router_policy.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/update_edge_router_policy.go
@@ -30,7 +30,7 @@ import (
 )
 
 type updateEdgeRouterPolicyOptions struct {
-	commonOptions
+	edgeOptions
 	name            string
 	edgeRouterRoles []string
 	identityRoles   []string
@@ -38,7 +38,7 @@ type updateEdgeRouterPolicyOptions struct {
 
 func newUpdateEdgeRouterPolicyCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &updateEdgeRouterPolicyOptions{
-		commonOptions: commonOptions{
+		edgeOptions: edgeOptions{
 			CommonOptions: common.CommonOptions{Factory: f, Out: out, Err: errOut},
 		},
 	}
@@ -68,17 +68,17 @@ func newUpdateEdgeRouterPolicyCmd(f cmdutil.Factory, out io.Writer, errOut io.Wr
 }
 
 func runUpdateEdgeRouterPolicy(o *updateEdgeRouterPolicyOptions) error {
-	id, err := mapNameToID("edge-router-policies", o.Args[0], o.commonOptions)
+	id, err := mapNameToID("edge-router-policies", o.Args[0], o.edgeOptions)
 	if err != nil {
 		return err
 	}
 
-	edgeRouterRoles, err := convertNamesToIds(o.edgeRouterRoles, "edge-routers", o.commonOptions)
+	edgeRouterRoles, err := convertNamesToIds(o.edgeRouterRoles, "edge-routers", o.edgeOptions)
 	if err != nil {
 		return err
 	}
 
-	identityRoles, err := convertNamesToIds(o.identityRoles, "identities", o.commonOptions)
+	identityRoles, err := convertNamesToIds(o.identityRoles, "identities", o.edgeOptions)
 	if err != nil {
 		return err
 	}
@@ -105,6 +105,6 @@ func runUpdateEdgeRouterPolicy(o *updateEdgeRouterPolicyOptions) error {
 		return errors.New("no change specified. must specify at least one attribute to change")
 	}
 
-	_, err = patchEntityOfType(fmt.Sprintf("edge-router-policies/%v", id), entityData.String(), &o.commonOptions)
+	_, err = patchEntityOfType(fmt.Sprintf("edge-router-policies/%v", id), entityData.String(), &o.edgeOptions)
 	return err
 }

--- a/ziti/cmd/ziti/cmd/edge_controller/update_identity.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/update_identity.go
@@ -30,14 +30,14 @@ import (
 )
 
 type updateIdentityOptions struct {
-	commonOptions
+	edgeOptions
 	name           string
 	roleAttributes []string
 }
 
 func newUpdateIdentityCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &updateIdentityOptions{
-		commonOptions: commonOptions{
+		edgeOptions: edgeOptions{
 			CommonOptions: common.CommonOptions{Factory: f, Out: out, Err: errOut},
 		},
 	}
@@ -68,7 +68,7 @@ func newUpdateIdentityCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *c
 
 // runUpdateIdentity update a new identity on the Ziti Edge Controller
 func runUpdateIdentity(o *updateIdentityOptions) error {
-	id, err := mapNameToID("identities", o.Args[0], o.commonOptions)
+	id, err := mapNameToID("identities", o.Args[0], o.edgeOptions)
 	if err != nil {
 		return err
 	}
@@ -89,6 +89,6 @@ func runUpdateIdentity(o *updateIdentityOptions) error {
 		return errors.New("no change specified. must specify at least one attribute to change")
 	}
 
-	_, err = patchEntityOfType(fmt.Sprintf("identities/%v", id), entityData.String(), &o.commonOptions)
+	_, err = patchEntityOfType(fmt.Sprintf("identities/%v", id), entityData.String(), &o.edgeOptions)
 	return err
 }

--- a/ziti/cmd/ziti/cmd/edge_controller/update_identity_configs.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/update_identity_configs.go
@@ -28,13 +28,13 @@ import (
 )
 
 type updateIdentityConfigsOptions struct {
-	commonOptions
+	edgeOptions
 	remove bool
 }
 
 func newUpdateIdentityConfigsCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &updateIdentityConfigsOptions{
-		commonOptions: commonOptions{
+		edgeOptions: edgeOptions{
 			CommonOptions: common.CommonOptions{Factory: f, Out: out, Err: errOut},
 		},
 	}
@@ -63,17 +63,17 @@ func newUpdateIdentityConfigsCmd(f cmdutil.Factory, out io.Writer, errOut io.Wri
 
 // runupdateIdentityConfigs update a new identity on the Ziti Edge Controller
 func runupdateIdentityConfigs(o *updateIdentityConfigsOptions) error {
-	id, err := mapNameToID("identities", o.Args[0], o.commonOptions)
+	id, err := mapNameToID("identities", o.Args[0], o.edgeOptions)
 	if err != nil {
 		return err
 	}
 
-	serviceId, err := mapNameToID("services", o.Args[1], o.commonOptions)
+	serviceId, err := mapNameToID("services", o.Args[1], o.edgeOptions)
 	if err != nil {
 		return err
 	}
 
-	configId, err := mapNameToID("configs", o.Args[2], o.commonOptions)
+	configId, err := mapNameToID("configs", o.Args[2], o.edgeOptions)
 	if err != nil {
 		return err
 	}
@@ -89,9 +89,9 @@ func runupdateIdentityConfigs(o *updateIdentityConfigsOptions) error {
 	body := entityData.String()
 
 	if o.remove {
-		_, err = deleteEntityOfTypeWithBody(path, body, &o.commonOptions)
+		_, err = deleteEntityOfTypeWithBody(path, body, &o.edgeOptions)
 	} else {
-		_, err = postEntityOfType(path, body, &o.commonOptions)
+		_, err = postEntityOfType(path, body, &o.edgeOptions)
 	}
 	return err
 }

--- a/ziti/cmd/ziti/cmd/edge_controller/update_posture_check.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/update_posture_check.go
@@ -44,7 +44,7 @@ func newUpdatePostureCheckCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer
 }
 
 type updatePostureCheckOptions struct {
-	commonOptions
+	edgeOptions
 	name           string
 	tags           map[string]string
 	roleAttributes []string
@@ -76,7 +76,7 @@ type updatePostureCheckOsOptions struct {
 func newUpdatePostureCheckMacCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &updatePostureCheckMacOptions{
 		updatePostureCheckOptions: updatePostureCheckOptions{
-			commonOptions: commonOptions{
+			edgeOptions: edgeOptions{
 				CommonOptions: common.CommonOptions{Factory: f, Out: out, Err: errOut},
 			},
 		},
@@ -109,7 +109,7 @@ func newUpdatePostureCheckMacCmd(f cmdutil.Factory, out io.Writer, errOut io.Wri
 
 // runUpdatePostureCheckMac update a new identity on the Ziti Edge Controller
 func runUpdatePostureCheckMac(o *updatePostureCheckMacOptions) error {
-	id, err := mapNameToID("posture-checks", o.Args[0], o.commonOptions)
+	id, err := mapNameToID("posture-checks", o.Args[0], o.edgeOptions)
 	if err != nil {
 		return err
 	}
@@ -137,14 +137,14 @@ func runUpdatePostureCheckMac(o *updatePostureCheckMacOptions) error {
 
 	setJSONValue(entityData, PostureCheckTypeMAC, "typeId")
 
-	_, err = patchEntityOfType(fmt.Sprintf("posture-checks/%v", id), entityData.String(), &o.commonOptions)
+	_, err = patchEntityOfType(fmt.Sprintf("posture-checks/%v", id), entityData.String(), &o.edgeOptions)
 	return err
 }
 
 func newUpdatePostureCheckDomainCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &updatePostureCheckDomainOptions{
 		updatePostureCheckOptions: updatePostureCheckOptions{
-			commonOptions: commonOptions{
+			edgeOptions: edgeOptions{
 				CommonOptions: common.CommonOptions{Factory: f, Out: out, Err: errOut},
 			},
 		},
@@ -177,7 +177,7 @@ func newUpdatePostureCheckDomainCmd(f cmdutil.Factory, out io.Writer, errOut io.
 
 // runUpdatePostureCheckDomain update a new identity on the Ziti Edge Controller
 func runUpdatePostureCheckDomain(o *updatePostureCheckDomainOptions) error {
-	id, err := mapNameToID("posture-checks", o.Args[0], o.commonOptions)
+	id, err := mapNameToID("posture-checks", o.Args[0], o.edgeOptions)
 	if err != nil {
 		return err
 	}
@@ -209,7 +209,7 @@ func runUpdatePostureCheckDomain(o *updatePostureCheckDomainOptions) error {
 
 	setJSONValue(entityData, PostureCheckTypeDomain, "typeId")
 
-	_, err = patchEntityOfType(fmt.Sprintf("posture-checks/%v", id), entityData.String(), &o.commonOptions)
+	_, err = patchEntityOfType(fmt.Sprintf("posture-checks/%v", id), entityData.String(), &o.edgeOptions)
 	return err
 }
 
@@ -218,7 +218,7 @@ func runUpdatePostureCheckDomain(o *updatePostureCheckDomainOptions) error {
 func newUpdatePostureCheckProcessCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &updatePostureCheckProcessOptions{
 		updatePostureCheckOptions: updatePostureCheckOptions{
-			commonOptions: commonOptions{
+			edgeOptions: edgeOptions{
 				CommonOptions: common.CommonOptions{Factory: f, Out: out, Err: errOut},
 			},
 		},
@@ -256,7 +256,7 @@ func newUpdatePostureCheckProcessCmd(f cmdutil.Factory, out io.Writer, errOut io
 
 // runUpdatePostureCheckProcess update a new identity on the Ziti Edge Controller
 func runUpdatePostureCheckProcess(o *updatePostureCheckProcessOptions) error {
-	id, err := mapNameToID("posture-checks", o.Args[0], o.commonOptions)
+	id, err := mapNameToID("posture-checks", o.Args[0], o.edgeOptions)
 	if err != nil {
 		return err
 	}
@@ -317,7 +317,7 @@ func runUpdatePostureCheckProcess(o *updatePostureCheckProcessOptions) error {
 
 	setJSONValue(entityData, PostureCheckTypeProcess, "typeId")
 
-	_, err = patchEntityOfType(fmt.Sprintf("posture-checks/%v", id), entityData.String(), &o.commonOptions)
+	_, err = patchEntityOfType(fmt.Sprintf("posture-checks/%v", id), entityData.String(), &o.edgeOptions)
 	return err
 }
 
@@ -325,7 +325,7 @@ func runUpdatePostureCheckProcess(o *updatePostureCheckProcessOptions) error {
 func newUpdatePostureCheckOsCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &updatePostureCheckOsOptions{
 		updatePostureCheckOptions: updatePostureCheckOptions{
-			commonOptions: commonOptions{
+			edgeOptions: edgeOptions{
 				CommonOptions: common.CommonOptions{Factory: f, Out: out, Err: errOut},
 			},
 		},
@@ -358,7 +358,7 @@ func newUpdatePostureCheckOsCmd(f cmdutil.Factory, out io.Writer, errOut io.Writ
 
 // runUpdatePostureCheckOs update a new identity on the Ziti Edge Controller
 func runUpdatePostureCheckOs(o *updatePostureCheckOsOptions) error {
-	id, err := mapNameToID("posture-checks", o.Args[0], o.commonOptions)
+	id, err := mapNameToID("posture-checks", o.Args[0], o.edgeOptions)
 	if err != nil {
 		return err
 	}
@@ -394,6 +394,6 @@ func runUpdatePostureCheckOs(o *updatePostureCheckOsOptions) error {
 
 	setJSONValue(entityData, PostureCheckTypeOS, "typeId")
 
-	_, err = patchEntityOfType(fmt.Sprintf("posture-checks/%v", id), entityData.String(), &o.commonOptions)
+	_, err = patchEntityOfType(fmt.Sprintf("posture-checks/%v", id), entityData.String(), &o.edgeOptions)
 	return err
 }

--- a/ziti/cmd/ziti/cmd/edge_controller/update_service.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/update_service.go
@@ -30,7 +30,7 @@ import (
 )
 
 type updateServiceOptions struct {
-	commonOptions
+	edgeOptions
 	name               string
 	terminatorStrategy string
 	roleAttributes     []string
@@ -39,7 +39,7 @@ type updateServiceOptions struct {
 
 func newUpdateServiceCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &updateServiceOptions{
-		commonOptions: commonOptions{
+		edgeOptions: edgeOptions{
 			CommonOptions: common.CommonOptions{Factory: f, Out: out, Err: errOut},
 		},
 	}
@@ -73,7 +73,7 @@ func newUpdateServiceCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *co
 
 // runUpdateService update a new service on the Ziti Edge Controller
 func runUpdateService(o *updateServiceOptions) error {
-	id, err := mapNameToID("services", o.Args[0], o.commonOptions)
+	id, err := mapNameToID("services", o.Args[0], o.edgeOptions)
 	if err != nil {
 		return err
 	}
@@ -104,6 +104,6 @@ func runUpdateService(o *updateServiceOptions) error {
 		return errors.New("no change specified. must specify at least one attribute to change")
 	}
 
-	_, err = patchEntityOfType(fmt.Sprintf("services/%v", id), entityData.String(), &o.commonOptions)
+	_, err = patchEntityOfType(fmt.Sprintf("services/%v", id), entityData.String(), &o.edgeOptions)
 	return err
 }

--- a/ziti/cmd/ziti/cmd/edge_controller/update_service_edge_router_policy.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/update_service_edge_router_policy.go
@@ -30,7 +30,7 @@ import (
 )
 
 type updateServiceEdgeRouterPolicyOptions struct {
-	commonOptions
+	edgeOptions
 	name            string
 	edgeRouterRoles []string
 	serviceRoles    []string
@@ -38,7 +38,7 @@ type updateServiceEdgeRouterPolicyOptions struct {
 
 func newUpdateServiceEdgeRouterPolicyCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &updateServiceEdgeRouterPolicyOptions{
-		commonOptions: commonOptions{
+		edgeOptions: edgeOptions{
 			CommonOptions: common.CommonOptions{Factory: f, Out: out, Err: errOut},
 		},
 	}
@@ -68,17 +68,17 @@ func newUpdateServiceEdgeRouterPolicyCmd(f cmdutil.Factory, out io.Writer, errOu
 }
 
 func runUpdateServiceEdgeRouterPolicy(o *updateServiceEdgeRouterPolicyOptions) error {
-	id, err := mapNameToID("service-edge-router-policies", o.Args[0], o.commonOptions)
+	id, err := mapNameToID("service-edge-router-policies", o.Args[0], o.edgeOptions)
 	if err != nil {
 		return err
 	}
 
-	edgeRouterRoles, err := convertNamesToIds(o.edgeRouterRoles, "edge-routers", o.commonOptions)
+	edgeRouterRoles, err := convertNamesToIds(o.edgeRouterRoles, "edge-routers", o.edgeOptions)
 	if err != nil {
 		return err
 	}
 
-	serviceRoles, err := convertNamesToIds(o.serviceRoles, "services", o.commonOptions)
+	serviceRoles, err := convertNamesToIds(o.serviceRoles, "services", o.edgeOptions)
 	if err != nil {
 		return err
 	}
@@ -105,6 +105,6 @@ func runUpdateServiceEdgeRouterPolicy(o *updateServiceEdgeRouterPolicyOptions) e
 		return errors.New("no change specified. must specify at least one attribute to change")
 	}
 
-	_, err = patchEntityOfType(fmt.Sprintf("service-edge-router-policies/%v", id), entityData.String(), &o.commonOptions)
+	_, err = patchEntityOfType(fmt.Sprintf("service-edge-router-policies/%v", id), entityData.String(), &o.edgeOptions)
 	return err
 }

--- a/ziti/cmd/ziti/cmd/edge_controller/update_service_policy.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/update_service_policy.go
@@ -30,7 +30,7 @@ import (
 )
 
 type updateServicePolicyOptions struct {
-	commonOptions
+	edgeOptions
 	name              string
 	serviceRoles      []string
 	identityRoles     []string
@@ -39,7 +39,7 @@ type updateServicePolicyOptions struct {
 
 func newUpdateServicePolicyCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &updateServicePolicyOptions{
-		commonOptions: commonOptions{
+		edgeOptions: edgeOptions{
 			CommonOptions: common.CommonOptions{Factory: f, Out: out, Err: errOut},
 		},
 	}
@@ -70,22 +70,22 @@ func newUpdateServicePolicyCmd(f cmdutil.Factory, out io.Writer, errOut io.Write
 }
 
 func runUpdateServicePolicy(o *updateServicePolicyOptions) error {
-	id, err := mapNameToID("service-policies", o.Args[0], o.commonOptions)
+	id, err := mapNameToID("service-policies", o.Args[0], o.edgeOptions)
 	if err != nil {
 		return err
 	}
 
-	serviceRoles, err := convertNamesToIds(o.serviceRoles, "services", o.commonOptions)
+	serviceRoles, err := convertNamesToIds(o.serviceRoles, "services", o.edgeOptions)
 	if err != nil {
 		return err
 	}
 
-	identityRoles, err := convertNamesToIds(o.identityRoles, "identities", o.commonOptions)
+	identityRoles, err := convertNamesToIds(o.identityRoles, "identities", o.edgeOptions)
 	if err != nil {
 		return err
 	}
 
-	postureCheckRoles, err := convertNamesToIds(o.postureCheckRoles, "posture-checks", o.commonOptions)
+	postureCheckRoles, err := convertNamesToIds(o.postureCheckRoles, "posture-checks", o.edgeOptions)
 	if err != nil {
 		return err
 	}
@@ -117,6 +117,6 @@ func runUpdateServicePolicy(o *updateServicePolicyOptions) error {
 		return errors.New("no change specified. must specify at least one attribute to change")
 	}
 
-	_, err = patchEntityOfType(fmt.Sprintf("service-policies/%v", id), entityData.String(), &o.commonOptions)
+	_, err = patchEntityOfType(fmt.Sprintf("service-policies/%v", id), entityData.String(), &o.edgeOptions)
 	return err
 }

--- a/ziti/cmd/ziti/cmd/edge_controller/update_terminator.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/update_terminator.go
@@ -31,7 +31,7 @@ import (
 )
 
 type updateTerminatorOptions struct {
-	commonOptions
+	edgeOptions
 	router     string
 	address    string
 	binding    string
@@ -41,7 +41,7 @@ type updateTerminatorOptions struct {
 
 func newUpdateTerminatorCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &updateTerminatorOptions{
-		commonOptions: commonOptions{
+		edgeOptions: edgeOptions{
 			CommonOptions: common.CommonOptions{
 				Factory: f,
 				Out:     out,
@@ -79,7 +79,7 @@ func newUpdateTerminatorCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) 
 func runUpdateTerminator(o *updateTerminatorOptions) (err error) {
 	entityData := gabs.New()
 
-	router, err := mapNameToID("edge-routers", o.router, o.commonOptions)
+	router, err := mapNameToID("edge-routers", o.router, o.edgeOptions)
 	if err != nil {
 		router = o.router // might be a pure fabric router, id might not be UUID
 	}
@@ -121,6 +121,6 @@ func runUpdateTerminator(o *updateTerminatorOptions) (err error) {
 		return errors.New("no change specified. must specify at least one attribute to change")
 	}
 
-	_, err = patchEntityOfType(fmt.Sprintf("terminators/%v", o.Args[0]), entityData.String(), &o.commonOptions)
+	_, err = patchEntityOfType(fmt.Sprintf("terminators/%v", o.Args[0]), entityData.String(), &o.edgeOptions)
 	return err
 }

--- a/ziti/cmd/ziti/cmd/edge_controller/verify.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/verify.go
@@ -43,6 +43,6 @@ func newVerifyCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Com
 }
 
 // createEntityOfType create an entity of the given type on the Ziti Edge Controller
-func verifyEntityOfType(entityType, body, id string, options *commonOptions) error {
+func verifyEntityOfType(entityType, body, id string, options *edgeOptions) error {
 	return util.EdgeControllerVerify(entityType, id, body, options.Out, options.OutputJSONResponse, options.Timeout, options.Verbose)
 }

--- a/ziti/cmd/ziti/cmd/edge_controller/verify_ca.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/verify_ca.go
@@ -41,7 +41,7 @@ import (
 )
 
 type verifyCaOptions struct {
-	commonOptions
+	edgeOptions
 
 	certPath     string
 	certPemBytes []byte
@@ -62,7 +62,7 @@ type verifyCaOptions struct {
 // newVerifyCaCmd creates the 'edge controller verify ca' command for the given entity type
 func newVerifyCaCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &verifyCaOptions{
-		commonOptions: commonOptions{
+		edgeOptions: edgeOptions{
 			CommonOptions: common.CommonOptions{
 				Factory: f,
 				Out:     out,
@@ -135,14 +135,14 @@ func newVerifyCaCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.C
 
 func runValidateCa(options *verifyCaOptions) error {
 	var err error
-	options.caId, err = mapCaNameToID(options.caNameOrId, options.commonOptions)
+	options.caId, err = mapCaNameToID(options.caNameOrId, options.edgeOptions)
 
 	if err != nil {
 		return err
 	}
 
 	if options.isGenerateCert {
-		jsonContainer, err := util.EdgeControllerRequest("cas/"+options.caId, options.Out, options.OutputJSONResponse, options.commonOptions.Timeout, options.commonOptions.Verbose, func(request *resty.Request, url string) (*resty.Response, error) { return request.Get(url) })
+		jsonContainer, err := util.EdgeControllerRequest("cas/"+options.caId, options.Out, options.OutputJSONResponse, options.edgeOptions.Timeout, options.edgeOptions.Verbose, func(request *resty.Request, url string) (*resty.Response, error) { return request.Get(url) })
 
 		if err != nil {
 			return fmt.Errorf("could not request ca [%s] (%v}", options.caId, err)
@@ -161,7 +161,7 @@ func runValidateCa(options *verifyCaOptions) error {
 		}
 	}
 
-	return util.EdgeControllerVerify("cas", options.caId, string(options.certPemBytes), options.Out, options.OutputJSONResponse, options.commonOptions.Timeout, options.commonOptions.Verbose)
+	return util.EdgeControllerVerify("cas", options.caId, string(options.certPemBytes), options.Out, options.OutputJSONResponse, options.edgeOptions.Timeout, options.edgeOptions.Verbose)
 }
 
 func generateCert(options *verifyCaOptions, token string) ([]byte, crypto.Signer, error) {

--- a/ziti/cmd/ziti/cmd/edge_controller/version.go
+++ b/ziti/cmd/ziti/cmd/edge_controller/version.go
@@ -28,13 +28,13 @@ import (
 
 // versionOptions are the flags for version commands
 type versionOptions struct {
-	commonOptions
+	edgeOptions
 }
 
 // newVersionCmd creates the command
 func newVersionCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &versionOptions{
-		commonOptions: commonOptions{
+		edgeOptions: edgeOptions{
 			CommonOptions: common.CommonOptions{Factory: f, Out: out, Err: errOut},
 		},
 	}
@@ -59,7 +59,7 @@ func newVersionCmd(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Co
 
 // Run implements this command
 func (o *versionOptions) Run() error {
-	jsonParsed, err := util.EdgeControllerList("version", nil, o.OutputJSONResponse, o.Out, o.commonOptions.Timeout, o.commonOptions.Verbose)
+	jsonParsed, err := util.EdgeControllerList("version", nil, o.OutputJSONResponse, o.Out, o.edgeOptions.Timeout, o.edgeOptions.Verbose)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
There is already an object called CommonOptions at the root of the ziti CLI. Reading commonOption.CommonOption could be confusing. Renaming the edge common option now reads as edgeOptions.CommonOptions.