### PR TITLE
link mgmt race conditions

### DIFF
--- a/common/inspect/links_inspect_result.go
+++ b/common/inspect/links_inspect_result.go
@@ -47,17 +47,18 @@ type LinkDest struct {
 }
 
 type LinkState struct {
-	Id             string   `json:"id"`
-	Key            string   `json:"key"`
-	Status         string   `json:"status"`
-	DialAttempts   uint64   `json:"dialAttempts"`
-	ConnectedCount uint64   `json:"connectedCount"`
-	RetryDelay     string   `json:"retryDelay"`
-	NextDial       string   `json:"nextDial"`
-	TargetAddress  string   `json:"targetAddress"`
-	TargetGroups   []string `json:"targetGroups"`
-	TargetBinding  string   `json:"targetBinding"`
-	DialerGroups   []string `json:"dialerGroups"`
-	DialerBinding  string   `json:"dialerBinding"`
-	CtrlsNotified  bool     `json:"ctrlsNotified"`
+	Id                string   `json:"id"`
+	Key               string   `json:"key"`
+	Status            string   `json:"status"`
+	DialAttempts      uint64   `json:"dialAttempts"`
+	ConnectedCount    uint64   `json:"connectedCount"`
+	RetryDelay        string   `json:"retryDelay"`
+	NextDial          string   `json:"nextDial"`
+	TargetAddress     string   `json:"targetAddress"`
+	TargetGroups      []string `json:"targetGroups"`
+	TargetBinding     string   `json:"targetBinding"`
+	DialerGroups      []string `json:"dialerGroups"`
+	DialerBinding     string   `json:"dialerBinding"`
+	CtrlsNotified     bool     `json:"ctrlsNotified"`
+	EstablishedLinkId string   `json:"establishedLinkId"`
 }

