### PR TITLE
Making the init container a little more flexible

### DIFF
--- a/quickstart/docker/docker-compose.yml
+++ b/quickstart/docker/docker-compose.yml
@@ -37,6 +37,8 @@ services:
     volumes:
       - ziti-fs:/openziti
     entrypoint:
+      - "/openziti/scripts/run-with-ziti-cli.sh"
+    command:
       - "/openziti/scripts/access-control.sh"
 
   ziti-edge-router:

--- a/quickstart/docker/image/Dockerfile
+++ b/quickstart/docker/image/Dockerfile
@@ -25,7 +25,7 @@ COPY --chown=ziti ziti.ignore "${ZITI_BIN_DIR}"
 COPY --chown=ziti ziti-cli-functions.sh "${ZITI_SCRIPTS}/"
 COPY --chown=ziti run-controller.sh "${ZITI_SCRIPTS}/"
 COPY --chown=ziti run-router.sh "${ZITI_SCRIPTS}/"
+COPY --chown=ziti run-with-ziti-cli.sh "${ZITI_SCRIPTS}/"
 COPY --chown=ziti access-control.sh "${ZITI_SCRIPTS}/"
 
 RUN /bin/bash -c "source ${ZITI_SCRIPTS}/ziti-cli-functions.sh; ziti_createEnvFile; echo source ${ZITI_HOME}/ziti.env >> ~/.bashrc"
-

--- a/quickstart/docker/image/access-control.sh
+++ b/quickstart/docker/image/access-control.sh
@@ -1,52 +1,10 @@
 #!/bin/bash
 
-# Should we execute?
-initFile="/openziti/access-control.init"
-if [[ -f "${initFile}" ]]; then
-  echo " "
-  echo "*****************************************************"
-  echo " docker-compose init file has been detected"
-  echo " the initialization of the docker-compose environment has already happened"
-  echo " if you wish to allow this volume to be re-initialized, delete the file"
-  echo " located at ${initFile}"
-  echo "*****************************************************"
-  echo " "
-  exit 0
-fi
-
-# give the controller time to ramp up before running if running in docker-compose
-sleep 5
-
-. "${ZITI_SCRIPTS}/ziti-cli-functions.sh"
-
-if [[ "${ZITI_CONTROLLER_RAWNAME-}" == "" ]]; then export export ZITI_CONTROLLER_RAWNAME="ziti-controller"; fi
-if [[ "${ZITI_EDGE_CONTROLLER_RAWNAME-}" == "" ]]; then export export ZITI_EDGE_CONTROLLER_RAWNAME="ziti-edge-controller"; fi
-if [[ "${ZITI_EDGE_ROUTER_RAWNAME-}" == "" ]]; then export export ZITI_EDGE_ROUTER_RAWNAME="${ZITI_NETWORK-}-edge-router"; fi
-if [[ "${ZITI_EDGE_ROUTER_PORT-}" == "" ]]; then export ZITI_EDGE_ROUTER_PORT="3022"; fi
-if [[ "${ZITI_EDGE_ROUTER_HOSTNAME}" == "" ]]; then export ZITI_EDGE_ROUTER_HOSTNAME="${ZITI_EDGE_ROUTER_RAWNAME}${ZITI_DOMAIN_SUFFIX}"; fi
-if [[ "${ZITI_EDGE_ROUTER_ROLES}" == "" ]]; then export ZITI_EDGE_ROUTER_ROLES="${ZITI_EDGE_ROUTER_RAWNAME}"; fi
-
-. "${ZITI_HOME}"/ziti.env
-
-# Wait for the controller
-# shellcheck disable=SC2091
-until $(curl -s -o /dev/null --fail -k "https://${ZITI_EDGE_CTRL_ADVERTISED_HOST_PORT}"); do
-    echo "waiting for https://${ZITI_EDGE_CTRL_ADVERTISED_HOST_PORT}"
-    sleep 2
-done
-
-echo " "
 echo "*****************************************************"
 #### Add service policies
-
-zitiLogin
 
 # Allow all identities to use any edge router with the "public" attribute
 ziti edge create edge-router-policy all-endpoints-public-routers --edge-router-roles "#public" --identity-roles "#all"
 
 # Allow all edge-routers to access all services
 ziti edge create service-edge-router-policy all-routers-all-services --edge-router-roles "#all" --service-roles "#all"
-
-touch "${initFile}"
-
-echo "This docker volume has been initialized."

