### PR TITLE
quickstart compose configurable port forward interface

### DIFF
--- a/quickstart/docker/.env
+++ b/quickstart/docker/.env
@@ -7,6 +7,8 @@ ZITI_VERSION=latest
 ZITI_USER=admin
 ZITI_PWD=
 
+ZITI_INTERFACE=0.0.0.0
+# ZITI_GO_VERSION=
 # controller name, address/port information
 ZITI_CTRL_NAME=ziti-controller
 ZITI_CTRL_EDGE_ADVERTISED_ADDRESS=ziti-edge-controller

--- a/quickstart/docker/docker-compose.yml
+++ b/quickstart/docker/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     env_file:
       - ./.env
     ports:
-      - ${ZITI_CTRL_EDGE_ADVERTISED_PORT:-1280}:${ZITI_CTRL_EDGE_ADVERTISED_PORT:-1280}
-      - ${ZITI_CTRL_ADVERTISED_PORT:-6262}:${ZITI_CTRL_ADVERTISED_PORT:-6262}
+      - ${ZITI_INTERFACE:-0.0.0.0}:${ZITI_CTRL_EDGE_ADVERTISED_PORT:-1280}:${ZITI_CTRL_EDGE_ADVERTISED_PORT:-1280}
+      - ${ZITI_INTERFACE:-0.0.0.0}:${ZITI_CTRL_ADVERTISED_PORT:-6262}:${ZITI_CTRL_ADVERTISED_PORT:-6262}
     environment:
       - ZITI_CTRL_NAME=${ZITI_CTRL_NAME:-ziti-edge-controller}
       - ZITI_CTRL_EDGE_ADVERTISED_ADDRESS=${ZITI_CTRL_EDGE_ADVERTISED_ADDRESS:-ziti-edge-controller}
@@ -59,8 +59,8 @@ services:
     depends_on:
       - ziti-controller
     ports:
-      - ${ZITI_ROUTER_PORT:-3022}:${ZITI_ROUTER_PORT:-3022}
-      - ${ZITI_ROUTER_LISTENER_BIND_PORT:-10080}:${ZITI_ROUTER_LISTENER_BIND_PORT:-10080}
+      - ${ZITI_INTERFACE:-0.0.0.0}:${ZITI_ROUTER_PORT:-3022}:${ZITI_ROUTER_PORT:-3022}
+      - ${ZITI_INTERFACE:-0.0.0.0}:${ZITI_ROUTER_LISTENER_BIND_PORT:-10080}:${ZITI_ROUTER_LISTENER_BIND_PORT:-10080}
     environment:
       - ZITI_CTRL_ADVERTISED_ADDRESS=${ZITI_CTRL_ADVERTISED_ADDRESS:-ziti-controller}
       - ZITI_CTRL_ADVERTISED_PORT=${ZITI_CTRL_ADVERTISED_PORT:-6262}
@@ -86,8 +86,8 @@ services:
     depends_on:
       - ziti-controller
     ports:
-      - ${ZITI_ROUTER_WSS_PORT:-3023}:${ZITI_ROUTER_WSS_PORT:-3023}
-      - ${ZITI_ROUTER_LISTENER_BIND_PORT:-10081}:${ZITI_ROUTER_LISTENER_BIND_PORT:-10081}
+      - ${ZITI_INTERFACE:-0.0.0.0}:${ZITI_ROUTER_WSS_PORT:-3023}:${ZITI_ROUTER_WSS_PORT:-3023}
+      - ${ZITI_INTERFACE:-0.0.0.0}:${ZITI_ROUTER_LISTENER_BIND_PORT:-10081}:${ZITI_ROUTER_LISTENER_BIND_PORT:-10081}
     environment:
       - ZITI_CTRL_ADVERTISED_ADDRESS=${ZITI_CTRL_ADVERTISED_ADDRESS:-ziti-controller}
       - ZITI_CTRL_ADVERTISED_PORT=${ZITI_CTRL_ADVERTISED_PORT:-6262}
@@ -175,7 +175,7 @@ services:
   web-test-blue:
     image: crccheck/hello-world
     ports:
-      - 80:8000
+      - ${ZITI_INTERFACE:-0.0.0.0}:80:8000
     networks:
       zitiblue:
         aliases:
@@ -196,7 +196,7 @@ services:
     depends_on:
       - ziti-controller
     ports:
-      - 8443:8443
+      - ${ZITI_INTERFACE:-0.0.0.0}:8443:8443
     volumes:
       - ziti-fs:/persistent
     networks:

--- a/quickstart/docker/simplified-docker-compose.yml
+++ b/quickstart/docker/simplified-docker-compose.yml
@@ -1,12 +1,11 @@
-version: '2.4'
 services:
   ziti-controller:
     image: "${ZITI_IMAGE}:${ZITI_VERSION}"
     env_file:
       - ./.env
     ports:
-      - ${ZITI_CTRL_EDGE_ADVERTISED_PORT:-1280}:${ZITI_CTRL_EDGE_ADVERTISED_PORT:-1280}
-      - ${ZITI_CTRL_ADVERTISED_PORT:-6262}:${ZITI_CTRL_ADVERTISED_PORT:-6262}
+      - ${ZITI_INTERFACE:-0.0.0.0}:${ZITI_CTRL_EDGE_ADVERTISED_PORT:-1280}:${ZITI_CTRL_EDGE_ADVERTISED_PORT:-1280}
+      - ${ZITI_INTERFACE:-0.0.0.0}:${ZITI_CTRL_ADVERTISED_PORT:-6262}:${ZITI_CTRL_ADVERTISED_PORT:-6262}
     environment:
       - ZITI_CTRL_NAME=${ZITI_CTRL_NAME:-ziti-edge-controller}
       - ZITI_CTRL_EDGE_ADVERTISED_ADDRESS=${ZITI_CTRL_EDGE_ADVERTISED_ADDRESS:-ziti-edge-controller}
@@ -51,8 +50,8 @@ services:
     depends_on:
       - ziti-controller
     ports:
-      - ${ZITI_ROUTER_PORT:-3022}:${ZITI_ROUTER_PORT:-3022}
-      - ${ZITI_ROUTER_LISTENER_BIND_PORT:-10080}:${ZITI_ROUTER_LISTENER_BIND_PORT:-10080}
+      - ${ZITI_INTERFACE:-0.0.0.0}:${ZITI_ROUTER_PORT:-3022}:${ZITI_ROUTER_PORT:-3022}
+      - ${ZITI_INTERFACE:-0.0.0.0}:${ZITI_ROUTER_LISTENER_BIND_PORT:-10080}:${ZITI_ROUTER_LISTENER_BIND_PORT:-10080}
     environment:
       - ZITI_CTRL_ADVERTISED_ADDRESS=${ZITI_CTRL_ADVERTISED_ADDRESS:-ziti-controller}
       - ZITI_CTRL_ADVERTISED_PORT=${ZITI_CTRL_ADVERTISED_PORT:-6262}
@@ -83,7 +82,7 @@ services:
     depends_on:
       - ziti-controller
     ports:
-      - 8443:8443
+      - ${ZITI_INTERFACE:-0.0.0.0}:8443:8443
     volumes:
       - ziti-fs:/persistent
     networks:


### PR DESCRIPTION
continue forwarding ports from 0.0.0.0 by default and allow overriding the interface address, e.g., 127.0.21.71
resolves #1268 