### PR TITLE
Adding ability to run external router

### DIFF
--- a/quickstart/docker/image/Dockerfile
+++ b/quickstart/docker/image/Dockerfile
@@ -38,5 +38,6 @@ COPY --chown=ziti run-controller.sh "${ZITI_SCRIPTS}/"
 COPY --chown=ziti run-router.sh "${ZITI_SCRIPTS}/"
 COPY --chown=ziti run-with-ziti-cli.sh "${ZITI_SCRIPTS}/"
 COPY --chown=ziti access-control.sh "${ZITI_SCRIPTS}/"
+COPY --chown=ziti run-router-external.sh "${ZITI_SCRIPTS}/"
 
 RUN /bin/bash -c "source ${ZITI_SCRIPTS}/ziti-cli-functions.sh; ziti_createEnvFile; echo source ${ZITI_HOME}/ziti.env >> ~/.bashrc"

--- a/quickstart/docker/image/run-router-external.sh
+++ b/quickstart/docker/image/run-router-external.sh
@@ -7,24 +7,30 @@ sleep 5
 . "${ZITI_SCRIPTS}/ziti-cli-functions.sh"
 
 # If we have not defined these, then no point going further - so dont
-if [[ "${ZITI_EDGE_ROUTER_RAWNAME_OVERRIDE}" == "" ]]; then echo "ERROR: Missing ZITI_EDGE_ROUTER_RAWNAME_OVERRIDE definition" >&2; exit; fi
+if [[ "${ZITI_EDGE_ROUTER_HOSTNAME}" == "" ]]; then echo "ERROR: Missing ZITI_EDGE_ROUTER_HOSTNAME definition" >&2; exit; fi
 export ZITI_EDGE_ROUTER_RAWNAME=${ZITI_EDGE_ROUTER_RAWNAME_OVERRIDE}
 
-echo "ZITI_EDGE_ROUTER_RAWNAME = ${ZITI_EDGE_ROUTER_RAWNAME}"
+echo "ZITI_EDGE_ROUTER_HOSTNAME = ${ZITI_EDGE_ROUTER_HOSTNAME}"
 
 
 # If we dont have a key file, then we assume we haven't enrolled, so lets do that
-if [ ! -f ${ZITI_EDGE_ROUTER_RAWNAME}.key ]; then
+if [ ! -f ${ZITI_EDGE_ROUTER_HOSTNAME}.jwt ]; then
 
   # May have been a bad attempt before, so lets clean up
-  rm -f ${ZITI_HOME}/${ZITI_EDGE_ROUTER_RAWNAME}*
-  
+  rm -f ${ZITI_HOME}/${ZITI_EDGE_ROUTER_HOSTNAME}*
+
+
   # If we have override variables then override the base variable
   # This is required as the .bashrc loads the env file which clobbers passed in varibles
+  if [[ "${ZITI_EDGE_ROUTER_RAWNAME_OVERRIDE}" == "" ]]; then echo "ERROR: Missing ZITI_EDGE_ROUTER_RAWNAME_OVERRIDE definition" >&2; exit; fi
+    # May have been a bad attempt before, so lets clean up
+  rm -f ${ZITI_HOME}/${ZITI_EDGE_ROUTER_RAWNAME}*
+
   if [[ ${ZITI_CTRL_ADVERTISED_ADDRESS_OVERRIDE} != "" ]]; then export ZITI_CTRL_ADVERTISED_ADDRESS=${ZITI_CTRL_ADVERTISED_ADDRESS_OVERRIDE}; fi
   if [[ ${ZITI_USER_OVERRIDE} != "" ]]; then export ZITI_USER=${ZITI_USER_OVERRIDE}; fi
   if [[ ${ZITI_PWD_OVERRIDE} != "" ]]; then export ZITI_PWD=${ZITI_PWD_OVERRIDE}; fi
   if [[ ${ZITI_EDGE_CONTROLLER_PORT_OVERRIDE} != "" ]]; then export ZITI_EDGE_CONTROLLER_PORT=${ZITI_EDGE_CONTROLLER_PORT_OVERRIDE}; fi
+  if [[ ${ZITI_EDGE_ROUTER_HOSTNAME} == "" ]]; then export ZITI_EDGE_ROUTER_HOSTNAME=${ZITI_EDGE_ROUTER_RAWNAME}; fi
 
   # First off - lets make sure we have what we need
   if [[ ${ZITI_USER} == "" ]] || [[ ${ZITI_PWD} == "" ]]; then echo "ERROR:  Need ZITI_USER and ZITI_PWD defined" >&2; exit; fi