--- a/quickstart/docker/image/run-with-ziti-cli.sh
+++ b/quickstart/docker/image/run-with-ziti-cli.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+#
+# Base script for anything that requires the Ziti CLI
+#
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 scriptName"
+  exit 0
+fi
+
+if [[ ! -f $1 ]]; then
+  echo "Script $1 not found"
+  echo "Usage: $0 scriptName"
+  exit 1
+fi
+
+# Should we execute?
+initFile="/openziti/access-control.init"
+if [[ -f "${initFile}" ]]; then
+  echo " "
+  echo "*****************************************************"
+  echo " docker-compose init file has been detected"
+  echo " the initialization of the docker-compose environment has already happened"
+  echo " if you wish to allow this volume to be re-initialized, delete the file"
+  echo " located at ${initFile}"
+  echo "*****************************************************"
+  echo " "
+  exit 0
+fi
+
+# give the controller time to ramp up before running if running in docker-compose
+sleep 5
+
+. "${ZITI_SCRIPTS}/ziti-cli-functions.sh"
+
+if [[ "${ZITI_CONTROLLER_RAWNAME-}" == "" ]]; then export export ZITI_CONTROLLER_RAWNAME="ziti-controller"; fi
+if [[ "${ZITI_EDGE_CONTROLLER_RAWNAME-}" == "" ]]; then export export ZITI_EDGE_CONTROLLER_RAWNAME="ziti-edge-controller"; fi
+if [[ "${ZITI_EDGE_ROUTER_RAWNAME-}" == "" ]]; then export export ZITI_EDGE_ROUTER_RAWNAME="${ZITI_NETWORK-}-edge-router"; fi
+if [[ "${ZITI_EDGE_ROUTER_PORT-}" == "" ]]; then export ZITI_EDGE_ROUTER_PORT="3022"; fi
+if [[ "${ZITI_EDGE_ROUTER_HOSTNAME}" == "" ]]; then export ZITI_EDGE_ROUTER_HOSTNAME="${ZITI_EDGE_ROUTER_RAWNAME}${ZITI_DOMAIN_SUFFIX}"; fi
+if [[ "${ZITI_EDGE_ROUTER_ROLES}" == "" ]]; then export ZITI_EDGE_ROUTER_ROLES="${ZITI_EDGE_ROUTER_RAWNAME}"; fi
+
+. "${ZITI_HOME}"/ziti.env
+
+# Wait for the controller
+# shellcheck disable=SC2091
+until $(curl -s -o /dev/null --fail -k "https://${ZITI_EDGE_CTRL_ADVERTISED_HOST_PORT}"); do
+    echo "waiting for https://${ZITI_EDGE_CTRL_ADVERTISED_HOST_PORT}"
+    sleep 2
+done
+
+echo " "
+echo "*****************************************************"
+
+zitiLogin
+
+echo "*****************************************************"
+
+$1
+
+touch "${initFile}"
+
+echo "This docker volume has been initialized."

--- a/quickstart/docker/image/run-with-ziti-cli.sh
+++ b/quickstart/docker/image/run-with-ziti-cli.sh
@@ -11,7 +11,7 @@ fi
 if [[ ! -f $1 ]]; then
   echo "Script $1 not found"
   echo "Usage: $0 scriptName"
-  exit 1
+  exit 0
 fi
 
 # Should we execute?

--- a/quickstart/docker/image/run-with-ziti-cli.sh
+++ b/quickstart/docker/image/run-with-ziti-cli.sh
@@ -28,8 +28,8 @@ if [[ -f "${initFile}" ]]; then
   exit 0
 fi
 
-# give the controller time to ramp up before running if running in docker-compose
-sleep 5
+# give the controller scripts time to start and create the ziti environment file if running in docker compose 
+until $(test -f "${ZITI_HOME}/ziti.env"); do echo "waiting for ziti.env..."; sleep 1; done
 
 . "${ZITI_SCRIPTS}/ziti-cli-functions.sh"
 

--- a/quickstart/docker/simplified-docker-compose.yml
+++ b/quickstart/docker/simplified-docker-compose.yml
@@ -37,6 +37,8 @@ services:
     volumes:
       - ziti-fs:/openziti
     entrypoint:
+      - "/openziti/scripts/run-with-ziti-cli.sh"
+    command:
       - "/openziti/scripts/access-control.sh"
       
   ziti-edge-router:


### PR DESCRIPTION
I wanted to use the ziti quickstart container to set up a sample that uses docker-compose.  If the init script was only a little more flexible then I could use it to configure my example network without forcing the user to install the Ziti CLI locally.   With this PR,  I can add a second init container to run my setup. Something like this:

```
  example-network-init-container:
    image: "${ZITI_IMAGE}:${ZITI_VERSION}"
    depends_on:
      - ziti-controller
    environment:
      - ZITI_CONTROLLER_RAWNAME="${ZITI_CONTROLLER_RAWNAME}"
      - ZITI_EDGE_CONTROLLER_RAWNAME="${ZITI_EDGE_CONTROLLER_RAWNAME}"
    env_file:
      - ./.env
    networks:
      zitiblue:
        aliases:
          - ziti-edge-controller-init-container
      zitired:
        aliases:
          - ziti-edge-controller-init-container
    volumes:
      - ziti-fs:/openziti
      - .:/openziti/network-setup
    entrypoint:
      - "/openziti/scripts/run-with-ziti-cli.sh"
    command:
      - "/openziti/network-setup/network-setup.sh"
```

Where my network-setup.sh looks like this:
```
echo Creating identities
ziti edge create identity device private-service -o /openziti/network-setup/private-service.jwt -a "services"
ziti edge create identity device client -o /openziti/network-setup/client.jwt -a "clients"
ziti edge create identity device database -o /openziti/network-setup/database.jwt -a "databases"

echo Enrolling identities
ziti edge enroll -j /openziti/network-setup/private-service.jwt
ziti edge enroll -j /openziti/network-setup/client.jwt
ziti edge enroll -j /openziti/network-setup/database.jwt

echo Creating demo-service
ziti edge create config demo-service-config ziti-tunneler-client.v1 '{"hostname": "example.web","port": 8080}'
ziti edge create service demo-service --configs demo-service-config -a "demo-service"
...
```
