### PR TITLE
fixes #1926 adds chains to enrollment responses

### DIFF
--- a/controller/internal/routes/enroll_router.go
+++ b/controller/internal/routes/enroll_router.go
@@ -237,7 +237,7 @@ func (ro *EnrollRouter) extendRouterEnrollment(ae *env.AppEnv, rc *response.Requ
 			return
 		}
 
-		clientChainPem, err := ae.Managers.Enrollment.GetClientCertChain(certs.RawClientCert)
+		clientChainPem, err := ae.Managers.Enrollment.GetCertChainPem(certs.RawClientCert)
 		if err != nil {
 			rc.RespondWithError(err)
 			return
@@ -266,7 +266,7 @@ func (ro *EnrollRouter) extendRouterEnrollment(ae *env.AppEnv, rc *response.Requ
 			return
 		}
 
-		clientChainPem, err := ae.Managers.Enrollment.GetClientCertChain(certs.RawClientCert)
+		clientChainPem, err := ae.Managers.Enrollment.GetCertChainPem(certs.RawClientCert)
 
 		if err != nil {
 			rc.RespondWithError(err)

--- a/controller/model/enrollment_manager.go
+++ b/controller/model/enrollment_manager.go
@@ -215,10 +215,12 @@ func (self *EnrollmentManager) ReplaceWithAuthenticator(enrollmentId string, aut
 	})
 }
 
-func (self *EnrollmentManager) GetClientCertChain(certRaw []byte) (string, error) {
+// GetCertChainPem parses a given certificate in raw DER and attempt to provide string in PEM format of the
+// original certificate followed by each signing intermediate up to but not including the root CA.
+func (self *EnrollmentManager) GetCertChainPem(certRaw []byte) (string, error) {
 	clientCert, err := x509.ParseCertificate(certRaw)
 	if err != nil {
-		pfxlog.Logger().WithError(err).Error("error parsing client cert raw during enrollment")
+		pfxlog.Logger().WithError(err).Error("error parsing cert raw during enrollment, attempting to assemble chain")
 		return "", err
 	}
 

--- a/controller/model/enrollment_mod_erott.go
+++ b/controller/model/enrollment_mod_erott.go
@@ -19,10 +19,10 @@ package model
 import (
 	"fmt"
 	"github.com/openziti/edge-api/rest_model"
+	"github.com/openziti/foundation/v2/errorz"
 	"github.com/openziti/ziti/common/cert"
 	"github.com/openziti/ziti/controller/apierror"
 	"github.com/openziti/ziti/controller/change"
-	"github.com/openziti/foundation/v2/errorz"
 	"github.com/pkg/errors"
 	"time"
 )
@@ -107,14 +107,12 @@ func (module *EnrollModuleEr) Process(context EnrollmentContext) (*EnrollmentRes
 		return nil, apiError
 	}
 
-	serverCertPem, err := cert.RawToPem(serverCertRaw)
-
+	serverCertPem, err := module.env.GetManagers().Enrollment.GetCertChainPem(serverCertRaw)
 	if err != nil {
 		return nil, err
 	}
 
 	clientCertPem, err := cert.RawToPem(clientCertRaw)
-
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +123,7 @@ func (module *EnrollModuleEr) Process(context EnrollmentContext) (*EnrollmentRes
 
 	clientCertFingerprint := module.fingerprintGenerator.FromRaw(clientCertRaw)
 
-	clientChainPem, err := module.env.GetManagers().Enrollment.GetClientCertChain(clientCertRaw)
+	clientChainPem, err := module.env.GetManagers().Enrollment.GetCertChainPem(clientCertRaw)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/model/enrollment_mod_ott.go
+++ b/controller/model/enrollment_mod_ott.go
@@ -97,7 +97,7 @@ func (module *EnrollModuleOtt) Process(ctx EnrollmentContext) (*EnrollmentResult
 		Bytes: certRaw,
 	})
 
-	clientChainPem, err := module.env.GetManagers().Enrollment.GetClientCertChain(certRaw)
+	clientChainPem, err := module.env.GetManagers().Enrollment.GetCertChainPem(certRaw)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/model/enrollment_mod_trott.go
+++ b/controller/model/enrollment_mod_trott.go
@@ -96,7 +96,7 @@ func (module *EnrollModuleRouterOtt) Process(context EnrollmentContext) (*Enroll
 		return nil, apierror.NewCouldNotProcessCsr()
 	}
 
-	srvPem, err := cert.RawToPem(srvCert)
+	srvPem, err := module.env.GetManagers().Enrollment.GetCertChainPem(srvCert)
 
 	if err != nil {
 		return nil, apierror.NewCouldNotProcessCsr()
@@ -129,7 +129,7 @@ func (module *EnrollModuleRouterOtt) Process(context EnrollmentContext) (*Enroll
 		return nil, apierror.NewCouldNotProcessCsr()
 	}
 
-	clientChainPem, err := module.env.GetManagers().Enrollment.GetClientCertChain(cltCert)
+	clientChainPem, err := module.env.GetManagers().Enrollment.GetCertChainPem(cltCert)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/enrollment_router_test.go
+++ b/tests/enrollment_router_test.go
@@ -295,7 +295,7 @@ func Test_RouterEnrollment(t *testing.T) {
 				serverCertPem := enrollmentContainer.Path("data.serverCert").Data().(string)
 				serverCerts, err := parsePEMBundle([]byte(serverCertPem))
 				ctx.Req.NoError(err)
-				ctx.Req.Len(serverCerts, 1)
+				ctx.Req.Len(serverCerts, 2)
 
 				ctx.Req.True(enrollmentContainer.ExistsP("data.ca"))
 				caCertPem := enrollmentContainer.Path("data.ca").Data().(string)


### PR DESCRIPTION
- all server and client certs issued attempt to build a chain less root from the CA bundle during enrollment
- this change still requires all intermediates to be in the ca bundle, untill they are moved somewhere else or provided in some other fashion
- updated tests to expect chains in enrollment responses