### PR TITLE
Enhance Identity Existance Checks with Improved Error Handling

### DIFF
--- a/ziti/util/identities.go
+++ b/ziti/util/identities.go
@@ -247,7 +247,11 @@ func LoadSelectedIdentity() (RestClientIdentity, error) {
 		id := config.GetIdentity()
 		clientIdentity, found := config.EdgeIdentities[id]
 		if !found {
-			return nil, errors.Errorf("no identity '%v' found in cli config %v", id, configFile)
+			if len(config.EdgeIdentities) == 0 {
+				return nil, errors.New("no identities found in CLI config. Please log in using 'ziti edge login' command")
+			} else {
+				return nil, errors.Errorf("no identity '%v' found in CLI config %v. You can select an existing identity using 'ziti edge use <identity_name>'", id, configFile)
+			}
 		}
 		selectedIdentity = clientIdentity
 	}


### PR DESCRIPTION
This commit enhances the `LoadSelectedIdentity` function in the [identities.go](https://github.com/openziti/ziti/blob/a60ed6ffb6d539664151584ccd01b1740fc4d2b2/ziti/util/identities.go#L241C1-L255C2) file by adding improved error handling and checks for the existence of identities in the CLI configuration.

Previously, the function only threw an ambiguous error if the selected identity was not found in the CLI config.  However, with this enhancement, the function now checks if there are any saved identities in the CLI config.  If no identities are found, it returns an error instructing the user to log in using the `ziti edge login` command. Additionally, if the specified identity is not found, it returns an error message indicating that the identity could not be found in the CLI config and provides instructions on how to select an existing identity using `ziti edge use <identity_name>`.

These changes improve the robustness of the function by ensuring that appropriate error messages are provided in scenarios where the user is not logged in or when the selected identity is missing.

fixes #1772 thanks to @plorenz