### PR TITLE
tweak the expressInstall quickstart

### DIFF
--- a/quickstart/docker/docker-compose.yml
+++ b/quickstart/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2.4'
 services:
   ziti-controller:
     image: "${ZITI_IMAGE}:${ZITI_VERSION}"

--- a/quickstart/docker/image/Dockerfile
+++ b/quickstart/docker/image/Dockerfile
@@ -4,7 +4,6 @@ FROM ubuntu:rolling as fetch-ziti-bins
 ARG ZITI_VERSION_OVERRIDE
 ARG DEBIAN_FRONTEND=noninteractive
 
-COPY . /docker.build.context
 RUN apt-get update \
     && apt-get --yes install \
         jq \
@@ -19,6 +18,7 @@ RUN apt-get update \
     #   just build the Dockerfile \
     # to use a specific version of ziti, specify ZITI_VERSION_OVERRIDE then  \
     #   build the Dockerfile
+COPY . /docker.build.context
 RUN bash /docker.build.context/fetch-ziti-bins.sh /ziti-bin
 
 FROM ubuntu:rolling

--- a/quickstart/docker/image/run-controller.sh
+++ b/quickstart/docker/image/run-controller.sh
@@ -60,4 +60,4 @@ unset ZITI_PWD
 # create a place for the internal db
 mkdir -p $ZITI_HOME/db
 
-"${ZITI_BIN_DIR}/ziti" controller run "${ZITI_HOME}/${ZITI_CTRL_NAME}.yaml"
+"${ZITI_BIN_DIR}/ziti" controller run ${ZITI_VERBOSE:+--verbose} "${ZITI_HOME}/${ZITI_CTRL_NAME}.yaml"

--- a/quickstart/docker/image/run-router.sh
+++ b/quickstart/docker/image/run-router.sh
@@ -72,5 +72,5 @@ fi
 unset ZITI_USER
 unset ZITI_PWD
 
-"${ZITI_BIN_DIR}/ziti" router run "${ZITI_HOME}/${ZITI_ROUTER_NAME}.yaml" > "${ZITI_HOME}/${ZITI_ROUTER_NAME}.log"
+"${ZITI_BIN_DIR}/ziti" router run "${ZITI_HOME}/${ZITI_ROUTER_NAME}.yaml"
 

--- a/quickstart/docker/simplified-docker-compose.yml
+++ b/quickstart/docker/simplified-docker-compose.yml
@@ -2,7 +2,7 @@ services:
   ziti-controller:
     image: "${ZITI_IMAGE}:${ZITI_VERSION}"
     healthcheck:
-      test: curl -m 1 -s -k https://${ZITI_CTRL_EDGE_ADVERTISED_ADDRESS:-ziti-edge-controller}:${ZITI_CTRL_EDGE_ADVERTISED_PORT:-1280}/edge/client/v1/version
+      test: curl -m 1 -s -k -f https://${ZITI_CTRL_EDGE_ADVERTISED_ADDRESS:-ziti-edge-controller}:${ZITI_CTRL_EDGE_ADVERTISED_PORT:-1280}/edge/client/v1/version
       interval: 1s
       timeout: 3s
       retries: 30

--- a/ziti/cmd/edge/.gitignore
+++ b/ziti/cmd/edge/.gitignore
@@ -1,0 +1,1 @@
+/gotester.json


### PR DESCRIPTION
I've transplanted the changes from https://github.com/openziti/ziti/pull/1688 that were not strictly necessary for that branch to pass tests.