### PR TITLE
use generic debian package meta distro "debian"

### DIFF
--- a/.github/workflows/publish-linux-packages.yml
+++ b/.github/workflows/publish-linux-packages.yml
@@ -93,7 +93,7 @@ jobs:
         shell: bash
         run: >
           jf rt upload
-          ./release/${{ matrix.package_name }}*.${{ matrix.nfpm_packager }}
+          ./release/${{ matrix.package_name }}*.rpm
           /${{ env.ZITI_RPM_TEST_REPO }}/testing/${{ matrix.arch.rpm }}/
           --recursive=false
           --flat=true 
@@ -104,7 +104,7 @@ jobs:
         shell: bash
         run: >
           jf rt upload
-          ./release/${{ matrix.package_name }}*.${{ matrix.nfpm_packager }}
+          ./release/${{ matrix.package_name }}*.rpm
           /${{ env.ZITI_RPM_PROD_REPO }}/release/${{ matrix.arch.rpm }}/
           --recursive=false
           --flat=true 
@@ -114,9 +114,9 @@ jobs:
         shell: bash
         run: >
           jf rt upload
-          ./release/${{ matrix.package_name }}*.${{ matrix.nfpm_packager }}
+          ./release/${{ matrix.package_name }}*.deb
           /${{ env.ZITI_DEB_TEST_REPO }}/pool/${{ matrix.package_name }}/testing/${{ matrix.arch.deb }}/
-          --deb=testing/main/${{ matrix.arch.deb }}
+          --deb=debian/main/${{ matrix.arch.deb }}
           --recursive=false
           --flat=true 
 
@@ -126,8 +126,8 @@ jobs:
         shell: bash
         run: >
           jf rt upload
-          ./release/${{ matrix.package_name }}*.${{ matrix.nfpm_packager }}
+          ./release/${{ matrix.package_name }}*.deb
           /${{ env.ZITI_DEB_PROD_REPO }}/pool/${{ matrix.package_name }}/release/${{ matrix.arch.deb }}/
-          --deb=release/main/${{ matrix.arch.deb }}
+          --deb=debian/main/${{ matrix.arch.deb }}
           --recursive=false
           --flat=true 

--- a/.github/workflows/publish-linux-packages.yml
+++ b/.github/workflows/publish-linux-packages.yml
@@ -94,7 +94,7 @@ jobs:
         run: >
           jf rt upload
           ./release/${{ matrix.package_name }}*.rpm
-          /${{ env.ZITI_RPM_TEST_REPO }}/testing/${{ matrix.arch.rpm }}/
+          /${{ env.ZITI_RPM_TEST_REPO }}/testing/${{ matrix.package_name }}/${{ matrix.arch.rpm }}/
           --recursive=false
           --flat=true 
 
@@ -105,7 +105,7 @@ jobs:
         run: >
           jf rt upload
           ./release/${{ matrix.package_name }}*.rpm
-          /${{ env.ZITI_RPM_PROD_REPO }}/release/${{ matrix.arch.rpm }}/
+          /${{ env.ZITI_RPM_PROD_REPO }}/release/${{ matrix.package_name }}/${{ matrix.arch.rpm }}/
           --recursive=false
           --flat=true 
 
@@ -115,7 +115,7 @@ jobs:
         run: >
           jf rt upload
           ./release/${{ matrix.package_name }}*.deb
-          /${{ env.ZITI_DEB_TEST_REPO }}/pool/${{ matrix.package_name }}/testing/${{ matrix.arch.deb }}/
+          /${{ env.ZITI_DEB_TEST_REPO }}/pool/testing/${{ matrix.package_name }}/${{ matrix.arch.deb }}/
           --deb=debian/main/${{ matrix.arch.deb }}
           --recursive=false
           --flat=true 
@@ -127,7 +127,7 @@ jobs:
         run: >
           jf rt upload
           ./release/${{ matrix.package_name }}*.deb
-          /${{ env.ZITI_DEB_PROD_REPO }}/pool/${{ matrix.package_name }}/release/${{ matrix.arch.deb }}/
+          /${{ env.ZITI_DEB_PROD_REPO }}/pool/release/${{ matrix.package_name }}/${{ matrix.arch.deb }}/
           --deb=debian/main/${{ matrix.arch.deb }}
           --recursive=false
           --flat=true 


### PR DESCRIPTION
This sets the `deb.distribution` property in the Artifactory API and in the Debian packages metadata to "debian." When distributing package variants for various distributions, this property reflects the target distro, e.g., `buster`, `wheezy`, etc.

For this repo channel where we're distributing the `ziti` CLI, I mean to imply broad compatibility of artifacts in this channel with Debian-based distros, including Debian, Ubuntu, etc.

The `ziti` CLI is unlikely to demand distro-specific package variants.

If we end up distributing package variants for `openziti-controller`, we'll set `deb.distribution` appropriately so that `apt` can self-select the appropriate distro variant.