### PR TITLE
make version checking optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * Fixes an issue with `ziti` CLI when using a globally trusted CA
 * Fixes bug where `ziti agent stack` was calling `ziti agent stats`
+* ziti controller/router no longer compare the running version with 
+  the latest from github by default. Set ZITI_CHECK_VERSION=true to
+  enable this behavior
 
 ## Component Updates and Bug Fixes
 


### PR DESCRIPTION
This PR makes it optional to check the version of the software running and prevents any kind of "phone home looking" type of activity (even though it's only checking for the version, not actually "phoning home")