### PR TITLE
add and document Linux builder

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+/release/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - release-v*
-      - builx-action # TODO: prune after initial testing
   pull_request:
   workflow_dispatch:
 
@@ -73,7 +72,7 @@ jobs:
 
   tag-and-publish:
     name: Build Linux Binaries and Docker Image, Tag, and Publish
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: [ mac-os-build, windows-build ]
     steps:
       - name: Git Checkout
@@ -97,6 +96,7 @@ jobs:
       - name: Build and Test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GOX_CMD: 
         run: |
           sudo apt-get update
           sudo apt-get -yq install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf gcc-aarch64-linux-gnu
@@ -105,9 +105,11 @@ jobs:
           $(go env GOPATH)/bin/ziti-ci configure-git
           $(go env GOPATH)/bin/ziti-ci generate-build-info common/version/info_generated.go version
           go install github.com/mitchellh/gox@latest
-          CGO_ENABLED=true $(go env GOPATH)/bin/gox -os=linux -arch=amd64 -output=$GOX_OUTPUT ./...
-          CC=arm-linux-gnueabihf-gcc CGO_ENABLED=true gox -cgo -os=linux -arch=arm -output=$GOX_OUTPUT ./...
-          CC=aarch64-linux-gnu-gcc CGO_ENABLED=true gox -cgo -os=linux -arch=arm64 -output=$GOX_OUTPUT ./...
+          $(go env GOPATH)/bin/gox -cgo -os=linux -arch=amd64 -output=${GOX_OUTPUT} ./...
+          CC=arm-linux-gnueabihf-gcc  \
+          $(go env GOPATH)/bin/gox -cgo -os=linux -arch=arm   -output=${GOX_OUTPUT} ./...
+          CC=aarch64-linux-gnu-gcc \
+          $(go env GOPATH)/bin/gox -cgo -os=linux -arch=arm64 -output=${GOX_OUTPUT} ./...
           aws s3 sync --no-progress s3://ziti-cmd-build-tmp/${{ github.run_id }} release/
           aws s3 rm --recursive s3://ziti-cmd-build-tmp/${{ github.run_id }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,7 +96,6 @@ jobs:
       - name: Build and Test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GOX_CMD: 
         run: |
           sudo apt-get update
           sudo apt-get -yq install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf gcc-aarch64-linux-gnu

--- a/Dockerfile.linux-build
+++ b/Dockerfile.linux-build
@@ -1,70 +1,32 @@
-FROM ubuntu:18.04
+FROM debian:bullseye-slim
 #
 # this file mirrors the build params used in the GitHub Actions and enables
-# reproducible builds for downstream forks and Ziti contributors 
+# reproducible builds for downstream forks for Ziti contributors 
 #
 
 ARG latest_golang=1.17.2
 ARG go_distribution_file=go${latest_golang}.linux-amd64.tar.gz
-ARG GOPATH=/root/go
-ARG GOROOT=/usr/local/go
-RUN apt-get update
-RUN apt-get -yq install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf gcc-aarch64-linux-gnu
-RUN apt-get -yq install wget build-essential
-RUN wget -q https://golang.org/dl/${go_distribution_file}
+ARG go_path=/usr/share/go
+ARG go_root=/usr/local/go
+ARG go_cache=/usr/share/go_cache
+ARG uid=1000
+ARG gid=1000
+RUN apt-get -y update
+RUN apt-get -y install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf gcc-aarch64-linux-gnu
+RUN apt-get -y install wget build-essential
+
+RUN wget -q https://go.dev/dl/${go_distribution_file}
 RUN tar -xzf ${go_distribution_file} -C /usr/local/
-RUN mkdir ${GOPATH}
-ENV GOPATH=${GOPATH}
-ENV GOROOT=${GOROOT}
-ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+
+RUN mkdir ${go_path} ${go_cache}
+RUN chown -R ${uid}:${gid} ${go_path} ${go_cache}
+
+USER ${uid}:${gid}
+ENV GOPATH=${go_path}
+ENV GOROOT=${go_root}
+ENV GOCACHE=${go_cache}
+ENV PATH=${go_path}/bin:${go_root}/bin:$PATH
 RUN go install github.com/mitchellh/gox@latest
 WORKDIR /mnt
-CMD ["./linux-build.sh"]
+ENTRYPOINT ["./linux-build.sh"]
 
-##
-# build this Dockerfile
-##
-#
-#  MINIMUM_GOLANG=$(grep -Po '^go\s+\K\d+\.\d+(\.\d+)?$' go.mod)
-#  LATEST_GOLANG=$(curl -sSf "https://golang.org/VERSION?m=text" | /bin/grep -Po '^go(\s+)?\K\d+\.\d+\.\d+$')
-#  docker build --tag=zitibuilder --file=Dockerfile.linux-build --build-arg latest_golang=${LATEST_GOLANG} .
-
-##
-# build Ziti
-##
-#  docker run --rm --name=zitibuilder --volume=$PWD:/mnt zitibuilder             
-
-# $ tree ./release
-# ./release
-# ├── amd64
-# │   └── linux
-# │       ├── ziti
-# │       ├── ziti-controller
-# │       ├── ziti-fabric
-# │       ├── ziti-fabric-gw
-# │       ├── ziti-fabric-test
-# │       ├── ziti-probe
-# │       ├── ziti-router
-# │       └── ziti-tunnel
-# ├── arm
-# │   └── linux
-# │       ├── ziti
-# │       ├── ziti-controller
-# │       ├── ziti-fabric
-# │       ├── ziti-fabric-gw
-# │       ├── ziti-fabric-test
-# │       ├── ziti-probe
-# │       ├── ziti-router
-# │       └── ziti-tunnel
-# └── arm64
-#     └── linux
-#         ├── ziti
-#         ├── ziti-controller
-#         ├── ziti-fabric
-#         ├── ziti-fabric-gw
-#         ├── ziti-fabric-test
-#         ├── ziti-probe
-#         ├── ziti-router
-#         └── ziti-tunnel
-
-# 6 directories, 24 files

