### PR TITLE
resolve concurrency deadlock 

### DIFF
--- a/.github/workflows/jenkins-smoketest.yml
+++ b/.github/workflows/jenkins-smoketest.yml
@@ -13,11 +13,6 @@ on:
         type: string
         required: false   # this allows manually triggering the smoketest with the UNKNOWN version default
 
-# cancel older, redundant runs of same workflow on same branch
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: true
-
 jobs:
   jenkins-smoketest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
drop concurrency constraint on jenkins smoketest workflow that is typically called, not triggered because the value of `github.workflow` used to build the concurrency key string is not assigned to the name of the called workflow and so it collides with the caller workflow name