### PR TITLE
Idle Route Garbage Collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## What's New
 
 * Update to Golang 1.16
+* Idle route garbage collection: orphaned routing table entries will be garbage collected. New
+  infrastructure for session confirmation facilitating additional types of garbage collection
 
 # Release 0.19.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@
 * Update to Golang 1.16
 * Idle route garbage collection: orphaned routing table entries will be garbage collected. New
   infrastructure for session confirmation facilitating additional types of garbage collection
+* Configurable Xgress dial "dwell time"
+
+### Idle Route Garbage Collection
+
+The following router configuration stanza controls idle route garbage collection:
+
+```
+forwarder:
+  #
+  # After how many milliseconds of inactivity is a forwarding table entry considered idle?
+  #
+  idleSessionTimeout: 60000
+  #
+  # How frequently will we confirm idle sessions with the controller?
+  #
+  idleTxInterval: 60000
+```
+
+### Xgress Dial Dwell Time
+
+The following router configuration stanza controls Xgress dial "dwell time". You probably don't want to 
+use this unless you're debugging a timing-related issue in the overlay:
+
+```
+forwarder:
+  #
+  # (Debugging) Xgress dial "dwell time". When dialing, the Xgress framework will wait this number of milliseconds
+  # before responding in the affirmative to the controller.
+  #
+  xgressDialDwellTime: 0
+```
 
 # Release 0.19.6
 

--- a/etc/001.yml
+++ b/etc/001.yml
@@ -21,6 +21,14 @@ forwarder:
   #
   latencyProbeTimeout: 10000
   #
+  # After how many milliseconds of inactivity is a forwarding table entry considered idle?
+  #
+  idleSessionTimeout: 60000
+  #
+  # How frequently will we confirm idle sessions with the controller?
+  #
+  idleTxInterval: 60000
+  #
   # How many xgress dials can be queued for processing by the xgress dial workers. An xgress dial occurs
   # for services that have a terminator egress specified with an xgress binding (e.g. transport)
   # (minimum 1, max 10000, default 1000)
@@ -42,6 +50,11 @@ forwarder:
   # (minimum 1, max 10000, default 10)
   #
   linkDialWorkerCount: 10
+  #
+  # (Debugging) Xgress dial "dwell time". When dialing, the Xgress framework will wait this number of milliseconds
+  # before responding in the affirmative to the controller.
+  #
+  xgressDialDwellTime: 0
 
 #trace:
 #  path:                 001.trace

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.15
 
 //replace github.com/michaelquigley/dilithium => ../../q/research/dilithium
 
-//replace github.com/openziti/fabric => ../fabric
+replace github.com/openziti/fabric => ../fabric
 
 //replace github.com/openziti/sdk-golang => ../sdk-golang
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.16
 
 //replace github.com/michaelquigley/dilithium => ../../q/research/dilithium
 
-replace github.com/openziti/fabric => ../fabric
+//replace github.com/openziti/fabric => ../fabric
 
 //replace github.com/openziti/sdk-golang => ../sdk-golang
 
@@ -25,8 +25,8 @@ require (
 	github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d
 	github.com/keybase/go-ps v0.0.0-20190827175125-91aafc93ba19
 	github.com/michaelquigley/pfxlog v0.3.7
-	github.com/openziti/edge v0.19.27
-	github.com/openziti/fabric v0.16.24
+	github.com/openziti/edge v0.19.32
+	github.com/openziti/fabric v0.16.27
 	github.com/openziti/foundation v0.15.35
 	github.com/openziti/sdk-golang v0.15.21
 	github.com/pborman/uuid v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -620,10 +620,10 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
-github.com/openziti/edge v0.19.27 h1:KCopaqhptJ/HCQcW+pqPkV2FCpzFmILc77Vxv1wxo1w=
-github.com/openziti/edge v0.19.27/go.mod h1:Vd1/e++L26XVR1tlmV4su8IEfua7bHBpdcK3J5SDURs=
-github.com/openziti/fabric v0.16.24 h1:IzPLF/rn6sZzchbJOEIryYY9zlIX2ondome24p3hz/A=
-github.com/openziti/fabric v0.16.24/go.mod h1:iF5BPXp+MceayRx11hJV885EofqP6f4/xyW5dCupKYQ=
+github.com/openziti/edge v0.19.32 h1:66e9qAMALX3y8XsOF5+AXSSvhDDDrfnO8T16z9taKaw=
+github.com/openziti/edge v0.19.32/go.mod h1:9QOQtG0uNsfRlt2jtJalPEYYbALrz27NykztBMxX7qc=
+github.com/openziti/fabric v0.16.27 h1:/7hzhjm5X7pWLm/2aXM9YZyU2JSRhQ0KNEVt125FArk=
+github.com/openziti/fabric v0.16.27/go.mod h1:jjIq2i9XcSmaGpYAkm8lX/0JVeSycAF3Zi9SaXSEDkE=
 github.com/openziti/foundation v0.15.35 h1:FYL2TNKqRzXVN70XhU15Nw2OrWnd5Lbz0hz4heVsxqg=
 github.com/openziti/foundation v0.15.35/go.mod h1:0vyGpNqnK/WuVhUE1Kfq+UvCWIf/rUYViMrCrCZ2cTc=
 github.com/openziti/sdk-golang v0.15.21 h1:HeBvSXTSFixV1D8EdioNiO9nvGdqvIsxxx4Rkrs2ZLA=


### PR DESCRIPTION
Monitor and garbage collect idle routes (forwarding table entries). Introduces the machinery necessary for session confirmation, useful for other in-router garbage collection facilities.