### PR TITLE
don't resolve ca cert path if empty string

### DIFF
--- a/ziti/cmd/edge/login.go
+++ b/ziti/cmd/edge/login.go
@@ -123,8 +123,10 @@ func (o *loginOptions) Run() error {
 		return err
 	}
 
-	if certAbs, err := filepath.Abs(o.CaCert); err == nil {
-		o.CaCert = certAbs
+	if o.CaCert != "" {
+		if certAbs, err := filepath.Abs(o.CaCert); err == nil {
+			o.CaCert = certAbs
+		}
 	}
 
 	if ctrlUrl.Path == "" {


### PR DESCRIPTION
The following errors emit but don't cause login to fail when two conditions are true:
1. server host is supplied as positional `ziti edge login <host>`
2. server has alt certs that are verifiable by OS 

```bash
# where current working dir is /home/kbingham/Sites/netfoundry/github/ziti
 ❯ ./build/ziti edge login door.bingnet.cloud:8440 -u admin -p "$ZITI_PWD"                                                                                    
RESTY 2022/12/22 12:11:39 ERROR read /home/kbingham/Sites/netfoundry/github/ziti: is a directory
RESTY 2022/12/22 12:11:39 ERROR read /home/kbingham/Sites/netfoundry/github/ziti: is a directory
Token: cb7163bd-09e3-400d-bf45-54cde8c07e5e                      
Saving identity 'default' to /home/kbingham/.config/ziti/ziti-cli.json
```