--- a/controller/command/rate_limiter_test.go
+++ b/controller/command/rate_limiter_test.go
@@ -33,9 +33,12 @@ import (
 
 func Test_AdaptiveRateLimiter(t *testing.T) {
 	cfg := AdaptiveRateLimiterConfig{
-		Enabled: true,
-		MaxSize: 250,
-		MinSize: 5,
+		Enabled:          true,
+		MaxSize:          250,
+		MinSize:          5,
+		WorkTimerMetric:  "workTime",
+		QueueSizeMetric:  "queueSize",
+		WindowSizeMetric: "windowSize",
 	}
 
 	registry := metrics.NewRegistry("test", nil)

--- a/controller/handler_ctrl/router_link.go
+++ b/controller/handler_ctrl/router_link.go
@@ -38,6 +38,10 @@ func (h *routerLinkHandler) ContentType() int32 {
 }
 
 func (h *routerLinkHandler) HandleReceive(msg *channel.Message, ch channel.Channel) {
+	if !h.r.Connected.Load() || ch.IsClosed() {
+		return
+	}
+
 	log := pfxlog.ContextLogger(ch.Label())
 
 	link := &ctrl_pb.RouterLinks{}
@@ -46,7 +50,7 @@ func (h *routerLinkHandler) HandleReceive(msg *channel.Message, ch channel.Chann
 		return
 	}
 
-	go h.HandleLinks(link)
+	h.HandleLinks(link)
 }
 
 func (h *routerLinkHandler) HandleLinks(links *ctrl_pb.RouterLinks) {

--- a/controller/network/link_controller.go
+++ b/controller/network/link_controller.go
@@ -126,6 +126,15 @@ func (linkController *linkController) has(link *Link) bool {
 	return linkController.linkTable.has(link)
 }
 
+func (linkController *linkController) scanForDeadLinks() {
+	for entry := range linkController.linkTable.links.IterBuffered() {
+		link := entry.Val
+		if !link.Src.Connected.Load() {
+			linkController.remove(link)
+		}
+	}
+}
+
 func (linkController *linkController) routerReportedLink(linkId string, iteration uint32, linkProtocol, dialAddress string, src, dst *Router, dstId string) (*Link, bool) {
 	linkController.lock.Lock()
 	defer linkController.lock.Unlock()
@@ -211,7 +220,7 @@ func (linkController *linkController) leastExpensiveLink(a, b *Router) (*Link, b
 					selected = link
 					cost = linkCost
 				}
-			} else if link.Src == b {
+			} else if link.Src.Id == b.Id {
 				if linkCost < cost {
 					selected = link
 					cost = linkCost

--- a/controller/network/service.go
+++ b/controller/network/service.go
@@ -152,7 +152,7 @@ func (self *ServiceManager) GetIdForName(id string) (string, error) {
 }
 
 func (self *ServiceManager) readInTx(tx *bbolt.Tx, id string) (*Service, error) {
-	if service, found := self.cache.Get(id); found {
+	if service, _ := self.cache.Get(id); service != nil {
 		return service, nil
 	}
 

--- a/controller/raft/member.go
+++ b/controller/raft/member.go
@@ -73,20 +73,18 @@ func (self *Controller) ListMembers() ([]*Member, error) {
 		})
 	}
 
-	if len(result) == 0 {
-		for addr, peer := range peers {
-			if _, exists := memberSet[addr]; exists {
-				continue
-			}
-			result = append(result, &Member{
-				Id:        string(peer.Id),
-				Addr:      peer.Address,
-				Voter:     false,
-				Leader:    peer.Address == string(leaderAddr),
-				Version:   peer.Version.Version,
-				Connected: true,
-			})
+	for addr, peer := range peers {
+		if _, exists := memberSet[addr]; exists {
+			continue
 		}
+		result = append(result, &Member{
+			Id:        string(peer.Id),
+			Addr:      peer.Address,
+			Voter:     false,
+			Leader:    peer.Address == string(leaderAddr),
+			Version:   peer.Version.Version,
+			Connected: true,
+		})
 	}
 
 	return result, nil

--- a/controller/raft/mesh/mesh_test.go
+++ b/controller/raft/mesh/mesh_test.go
@@ -1,8 +1,8 @@
 package mesh
 
 import (
-	"github.com/openziti/ziti/controller/event"
 	"github.com/openziti/foundation/v2/versions"
+	"github.com/openziti/ziti/controller/event"
 	"runtime"
 	"testing"
 	"time"
@@ -59,7 +59,7 @@ func Test_AddPeer_PassesReadonlyWhenVersionsMatch(t *testing.T) {
 
 	p := &Peer{Version: testVersion("1")}
 
-	m.PeerConnected(p)
+	assert.NoError(t, m.PeerConnected(p))
 	assert.Equal(t, false, m.readonly.Load(), "Expected readonly to be false, got ", m.readonly.Load())
 }
 
@@ -72,7 +72,7 @@ func Test_AddPeer_TurnsReadonlyWhenVersionsDoNotMatch(t *testing.T) {
 
 	p := &Peer{Version: testVersion("dne")}
 
-	m.PeerConnected(p)
+	assert.NoError(t, m.PeerConnected(p))
 	assert.Equal(t, true, m.readonly.Load(), "Expected readonly to be true, got ", m.readonly.Load())
 }
 

--- a/etc/ctrl.with.edge.yml
+++ b/etc/ctrl.with.edge.yml
@@ -115,7 +115,7 @@ edge:
     # the smallest window size for auth attempts
     minSize: 5
     # the largest allowed window size for auth attempts
-    maxSize: 250
+    maxSize: 100
 
   # This section represents the configuration of the Edge API that is served over HTTPS
   api:

--- a/router/accepter.go
+++ b/router/accepter.go
@@ -19,6 +19,7 @@ func (self *xlinkAccepter) Accept(xlink xlink.Xlink) error {
 	logrus.WithField("linkId", xlink.Id()).
 		WithField("destId", xlink.DestinationId()).
 		WithField("iteration", xlink.Iteration()).
+		WithField("dialed", xlink.IsDialed()).
 		Info("accepted new link")
 	return nil
 }

--- a/router/handler_link/bind.go
+++ b/router/handler_link/bind.go
@@ -65,6 +65,8 @@ func (self *bindHandler) BindChannel(binding channel.Binding) error {
 		"linkId":        self.xlink.Id(),
 		"routerId":      self.xlink.DestinationId(),
 		"routerVersion": self.xlink.DestVersion(),
+		"iteration":     self.xlink.Iteration(),
+		"dialed":        self.xlink.IsDialed(),
 	})
 
 	binding.GetChannel().SetLogicalName("l/" + self.xlink.Id())

--- a/ziti/cmd/fabric/validate_router_links.go
+++ b/ziti/cmd/fabric/validate_router_links.go
@@ -32,7 +32,8 @@ import (
 
 type validateRouterLinksAction struct {
 	api.Options
-	includeValid bool
+	includeValidLinks   bool
+	includeValidRouters bool
 
 	eventNotify chan *mgmt_pb.RouterLinkDetails
 }
@@ -53,7 +54,8 @@ func NewValidateRouterLinksCmd(p common.OptionsProvider) *cobra.Command {
 	}
 
 	action.AddCommonFlags(validateLinksCmd)
-	validateLinksCmd.Flags().BoolVar(&action.includeValid, "include-valid", false, "Don't hide results for valid links")
+	validateLinksCmd.Flags().BoolVar(&action.includeValidLinks, "include-valid-links", false, "Don't hide results for valid links")
+	validateLinksCmd.Flags().BoolVar(&action.includeValidRouters, "include-valid-routers", false, "Don't hide results for valid routers")
 	return validateLinksCmd
 }
 
@@ -110,11 +112,23 @@ func (self *validateRouterLinksAction) validateRouterLinks(_ *cobra.Command, arg
 				result = fmt.Sprintf("error: unable to validate (%s)", routerDetail.Message)
 				errCount++
 			}
-			fmt.Printf("routerId: %s, routerName: %v, links: %v, %s\n",
-				routerDetail.RouterId, routerDetail.RouterName, len(routerDetail.LinkDetails), result)
+
+			routerHeaderDone := false
+			outputRouterHeader := func() {
+				fmt.Printf("routerId: %s, routerName: %v, links: %v, %s\n",
+					routerDetail.RouterId, routerDetail.RouterName, len(routerDetail.LinkDetails), result)
+				routerHeaderDone = true
+			}
+
+			if self.includeValidRouters {
+				outputRouterHeader()
+			}
 
 			for _, linkDetail := range routerDetail.LinkDetails {
-				if self.includeValid || !linkDetail.IsValid {
+				if self.includeValidLinks || !linkDetail.IsValid {
+					if !routerHeaderDone {
+						outputRouterHeader()
+					}
 					fmt.Printf("\tlinkId: %s, destConnected: %v, ctrlState: %v, routerState: %v, dest: %v, dialed: %v \n",
 						linkDetail.LinkId, linkDetail.DestConnected, linkDetail.CtrlState, linkDetail.RouterState.String(),
 						linkDetail.DestRouterId, linkDetail.Dialed)

--- a/zititest/zitilab/actions/edge/init_routers.go
+++ b/zititest/zitilab/actions/edge/init_routers.go
@@ -1,9 +1,11 @@
 package edge
 
 import (
+	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/fablab/kernel/lib/actions/component"
 	"github.com/openziti/fablab/kernel/model"
 	"github.com/openziti/ziti/zititest/zitilab"
+	zitilib_actions "github.com/openziti/ziti/zititest/zitilab/actions"
 )
 
 func InitEdgeRouters(componentSpec string, concurrency int) model.Action {
@@ -14,6 +16,10 @@ func InitEdgeRouters(componentSpec string, concurrency int) model.Action {
 }
 
 func (action *initEdgeRoutersAction) Execute(run model.Run) error {
+	if err := zitilib_actions.EdgeExec(run.GetModel(), "delete", "edge-router", "where", "true"); err != nil {
+		pfxlog.Logger().WithError(err).Warn("unable to delete routers")
+	}
+
 	return component.ExecInParallel(action.componentSpec, action.concurrency, zitilab.RouterActionsCreateAndEnroll).Execute(run)
 }
 

--- a/zititest/zitilab/component_common.go
+++ b/zititest/zitilab/component_common.go
@@ -48,7 +48,11 @@ func startZitiComponent(c *model.Component, zitiType string, version string, con
 
 	serviceCmd := fmt.Sprintf("nohup %s %s %s run --cli-agent-alias %s --log-formatter pfxlog %s > %s 2>&1 &",
 		useSudo, binaryPath, zitiType, c.Id, configPath, logsPath)
-	logrus.Info(serviceCmd)
+
+	if quiet, _ := c.GetBoolVariable("quiet_startup"); !quiet {
+		logrus.Info(serviceCmd)
+	}
+
 	value, err := c.GetHost().ExecLogged(serviceCmd)
 	if err != nil {
 		return err

--- a/zititest/zitilab/component_router.go
+++ b/zititest/zitilab/component_router.go
@@ -18,7 +18,6 @@ package zitilab
 
 import (
 	"fmt"
-	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/fablab/kernel/lib"
 	"github.com/openziti/fablab/kernel/lib/actions/host"
 	"github.com/openziti/fablab/kernel/model"
@@ -26,7 +25,9 @@ import (
 	"github.com/openziti/ziti/zititest/zitilab/stageziti"
 	"io/fs"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"time"
 )
 
 var _ model.ComponentType = (*RouterType)(nil)
@@ -128,23 +129,25 @@ func (self *RouterType) Start(r model.Run, c *model.Component) error {
 	return startZitiComponent(c, "router", self.Version, self.getConfigName(c))
 }
 
-func (self *RouterType) Stop(_ model.Run, c *model.Component) error {
-	return c.GetHost().KillProcesses("-TERM", self.getProcessFilter(c))
+func (self *RouterType) Stop(run model.Run, c *model.Component) error {
+	if err := c.GetHost().KillProcesses("-TERM", self.getProcessFilter(c)); err != nil {
+		return err
+	}
+	for i := 0; i < 10; i++ {
+		if isRunning, err := self.IsRunning(run, c); err == nil && !isRunning {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return c.GetHost().KillProcesses("-KILL", self.getProcessFilter(c))
 }
 
 func (self *RouterType) CreateAndEnroll(run model.Run, c *model.Component) error {
-	if err := zitilib_actions.EdgeExec(c.GetModel(), "delete", "edge-router", c.Id); err != nil {
-		pfxlog.Logger().
-			WithError(err).
-			WithField("router", c.Id).
-			Warn("unable to delete router (may not be present")
-	}
-
 	jwtFileName := filepath.Join(run.GetTmpDir(), c.Id+".jwt")
 
 	attributes := strings.Join(c.Tags, ",")
 
-	args := []string{"create", "edge-router", c.Id, "-j", "--jwt-output-file", jwtFileName, "-a", attributes}
+	args := []string{"create", "edge-router", c.Id, "--timeout", strconv.Itoa(60), "-j", "--jwt-output-file", jwtFileName, "-a", attributes}
 
 	isTunneler := c.HasLocalOrAncestralTag("tunneler")
 	if isTunneler {


### PR DESCRIPTION
- Fix link management race conditions found by chaos testing. Fixes #1709
- Ensure controller raft peers don't end up with duplicate connections. Fixes #1715
