### PR TITLE
Add lan interface router bootstrap

### DIFF
--- a/dist/dist-packages/linux/openziti-router/bootstrap.bash
+++ b/dist/dist-packages/linux/openziti-router/bootstrap.bash
@@ -14,10 +14,10 @@ function makeConfig() {
     fi
 
     # build config command
-    command=("ziti create config router ${ZITI_ROUTER_TYPE}
-             --tunnelerMode ${ZITI_ROUTER_MODE}
-             --routerName ${ZITI_ROUTER_NAME}
-             --output ${ZITI_ROUTER_CONFIG_FILE}")
+    command=("ziti create config router ${ZITI_ROUTER_TYPE}" \
+             "--tunnelerMode ${ZITI_ROUTER_MODE}" \
+             "--routerName ${ZITI_ROUTER_NAME}" \
+             "--output ${ZITI_ROUTER_CONFIG_FILE}")
 
     # check if ZITI_ROUTER_LAN_INTERFACE is specified and add --lanInterface flag accordingly
     if [[ -n "${ZITI_ROUTER_LAN_INTERFACE}" ]]; then
@@ -25,6 +25,7 @@ function makeConfig() {
     fi
 
     # execute config command
+    # shellcheck disable=SC2068
     ${command[@]}
 
   fi

--- a/dist/dist-packages/linux/openziti-router/bootstrap.bash
+++ b/dist/dist-packages/linux/openziti-router/bootstrap.bash
@@ -12,10 +12,21 @@ function makeConfig() {
       echo "ERROR: ZITI_CTRL_ADVERTISED_ADDRESS is not set" >&2
       return 1
     fi
-    ziti create config router "${ZITI_ROUTER_TYPE}" \
-      --tunnelerMode "${ZITI_ROUTER_MODE}" \
-      --routerName "${ZITI_ROUTER_NAME}" \
-      --output "${ZITI_ROUTER_CONFIG_FILE}"
+
+    # build config command
+    command=("ziti create config router ${ZITI_ROUTER_TYPE}
+             --tunnelerMode ${ZITI_ROUTER_MODE}
+             --routerName ${ZITI_ROUTER_NAME}
+             --output ${ZITI_ROUTER_CONFIG_FILE}")
+
+    # check if ZITI_ROUTER_LAN_INTERFACE is specified and add --lanInterface flag accordingly
+    if [[ -n "${ZITI_ROUTER_LAN_INTERFACE}" ]]; then
+      command+=("--lanInterface ${ZITI_ROUTER_LAN_INTERFACE}")
+    fi
+
+    # execute config command
+    ${command[@]}
+
   fi
 
 }


### PR DESCRIPTION
Added `--lanInterface` to package bootstrap create config command when `ZITI_ROUTER_LAN_INTERFACE` is specified. 