@@ -33,7 +39,7 @@ if [ ! -f ${ZITI_EDGE_ROUTER_RAWNAME}.key ]; then
   if [[ "${ZITI_EDGE_ROUTER_PORT-}" == "" ]]; then export ZITI_EDGE_ROUTER_PORT="3022"; fi
   if [[ "${ZITI_EDGE_ROUTER_ROLES}" == "" ]]; then export ZITI_EDGE_ROUTER_ROLES="${ZITI_EDGE_ROUTER_HOSTNAME}"; fi
 
-
+  echo "ZITI_EDGE_ROUTER_RAWNAME = ${ZITI_EDGE_ROUTER_RAWNAME}"
   echo "ZITI_EDGE_ROUTER_ROLES = ${ZITI_EDGE_ROUTER_ROLES}"
   echo "ZITI_EDGE_ROUTER_PORT = ${ZITI_EDGE_ROUTER_PORT}"
   echo "ZITI_CTRL_ADVERTISED_ADDRESS = ${ZITI_CTRL_ADVERTISED_ADDRESS}"
@@ -61,20 +67,21 @@ if [ ! -f ${ZITI_EDGE_ROUTER_RAWNAME}.key ]; then
     createPrivateRouterConfig "${ZITI_EDGE_ROUTER_RAWNAME}"
   fi
 
+  mv ${ZITI_HOME}/${ZITI_EDGE_ROUTER_RAWNAME}.yaml ${ZITI_HOME}/${ZITI_EDGE_ROUTER_HOSTNAME}.yaml
 
   echo "----------  Creating edge-router ${ZITI_EDGE_ROUTER_RAWNAME}...."
-  found=$(${ZITI_BIN_DIR}/ziti edge list edge-routers 'name = "'"${ZITI_EDGE_ROUTER_RAWNAME}"'"' | grep -c "${ZITI_EDGE_ROUTER_RAWNAME}")
+  found=$(${ZITI_BIN_DIR}/ziti edge list edge-routers 'name = "'"${ZITI_EDGE_ROUTER_HOSTNAME}"'"' | grep -c "${ZITI_EDGE_ROUTER_HOSTNAME}")
   if [[ found -gt 0 ]]; then
-    echo "----------  Found existing edge-router ${ZITI_EDGE_ROUTER_RAWNAME}...."
+    echo "----------  Found existing edge-router ${ZITI_EDGE_ROUTER_HOSTNAME}...."
   else
-    "${ZITI_BIN_DIR}/ziti" edge create edge-router "${ZITI_EDGE_ROUTER_RAWNAME}" -o "${ZITI_HOME}/${ZITI_EDGE_ROUTER_RAWNAME}.jwt" -t -a "${ZITI_EDGE_ROUTER_ROLES}"
+    "${ZITI_BIN_DIR}/ziti" edge create edge-router "${ZITI_EDGE_ROUTER_HOSTNAME}" -o "${ZITI_HOME}/${ZITI_EDGE_ROUTER_HOSTNAME}.jwt" -t -a "${ZITI_EDGE_ROUTER_ROLES}"
     sleep 1
-    echo "---------- Enrolling edge-router ${ZITI_EDGE_ROUTER_RAWNAME}...."
-  "${ZITI_BIN_DIR}/ziti-router" enroll "${ZITI_HOME}/${ZITI_EDGE_ROUTER_RAWNAME}.yaml" --jwt "${ZITI_HOME}/${ZITI_EDGE_ROUTER_RAWNAME}.jwt"
+    echo "---------- Enrolling edge-router ${ZITI_EDGE_ROUTER_HOSTNAME}...."
+  "${ZITI_BIN_DIR}/ziti-router" enroll "${ZITI_HOME}/${ZITI_EDGE_ROUTER_HOSTNAME}.yaml" --jwt "${ZITI_HOME}/${ZITI_EDGE_ROUTER_HOSTNAME}.jwt"
     echo ""
   fi
 fi
 
 # Run the router
