### PR TITLE
golangci-lint: remove deprecated `run.skip-files`

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -28,7 +28,7 @@ jobs:
         uses: golangci/golangci-lint-action@v4
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.55.2
+          version: v1.57.2
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,8 @@
 run:
   build-tags:
     - apitests
-  deadline: 8m
+  # Default: 1m
+  timeout: 8m
 
 # golangci gives false positives for implementations of methods using generics in generic interfaces
 issues:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,8 +2,6 @@ run:
   build-tags:
     - apitests
   deadline: 8m
-  skip-files:
-    - ziti/cmd/edge/verify_ca.go
 
 # golangci gives false positives for implementations of methods using generics in generic interfaces
 issues:
@@ -11,3 +9,6 @@ issues:
     - path: 'controller/model/.*.go'
       linters:
         - unused
+    - path: 'ziti/cmd/edge/verify_ca.go'
+      linters:
+        - staticcheck


### PR DESCRIPTION
Hi,

This is a trivial PR upgrading golangci-lint and fixing a Warning message,

```bash
WARN [config_reader] The configuration option `run.skip-files` is deprecated, please use `issues.exclude-files`.
```

It seems also that `deadline` is completely deprecated in favour of `timeout`.

