### PR TITLE
fixes 1422 ignores non-CAs for ca bundle, validate cert format

### DIFF
--- a/controller/config/config.go
+++ b/controller/config/config.go
@@ -461,7 +461,7 @@ func CalculateCaPems(caPems *bytes.Buffer) *bytes.Buffer {
 				continue
 			}
 
-			if cert.IsCA != true {
+			if !cert.IsCA {
 				pfxlog.Logger().
 					WithField("type", block.Type).
 					WithField("block", pem.EncodeToMemory(block)).


### PR DESCRIPTION
Adds some type/parsing/error checking to the CA bundle processing. This includes not allowing non-CA certificates in the bundle.