### PR TITLE
pass ziti version with leading `v`

### DIFF
--- a/quickstart/docker/pushLatestDocker.sh
+++ b/quickstart/docker/pushLatestDocker.sh
@@ -16,7 +16,7 @@ fi
 
 docker buildx create --use --name=ziti-builder
 docker buildx build --platform linux/amd64,linux/arm64 "${SCRIPT_DIR}/image" \
-  --build-arg ZITI_VERSION_OVERRIDE="${ZITI_VERSION}" \
+  --build-arg ZITI_VERSION_OVERRIDE="v${ZITI_VERSION}" \
   --tag "openziti/quickstart:${ZITI_VERSION}" \
   --tag "openziti/quickstart:latest" \
   --push


### PR DESCRIPTION
Now it actually works.

https://github.com/openziti/ziti/actions/runs/4165144101