### PR TITLE
when no file exists, initialize the maps before returning an empty co…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Release 0.24.1
+
+## What's New
+* Bug Fix: Very first time using ziti cli to login with `ziti edge login` would panic
+
 # Release 0.24.0
 
 ## Breaking Changes

--- a/ziti/cmd/ziti/util/identities.go
+++ b/ziti/cmd/ziti/util/identities.go
@@ -249,6 +249,8 @@ func LoadRestClientConfig() (*RestClientConfig, string, error) {
 	_, err = os.Stat(configFile)
 	if err != nil {
 		if os.IsNotExist(err) {
+			config.EdgeIdentities = map[string]*RestClientEdgeIdentity{}
+			config.FabricIdentities = map[string]*RestClientFabricIdentity{}
 			return config, configFile, nil
 		}
 		return nil, "", errors.Wrapf(err, "error while statting config file %v", configFile)


### PR DESCRIPTION
fixes #550 - ziti edge login fails on first login ever (when file doesn't exist)