### PR TITLE
fixes tests that would check for OS specific error messages

### DIFF
--- a/ziti/cmd/create/create_config_controller_test.go
+++ b/ziti/cmd/create/create_config_controller_test.go
@@ -3,10 +3,12 @@ package create
 import (
 	"fmt"
 	cmdhelper "github.com/openziti/ziti/ziti/cmd/helpers"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 	"os"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -111,15 +113,15 @@ func init() {
 }
 
 func TestControllerOutputPathDoesNotExist(t *testing.T) {
-	expectedErrorMsg := "stat /IDoNotExist: no such file or directory"
-
 	// Create the options with non-existent path
 	options := &CreateConfigControllerOptions{}
 	options.Output = "/IDoNotExist/MyController.yaml"
 
 	err := options.run(&ConfigTemplateValues{})
 
-	assert.EqualError(t, err, expectedErrorMsg, "Error does not match, expected %s but got %s", expectedErrorMsg, err)
+	//check wrapped error type and not internal strings as they vary between operating systems
+	assert.Error(t, err)
+	assert.Equal(t, errors.Unwrap(err), syscall.ENOENT)
 }
 
 func TestCreateConfigControllerTemplateValues(t *testing.T) {

--- a/ziti/cmd/create/create_config_router_edge_test.go
+++ b/ziti/cmd/create/create_config_router_edge_test.go
@@ -2,11 +2,13 @@ package create
 
 import (
 	"github.com/openziti/ziti/ziti/constants"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"os"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -215,8 +217,6 @@ func TestEdgeRouterCannotBeWSSAndPrivate(t *testing.T) {
 }
 
 func TestEdgeRouterOutputPathDoesNotExist(t *testing.T) {
-	expectedErrorMsg := "stat /IDoNotExist: no such file or directory"
-
 	// Set the router options
 	routerOptions := clearEnvAndInitializeTestData()
 	routerOptions.TunnelerMode = defaultTunnelerMode
@@ -225,7 +225,8 @@ func TestEdgeRouterOutputPathDoesNotExist(t *testing.T) {
 
 	err := routerOptions.runEdgeRouter(&ConfigTemplateValues{})
 
-	assert.EqualError(t, err, expectedErrorMsg, "Error does not match, expected %s but got %s", expectedErrorMsg, err)
+	assert.Error(t, err)
+	assert.Equal(t, errors.Unwrap(err), syscall.ENOENT)
 }
 
 func TestExecuteCreateConfigRouterEdgeHasNonBlankTemplateValues(t *testing.T) {

--- a/ziti/cmd/create/create_config_router_fabric_test.go
+++ b/ziti/cmd/create/create_config_router_fabric_test.go
@@ -2,10 +2,12 @@ package create
 
 import (
 	"github.com/openziti/ziti/ziti/constants"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"os"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -94,7 +96,6 @@ func TestBlankFabricRouterNameBecomesHostname(t *testing.T) {
 
 func TestFabricRouterOutputPathDoesNotExist(t *testing.T) {
 	routerOptions := clearEnvAndInitializeTestData()
-	expectedErrorMsg := "stat /IDoNotExist: no such file or directory"
 
 	// Set the router options
 	clearEnvAndInitializeTestData()
@@ -103,7 +104,8 @@ func TestFabricRouterOutputPathDoesNotExist(t *testing.T) {
 
 	err := routerOptions.runFabricRouter(&ConfigTemplateValues{})
 
-	assert.EqualError(t, err, expectedErrorMsg, "Error does not match, expected %s but got %s", expectedErrorMsg, err)
+	assert.Error(t, err)
+	assert.Equal(t, errors.Unwrap(err), syscall.ENOENT)
 }
 
 func TestDefaultZitiFabricRouterListenerBindPort(t *testing.T) {

--- a/ziti/cmd/helpers/env_helpers.go
+++ b/ziti/cmd/helpers/env_helpers.go
@@ -28,7 +28,7 @@ import (
 
 func HomeDir() string {
 	if h := os.Getenv("HOME"); h != "" {
-		return h
+		return NormalizePath(h)
 	}
 	h := os.Getenv("USERPROFILE") // windows
 	if h == "" {


### PR DESCRIPTION
- now checks for system.ENOENT (error no entity) error types
- fixed issues where HOME env variable was assumed non-windows