### PR TITLE
watch for signal interrupts

### DIFF
--- a/ziti-controller/subcmd/run.go
+++ b/ziti-controller/subcmd/run.go
@@ -25,6 +25,9 @@ import (
 	"github.com/openziti/ziti/common/version"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"os"
+	"os/signal"
+	"syscall"
 )
 
 func init() {
@@ -54,28 +57,39 @@ func run(cmd *cobra.Command, args []string) {
 			}
 		}
 
-		var c *controller.Controller
-		if c, err = controller.NewController(config, version.GetCmdBuildInfo()); err != nil {
+		var fabricController *controller.Controller
+		if fabricController, err = controller.NewController(config, version.GetCmdBuildInfo()); err != nil {
 			fmt.Printf("unable to create fabric controller %+v\n", err)
 			panic(err)
 		}
 
-		ec, err := server.NewController(config)
+		edgeController, err := server.NewController(config)
 
 		if err != nil {
 			panic(err)
 		}
 
-		ec.SetHostController(c)
-		ec.Initialize()
-
-		go ec.RunAndWait()
-
-		if err = c.Run(); err != nil {
+		edgeController.SetHostController(fabricController)
+		edgeController.Initialize()
+		go waitForShutdown(fabricController, edgeController)
+		go edgeController.Run()
+		if err := fabricController.Run(); err != nil {
 			panic(err)
 		}
+
 
 	} else {
 		panic(err)
 	}
+}
+
+func waitForShutdown(fabricController *controller.Controller, edgeController *server.Controller) {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
+
+	<-ch
+
+	pfxlog.Logger().Info("shutting down ziti-controller")
+	edgeController.Shutdown()
+	fabricController.Shutdown()
 }

--- a/ziti-router/subcmd/run.go
+++ b/ziti-router/subcmd/run.go
@@ -123,7 +123,5 @@ func waitForShutdown(r *router.Router) {
 
 	if err := r.Shutdown(); err != nil {
 		pfxlog.Logger().Info("error encountered during shutdown: %v", err)
-		os.Exit(1)
 	}
-	os.Exit(0)
 }

--- a/ziti-router/subcmd/run.go
+++ b/ziti-router/subcmd/run.go
@@ -31,6 +31,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"io"
+	"os"
+	"os/signal"
+	"syscall"
 )
 
 func init() {
@@ -45,6 +48,7 @@ var runCmd = &cobra.Command{
 }
 
 func run(cmd *cobra.Command, args []string) {
+
 	logrus.WithField("version", version.GetVersion()).
 		WithField("go-version", version.GetGoVersion()).
 		WithField("os", version.GetOS()).
@@ -89,6 +93,8 @@ func run(cmd *cobra.Command, args []string) {
 			logrus.Panicf("error registering edge tunnel in framework (%v)", err)
 		}
 
+		go waitForShutdown(r)
+
 		if err := r.Run(); err != nil {
 			logrus.WithError(err).Fatal("error starting")
 		}
@@ -104,4 +110,20 @@ func getFlags(cmd *cobra.Command) map[string]*pflag.Flag {
 		ret[f.Name] = f
 	})
 	return ret
+}
+
+func waitForShutdown(r *router.Router) {
+
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
+
+	<-ch
+
+	pfxlog.Logger().Info("shutting down ziti-router")
+
+	if err := r.Shutdown(); err != nil {
+		pfxlog.Logger().Info("error encountered during shutdown: %v", err)
+		os.Exit(1)
+	}
+	os.Exit(0)
 }


### PR DESCRIPTION
This implementation tries to use the router.Shutdown() method.

Currently it does exit but only after this panic:

```
goroutine 56 [running]:
reflect.MakeSlice(0x1e38570, 0x1991e40, 0x0, 0xffffffffffffffff, 0x0, 0x0, 0x0)
        .../go/src/reflect/value.go:2297 +0x1ac
github.com/openziti/foundation/util/cowslice.Delete(0xc000005b18, 0x19ecd40, 0xc000686160)
        .../repos/openziti/foundation/util/cowslice/registry.go:41 +0x1c5
github.com/openziti/foundation/events.RemoveMetricsEventHandler(...)
        .../repos/openziti/foundation/events/registrations.go:13
github.com/openziti/fabric/router.(*Router).Shutdown(0xc00047bd40, 0x4, 0xc0004ede98)
        .../repos/openziti/fabric/router/router.go:151 +0x8c
github.com/openziti/ziti/ziti-router/subcmd.waitForShutdown(0xc00047bd40)
        .../repos/openziti/ziti/ziti-router/subcmd/run.go:124 +0x1ab
created by github.com/openziti/ziti/ziti-router/subcmd.run
        .../repos/openziti/ziti/ziti-router/subcmd/run.go:96 +0xd4e
```

I am still hunting that down. The other option is simply to call `os.Exit()` as code in `foundation` used to do for us.

Edit: above is fixed in a fabric PR.