### PR TITLE
use Go version from go.mod

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,9 +46,10 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Go
+      id: setup-go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22.x'
+        go-version-file: ./go.mod
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/fablab-db-creation.yml
+++ b/.github/workflows/fablab-db-creation.yml
@@ -26,10 +26,11 @@ jobs:
         with:
           path: ziti
 
-      - name: Set up Go
+      - name: Install Go
+        id: setup-go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.x'
+          go-version-file: ./go.mod
 
       - name: Install Ziti CI
         uses: openziti/ziti-ci@v1

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,12 +16,13 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - name: Install Go
+        id: setup-go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.x'
-
-      - uses: actions/checkout@v4
+          go-version-file: ./go.mod
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.x'
+          go-version-file: ./go.mod
 
       - name: Install Ziti CI
         uses: openziti/ziti-ci@v1
@@ -80,7 +80,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.x'
+          go-version-file: ./go.mod
 
       - name: Install Ziti CI
         uses: openziti/ziti-ci@v1
@@ -111,7 +111,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.x'
+          go-version-file: ./go.mod
 
       - name: Install Ziti CI
         uses: openziti/ziti-ci@v1
@@ -147,7 +147,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.x'
+          go-version-file: ./go.mod
 
       - name: Install Ziti CI
         uses: openziti/ziti-ci@v1
@@ -178,7 +178,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.x'
+          go-version-file: ./go.mod
 
       - name: Install Ziti CI
         uses: openziti/ziti-ci@v1
@@ -301,7 +301,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.x'
+          go-version-file: ./go.mod
 
       - name: Install Ziti CI
         uses: openziti/ziti-ci@v1
@@ -416,7 +416,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.x'
+          go-version-file: ./go.mod
 
       - name: Install Python
         uses: actions/setup-python@v5

--- a/.github/workflows/release-quickstart.yml
+++ b/.github/workflows/release-quickstart.yml
@@ -46,6 +46,12 @@ jobs:
       - name: Checkout Workspace
         uses: actions/checkout@v4
 
+      - name: Install Go
+        id: setup-go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: ./go.mod
+
       - name: Install Ziti CI
         uses: openziti/ziti-ci@v1
 

--- a/.github/workflows/test-quickstart.yml
+++ b/.github/workflows/test-quickstart.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.x'
+          go-version-file: ./go.mod
 
       - name: Build and run a quickstart container image
         shell: bash

--- a/.github/workflows/update-dependency.yml
+++ b/.github/workflows/update-dependency.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.x'
+          go-version-file: ./go.mod
 
       - name: Install Ziti CI
         uses: openziti/ziti-ci@v1


### PR DESCRIPTION
fix [failing job](https://github.com/openziti/ziti/actions/runs/8428782265/job/23081932207) due to go 1.21 trying to run 1.22 codebase and update existing Go setup actions to also use Go version from go.mod instead of hard coding