### PR TITLE
publish container images on release-next

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - release-v*
+      - release-next
   pull_request:
   workflow_dispatch:
 
@@ -276,9 +277,18 @@ jobs:
     with:
       ziti-version: ${{ needs.publish.outputs.ZITI_VERSION }}
 
-  call-publish-docker-images:
+  call-publish-prerelease-docker-images:
+    if: github.ref == 'refs/heads/release-next'
+    name: Publish Pre-Release Docker Images
+    needs: publish
+    uses: ./.github/workflows/publish-docker-images.yml
+    secrets: inherit
+    with:
+      ziti-version: release-next
+
+  call-publish-release-docker-images:
     if: github.ref == 'refs/heads/main'
-    name: Publish Docker Images
+    name: Publish Release Docker Images
     needs: publish
     uses: ./.github/workflows/publish-docker-images.yml
     secrets: inherit

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       ziti-version:
-        description: 'Ziti Release Version'
+        description: 'Tag or Branch Ref to Publish'
         type: string
         required: true
 
@@ -13,6 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ZITI_VERSION: ${{ inputs.ziti-version || github.event.inputs.ziti-version }}
+      ZITI_CLI_IMAGE: ${{ vars.ZITI_CLI_IMAGE || 'docker.io/openziti/ziti-cli' }}
+      ZITI_CONTROLLER_IMAGE: ${{ vars.ZITI_CONTROLLER_IMAGE || 'docker.io/openziti/ziti-controller' }}
+      ZITI_ROUTER_IMAGE: ${{ vars.ZITI_ROUTER_IMAGE || 'docker.io/openziti/ziti-router' }}
+      ZITI_TUNNEL_IMAGE: ${{ vars.ZITI_TUNNEL_IMAGE || 'docker.io/openziti/ziti-tunnel' }}
     steps:
       - name: Checkout Workspace
         uses: actions/checkout@v3
@@ -40,11 +44,14 @@ jobs:
 
       - name: Set Up Container Image Tags for Base CLI Container
         env:
-          RELEASE_REPO: openziti/ziti-cli
+          IMAGE_REPO: ${{ env.ZITI_CLI_IMAGE }}
         id: tagprep_cli
         run: |
           DOCKER_TAGS=""
-          DOCKER_TAGS="${RELEASE_REPO}:${ZITI_VERSION},${RELEASE_REPO}:latest"
+          DOCKER_TAGS="${IMAGE_REPO}:${ZITI_VERSION}"
+          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            DOCKER_TAGS+=",${IMAGE_REPO}:latest"
+          fi
           echo "DEBUG: DOCKER_TAGS=${DOCKER_TAGS}"
           echo DOCKER_TAGS="${DOCKER_TAGS}" >> $GITHUB_OUTPUT
 
@@ -65,11 +72,14 @@ jobs:
 
       - name: Set Up Container Image Tags for Controller Container
         env:
-          RELEASE_REPO: openziti/ziti-controller
+          IMAGE_REPO: ${{ env. ZITI_CONTROLLER_IMAGE }}
         id: tagprep_ctrl
         run: |
           DOCKER_TAGS=""
-          DOCKER_TAGS="${RELEASE_REPO}:${ZITI_VERSION},${RELEASE_REPO}:latest"
+          DOCKER_TAGS="${IMAGE_REPO}:${ZITI_VERSION}"
+          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            DOCKER_TAGS+=",${IMAGE_REPO}:latest"
+          fi
           echo "DEBUG: DOCKER_TAGS=${DOCKER_TAGS}"
           echo DOCKER_TAGS="${DOCKER_TAGS}" >> $GITHUB_OUTPUT
 
@@ -85,15 +95,19 @@ jobs:
           tags: ${{ steps.tagprep_ctrl.outputs.DOCKER_TAGS }}
           build-args: |
             ZITI_VERSION=${{ env.ZITI_VERSION }}
+            ZITI_CLI_IMAGE=${{ env.ZITI_CLI_IMAGE }}
           push: true
 
       - name: Set Up Container Image Tags for Router Container
         env:
-          RELEASE_REPO: openziti/ziti-router
+          IMAGE_REPO: ${{ env.ZITI_ROUTER_IMAGE }}
         id: tagprep_router
         run: |
           DOCKER_TAGS=""
-          DOCKER_TAGS="${RELEASE_REPO}:${ZITI_VERSION},${RELEASE_REPO}:latest"
+          DOCKER_TAGS="${IMAGE_REPO}:${ZITI_VERSION}"
+          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            DOCKER_TAGS+=",${IMAGE_REPO}:latest"
+          fi
           echo "DEBUG: DOCKER_TAGS=${DOCKER_TAGS}"
           echo DOCKER_TAGS="${DOCKER_TAGS}" >> $GITHUB_OUTPUT
 
