### PR TITLE
fixes #2026 root version handlers 404

### DIFF
--- a/controller/server/client-api.go
+++ b/controller/server/client-api.go
@@ -122,7 +122,7 @@ func (clientApi ClientApiHandler) RootPath() string {
 }
 
 func (clientApi ClientApiHandler) IsHandler(r *http.Request) bool {
-	return strings.HasPrefix(r.URL.Path, clientApi.RootPath()) || r.URL.Path == WellKnownEstCaCerts
+	return strings.HasPrefix(r.URL.Path, clientApi.RootPath()) || r.URL.Path == WellKnownEstCaCerts || r.URL.Path == VersionPath || r.URL.Path == RootPath
 }
 
 func (clientApi ClientApiHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
@@ -164,6 +164,10 @@ func (clientApi ClientApiHandler) newHandler(ae *env.AppEnv) http.Handler {
 		// the prefixed path for route resolution.
 		if r.URL.Path == WellKnownEstCaCerts {
 			r.URL.Path = controller.ClientRestApiBaseUrlLatest + WellKnownEstCaCerts
+		}
+
+		if r.URL.Path == VersionPath || r.URL.Path == RootPath {
+			r.URL.Path = controller.ClientRestApiBaseUrlLatest + VersionPath
 		}
 
 		if r.URL.Path == controller.ClientRestApiSpecUrl {

--- a/controller/server/management-api.go
+++ b/controller/server/management-api.go
@@ -20,18 +20,22 @@ import (
 	"fmt"
 	"github.com/openziti/edge-api/rest_management_api_client"
 	"github.com/openziti/edge-api/rest_management_api_server"
+	"github.com/openziti/xweb/v2"
 	"github.com/openziti/ziti/controller"
+	"github.com/openziti/ziti/controller/api"
 	"github.com/openziti/ziti/controller/apierror"
 	"github.com/openziti/ziti/controller/env"
 	"github.com/openziti/ziti/controller/response"
-	"github.com/openziti/ziti/controller/api"
-	"github.com/openziti/xweb/v2"
 	"net/http"
 	"strings"
 	"time"
 )
 
-const WellKnownEstCaCerts = "/.well-known/est/cacerts"
+const (
+	WellKnownEstCaCerts = "/.well-known/est/cacerts"
+	VersionPath         = "/version"
+	RootPath            = "/"
+)
 
 var _ xweb.ApiHandlerFactory = &ManagementApiFactory{}
 
@@ -89,7 +93,7 @@ func (managementApi ManagementApiHandler) RootPath() string {
 }
 
 func (managementApi ManagementApiHandler) IsHandler(r *http.Request) bool {
-	return strings.HasPrefix(r.URL.Path, managementApi.RootPath()) || r.URL.Path == WellKnownEstCaCerts
+	return strings.HasPrefix(r.URL.Path, managementApi.RootPath()) || r.URL.Path == WellKnownEstCaCerts || r.URL.Path == VersionPath || r.URL.Path == RootPath
 }
 
 func (managementApi ManagementApiHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
@@ -123,6 +127,10 @@ func (managementApi ManagementApiHandler) newHandler(ae *env.AppEnv) http.Handle
 		// the prefixed path for route resolution
 		if r.URL.Path == WellKnownEstCaCerts {
 			r.URL.Path = controller.ManagementRestApiBaseUrlLatest + WellKnownEstCaCerts
+		}
+
+		if r.URL.Path == VersionPath || r.URL.Path == RootPath {
+			r.URL.Path = controller.ManagementRestApiBaseUrlLatest + VersionPath
 		}
 
 		rc := ae.CreateRequestContext(rw, r)

--- a/tests/root_endpoint_test.go
+++ b/tests/root_endpoint_test.go
@@ -1,0 +1,115 @@
+package tests
+
+import (
+	"testing"
+)
+
+func Test_Root_Endpoints(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+
+	t.Run("version can be retrieved", func(t *testing.T) {
+
+		t.Run("version can be retrieved from root path plus version", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			versionRootUrl := "https://" + ctx.ApiHost + "/version"
+
+			resp, err := ctx.newAnonymousClientApiRequest().Get(versionRootUrl)
+			ctx.Req.NoError(err)
+			ctx.Req.NotNil(resp)
+			ctx.Req.Equal(200, resp.StatusCode())
+			ctx.Req.NotEmpty(resp.Body())
+		})
+
+		t.Run("version can be retrieved from root path", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			versionRootUrl := "https://" + ctx.ApiHost + "/"
+
+			resp, err := ctx.newAnonymousClientApiRequest().Get(versionRootUrl)
+			ctx.Req.NoError(err)
+			ctx.Req.NotNil(resp)
+			ctx.Req.Equal(200, resp.StatusCode())
+			ctx.Req.NotEmpty(resp.Body())
+		})
+
+		t.Run("version can be retrieved from the base management path plus version", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			versionRootUrl := "https://" + ctx.ApiHost + "/edge/management/v1/version"
+
+			resp, err := ctx.newAnonymousClientApiRequest().Get(versionRootUrl)
+			ctx.Req.NoError(err)
+			ctx.Req.NotNil(resp)
+			ctx.Req.Equal(200, resp.StatusCode())
+			ctx.Req.NotEmpty(resp.Body())
+		})
+
+		t.Run("version can be retrieved from the base management path", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			versionRootUrl := "https://" + ctx.ApiHost + "/edge/management/v1"
+
+			resp, err := ctx.newAnonymousClientApiRequest().Get(versionRootUrl)
+			ctx.Req.NoError(err)
+			ctx.Req.NotNil(resp)
+			ctx.Req.Equal(200, resp.StatusCode())
+			ctx.Req.NotEmpty(resp.Body())
+		})
+
+		t.Run("version can be retrieved from the base client path plus version", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			versionRootUrl := "https://" + ctx.ApiHost + "/edge/client/v1/version"
+
+			resp, err := ctx.newAnonymousClientApiRequest().Get(versionRootUrl)
+			ctx.Req.NoError(err)
+			ctx.Req.NotNil(resp)
+			ctx.Req.Equal(200, resp.StatusCode())
+			ctx.Req.NotEmpty(resp.Body())
+		})
+
+		t.Run("version can be retrieved from the base client path", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			versionRootUrl := "https://" + ctx.ApiHost + "/edge/client/v1"
+
+			resp, err := ctx.newAnonymousClientApiRequest().Get(versionRootUrl)
+			ctx.Req.NoError(err)
+			ctx.Req.NotNil(resp)
+			ctx.Req.Equal(200, resp.StatusCode())
+			ctx.Req.NotEmpty(resp.Body())
+		})
+	})
+
+	t.Run(".well-known endpoint can be retrieved", func(t *testing.T) {
+		t.Run("well-known/est/ca/certs can be retrieved from root path", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			caCertsRootUrl := "https://" + ctx.ApiHost + "/.well-known/est/cacerts"
+
+			resp, err := ctx.newAnonymousClientApiRequest().Get(caCertsRootUrl)
+			ctx.Req.NoError(err)
+			ctx.Req.NotNil(resp)
+			ctx.Req.Equal(200, resp.StatusCode())
+			ctx.Req.NotEmpty(resp.Body())
+		})
+
+		t.Run("well-known/est/ca/certs can be retrieved from management path", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			caCertsRootUrl := "https://" + ctx.ApiHost + "/edge/management/v1//.well-known/est/cacerts"
+
+			resp, err := ctx.newAnonymousClientApiRequest().Get(caCertsRootUrl)
+			ctx.Req.NoError(err)
+			ctx.Req.NotNil(resp)
+			ctx.Req.Equal(200, resp.StatusCode())
+			ctx.Req.NotEmpty(resp.Body())
+		})
+
+		t.Run("well-known/est/ca/certs can be retrieved from client path", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			caCertsRootUrl := "https://" + ctx.ApiHost + "/edge/client/v1/.well-known/est/cacerts"
+
+			resp, err := ctx.newAnonymousClientApiRequest().Get(caCertsRootUrl)
+			ctx.Req.NoError(err)
+			ctx.Req.NotNil(resp)
+			ctx.Req.Equal(200, resp.StatusCode())
+			ctx.Req.NotEmpty(resp.Body())
+		})
+	})
+}


### PR DESCRIPTION
- adds test cases for all root handler (version, well-know)
- adds tests for all version targets (root, base + root, root + version)
- fixes handlers for all combinations that wern't working