### PR TITLE
use ziti-edge-tunnel 0.22.30 in smoke tests

### DIFF
--- a/zititest/models/smoke/smoketest.go
+++ b/zititest/models/smoke/smoketest.go
@@ -38,7 +38,7 @@ import (
 	"time"
 )
 
-const ZitiEdgeTunnelVersion = "v0.22.28"
+const ZitiEdgeTunnelVersion = "v0.22.30"
 
 //go:embed configs
 var configResource embed.FS


### PR DESCRIPTION
0.22.30 fixes a race condition when configuring the link dns servers for the tun device