### PR TITLE
Use docker buildx to build/push Quickstart image

### DIFF
--- a/quickstart/docker/image/Dockerfile
+++ b/quickstart/docker/image/Dockerfile
@@ -1,3 +1,15 @@
+FROM ubuntu:rolling as fetch-ziti-bins
+
+# optional arg to specify which version to fetch when local "ziti-bin" directory is not present
+ARG ZITI_VERSION_OVERRIDE
+
+COPY . /docker.build.context
+RUN apt update && apt install jq curl -y && \
+    # get local ziti build in "ziti-bin", if present.
+    # otherwise fetch from releases (respecting ZITI_VERSION_OVERRIDE, if set).
+    # put the result in /ziti-bin
+    /bin/bash /docker.build.context/fetch-ziti-bins.sh /ziti-bin
+
 FROM ubuntu:rolling
 
 RUN apt update && \
@@ -20,7 +32,7 @@ ENV ZITI_BIN_ROOT="${ZITI_BIN_DIR}"
 ENV ZITI_SCRIPTS=/var/openziti/scripts
 
 # copy the ziti binaries to a directory already on the path
-COPY --chown=ziti ziti.ignore "${ZITI_BIN_DIR}"
+COPY --chown=ziti --from=fetch-ziti-bins /ziti-bin "${ZITI_BIN_DIR}"
 COPY --chown=ziti ziti-cli-functions.sh "${ZITI_SCRIPTS}/"
 COPY --chown=ziti run-controller.sh "${ZITI_SCRIPTS}/"
 COPY --chown=ziti run-router.sh "${ZITI_SCRIPTS}/"

--- a/quickstart/docker/image/fetch-ziti-bins.sh
+++ b/quickstart/docker/image/fetch-ziti-bins.sh
@@ -7,8 +7,7 @@ dest="${1}"
 if [ -d /docker.build.context/ziti-bin -a ]; then
   mv /docker.build.context/ziti-bin/ "${dest}"
 else
-   ZITI_BIN_ROOT="${dest}"
-   ZITI_BIN_DIR="${ZITI_BIN_ROOT}"
    source /docker.build.context/ziti-cli-functions.sh
    getZiti
+   mv "${ZITI_BIN_DIR}" "${dest}"
 fi

--- a/quickstart/docker/image/fetch-ziti-bins.sh
+++ b/quickstart/docker/image/fetch-ziti-bins.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# this script is executed during the docker build, after the build context has been copied to /docker.build.context
+
+dest="${1}"
+
+if [ -d /docker.build.context/ziti-bin -a ]; then
+  mv /docker.build.context/ziti-bin/ "${dest}"
+else
+   ZITI_BIN_ROOT="${dest}"
+   ZITI_BIN_DIR="${ZITI_BIN_ROOT}"
+   source /docker.build.context/ziti-cli-functions.sh
+   getZiti
+fi

--- a/quickstart/docker/pushLatestDocker.sh
+++ b/quickstart/docker/pushLatestDocker.sh
@@ -14,6 +14,7 @@ if [ -z "${ZITI_VERSION}" ]; then
   exit 1
 fi
 
+docker buildx create --use --name=ziti-builder
 docker buildx build --platform linux/amd64,linux/arm64 "${SCRIPT_DIR}/image" \
   --build-arg ZITI_VERSION="${ZITI_VERSION}" \
   --tag "openziti/quickstart:${ZITI_VERSION}" \

--- a/quickstart/docker/pushLatestDocker.sh
+++ b/quickstart/docker/pushLatestDocker.sh
@@ -16,7 +16,7 @@ fi
 
 docker buildx create --use --name=ziti-builder
 docker buildx build --platform linux/amd64,linux/arm64 "${SCRIPT_DIR}/image" \
-  --build-arg ZITI_VERSION="${ZITI_VERSION}" \
+  --build-arg ZITI_VERSION_OVERRIDE="${ZITI_VERSION}" \
   --tag "openziti/quickstart:${ZITI_VERSION}" \
   --tag "openziti/quickstart:latest" \
   --push

--- a/quickstart/docker/pushLatestDocker.sh
+++ b/quickstart/docker/pushLatestDocker.sh
@@ -3,32 +3,19 @@ set -eo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
-ZITI_QUICKSTART_ROOT="$(realpath ${SCRIPT_DIR}/..)"
-ZITI_BIN_ROOT="${ZITI_QUICKSTART_ROOT}/docker"
+if [ -z "${ZITI_VERSION}" ]; then
+  ZITI_QUICKSTART_ROOT="$(realpath ${SCRIPT_DIR}/..)"
+  v=$(source "${ZITI_QUICKSTART_ROOT}/ziti-cli-functions.sh"; getLatestZitiVersion > /dev/null 2>&1; echo ${ZITI_BINARIES_VERSION})
+  ZITI_VERSION=$(echo "${v}" | sed -e 's/^v//')
+fi
 
-for arch in amd64 arm64; do
-  (export ZITI_OSTYPE=linux; export ZITI_ARCH="${arch}"
-   source "${ZITI_QUICKSTART_ROOT}/ziti-cli-functions.sh"
-   if [ -d "${SCRIPT_DIR}/image/ziti.ignore" ]; then
-     rm -rf "${SCRIPT_DIR}/image/ziti.ignore"
-   fi
+if [ -z "${ZITI_VERSION}" ]; then
+  echo "ZITI_VERSION was not set and auto-detection failed."
+  exit 1
+fi
 
-   getZiti
-
-   mv "${ZITI_BIN_DIR}" "${SCRIPT_DIR}/image/ziti.ignore/"
-   docker build --platform linux/${arch} "${SCRIPT_DIR}/image" -t openziti/quickstart
-
-   if [ -d "${SCRIPT_DIR}/image/ziti.ignore" ]; then
-     rm -rf "${SCRIPT_DIR}/image/ziti.ignore"
-   fi
-
-   vers="$(echo "${ZITI_BINARIES_VERSION}" | cut -c 2-100)"
-   echo DOCKERTAG: docker tag openziti/quickstart "openziti/quickstart:${vers}"
-   docker tag openziti/quickstart "openziti/quickstart:${vers}"
-   echo DOCKERTAG: docker tag openziti/quickstart "openziti/quickstart:latest"
-   docker tag openziti/quickstart "openziti/quickstart:latest"
-   echo DOCKERPUSH: docker push "openziti/quickstart:${vers}"
-   docker push "openziti/quickstart:${vers}"
-   echo DOCKERPUSH: docker push "openziti/quickstart:latest"
-   docker push "openziti/quickstart:latest")
-done
+docker buildx build --platform linux/amd64,linux/arm64 "${SCRIPT_DIR}/image" \
+  --build-arg ZITI_VERSION="${ZITI_VERSION}" \
+  --tag "openziti/quickstart:${ZITI_VERSION}" \
+  --tag "openziti/quickstart:latest" \
+  --push


### PR DESCRIPTION
The only way I've found to successfully push Multiplatform images is with `docker buildx build --push`. The major downside of using buildx is that it's cumbersome for local development.

To the best of my knowledge in order to use an image that was built with buildx locally, you must push and then pull the image. I think this is a worthwhile tradeoff for mutliplatform representation on the Quickstart image.