### PR TITLE
order GNU find params to stop conditionally printing results

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -272,16 +272,16 @@ jobs:
 
       - name: List downloaded release artifacts
         run: |
-          ls -lR release/
+          ls -lAhR release/
 
       - name: Restore execute filemode on macOS and Linux release artifacts before publishing
         run: |
           find  ./release \
+                -type f \
+                -print0 \
                 -path "./release/*/darwin/ziti" \
                 -o \
                 -path "./release/*/linux/ziti" \
-                -type f \
-                -print0 \
             | xargs -0 chmod -c +x
 
       - name: Install Jfrog CLI


### PR DESCRIPTION
This corrects a CI bug where only Linux binaries have execute filemode bit set, excluding macOS binaries