### PR TITLE
add create config environment --no-shell option 

### DIFF
--- a/ziti/cmd/create/config_templates/environment.yml
+++ b/ziti/cmd/create/config_templates/environment.yml
@@ -2,5 +2,9 @@
 {{ $varDeclare := .OSVarDeclare }}
 {{- range .EnvVars}}
 {{ $commentPrefix }} {{ .Description }}
+{{- if $varDeclare }}
 {{ $varDeclare }} {{ .Name }}={{ .Value }}
+{{- else }}
+{{ .Name }}={{ .Value }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
add option suppress shell variable declarations for generic env assignments usable with Docker Compose and systemd; fixed #1858