### PR TITLE
fixes #1980 adds ctrl/client api addrs to enrollments

### DIFF
--- a/controller/model/controller_manager.go
+++ b/controller/model/controller_manager.go
@@ -338,3 +338,30 @@ func (self *ControllerManager) PeersDisconnected(peers []*event.ClusterPeer) {
 		}
 	}
 }
+
+func (self *ControllerManager) ListAll() ([]*Controller, error) {
+	handler := &ControllerListResult{}
+	if err := self.ListWithHandler("", handler.collect); err != nil {
+		return nil, err
+	}
+
+	return handler.Controllers, nil
+}
+
+type ControllerListResult struct {
+	manager     *ControllerManager
+	Controllers []*Controller
+	models.QueryMetaData
+}
+
+func (result *ControllerListResult) collect(tx *bbolt.Tx, ids []string, queryMetaData *models.QueryMetaData) error {
+	result.QueryMetaData = *queryMetaData
+	for _, key := range ids {
+		entity, err := result.manager.readInTx(tx, key)
+		if err != nil {
+			return err
+		}
+		result.Controllers = append(result.Controllers, entity)
+	}
+	return nil
+}

--- a/controller/model/controller_model.go
+++ b/controller/model/controller_model.go
@@ -18,6 +18,7 @@ package model
 
 import (
 	"github.com/openziti/storage/boltz"
+	"github.com/openziti/ziti/controller"
 	"github.com/openziti/ziti/controller/db"
 	"github.com/openziti/ziti/controller/models"
 	"go.etcd.io/bbolt"
@@ -94,4 +95,16 @@ func (entity *Controller) fillFrom(env Env, tx *bbolt.Tx, boltController *db.Con
 	}
 
 	return nil
+}
+
+func (entity *Controller) GetClientApi() string {
+	if curApis, ok := entity.ApiAddresses[controller.ClientApiBinding]; ok {
+		for _, curApi := range curApis {
+			if curApi.Version == controller.VersionV1 {
+				return curApi.Url
+			}
+		}
+	}
+
+	return ""
 }

--- a/controller/model/edge_router_manager.go
+++ b/controller/model/edge_router_manager.go
@@ -115,6 +115,8 @@ func (self *EdgeRouterManager) ApplyCreate(cmd *CreateEdgeRouterCmd, ctx boltz.M
 			return err
 		}
 
+		enrollment.FillApiInfo(self.env)
+
 		if err = enrollment.FillJwtInfo(self.env, edgeRouter.Id); err != nil {
 			return err
 		}

--- a/controller/model/identity_manager.go
+++ b/controller/model/identity_manager.go
@@ -125,6 +125,9 @@ func (self *IdentityManager) ApplyCreateWithEnrollments(cmd *CreateIdentityWithE
 		for _, enrollment := range enrollmentsModels {
 			enrollment.IdentityId = &identityModel.Id
 
+			enrollment.FillApiInfo(self.env)
+			enrollment.CtrlAddresses = nil
+
 			if err = enrollment.FillJwtInfo(self.env, identityModel.Id); err != nil {
 				return err
 			}


### PR DESCRIPTION
- client and ctrl for edge routers
- client only for identities
- limits to the first 3 in data model that are online