### PR TITLE
Improve link mgmt backwards compatibility. Fixes #1900

### DIFF
--- a/controller/network/link_controller.go
+++ b/controller/network/link_controller.go
@@ -242,7 +242,7 @@ func (linkController *linkController) missingLinks(routers []*Router, pendingTim
 
 	missingLinks := make([]*Link, 0)
 	for _, srcR := range routers {
-		if srcR.HasCapability(ctrl_pb.RouterCapability_LinkManagement) {
+		if srcR.SupportsRouterLinkMgmt() {
 			continue
 		}
 

--- a/controller/network/router.go
+++ b/controller/network/router.go
@@ -31,6 +31,7 @@ import (
 	"github.com/openziti/ziti/controller/fields"
 	"github.com/openziti/ziti/controller/xt"
 	"google.golang.org/protobuf/proto"
+	"maps"
 	"reflect"
 	"strings"
 	"sync"
@@ -104,6 +105,14 @@ func (entity *Router) SetMetadata(metadata *ctrl_pb.RouterMetadata) {
 
 func (entity *Router) HasCapability(capability ctrl_pb.RouterCapability) bool {
 	return entity.Metadata != nil && genext.Contains(entity.Metadata.Capabilities, capability)
+}
+
+func (entity *Router) SupportsRouterLinkMgmt() bool {
+	if entity.VersionInfo == nil {
+		return true
+	}
+	supportsLinkMgmt, err := entity.VersionInfo.HasMinimumVersion("0.32.1")
+	return err != nil || supportsLinkMgmt
 }
 
 func NewRouter(id, name, fingerprint string, cost uint16, noTraversal bool) *Router {
@@ -593,9 +602,7 @@ func (self *RouterLinks) Add(link *Link, otherRouterId string) {
 
 	byRouter := self.GetLinksByRouter()
 	newLinksByRouter := map[string][]*Link{}
-	for k, v := range byRouter {
-		newLinksByRouter[k] = v
-	}
+	maps.Copy(newLinksByRouter, byRouter)
 	forRouterList := newLinksByRouter[otherRouterId]
 	newForRouterList := append([]*Link{link}, forRouterList...)
 	newLinksByRouter[otherRouterId] = newForRouterList
@@ -606,7 +613,7 @@ func (self *RouterLinks) Remove(link *Link, otherRouterId string) {
 	self.Lock()
 	defer self.Unlock()
 	links := self.GetLinks()
-	newLinks := make([]*Link, 0, len(links)+1)
+	newLinks := make([]*Link, 0, len(links))
 	for _, l := range links {
 		if link != l {
 			newLinks = append(newLinks, l)
@@ -616,9 +623,7 @@ func (self *RouterLinks) Remove(link *Link, otherRouterId string) {
 
 	byRouter := self.GetLinksByRouter()
 	newLinksByRouter := map[string][]*Link{}
-	for k, v := range byRouter {
-		newLinksByRouter[k] = v
-	}
+	maps.Copy(newLinksByRouter, byRouter)
 	forRouterList := newLinksByRouter[otherRouterId]
 	var newForRouterList []*Link
 	for _, l := range forRouterList {
@@ -633,7 +638,6 @@ func (self *RouterLinks) Remove(link *Link, otherRouterId string) {
 	}
 
 	self.linkByRouter.Store(newLinksByRouter)
-
 }
 
 func (self *RouterLinks) Clear() {

--- a/router/handler_ctrl/validate_terminators_v2.go
+++ b/router/handler_ctrl/validate_terminators_v2.go
@@ -131,8 +131,15 @@ func (handler *validateTerminatorsV2Handler) validateTerminators(msg *channel.Me
 func (handler *validateTerminatorsV2Handler) validateTerminator(dialer xgress.Dialer, terminator *ctrl_pb.Terminator, fixInvalid bool) *ctrl_pb.RouterTerminatorState {
 	if inspectable, ok := dialer.(xgress.InspectableDialer); ok {
 		valid, state := inspectable.InspectTerminator(terminator.Id, terminator.Address, fixInvalid)
+		if valid {
+			return &ctrl_pb.RouterTerminatorState{
+				Valid:  true,
+				Detail: state,
+				Marker: terminator.Marker,
+			}
+		}
 		return &ctrl_pb.RouterTerminatorState{
-			Valid:  valid,
+			Valid:  false,
 			Detail: state,
 			Reason: ctrl_pb.TerminatorInvalidReason_UnknownTerminator,
 			Marker: terminator.Marker,


### PR DESCRIPTION
* We're sending peer change messages to older routers that don't understand them.
* We should probably use the older controller link management code for routers without the link management stability fixes
* Includes a few minor cleanups