-"${ZITI_BIN_DIR}/ziti-router" run "${ZITI_HOME}/${ZITI_EDGE_ROUTER_RAWNAME}.yaml" > "${ZITI_HOME}/ziti-${ZITI_EDGE_ROUTER_RAWNAME}.log"
+"${ZITI_BIN_DIR}/ziti-router" run "${ZITI_HOME}/${ZITI_EDGE_ROUTER_HOSTNAME}.yaml" > "${ZITI_HOME}/ziti-${ZITI_EDGE_ROUTER_HOSTNAME}.log"
 

--- a/quickstart/docker/image/run-router-external.sh
+++ b/quickstart/docker/image/run-router-external.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# give the controller time to ramp up before running if running in docker-compose
+echo "Waiting for 5 seconds...."
+sleep 5
+
+. "${ZITI_SCRIPTS}/ziti-cli-functions.sh"
+
+# If we have not defined these, then no point going further - so dont
+if [[ "${ZITI_EDGE_ROUTER_RAWNAME_OVERRIDE}" == "" ]]; then echo "ERROR: Missing ZITI_EDGE_ROUTER_RAWNAME_OVERRIDE definition" >&2; exit; fi
+export ZITI_EDGE_ROUTER_RAWNAME=${ZITI_EDGE_ROUTER_RAWNAME_OVERRIDE}
+
+echo "ZITI_EDGE_ROUTER_RAWNAME = ${ZITI_EDGE_ROUTER_RAWNAME}"
+
+
+# If we dont have a key file, then we assume we haven't enrolled, so lets do that
+if [ ! -f ${ZITI_EDGE_ROUTER_RAWNAME}.key ]; then
+
+  # May have been a bad attempt before, so lets clean up
+  rm -f ${ZITI_HOME}/${ZITI_EDGE_ROUTER_RAWNAME}*
+  
+  # If we have override variables then override the base variable
+  # This is required as the .bashrc loads the env file which clobbers passed in varibles
+  if [[ ${ZITI_CTRL_ADVERTISED_ADDRESS_OVERRIDE} != "" ]]; then export ZITI_CTRL_ADVERTISED_ADDRESS=${ZITI_CTRL_ADVERTISED_ADDRESS_OVERRIDE}; fi
+  if [[ ${ZITI_USER_OVERRIDE} != "" ]]; then export ZITI_USER=${ZITI_USER_OVERRIDE}; fi
+  if [[ ${ZITI_PWD_OVERRIDE} != "" ]]; then export ZITI_PWD=${ZITI_PWD_OVERRIDE}; fi
+  if [[ ${ZITI_EDGE_CONTROLLER_PORT_OVERRIDE} != "" ]]; then export ZITI_EDGE_CONTROLLER_PORT=${ZITI_EDGE_CONTROLLER_PORT_OVERRIDE}; fi
+
+  # First off - lets make sure we have what we need
+  if [[ ${ZITI_USER} == "" ]] || [[ ${ZITI_PWD} == "" ]]; then echo "ERROR:  Need ZITI_USER and ZITI_PWD defined" >&2; exit; fi
+  if [[ "$1" == "" ]]; then echo "ERROR:  Have not defined router type.  It should be one of edge,wss,fabric or private." >&2; exit; fi
+  if [[ "${ZITI_CTRL_ADVERTISED_ADDRESS}" == "" ]]; then echo "ERROR: Missing ZITI_CTRL_ADVERTISED_ADDRESS_OVERRIDE definition" >&2; exit; fi
+  if [[ "${ZITI_EDGE_ROUTER_PORT-}" == "" ]]; then export ZITI_EDGE_ROUTER_PORT="3022"; fi
+  if [[ "${ZITI_EDGE_ROUTER_ROLES}" == "" ]]; then export ZITI_EDGE_ROUTER_ROLES="${ZITI_EDGE_ROUTER_HOSTNAME}"; fi
+
+
+  echo "ZITI_EDGE_ROUTER_ROLES = ${ZITI_EDGE_ROUTER_ROLES}"
+  echo "ZITI_EDGE_ROUTER_PORT = ${ZITI_EDGE_ROUTER_PORT}"
+  echo "ZITI_CTRL_ADVERTISED_ADDRESS = ${ZITI_CTRL_ADVERTISED_ADDRESS}"
+  echo "ZITI_CTRL_PORT = ${ZITI_CTRL_PORT}"
+  echo "ZITI_USER = ${ZITI_USER}"
+  if [[ ! "${ZITI_PWD}" == "" ]]; then echo "ZITI_PWD = (obscured)"; fi
+
+  # Login to the cloud controller
+  "${ZITI_BIN_DIR}/ziti" edge login -y ${ZITI_CTRL_ADVERTISED_ADDRESS}:${ZITI_EDGE_CONTROLLER_PORT} -u ${ZITI_USER} -p ${ZITI_PWD}
+
+  if [[ "$1" == "edge" ]]; then
+    echo "CREATING EDGE ROUTER CONFIG"
+    createEdgeRouterConfig "${ZITI_EDGE_ROUTER_RAWNAME}"
+  fi
+  if [[ "$1" == "wss" ]]; then
+    echo "CREATING EDGE ROUTER WSS CONFIG"
+    createEdgeRouterWssConfig "${ZITI_EDGE_ROUTER_RAWNAME}"
+  fi
+  if [[ "$1" == "fabric" ]]; then
+    echo "CREATING FABRIC ROUTER CONFIG"
+    createFabricRouterConfig "${ZITI_EDGE_ROUTER_RAWNAME}"
+  fi
+  if [[ "$1" == "private" ]]; then
+    echo "CREATING PRIVATE ROUTER CONFIG"
+    createPrivateRouterConfig "${ZITI_EDGE_ROUTER_RAWNAME}"
+  fi
+
+
+  echo "----------  Creating edge-router ${ZITI_EDGE_ROUTER_RAWNAME}...."
+  found=$(${ZITI_BIN_DIR}/ziti edge list edge-routers 'name = "'"${ZITI_EDGE_ROUTER_RAWNAME}"'"' | grep -c "${ZITI_EDGE_ROUTER_RAWNAME}")
+  if [[ found -gt 0 ]]; then
+    echo "----------  Found existing edge-router ${ZITI_EDGE_ROUTER_RAWNAME}...."
+  else
+    "${ZITI_BIN_DIR}/ziti" edge create edge-router "${ZITI_EDGE_ROUTER_RAWNAME}" -o "${ZITI_HOME}/${ZITI_EDGE_ROUTER_RAWNAME}.jwt" -t -a "${ZITI_EDGE_ROUTER_ROLES}"
+    sleep 1
+    echo "---------- Enrolling edge-router ${ZITI_EDGE_ROUTER_RAWNAME}...."
+  "${ZITI_BIN_DIR}/ziti-router" enroll "${ZITI_HOME}/${ZITI_EDGE_ROUTER_RAWNAME}.yaml" --jwt "${ZITI_HOME}/${ZITI_EDGE_ROUTER_RAWNAME}.jwt"
+    echo ""
+  fi
+fi
+
+# Run the router
+"${ZITI_BIN_DIR}/ziti-router" run "${ZITI_HOME}/${ZITI_EDGE_ROUTER_RAWNAME}.yaml" > "${ZITI_HOME}/ziti-${ZITI_EDGE_ROUTER_RAWNAME}.log"
+


