### PR TITLE
make express install more clear

### DIFF
--- a/quickstart/docker/image/ziti-cli-functions.sh
+++ b/quickstart/docker/image/ziti-cli-functions.sh
@@ -377,12 +377,6 @@ function ziti_expressConfiguration {
 
   "${ZITI_BIN_DIR-}/ziti-router" enroll "${ZITI_HOME_OS_SPECIFIC}/${ZITI_EDGE_ROUTER_RAWNAME}.yaml" --jwt "${ZITI_HOME_OS_SPECIFIC}/${ZITI_EDGE_ROUTER_RAWNAME}.jwt" &> "${ZITI_HOME_OS_SPECIFIC}/${ZITI_EDGE_ROUTER_RAWNAME}.enrollment.log"
   echo ""
-  #sleep 1
-  #routerLog=""
-  # shellcheck disable=SC2034
-  #"${ZITI_BIN_DIR}/ziti-router" run "${ZITI_HOME_OS_SPECIFIC}/${ZITI_EDGE_ROUTER_RAWNAME}.yaml" > "${ZITI_HOME_OS_SPECIFIC}/${ZITI_EDGE_ROUTER_RAWNAME}.log" 2>&1 &
-  #routerPid=$!
-  #echo -e "ziti-router started as process id: $routerPid. log located at: $(BLUE "${routerLog}")"
 
   killall ziti-controller
   echo "Edge Router enrolled. Controller stopped."

--- a/quickstart/docker/image/ziti-cli-functions.sh
+++ b/quickstart/docker/image/ziti-cli-functions.sh
@@ -352,7 +352,6 @@ function ziti_expressConfiguration {
   #createControllerSystemdFile
   initializeController
   startZitiController
-  ctrlPid=$?
   echo "waiting for the controller to come online to allow the edge router to enroll"
   waitForController
 
@@ -385,8 +384,8 @@ function ziti_expressConfiguration {
   #routerPid=$!
   #echo -e "ziti-router started as process id: $routerPid. log located at: $(BLUE "${routerLog}")"
 
-  $(kill $ctrlPid) 2&>1 /dev/null
-  echo "Edge Router enrolled. Stopping controller using pid: $ctrlPid"
+  killall ziti-controller
+  echo "Edge Router enrolled. Controller stopped."
 
   echo ""
   echo -e "$(GREEN "Congratulations. Express setup complete!")"

--- a/quickstart/docker/image/ziti-cli-functions.sh
+++ b/quickstart/docker/image/ziti-cli-functions.sh
@@ -42,7 +42,7 @@ function BLUE {
 }
 
 function zitiLogin {
-  "${ZITI_BIN_DIR-}/ziti" edge login "${ZITI_EDGE_CONTROLLER_API}" -u "${ZITI_USER-}" -p "${ZITI_PWD}" -c "${ZITI_PKI_OS_SPECIFIC}/${ZITI_EDGE_CONTROLLER_ROOTCA_NAME}/certs/${ZITI_EDGE_CONTROLLER_INTERMEDIATE_NAME}.cert" > /dev/null
+  "${ZITI_BIN_DIR-}/ziti" edge login "${ZITI_EDGE_CONTROLLER_API}" -u "${ZITI_USER-}" -p "${ZITI_PWD}" -c "${ZITI_PKI_OS_SPECIFIC}/${ZITI_EDGE_CONTROLLER_ROOTCA_NAME}/certs/${ZITI_EDGE_CONTROLLER_INTERMEDIATE_NAME}.cert"
 }
 function cleanZitiController {
   ziti_home="${ZITI_HOME-}"
@@ -73,6 +73,9 @@ function startExpressEdgeRouter {
   pid=$!
   echo -e "Express Edge Router started as process id: $pid. log located at: $(BLUE "${ZITI_HOME_OS_SPECIFIC}/${ZITI_EDGE_ROUTER_RAWNAME}.log")"
   return $pid
+}
+function stopAllEdgeRouters {
+  killall ziti-router
 }
 function checkHostsFile {
   ctrlexists=$(grep -c "${ZITI_CONTROLLER_HOSTNAME}" /etc/hosts)


### PR DESCRIPTION
* removed foolish 'unused' variables and redirect to /dev/null instead 
* add startExpressEdgeRouter function
* don't emit systemd files by default since those won't work on mac/wsl
* reference start functions at the end to show someone how to start/stop ziti locally

output should end up looking like:
![image](https://user-images.githubusercontent.com/46322585/140996580-704efe22-03d3-4388-b219-9144b0557b0f.png)
