### PR TITLE
fix: shellcheck

### DIFF
--- a/quickstart/docker/image/ziti-cli-functions.sh
+++ b/quickstart/docker/image/ziti-cli-functions.sh
@@ -979,7 +979,8 @@ function ziti_createEnvFile {
 
   export ZITI_HOME="${ZITI_HOME}"
   if [[ "${ZITI_OSTYPE}" == "windows" ]]; then
-    export ZITI_HOME_OS_SPECIFIC="$(cygpath -m "${ZITI_HOME}")"
+    ZITI_HOME_OS_SPECIFIC="$(cygpath -m "${ZITI_HOME}")"
+    export ZITI_HOME_OS_SPECIFIC
   else
     export ZITI_HOME_OS_SPECIFIC="${ZITI_HOME}"
   fi
@@ -1016,7 +1017,8 @@ function ziti_createEnvFile {
 
   export ZITI_PKI="${ZITI_SHARED}/pki"
   if [[ "${ZITI_OSTYPE}" == "windows" ]]; then
-    export ZITI_PKI_OS_SPECIFIC="$(cygpath -m "${ZITI_PKI}")"
+    ZITI_PKI_OS_SPECIFIC="$(cygpath -m "${ZITI_PKI}")"
+    export ZITI_PKI_OS_SPECIFIC
   else
     export ZITI_PKI_OS_SPECIFIC="${ZITI_PKI}"
   fi
@@ -1382,7 +1384,7 @@ function createZacSystemdFile {
 
   if which node >/dev/null; then
     # store the absolute path to the node executable because it's required by systemd on Amazon Linux, at least
-    NODE_BIN=$(readlink -f $(which node))
+    NODE_BIN=$(readlink -f "$(which node)")
   else
     echo "ERROR: missing executable 'node'" >&2
     return 1
@@ -1439,6 +1441,7 @@ function checkEnvVariable() {
   do
     # Parameter expansion is different between shells
     if [[ -n "$ZSH_VERSION" ]]; then
+      # shellcheck disable=SC2296
       if [[ -z "${(P)arg}" ]]; then
         echo -e "  * ERROR: $(RED "${arg} is not set") "
         return 1


### PR DESCRIPTION
Fixup for the following shellcheck complaints.  Note the final is shown as an error -- I don't use zsh, but assume the form is correct so added an exclusion here:
```
In quickstart/docker/image/ziti-cli-functions.sh line 982:
    export ZITI_HOME_OS_SPECIFIC="$(cygpath -m "${ZITI_HOME}")"
           ^-------------------^ SC2155 (warning): Declare and assign separately to avoid masking return values.

In quickstart/docker/image/ziti-cli-functions.sh line 1019:
    export ZITI_PKI_OS_SPECIFIC="$(cygpath -m "${ZITI_PKI}")"
           ^------------------^ SC2155 (warning): Declare and assign separately to avoid masking return values.

In quickstart/docker/image/ziti-cli-functions.sh line 1385:
    NODE_BIN=$(readlink -f $(which node))
                           ^-----------^ SC2046 (warning): Quote this to prevent word splitting.

In quickstart/docker/image/ziti-cli-functions.sh line 1442:
      if [[ -z "${(P)arg}" ]]; then
                  ^----^ SC2296 (error): Parameter expansions can't start with (. Double check syntax.
```
Some of the other shell files report similar warns/errors in the repo, but this one is affecting me directly and I'm [patching](https://github.com/johnalotoski/openziti-bins/blob/3da1705e88071c37cae30a142bdefa3f31893cff/flake.nix#L134-L136) for it.