--- a/linux-build.sh
+++ b/linux-build.sh
@@ -2,11 +2,71 @@
 #
 # build the Linux artifacts for amd64, arm, arm64
 #
-# see instructions to run reproducible build with Docker in ./Dockerfile.linux-build
+# runs one background job per desired architecture unless there are too few CPUs
 #
+# 
+
 set -o pipefail -e -u
 
+# if no architectures supplied then default list of three
+if (( ${#} )); then
+    typeset -a JOBS=(${@})
+else
+    typeset -a JOBS=(amd64 arm arm64)
+fi
+
+# specify the Go template used by Gox to save the artifacts
 GOX_OUTPUT="release/{{.Arch}}/{{.OS}}/{{.Dir}}"
-CGO_ENABLED=true gox -os=linux -arch=amd64 -output=${GOX_OUTPUT} ./...
-CC=arm-linux-gnueabihf-gcc CGO_ENABLED=true gox -cgo -os=linux -arch=arm -output=${GOX_OUTPUT} ./...
-CC=aarch64-linux-gnu-gcc CGO_ENABLED=true gox -cgo -os=linux -arch=arm64 -output=$GOX_OUTPUT ./...
+# count the number of available CPUs for time-efficient parallelism
+PROC_COUNT=$(nproc --all)
+# compute the number of processors available for each job, rounded down to integer
+PROCS_PER_JOB=$((PROC_COUNT / ${#JOBS[@]}))
+# if multiple jobs and at least one processor for each job then background, else foreground with all available CPUs-1 (gox default)
+if (( ${#JOBS[@]} > 1 && ${PROCS_PER_JOB} )); then 
+    BACKGROUND="&"
+    # initialize an associative array in which to map background PIDs to the ARCH being built
+    typeset -A BUILDS
+else
+    BACKGROUND=""   # run normally in foreground
+    PROCS_PER_JOB=0 # invokes gox default to use all CPUs-1
+fi
+
+for ARCH in ${JOBS[@]}; do
+    GOX_CMD="
+        gox \
+            -cgo \
+            -os=linux \
+            -arch=${ARCH} \
+            -output=${GOX_OUTPUT} \
+            -parallel=${PROCS_PER_JOB} \
+            ./...
+    "
+case ${ARCH} in
+        amd64)  eval ${GOX_CMD} ${BACKGROUND}
+                (( ${PROCS_PER_JOB} )) && BUILDS[${!}]=${ARCH}  # if greater than zero procs per job then map background pid->arch
+        ;;
+        arm)    eval CC=arm-linux-gnueabihf-gcc ${GOX_CMD} ${BACKGROUND}
+                (( ${PROCS_PER_JOB} )) && BUILDS[${!}]=${ARCH}
+        ;;
+        arm64)  eval CC=aarch64-linux-gnu-gcc ${GOX_CMD} ${BACKGROUND}
+                (( ${PROCS_PER_JOB} )) && BUILDS[${!}]=${ARCH}
+        ;;
+        *)      echo "ERROR: invalid architecture '${ARCH}', must be one of amd64, arm, arm64" >&2
+                exit 1
+        ;;
+    esac
+done
+
+# if not background in parallel then exit now with well earned success
+[[ -z "${BACKGROUND:-}" ]] || exit 0
+
+# Wait for builds in the background and exit with an error if any fail
+EXIT=0
+while true; do
+    # "wait -p" requires BASH >=5.1 which is present in Ubuntu 20.10 and Debian Bullseye
+    wait -n -p JOB_PID; JOB_RESULT=$?
+    echo "Building for ${BUILDS[$JOB_PID]} finished with result ${JOB_RESULT}"
+    (( ${JOB_RESULT} )) && EXIT=1
+done
+
+exit ${EXIT}

--- a/ziti-fabric-test/main.go
+++ b/ziti-fabric-test/main.go
@@ -19,6 +19,8 @@
 package main
 
 import (
+	"math/rand"
+
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/foundation/transport"
 	"github.com/openziti/foundation/transport/quic"
@@ -33,7 +35,6 @@ import (
 	_ "github.com/openziti/ziti/ziti-fabric-test/subcmd/loop2"
 	_ "github.com/openziti/ziti/ziti-fabric-test/subcmd/loop3"
 	"github.com/sirupsen/logrus"
-	"math/rand"
 )
 
 func init() {

--- a/ziti-fabric/main.go
+++ b/ziti-fabric/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/foundation/transport"
 	"github.com/openziti/foundation/transport/quic"


### PR DESCRIPTION
This documents how developers may build Linux executables for amd64, arm, arm64 with the same parameters used by the OpenZiti project's GitHub Actions workflow.