### PR TITLE
enable the newly exposed verbose option from enrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
     * The init and uninstall commands have been removed
     * The install, upgrade, use and version commands have been hidden and will be hidden once tests using them are updated or replaced
 * The demo and tutorial commands have been moved under the new learn subcommand
+* `ziti edge enroll` now has a verbose option for additional debugging
 
 # Release 0.26.11
 

--- a/common/enrollment/enroll.go
+++ b/common/enrollment/enroll.go
@@ -111,6 +111,7 @@ func NewEnrollCommand(p common.OptionsProvider) *cobra.Command {
 	enrollSubCmd.Flags().StringVarP(&action.Username, "username", "u", "", "Username for updb enrollment, prompted if not provided and necessary")
 	enrollSubCmd.Flags().StringVarP(&action.Password, "password", "p", "", "Password for updb enrollment, prompted if not provided and necessary")
 	enrollSubCmd.Flags().BoolVar(&action.RemoveJwt, "rm", false, "Remove the JWT on success")
+	enrollSubCmd.Flags().BoolVarP(&action.Verbose, "verbose", "v", false, "Enable verbose logging")
 
 	action.KeyAlg.Set("RSA") // set default
 	enrollSubCmd.Flags().VarP(&action.KeyAlg, "keyAlg", "a", "Crypto algorithm to use when generating private key")
@@ -170,6 +171,7 @@ func (e *EnrollAction) Run() error {
 		AdditionalCAs: e.CaOverride,
 		Username:      e.Username,
 		Password:      e.Password,
+		Verbose:       e.Verbose,
 	}
 
 	if tkn.EnrollmentMethod == "updb" {


### PR DESCRIPTION
add the ability to use --verbose when enrolling for additional logging