### PR TITLE
output the default/current values for `ziti edge quickstart`

### DIFF
--- a/ziti/cmd/edge/quickstart.go
+++ b/ziti/cmd/edge/quickstart.go
@@ -55,6 +55,12 @@ type QuickstartOpts struct {
 
 // NewQuickStartCmd creates a command object for the "create" command
 func NewQuickStartCmd(out io.Writer, errOut io.Writer, context context.Context) *cobra.Command {
+	currentCtrlAddy := helpers.GetCtrlEdgeAdvertisedAddress()
+	currentCtrlPort := helpers.GetCtrlEdgeAdvertisedPort()
+	currentRouterAddy := helpers.GetRouterAdvertisedAddress()
+	currentRouterPort := helpers.GetZitiEdgeRouterPort()
+	defautlCtrlPort, _ := strconv.ParseInt(constants.DefaultCtrlEdgeAdvertisedPort, 10, 16)
+	defautlRouterPort, _ := strconv.ParseInt(constants.DefaultZitiEdgeRouterPort, 10, 16)
 	options := &QuickstartOpts{}
 	cmd := &cobra.Command{
 		Use:   "quickstart",
@@ -72,10 +78,10 @@ func NewQuickStartCmd(out io.Writer, errOut io.Writer, context context.Context) 
 	cmd.Flags().BoolVar(&options.AlreadyInitialized, "already-initialized", false, "Specifies the PKI does not need to be created and the db does not need to be initialized. Recommended to be combined with --home. If --home is not specified the environment will be destroyed on shutdown! default: false")
 	cmd.Flags().StringVar(&options.Home, "home", "", "Sets the directory the environment should be installed into. Defaults to a temporary directory. If specified, the environment will not be removed on exit.")
 
-	cmd.Flags().StringVar(&options.ControllerAddress, "ctrl-address", "", "Sets the advertised address for the control plane and API")
-	cmd.Flags().Int16Var(&options.ControllerPort, "ctrl-port", 0, "Sets the port to use for the control plane and API")
-	cmd.Flags().StringVar(&options.RouterAddress, "router-address", "", "Sets the advertised address for the integrated router")
-	cmd.Flags().Int16Var(&options.RouterPort, "router-port", 0, "Sets the port to use for the integrated router")
+	cmd.Flags().StringVar(&options.ControllerAddress, "ctrl-address", "", "Sets the advertised address for the control plane and API. current: "+currentCtrlAddy)
+	cmd.Flags().Int16Var(&options.ControllerPort, "ctrl-port", int16(defautlCtrlPort), "Sets the port to use for the control plane and API. current: "+currentCtrlPort)
+	cmd.Flags().StringVar(&options.RouterAddress, "router-address", "", "Sets the advertised address for the integrated router. current: "+currentRouterAddy)
+	cmd.Flags().Int16Var(&options.RouterPort, "router-port", int16(defautlRouterPort), "Sets the port to use for the integrated router. current: "+currentRouterPort)
 	return cmd
 }
 


### PR DESCRIPTION
Without setting any env vars you'll now see the default/current value that will be used:
```
Flags:
      --already-initialized     Specifies the PKI does not need to be created and the db does not need to be initialized. Recommended to be combined with --home. If --home is not specified the environment will be destroyed on shutdown! default: false
      --ctrl-address string     Sets the advertised address for the control plane and API. current: sg3u22
      --ctrl-port int16         Sets the port to use for the control plane and API. current: 1280 (default 1280)
  -h, --help                    help for quickstart
      --home string             Sets the directory the environment should be installed into. Defaults to a temporary directory. If specified, the environment will not be removed on exit.
  -p, --password string         Password to use for authenticating to the Ziti Edge Controller. default: admin
      --router-address string   Sets the advertised address for the integrated router. current: sg3u22
      --router-port int16       Sets the port to use for the integrated router. current: 3022 (default 3022)
  -u, --username string         Username to use when creating the Ziti Edge Controller. default: admin
```

If you set env vars, like as shown from the doc to override values you'll see:
```
export ZITI_CTRL_EDGE_ADVERTISED_ADDRESS="my.sherona"
export ZITI_ROUTER_ADVERTISED_ADDRESS="ma.ma.ma.my.shernoa"
export ZITI_CTRL_EDGE_ADVERTISED_PORT=8441
export ZITI_ROUTER_PORT=8442


Flags:
      --already-initialized     Specifies the PKI does not need to be created and the db does not need to be initialized. Recommended to be combined with --home. If --home is not specified the environment will be destroyed on shutdown! default: false
      --ctrl-address string     Sets the advertised address for the control plane and API. current: my.sherona
      --ctrl-port int16         Sets the port to use for the control plane and API. current: 8441 (default 1280)
  -h, --help                    help for quickstart
      --home string             Sets the directory the environment should be installed into. Defaults to a temporary directory. If specified, the environment will not be removed on exit.
  -p, --password string         Password to use for authenticating to the Ziti Edge Controller. default: admin
      --router-address string   Sets the advertised address for the integrated router. current: ma.ma.ma.my.shernoa
      --router-port int16       Sets the port to use for the integrated router. current: 8442 (default 3022)
  -u, --username string         Username to use when creating the Ziti Edge Controller. default: admin
```