### PR TITLE
quickstart: ignore only the correct location of the ziti-bin directory

### DIFF
--- a/quickstart/.gitignore
+++ b/quickstart/.gitignore
@@ -1,2 +1,3 @@
-ziti-bin
+# only ignore the correct location of the ziti-bin dir to highlight any misplace files
+/docker/image/ziti-bin
 test/gotester.json

--- a/quickstart/docker/.gitignore
+++ b/quickstart/docker/.gitignore
@@ -1,1 +1,2 @@
-ziti-bin
+# only ignore the correct location of the ziti-bin dir to highlight any misplace files
+/image/ziti-bin


### PR DESCRIPTION
There was an inconsistency between the scripts that build the quickstart image that could cause the image to be built with unintended contents of the ziti-bin dir. The only correct location of the dir is quickstart/docker/image/ziti-bin because that is where it can be included in the Docker build context.

These changes are intended to highlight the location of any misplaced ziti-bin dirs within devs' working copies by ignoring only the correct location of ziti-bin.