### PR TITLE
Setting ZITI_BIN_ROOT explicitly for docker environments

### DIFF
--- a/quickstart/docker/image/Dockerfile
+++ b/quickstart/docker/image/Dockerfile
@@ -16,6 +16,7 @@ ENV ENV_FILE="${ZITI_HOME}/ziti.env"
 ENV ZITI_NETWORK=ziti
 # Don't put these paths on shared volume in docker-compose deployment (https://github.com/openziti/ziti/issues/912)
 ENV ZITI_BIN_DIR=/var/openziti/ziti-bin
+ENV ZITI_BIN_ROOT="${ZITI_BIN_DIR}"
 ENV ZITI_SCRIPTS=/var/openziti/scripts
 
 # copy the ziti binaries to a directory already on the path

--- a/quickstart/docker/image/ziti-cli-functions.sh
+++ b/quickstart/docker/image/ziti-cli-functions.sh
@@ -1116,8 +1116,6 @@ function ziti_createEnvFile {
   export ZITI_SIGNING_ROOTCA_NAME="${ZITI_SIGNING_CERT_NAME}-root-ca"
   export ZITI_SIGNING_INTERMEDIATE_NAME="${ZITI_SIGNING_CERT_NAME}-intermediate"
 
-  export ZITI_BIN_ROOT="${ZITI_HOME}/ziti-bin"
-
   if [[ "${ZITI_CTRL_MGMT_PORT-}" == "" ]]; then export ZITI_CTRL_MGMT_PORT="10000"; fi
   if [[ "${ZITI_CTRL_MGMT_HOST_PORT-}" == "" ]]; then export ZITI_CTRL_MGMT_HOST_PORT="${ZITI_CONTROLLER_HOSTNAME}:${ZITI_CTRL_MGMT_PORT}"; fi
   if [[ "${ZITI_CTRL_IDENTITY_CERT-}" == "" ]]; then export ZITI_CTRL_IDENTITY_CERT="${ZITI_PKI_OS_SPECIFIC}/${ZITI_CONTROLLER_INTERMEDIATE_NAME}/certs/${ZITI_CONTROLLER_HOSTNAME}-client.cert"; fi


### PR DESCRIPTION
Removing overwrite of ZITI_BIN_ROOT
closes #917

Signed-off-by: gberl002 <geoff.berl@netfoundry.io>