### PR TITLE
define alt_server_certs at the top level only

### DIFF
--- a/ziti/cmd/create/config_templates/router.yml
+++ b/ziti/cmd/create/config_templates/router.yml
@@ -92,9 +92,6 @@ edge:
 {{ if not .Router.IsWss }}#{{ end }}    enableCompression: {{ .Router.Wss.EnableCompression }}
 {{ if not .Router.IsWss }}#{{ end }}    server_cert: {{ .Router.IdentityServerCert }}
 {{ if not .Router.IsWss }}#{{ end }}    key: {{ .Router.IdentityKey }}
-{{ if not .Router.AltCertsEnabled }}#{{ end }}alt_server_certs:
-{{ if not .Router.AltCertsEnabled }}#{{ end }}  - server_cert:  "{{ .Router.AltServerCert }}"
-{{ if not .Router.AltCertsEnabled }}#{{ end }}    server_key:   "{{ .Router.AltServerKey }}"
 forwarder:
   latencyProbeInterval: {{ .Router.Forwarder.LatencyProbeInterval.Seconds }}
   xgressDialQueueLength: {{ .Router.Forwarder.XgressDialQueueLength }}


### PR DESCRIPTION
see https://openziti.discourse.group/t/right-place-for-the-alt-server-cert-in-router-config/2815/ for discussion. alt_server_certs should be declared on the identity block only