### PR TITLE
fixes #1964, fixes #1960 adds the ability to handle and process beare…

### DIFF
--- a/common/oidc_tokens.go
+++ b/common/oidc_tokens.go
@@ -220,6 +220,31 @@ type IdTokenClaims struct {
 	CustomClaims
 }
 
+func (r *IdTokenClaims) GetExpirationTime() (*jwt.NumericDate, error) {
+	return &jwt.NumericDate{Time: r.TokenClaims.GetExpiration()}, nil
+}
+
+func (r *IdTokenClaims) GetNotBefore() (*jwt.NumericDate, error) {
+	notBefore := r.TokenClaims.NotBefore.AsTime()
+	return &jwt.NumericDate{Time: notBefore}, nil
+}
+
+func (r *IdTokenClaims) GetIssuedAt() (*jwt.NumericDate, error) {
+	return &jwt.NumericDate{Time: r.TokenClaims.GetIssuedAt()}, nil
+}
+
+func (r *IdTokenClaims) GetIssuer() (string, error) {
+	return r.TokenClaims.Issuer, nil
+}
+
+func (r *IdTokenClaims) GetSubject() (string, error) {
+	return r.TokenClaims.Issuer, nil
+}
+
+func (r *IdTokenClaims) GetAudience() (jwt.ClaimStrings, error) {
+	return jwt.ClaimStrings(r.TokenClaims.Audience), nil
+}
+
 func (c *IdTokenClaims) TotpComplete() bool {
 	for _, amr := range c.AuthenticationMethodsReferences {
 		if amr == "totp" {

--- a/router/xgress_common/edge.go
+++ b/router/xgress_common/edge.go
@@ -19,7 +19,23 @@ package xgress_common
 import "strings"
 
 const JwtTokenPrefix = "ey"
+const JwtExpectedDelimCount = 2
 
+// IsBearerToken checks to see if a string has the basic structure required of a JWT.
 func IsBearerToken(s string) bool {
-	return strings.HasPrefix(s, JwtTokenPrefix)
+	if strings.HasPrefix(s, JwtTokenPrefix) {
+		sectionCount := 0
+		for _, ch := range s {
+			if ch == '.' {
+				sectionCount++
+				if sectionCount > 3 {
+					return false
+				}
+			}
+		}
+
+		return sectionCount == JwtExpectedDelimCount
+	}
+
+	return false
 }

--- a/router/xgress_edge/accept.go
+++ b/router/xgress_edge/accept.go
@@ -84,6 +84,13 @@ func (self *Acceptor) BindChannel(binding channel.Binding) error {
 		},
 	})
 
+	binding.AddTypedReceiveHandler(&channel.AsyncFunctionReceiveAdapter{
+		Type: edge.ContentTypeUpdateToken,
+		Handler: func(m *channel.Message, ch channel.Channel) {
+			proxy.processTokenUpdate(self.listener.factory.stateManager, m, ch)
+		},
+	})
+
 	binding.AddReceiveHandlerF(edge.ContentTypeStateClosed, proxy.msgMux.HandleReceive)
 
 	binding.AddReceiveHandlerF(edge.ContentTypeTraceRoute, proxy.processTraceRoute)

--- a/router/xgress_edge/listener.go
+++ b/router/xgress_edge/listener.go
@@ -771,8 +771,6 @@ func (self *edgeClientConn) processTokenUpdate(manager state.Manager, req *chann
 	if err := ch.Send(reply); err != nil {
 		logrus.WithError(err).WithField("reqSeq", reply.Sequence()).Error("error responding to token update request with success")
 	}
-	return
-
 }
 
 func getResultOrFailure(msg *channel.Message, err error, result protobufs.TypedMessage) error {

--- a/tests/auth_distributed_test.go
+++ b/tests/auth_distributed_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"github.com/go-resty/resty/v2"
 	"github.com/google/uuid"
-	"github.com/openziti/ziti/common"
 	"github.com/openziti/ziti/controller/oidc_auth"
 	"github.com/zitadel/oidc/v2/pkg/client/rp"
 	httphelper "github.com/zitadel/oidc/v2/pkg/http"
@@ -22,7 +21,7 @@ type testRpServer struct {
 	Server       *http.Server
 	Port         string
 	Listener     net.Listener
-	TokenChan    <-chan *oidc.Tokens[*common.IdTokenClaims]
+	TokenChan    <-chan *oidc.Tokens[*oidc.IDTokenClaims]
 	CallbackPath string
 	CallbackUri  string
 	LoginUri     string
@@ -42,7 +41,7 @@ func (t *testRpServer) Start() {
 }
 
 func newOidcTestRp(apiHost string) (*testRpServer, error) {
-	tokenOutChan := make(chan *oidc.Tokens[*common.IdTokenClaims], 1)
+	tokenOutChan := make(chan *oidc.Tokens[*oidc.IDTokenClaims], 1)
 	result := &testRpServer{
 		CallbackPath: "/auth/callback",
 		TokenChan:    tokenOutChan,
@@ -111,7 +110,7 @@ func newOidcTestRp(apiHost string) (*testRpServer, error) {
 
 	serverMux.Handle("/login", loginHandler)
 
-	marshalToken := func(w http.ResponseWriter, r *http.Request, tokens *oidc.Tokens[*common.IdTokenClaims], state string, relyingParty rp.RelyingParty) {
+	marshalToken := func(w http.ResponseWriter, r *http.Request, tokens *oidc.Tokens[*oidc.IDTokenClaims], state string, relyingParty rp.RelyingParty) {
 		tokenOutChan <- tokens
 		_, _ = w.Write([]byte("done!"))
 	}
@@ -160,7 +159,7 @@ func Test_Authenticate_Distributed_Auth(t *testing.T) {
 		ctx.Req.NoError(err)
 		ctx.Req.Equal(http.StatusOK, resp.StatusCode())
 
-		var outTokens *oidc.Tokens[*common.IdTokenClaims]
+		var outTokens *oidc.Tokens[*oidc.IDTokenClaims]
 
 		select {
 		case tokens := <-rpServer.TokenChan:
@@ -200,7 +199,7 @@ func Test_Authenticate_Distributed_Auth(t *testing.T) {
 		ctx.Req.NoError(err)
 		ctx.Req.Equal(http.StatusOK, resp.StatusCode())
 
-		var outTokens *oidc.Tokens[*common.IdTokenClaims]
+		var outTokens *oidc.Tokens[*oidc.IDTokenClaims]
 
 		select {
 		case tokens := <-rpServer.TokenChan:


### PR DESCRIPTION
…r token updates

- established connections can now send an update token message with the body of a new bearer token
- the new token's signer is verified from the router data model along with the claims (matching subject, api session id, etc.)
- cleans up token exchange claim handling in the controller