@@ -106,17 +120,21 @@ jobs:
           tags: ${{ steps.tagprep_router.outputs.DOCKER_TAGS }}
           build-args: |
             ZITI_VERSION=${{ env.ZITI_VERSION }}
+            ZITI_CLI_IMAGE=${{ env.ZITI_CLI_IMAGE }}
           push: true
 
       - name: Set Up Container Image Tags for Go Tunneler Container
         env:
-          SNAPSHOT_REPO: netfoundry/ziti-tunnel
-          RELEASE_REPO: openziti/ziti-tunnel
+          IMAGE_REPO: ${{ env.ZITI_TUNNEL_IMAGE }}
+          LEGACY_REPO: netfoundry/ziti-tunnel
         id: tagprep_tun
         run: |
           DOCKER_TAGS=""
-          for REPO in ${SNAPSHOT_REPO} ${RELEASE_REPO}; do
-            DOCKER_TAGS+=",${REPO}:${ZITI_VERSION},${REPO}:latest"
+          for REPO in ${LEGACY_REPO} ${IMAGE_REPO}; do
+            DOCKER_TAGS="${IMAGE_REPO}:${ZITI_VERSION}"
+            if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+              DOCKER_TAGS+=",${IMAGE_REPO}:latest"
+            fi
           done
           DOCKER_TAGS=${DOCKER_TAGS#,} # drop leading comma char
           echo "DEBUG: DOCKER_TAGS=${DOCKER_TAGS}"
@@ -131,4 +149,5 @@ jobs:
           tags: ${{ steps.tagprep_tun.outputs.DOCKER_TAGS }}
           build-args: |
             ZITI_VERSION=${{ env.ZITI_VERSION }}
+            ZITI_CLI_IMAGE=${{ env.ZITI_CLI_IMAGE }}
           push: true

--- a/.github/workflows/push-quickstart.yml
+++ b/.github/workflows/push-quickstart.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKER_HUB_API_USER }}
+          username: ${{ vars.DOCKER_HUB_API_USER }}
           password: ${{ secrets.DOCKER_HUB_API_TOKEN }}
       - name: Push to Docker
         run: ./quickstart/docker/pushLatestDocker.sh

--- a/docker-images/ziti-cli/Dockerfile
+++ b/docker-images/ziti-cli/Dockerfile
@@ -40,7 +40,7 @@ RUN   INSTALL_PKGS="python38 python38-pip tar" && \
 COPY --from=bitnami-kubectl /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/
 
 ### add license in the path prescribed by OpenShift
-RUN mkdir -m0755 /licenses
+RUN mkdir -p -m0755 /licenses
 COPY ./LICENSE /licenses/apache.txt
 
 RUN mkdir -p /usr/local/bin

--- a/docker-images/ziti-controller/Dockerfile
+++ b/docker-images/ziti-controller/Dockerfile
@@ -1,6 +1,7 @@
 ARG ZITI_VERSION="latest"
+ARG ZITI_CLI_IMAGE="docker.io/openziti/ziti-cli"
 # this builds docker.io/openziti/ziti-controller
-FROM docker.io/openziti/ziti-cli:${ZITI_VERSION}
+FROM ${ZITI_CLI_IMAGE}:${ZITI_VERSION}
 
 # This build stage grabs artifacts that are copied into the final image.
 # It uses the same base as the final image to maximize docker cache hits.

--- a/docker-images/ziti-router/Dockerfile
+++ b/docker-images/ziti-router/Dockerfile
@@ -1,6 +1,7 @@
 ARG ZITI_VERSION="latest"
+ARG ZITI_CLI_IMAGE="docker.io/openziti/ziti-cli"
 # this builds docker.io/openziti/ziti-router
-FROM docker.io/openziti/ziti-cli:${ZITI_VERSION}
+FROM ${ZITI_CLI_IMAGE}:${ZITI_VERSION}
 
 # This build stage grabs artifacts that are copied into the final image.
 # It uses the same base as the final image to maximize docker cache hits.

--- a/docker-images/ziti-tunnel/Dockerfile
+++ b/docker-images/ziti-tunnel/Dockerfile
@@ -1,6 +1,8 @@
 ARG ZITI_VERSION="latest"
+ARG ZITI_CLI_IMAGE="docker.io/openziti/ziti-cli"
 # this builds docker.io/openziti/ziti-tunnel, the legacy tunneler. The preferred tunneler is openziti/ziti-edge-tunnel documented in https://docs.openziti.io/docs/reference/tunnelers/linux/container/
-FROM docker.io/openziti/ziti-cli:${ZITI_VERSION}
+# this builds docker.io/openziti/ziti-router
+FROM ${ZITI_CLI_IMAGE}:${ZITI_VERSION}
 
 # This build stage grabs artifacts that are copied into the final image.
 # It uses the same base as the final image to maximize docker cache hits.


### PR DESCRIPTION

This changes the build to enable open-source contributors and team members to consume the bleeding-edge builds from release-next as a container image in Hub, i.e. `:release-next`.