### PR TITLE
* added short sleep after controller comes online. noticed routers would

### DIFF
--- a/quickstart/docker/image/run-edge-router.sh
+++ b/quickstart/docker/image/run-edge-router.sh
@@ -11,6 +11,8 @@ until $(curl -s -o /dev/null --fail -k "https://${ZITI_EDGE_CTRL_ADVERTISED}"); 
     sleep 2
 done
 
+sleep 2
+
 if [[ "${ZITI_EDGE_ROUTER_HOSTNAME}" == "" ]]; then export ZITI_EDGE_ROUTER_HOSTNAME="${ZITI_EDGE_ROUTER_RAWNAME}${ZITI_DOMAIN_SUFFIX}"; fi
 if [[ "${ZITI_EDGE_ROUTER_PORT}" == "" ]]; then export ZITI_EDGE_ROUTER_PORT="3022"; fi
 

--- a/quickstart/docker/pushDevBuild.sh
+++ b/quickstart/docker/pushDevBuild.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+ZITI_QUICKSTART_ROOT="$(realpath ${SCRIPT_DIR}/..)"
+ZITI_ROOT="$(realpath ${ZITI_QUICKSTART_ROOT}/..)"
+ZITI_DOCKER_ROOT="${ZITI_QUICKSTART_ROOT}/docker"
+
+echo "SCRIPT_DIR           :$SCRIPT_DIR"
+echo "ZITI_QUICKSTART_ROOT :$ZITI_QUICKSTART_ROOT"
+echo "ZITI_ROOT            :$ZITI_ROOT"
+echo "ZITI_DOCKER_ROOT     :$ZITI_DOCKER_ROOT"
+
+cd $ZITI_ROOT
+rm -rf ./linux-build
+mkdir linux-build
+echo "building"
+go build -o linux-build ./...
+echo "built..."
+
+if [ -d "${ZITI_DOCKER_ROOT}/image/ziti.ignore" ]; then
+  rm -rf "${ZITI_DOCKER_ROOT}/image/ziti.ignore"
+fi
+
+mkdir "${ZITI_DOCKER_ROOT}/image/ziti.ignore"
+cp "${ZITI_ROOT}/linux-build/"* "${ZITI_DOCKER_ROOT}/image/ziti.ignore"
+
+cd "${ZITI_DOCKER_ROOT}"
+docker build "${SCRIPT_DIR}/image" -t openziti/quickstart:dev
+
+if [ -d "${ZITI_DOCKER_ROOT}/image/ziti.ignore" ]; then
+  rm -rf "${ZITI_DOCKER_ROOT}/image/ziti.ignore"
+fi
+
+docker run --rm -it openziti/quickstart:dev /openziti/ziti-bin/ziti version
+
+vers="$(echo "${ZITI_BINARIES_VERSION}" | cut -c 2-100)"
+docker tag "openziti/quickstart:dev" "openziti/quickstart:dev"
+
+echo "to complete the quickstart:dev push, issue:"
+echo ""
+echo "docker push \"openziti/quickstart:dev\""
+

--- a/ziti/cmd/ziti/cmd/config_templates/router.yml
+++ b/ziti/cmd/ziti/cmd/config_templates/router.yml
@@ -17,27 +17,41 @@ ctrl:
   endpoint:             tls:{{ .Controller.AdvertisedAddress }}:{{ .Controller.Port }}
 
 link:
+  dialers:
+    - binding: transport
 {{ if .Router.IsPrivate }}#{{ end }}  listeners:
 {{ if .Router.IsPrivate }}#{{ end }}    - binding:          transport
 {{ if .Router.IsPrivate }}#{{ end }}      bind:             tls:0.0.0.0:10080
 {{ if .Router.IsPrivate }}#{{ end }}      advertise:        tls:{{ .Router.Edge.Hostname }}:10080
 {{ if .Router.IsPrivate }}#{{ end }}      options:
 {{ if .Router.IsPrivate }}#{{ end }}        outQueueSize:   16
-  dialers:
-    - binding: transport
 
-{{ if .Router.IsFabric }}#{{- end }}listeners:
-  #bindings of edge and tunnel requires an "edge" section below
+{{ if or .Router.IsFabric .Router.IsPrivate }}#{{ end }}listeners:
+# bindings of edge and tunnel requires an "edge" section below
 {{ if or .Router.IsFabric .Router.IsPrivate }}#{{ end }}  - binding: edge
 {{ if or .Router.IsFabric .Router.IsPrivate }}#{{ end }}    address: {{ if .Router.IsWss }}ws{{ else }}tls{{end}}:0.0.0.0:{{ .Router.Edge.Port }}
 {{ if or .Router.IsFabric .Router.IsPrivate }}#{{ end }}    options:
 {{ if or .Router.IsFabric .Router.IsPrivate }}#{{ end }}      advertise: {{ .Router.Edge.Hostname }}:{{ if .Router.IsWss }}3023{{ else }}{{ .Router.Edge.Port }}{{ end }}
 {{ if or .Router.IsFabric .Router.IsPrivate }}#{{ end }}      connectTimeoutMs: {{ .Router.Listener.ConnectTimeoutMs }}
 {{ if or .Router.IsFabric .Router.IsPrivate }}#{{ end }}      getSessionTimeout: {{ .Router.Listener.GetSessionTimeoutS }}s
-{{ if .Router.IsFabric }}#{{- end }}  - binding: tunnel
-{{ if .Router.IsFabric }}#{{- end }}    options:
-{{ if .Router.IsFabric }}#{{- end }}      mode: host #tproxy|host
+{{ if or .Router.IsFabric .Router.IsPrivate }}#{{ end }}  - binding: tunnel
+{{ if or .Router.IsFabric .Router.IsPrivate }}#{{ end }}    options:
+{{ if or .Router.IsFabric .Router.IsPrivate }}#{{ end }}      mode: host #tproxy|host
 
+{{ if or .Router.IsFabric .Router.IsPrivate }}
+csr:
+  country: US
+  province: NC
+  locality: Charlotte
+  organization: NetFoundry
+  organizationalUnit: Ziti
+  sans:
+    dns:
+      - {{ .Router.Edge.Hostname }}
+      - localhost
+    ip:
+      - "127.0.0.1"
+{{ else }}
 edge:
   csr:
     country: US
@@ -51,7 +65,7 @@ edge:
         - localhost
       ip:
         - "127.0.0.1"
-
+{{ end }}
 {{ if not .Router.IsWss }}#{{ end }}transport:
 {{ if not .Router.IsWss }}#{{ end }}  ws:
 {{ if not .Router.IsWss }}#{{ end }}    writeTimeout: {{ .Router.Wss.WriteTimeout }}


### PR DESCRIPTION
*  sometimes fail to start with what seems like a small enrolling race condition
* move the link.dialers section to the first part. they are always there
* put back the "CSR" section which was removed by mistake for private/fabric only routers