### PR TITLE
quickstart/test: fix dropped error

### DIFF
--- a/quickstart/test/quickstart_test.go
+++ b/quickstart/test/quickstart_test.go
@@ -128,7 +128,10 @@ func buildDockerQuickstartTestImage() {
 		All:     false,
 		Filters: danglers,
 	})
-
+	if err != nil {
+		fmt.Println(err)
+		log.Fatal("failed to collect docker image list")
+	}
 	for _, img := range results {
 		_, err = cli.ImageRemove(ctx, img.ID, types.ImageRemoveOptions{})
 		if err != nil {


### PR DESCRIPTION
This fixes a dropped `err` variable in the `quickstart/test` package.