### PR TITLE
Optimize network run loop. Fixes #1897

### DIFF
--- a/controller/api_impl/link_router.go
+++ b/controller/api_impl/link_router.go
@@ -122,7 +122,7 @@ func (r *LinkRouter) Patch(n *network.Network, rc api.RequestContext, params lin
 		if fields.IsUpdated("down") {
 			l.SetDown(params.Link.Down)
 		}
-		n.LinkChanged(l)
+		n.RerouteLink(l)
 		return nil
 	})
 }

--- a/controller/handler_ctrl/fault.go
+++ b/controller/handler_ctrl/fault.go
@@ -122,7 +122,9 @@ func (h *faultHandler) handleFaultedLink(log *logrus.Entry, fault *ctrl_pb.Fault
 
 		wasConnected := link.IsUsable()
 		if err := h.network.LinkFaulted(link, fault.Subject == ctrl_pb.FaultSubject_LinkDuplicate); err == nil {
-			h.network.LinkChanged(link)
+			if wasConnected {
+				h.network.RerouteLink(link)
+			}
 			otherRouter := link.Src
 			if link.Src.Id == h.r.Id {
 				otherRouter = link.GetDest()

--- a/controller/network/util_test.go
+++ b/controller/network/util_test.go
@@ -22,9 +22,9 @@ import (
 	"github.com/openziti/ziti/controller/models"
 	"github.com/openziti/ziti/controller/xt_smartrouting"
 
-	"github.com/openziti/ziti/controller/db"
 	"github.com/openziti/transport/v2"
 	"github.com/openziti/transport/v2/tcp"
+	"github.com/openziti/ziti/controller/db"
 )
 
 func newTestEntityHelper(ctx *db.TestContext, network *Network) *testEntityHelper {
@@ -88,8 +88,7 @@ func (self *testEntityHelper) addTestService(serviceName string) *Service {
 func (self *testEntityHelper) discardControllerEvents() {
 	for {
 		select {
-		case <-self.network.routerChanged:
-		case <-self.network.linkChanged:
+		case <-self.network.assembleAndCleanC:
 		default:
 			return
 		}


### PR DESCRIPTION
* When routers change (connect/disconnect), we re-check the mesh. We are passing in the routers to the channel and they can build up, which is unnecessary. We only need to signal once for all the routers that change since the last time we checked, that the mesh needs to be checked.
* We pass link changes through the run method, which is unnecessary since we pass it to a new goroutine. This inefficiency should be fixed.
* We're evaluating all faulted links for rerouting, even if they were still pending. Only reroute connected links.
* We're using time.After in each for loop, which can accumulate timers. Use a single Ticker instead.