### PR TITLE
Add latest beta to cloudfront

### DIFF
--- a/dist/cloudfront/get.openziti.io/routes.yml
+++ b/dist/cloudfront/get.openziti.io/routes.yml
@@ -30,9 +30,9 @@
   file: package-repos.gpg
   
 - get: /zdew/
-  raw: /openziti/desktop-edge-win/release-next/
+  raw: /openziti/desktop-edge-win/release-next/release-stream
   file: latest.json
   
 - get: /zdew/
-  raw: /openziti/desktop-edge-win/release-next/
+  raw: /openziti/desktop-edge-win/release-next/release-stream
   file: beta.json

--- a/dist/cloudfront/get.openziti.io/routes.yml
+++ b/dist/cloudfront/get.openziti.io/routes.yml
@@ -30,9 +30,6 @@
   file: package-repos.gpg
   
 - get: /zdew/
-  raw: /openziti/desktop-edge-win/release-next/release-stream/
+  raw: /openziti/desktop-edge-win/release-next/
   file: latest.json
   
-- get: /zdew/
-  raw: /openziti/desktop-edge-win/release-next/release-stream/
-  file: beta.json

--- a/dist/cloudfront/get.openziti.io/routes.yml
+++ b/dist/cloudfront/get.openziti.io/routes.yml
@@ -30,6 +30,6 @@
   file: package-repos.gpg
   
 - get: /zdew/
-  raw: /openziti/desktop-edge-win/release-next/release-streams
+  raw: /openziti/desktop-edge-win/release-next/release-streams/
   file: latest.json
   

--- a/dist/cloudfront/get.openziti.io/routes.yml
+++ b/dist/cloudfront/get.openziti.io/routes.yml
@@ -29,7 +29,7 @@
   raw: /openziti/ziti-tunnel-sdk-c/main/
   file: package-repos.gpg
   
-- get: /zdew/
-  raw: /openziti/desktop-edge-win/release-next/
+- get: /zdew/release-streams/
+  raw: /openziti/desktop-edge-win/release-next
   file: latest.json
   

--- a/dist/cloudfront/get.openziti.io/routes.yml
+++ b/dist/cloudfront/get.openziti.io/routes.yml
@@ -31,4 +31,8 @@
   
 - get: /zdew/
   raw: /openziti/desktop-edge-win/release-next/
-  file: version-check.json
+  file: latest.json
+  
+- get: /zdew/
+  raw: /openziti/desktop-edge-win/release-next/
+  file: beta.json

--- a/dist/cloudfront/get.openziti.io/routes.yml
+++ b/dist/cloudfront/get.openziti.io/routes.yml
@@ -29,7 +29,7 @@
   raw: /openziti/ziti-tunnel-sdk-c/main/
   file: package-repos.gpg
   
-- get: /zdew/release-streams/
-  raw: /openziti/desktop-edge-win/release-next
+- get: /zdew/
+  raw: /openziti/desktop-edge-win/release-next/release-streams
   file: latest.json
   

--- a/dist/cloudfront/get.openziti.io/routes.yml
+++ b/dist/cloudfront/get.openziti.io/routes.yml
@@ -30,9 +30,9 @@
   file: package-repos.gpg
   
 - get: /zdew/
-  raw: /openziti/desktop-edge-win/release-next/release-stream
+  raw: /openziti/desktop-edge-win/release-next/release-stream/
   file: latest.json
   
 - get: /zdew/
-  raw: /openziti/desktop-edge-win/release-next/release-stream
+  raw: /openziti/desktop-edge-win/release-next/release-stream/
   file: beta.json


### PR DESCRIPTION
add two release streams, "latest" and "beta". we'll consider adding lts after any discussions