### PR TITLE
increase zet log verbosity

### DIFF
--- a/zititest/models/smoke/smoketest.go
+++ b/zititest/models/smoke/smoketest.go
@@ -178,7 +178,7 @@ var Model = &model.Model{
 							Scope: model.Scope{Tags: model.Tags{"sdk-app", "client"}},
 							Type: &zitilab.ZitiEdgeTunnelType{
 								Version:        ZitiEdgeTunnelVersion,
-								VerbosityLevel: 4,
+								VerbosityLevel: 6,
 							},
 						},
 					},
@@ -231,7 +231,7 @@ var Model = &model.Model{
 							Scope: model.Scope{Tags: model.Tags{"sdk-app", "host", "zet-host"}},
 							Type: &zitilab.ZitiEdgeTunnelType{
 								Version:        ZitiEdgeTunnelVersion,
-								VerbosityLevel: 4,
+								VerbosityLevel: 6,
 							},
 						},
 						"iperf-server-zet": {

--- a/zititest/zitilab/component_ziti_edge_tunnel.go
+++ b/zititest/zitilab/component_ziti_edge_tunnel.go
@@ -120,7 +120,7 @@ func (self *ZitiEdgeTunnelType) Start(_ model.Run, c *model.Component) error {
 		verbosity = fmt.Sprintf("-v %v", self.VerbosityLevel)
 	}
 
-	serviceCmd := fmt.Sprintf("%ssudo %s run %s  -i %s > %s 2>&1 &", logging, binaryPath, verbosity, configPath, logsPath)
+	serviceCmd := fmt.Sprintf("ZITI_TIME_FORMAT=utc %ssudo -E %s run %s -i %s > %s 2>&1 &", logging, binaryPath, verbosity, configPath, logsPath)
 	logrus.Infof("starting: %s", serviceCmd)
 	value, err := c.GetHost().ExecLogged(serviceCmd)
 	if err != nil {


### PR DESCRIPTION
and use utc timestamps for easier correlation with events from other services