### PR TITLE
rename ziti-cli package as "openziti" 

### DIFF
--- a/.github/workflows/publish-linux-packages.yml
+++ b/.github/workflows/publish-linux-packages.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         package_name:
-          - ziti-cli
+          - openziti
         arch:
           - goreleaser: amd64
             gox: amd64
@@ -39,8 +39,10 @@ jobs:
       ZITI_HOMEPAGE: "https://openziti.io"
       ZITI_VENDOR: "NetFoundry"
       GOARCH: ${{ matrix.arch.goreleaser }}
-      ZITI_DEB_REPO: ${{ vars.ZITI_DEB_REPO || 'zitipax-openziti-deb-stable' }}
-      ZITI_RPM_REPO: ${{ vars.ZITI_RPM_REPO || 'zitipax-openziti-rpm-stable' }}
+      ZITI_DEB_TEST_REPO: ${{ vars.ZITI_DEB_TEST_REPO || 'zitipax-openziti-deb-test' }}
+      ZITI_DEB_PROD_REPO: ${{ vars.ZITI_DEB_PROD_REPO || 'zitipax-openziti-deb-stable' }}
+      ZITI_RPM_TEST_REPO: ${{ vars.ZITI_RPM_TEST_REPO || 'zitipax-openziti-rpm-test' }}
+      ZITI_RPM_PROD_REPO: ${{ vars.ZITI_RPM_PROD_REPO || 'zitipax-openziti-rpm-stable' }}
     steps:
       - name: Checkout Workspace
         uses: actions/checkout@v3
@@ -92,7 +94,7 @@ jobs:
         run: >
           jf rt upload
           ./release/${{ matrix.package_name }}*.${{ matrix.nfpm_packager }}
-          /${{ env.ZITI_RPM_REPO }}/testing/${{ matrix.arch.rpm }}/
+          /${{ env.ZITI_RPM_TEST_REPO }}/testing/${{ matrix.arch.rpm }}/
           --recursive=false
           --flat=true 
 
@@ -103,7 +105,7 @@ jobs:
         run: >
           jf rt upload
           ./release/${{ matrix.package_name }}*.${{ matrix.nfpm_packager }}
-          /${{ env.ZITI_RPM_REPO }}/release/${{ matrix.arch.rpm }}/
+          /${{ env.ZITI_RPM_PROD_REPO }}/release/${{ matrix.arch.rpm }}/
           --recursive=false
           --flat=true 
 
@@ -113,7 +115,7 @@ jobs:
         run: >
           jf rt upload
           ./release/${{ matrix.package_name }}*.${{ matrix.nfpm_packager }}
-          /${{ env.ZITI_DEB_REPO }}/pool/${{ matrix.package_name }}/testing/${{ matrix.arch.deb }}/
+          /${{ env.ZITI_DEB_TEST_REPO }}/pool/${{ matrix.package_name }}/testing/${{ matrix.arch.deb }}/
           --deb=testing/main/${{ matrix.arch.deb }}
           --recursive=false
           --flat=true 
@@ -125,7 +127,7 @@ jobs:
         run: >
           jf rt upload
           ./release/${{ matrix.package_name }}*.${{ matrix.nfpm_packager }}
-          /${{ env.ZITI_DEB_REPO }}/pool/${{ matrix.package_name }}/release/${{ matrix.arch.deb }}/
+          /${{ env.ZITI_DEB_PROD_REPO }}/pool/${{ matrix.package_name }}/release/${{ matrix.arch.deb }}/
           --deb=release/main/${{ matrix.arch.deb }}
           --recursive=false
           --flat=true 

--- a/dist/dist-packages/linux/nfpm-openziti.yaml
+++ b/dist/dist-packages/linux/nfpm-openziti.yaml
@@ -21,6 +21,8 @@ contents:
   - src: /opt/openziti/bin/ziti
     dst: /usr/bin/ziti
     type: symlink
+replaces:
+  - ziti-cli
 
 # packager-neutral scripts may be overriden by packager-specific scripts
 # scripts:

--- a/dist/dist-packages/linux/nfpm-openziti.yaml
+++ b/dist/dist-packages/linux/nfpm-openziti.yaml
@@ -2,13 +2,13 @@
 #
 # check https://nfpm.goreleaser.com/configuration for detailed usage
 #
-name: ziti-cli
+name: openziti
 arch: ${GOARCH}
 platform: linux
 version: ${ZITI_VERSION}
 maintainer: ${ZITI_MAINTAINER}
 description: >
-  The ziti-cli package provides the ziti executable binary as a command line
+  The openziti package provides the ziti executable binary as a command line
   interface for Ziti.
 vendor: ${ZITI_VENDOR}
 homepage: ${ZITI_HOMEPAGE}


### PR DESCRIPTION
and split test vs. prod uploads at the Artifactory repo level; resolves #911