### PR DESCRIPTION
This PR adds the ability to stand up a router outside of the docker quickstart environment.  
The script does not use the `ziti.env` configuration file and requires on first run that all required variables are passed through on first run.

**To use**
create a docker-compose file including the following configuration:

```
  ziti-edge-router:
    environment:
      - ZITI_EDGE_ROUTER_RAWNAME_OVERRIDE=*URL or IP clients connect to router*
      - ZITI_EDGE_ROUTER_ROLES=*roles to assign*
      - ZITI_EDGE_ROUTER_PORT=*normally 3022*
      - ZITI_EDGE_ROUTER_LISTENER_BIND_PORT=*router fabric port*
      - ZITI_CTRL_PORT=*controller management port*
      - ZITI_EDGE_CONTROLLER_PORT_OVERRIDE=*normally 1280*
      - ZITI_CTRL_ADVERTISED_ADDRESS_OVERRIDE=*controller_FQDN_Name or IP*
      - ZITI_USER_OVERRIDE=*admin username*
      - ZITI_PWD_OVERRIDE=*admin password*
    command: "/var/openziti/scripts/run-router-external.sh edge"
```

when you start the container, a new router configuration is created and then started.  As per other scripts, the type of router created is specified in the *command* option (in this case edge).

Once the router is up and going, then all environment variables except the *ZITI_EDGE_ROUTER_RAWNAME_OVERRIDE* can be removed, as the other variables are only required for the generation of the configuration.

