### PR TITLE
fixed #2240 secondary ext-jwt processing would fail...

### DIFF
--- a/controller/db/external_jwt_signer_store.go
+++ b/controller/db/external_jwt_signer_store.go
@@ -74,6 +74,7 @@ func (entity *ExternalJwtSigner) GetEntityType() string {
 var _ ExternalJwtSignerStore = (*externalJwtSignerStoreImpl)(nil)
 
 type ExternalJwtSignerStore interface {
+	NameIndexed
 	Store[*ExternalJwtSigner]
 }
 
@@ -94,6 +95,10 @@ type externalJwtSignerStoreImpl struct {
 	kidIndex           boltz.ReadIndex
 	symbolIssuer       boltz.EntitySymbol
 	issuerIndex        boltz.ReadIndex
+}
+
+func (store *externalJwtSignerStoreImpl) GetNameIndex() boltz.ReadIndex {
+	return store.indexName
 }
 
 func (store *externalJwtSignerStoreImpl) initializeLocal() {

--- a/controller/env/appenv.go
+++ b/controller/env/appenv.go
@@ -573,6 +573,11 @@ func (ae *AppEnv) ProcessJwt(rc *response.RequestContext, token *jwt.Token) erro
 }
 
 func (ae *AppEnv) FillRequestContext(rc *response.RequestContext) error {
+	// do no process auth headers on authenticate request
+	if strings.HasSuffix(rc.Request.URL.Path, "/v1/authenticate") && !strings.HasSuffix(rc.Request.URL.Path, "/authenticate/mfa") {
+		return nil
+	}
+
 	ztSession := ae.getZtSessionFromRequest(rc.Request)
 
 	if ztSession != "" {

--- a/controller/model/authenticator.go
+++ b/controller/model/authenticator.go
@@ -24,14 +24,11 @@ import (
 )
 
 type AuthResult interface {
-	IdentityId() string
-	ExternalId() string
 	AuthenticatorId() string
 	SessionCerts() []*x509.Certificate
 	Identity() *Identity
 	Authenticator() *Authenticator
 	AuthPolicy() *AuthPolicy
-	AuthPolicyId() string
 	IsSuccessful() bool
 }
 
@@ -121,23 +118,12 @@ func (context *AuthContextHttp) GetChangeContext() *change.Context {
 var _ AuthResult = &AuthResultBase{}
 
 type AuthResultBase struct {
-	identityId      string
-	externalId      string
 	identity        *Identity
 	authenticatorId string
 	authenticator   *Authenticator
 	sessionCerts    []*x509.Certificate
-	authPolicyId    string
 	authPolicy      *AuthPolicy
 	env             Env
-}
-
-func (a *AuthResultBase) IdentityId() string {
-	return a.identityId
-}
-
-func (a *AuthResultBase) ExternalId() string {
-	return a.externalId
 }
 
 func (a *AuthResultBase) AuthenticatorId() string {
@@ -149,14 +135,6 @@ func (a *AuthResultBase) SessionCerts() []*x509.Certificate {
 }
 
 func (a *AuthResultBase) Identity() *Identity {
-	if a.identity == nil {
-		if a.identityId != "" {
-			a.identity, _ = a.env.GetManagers().Identity.Read(a.identityId)
-		} else if a.externalId != "" {
-			a.identity, _ = a.env.GetManagers().Identity.ReadByExternalId(a.externalId)
-		}
-
-	}
 	return a.identity
 }
 
@@ -168,17 +146,9 @@ func (a *AuthResultBase) Authenticator() *Authenticator {
 }
 
 func (a *AuthResultBase) AuthPolicy() *AuthPolicy {
-	if a.authPolicy == nil {
-		a.authPolicy, _ = a.env.GetManagers().AuthPolicy.Read(a.authPolicyId)
-	}
-
 	return a.authPolicy
 }
 
-func (a *AuthResultBase) AuthPolicyId() string {
-	return a.authPolicyId
-}
-
 func (a *AuthResultBase) IsSuccessful() bool {
-	return a.identityId != ""
+	return a.identity != nil
 }

--- a/controller/model/authenticator_mod_cert.go
+++ b/controller/model/authenticator_mod_cert.go
@@ -23,7 +23,6 @@ import (
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/foundation/v2/errorz"
 	nfpem "github.com/openziti/foundation/v2/pem"
-	"github.com/openziti/foundation/v2/stringz"
 	"github.com/openziti/ziti/common/cert"
 	"github.com/openziti/ziti/controller/apierror"
 	"github.com/openziti/ziti/controller/change"
@@ -225,13 +224,10 @@ func (module *AuthModuleCert) Process(context AuthContext) (AuthResult, error) {
 	}
 
 	return &AuthResultBase{
-		identityId:      identity.Id,
-		externalId:      stringz.OrEmpty(identity.ExternalId),
 		identity:        identity,
 		authenticatorId: authenticator.Id,
 		authenticator:   authenticator,
 		sessionCerts:    []*x509.Certificate{clientCert},
-		authPolicyId:    authPolicy.Id,
 		authPolicy:      authPolicy,
 		env:             module.env,
 	}, nil

--- a/controller/model/authenticator_mod_ext_jwt.go
+++ b/controller/model/authenticator_mod_ext_jwt.go
@@ -268,225 +268,157 @@ func (a *AuthModuleExtJwt) ProcessSecondary(context AuthContext) (AuthResult, er
 
 type AuthResultJwt struct {
 	AuthResultBase
-	externalJwtSignerId string
-	externalJwtSigner   *db.ExternalJwtSigner
+	externalJwtSigner *db.ExternalJwtSigner
 }
 
 func (a *AuthResultJwt) IsSuccessful() bool {
-	return a.externalJwtSignerId != "" && a.AuthResultBase.identityId != ""
+	return a.externalJwtSigner != nil && a.AuthResultBase.identityId != ""
 }
 
 func (a *AuthResultJwt) AuthenticatorId() string {
-	return "extJwtId:" + a.externalJwtSignerId
+	if a.externalJwtSigner == nil {
+		return ""
+	}
+
+	return "extJwtId:" + a.externalJwtSigner.Id
 }
 
 func (a *AuthModuleExtJwt) process(context AuthContext, isPrimary bool) (AuthResult, error) {
 	logger := pfxlog.Logger().WithField("authMethod", AuthMethodExtJwt)
 
-	headers := map[string]interface{}{}
+	jwtStr, err := a.getJwtFromAuthHeader(context)
 
-	for key, value := range context.GetHeaders() {
-		headers[strings.ToLower(key)] = value
-	}
-
-	var authHeaders []string
-
-	if authHeaderVal, ok := headers["authorization"]; ok {
-		authHeaders = authHeaderVal.([]string)
-	}
-
-	if len(authHeaders) != 1 {
-		logger.Error("no authorization header found")
+	if err != nil {
+		logger.WithError(err).Error("error attempting to obtain JWT from authentication header")
 		return nil, apierror.NewInvalidAuth()
 	}
-	authHeader := authHeaders[0]
-
-	if !strings.HasPrefix(authHeader, "Bearer ") {
-		logger.Error("authorization header missing Bearer prefix")
-		return nil, apierror.NewInvalidAuth()
-	}
-
-	jwtStr := strings.Replace(authHeader, "Bearer ", "", 1)
 
 	//pubKeyLookup also handles extJwtSigner.enabled checking
 	jwtToken, err := jwt.Parse(jwtStr, a.pubKeyLookup)
 
-	if err == nil && jwtToken.Valid {
-		mapClaims := jwtToken.Claims.(jwt.MapClaims)
-		extJwt := mapClaims[ExtJwtInternalClaim].(*db.ExternalJwtSigner)
-
-		if extJwt == nil {
-			logger.Error("no external jwt signer found for internal claims")
-			return nil, apierror.NewInvalidAuth()
-		}
-
-		logger = logger.WithField("externalJwtSignerId", extJwt.Id)
-
-		issuer := ""
-		if issuerVal, ok := mapClaims["iss"]; ok {
-			issuer, ok = issuerVal.(string)
-			if !ok {
-				logger.Error("issuer in claims was not a string")
-				return nil, apierror.NewInvalidAuth()
-			}
-		}
-
-		logger = logger.WithField("claimsIssuer", issuer)
-
-		if extJwt.Issuer != nil && *extJwt.Issuer != issuer {
-			logger.WithField("expectedIssuer", *extJwt.Issuer).Error("invalid issuer")
-			return nil, apierror.NewInvalidAuth()
-		}
-
-		if extJwt.Audience != nil {
-			audValues := mapClaims["aud"]
-
-			if audValues == nil {
-				logger.WithField("audience", audValues).Error("audience is missing")
-				return nil, apierror.NewInvalidAuth()
-			}
-
-			audSlice, ok := audValues.([]string)
-
-			if !ok {
-				audISlice, ok := audValues.([]interface{})
-
-				if ok {
-					audSlice = []string{}
-					for _, aud := range audISlice {
-						audSlice = append(audSlice, aud.(string))
-					}
-				} else {
-					audString, ok := audValues.(string)
-
-					if !ok {
-						logger.WithField("audience", audValues).Error("audience is not a string or array of strings")
-						return nil, apierror.NewInvalidAuth()
-					}
-
-					audSlice = []string{audString}
-				}
-			}
-
-			found := false
-			for _, validAud := range audSlice {
-				if validAud == *extJwt.Audience {
-					found = true
-					break
-				}
-			}
-
-			if !found {
-				logger.WithField("expectedAudience", *extJwt.Audience).WithField("claimsAudiences", audSlice).Error("invalid audience")
-				return nil, apierror.NewInvalidAuth()
-			}
-		}
-
-		idClaimProperty := "sub"
-		if extJwt.ClaimsProperty != nil {
-			idClaimProperty = *extJwt.ClaimsProperty
-		}
-
-		logger = logger.WithField("idClaimProperty", idClaimProperty)
-
-		identityIdInterface, ok := mapClaims[idClaimProperty]
-
-		if !ok {
-			logger.Error("claims property on external jwt signer not found in claims")
-			return nil, apierror.NewInvalidAuth()
-		}
-
-		claimsId, ok := identityIdInterface.(string)
-
-		if !ok || claimsId == "" {
-			logger.Error("expected claims id was not a string or was empty")
-			return nil, apierror.NewInvalidAuth()
-		}
-
-		var authPolicy *AuthPolicy
-
-		var identity *Identity
-		if extJwt.UseExternalId {
-			authPolicy, identity, err = getAuthPolicyByExternalId(a.env, AuthMethodExtJwt, "", claimsId)
-		} else {
-			authPolicy, identity, err = getAuthPolicyByIdentityId(a.env, AuthMethodExtJwt, "", claimsId)
-		}
-
-		if err != nil {
-			logger.WithError(err).Error("encountered unhandled error during authentication")
-			return nil, apierror.NewInvalidAuth()
-		}
-
-		if authPolicy == nil {
-			logger.WithError(err).Error("encountered unhandled nil auth policy during authentication")
-			return nil, apierror.NewInvalidAuth()
-		}
-
-		if identity == nil {
-			logger.WithError(err).Error("encountered unhandled nil identity during authentication")
-			return nil, apierror.NewInvalidAuth()
-		}
-
-		externalJwtSignerId := ""
-		if identity.Disabled {
-			logger.
-				WithField("disabledAt", identity.DisabledAt).
-				WithField("disabledUntil", identity.DisabledUntil).
-				Error("authentication failed, identity is disabled")
-			return nil, apierror.NewInvalidAuth()
-		}
-
-		if !authPolicy.Primary.ExtJwt.Allowed {
-			logger.Error("external jwt authentication on auth policy is disabled")
-			return nil, apierror.NewInvalidAuth()
-		}
-
-		if isPrimary {
-			if len(authPolicy.Primary.ExtJwt.AllowedExtJwtSigners) > 0 {
-				found := false
-				for _, allowedId := range authPolicy.Primary.ExtJwt.AllowedExtJwtSigners {
-					if allowedId == extJwt.Id {
-						externalJwtSignerId = allowedId
-						found = true
-						break
-					}
-				}
-
-				if !found {
-					logger.
-						WithField("allowedSigners", authPolicy.Primary.ExtJwt.AllowedExtJwtSigners).
-						Error("auth policy does not allow specified signer")
-					return nil, apierror.NewInvalidAuth()
-				}
-			} else {
-				externalJwtSignerId = extJwt.Id
-			}
-		} else if authPolicy.Secondary.RequiredExtJwtSigner != nil {
-			if extJwt.Id != *authPolicy.Secondary.RequiredExtJwtSigner {
-				return nil, apierror.NewInvalidAuth()
-			}
-
-			externalJwtSignerId = extJwt.Id
-		}
-
-		result := &AuthResultJwt{
-			AuthResultBase: AuthResultBase{
-				authPolicyId: authPolicy.Id,
-				authPolicy:   authPolicy,
-				identity:     identity,
-				identityId:   identity.Id,
-				externalId:   stringz.OrEmpty(identity.ExternalId),
-				env:          a.env,
-			},
-			externalJwtSignerId: externalJwtSignerId,
-			externalJwtSigner:   extJwt,
-		}
-
-		return result, nil
+	if err != nil {
+		logger.WithError(err).Error("authorization failed, jwt did not verify due to error")
+		return nil, apierror.NewInvalidAuth()
 	}
 
-	logger.Error("authorization failed, jwt did not verify")
-	return nil, apierror.NewInvalidAuth()
+	if !jwtToken.Valid {
+		logger.Error("authorization failed, jwt did not pass signature verification")
+		return nil, apierror.NewInvalidAuth()
+	}
+
+	mapClaims := jwtToken.Claims.(jwt.MapClaims)
+	extJwt := mapClaims[ExtJwtInternalClaim].(*db.ExternalJwtSigner)
+
+	if extJwt == nil {
+		logger.Error("no external jwt signer found for internal claims")
+		return nil, apierror.NewInvalidAuth()
+	}
+
+	logger = logger.WithField("extJwtSignerId", extJwt.Id).
+		WithField("issuer", stringz.OrEmpty(extJwt.Issuer)).
+		WithField("audience", stringz.OrEmpty(extJwt.Audience))
+
+	err = a.verifyIssuer(extJwt.Issuer, mapClaims)
+
+	if err != nil {
+		logger.WithError(err).Error("issuer validation failed")
+	}
+
+	err = a.verifyAudience(extJwt.Audience, mapClaims)
+
+	if err != nil {
+		logger.WithError(err).Error("audience validation failed")
+		return nil, apierror.NewInvalidAuth()
+	}
+
+	idClaimProperty := "sub"
+	if extJwt.ClaimsProperty != nil {
+		idClaimProperty = *extJwt.ClaimsProperty
+	}
+
+	logger = logger.WithField("idClaimProperty", idClaimProperty)
+
+	identityIdInterface, ok := mapClaims[idClaimProperty]
+
+	if !ok {
+		logger.Error("claims property on external jwt signer not found in claims")
+		return nil, apierror.NewInvalidAuth()
+	}
+
+	claimsId, ok := identityIdInterface.(string)
+
+	if !ok || claimsId == "" {
+		logger.Error("expected claims id was not a string or was empty")
+		return nil, apierror.NewInvalidAuth()
+	}
+
+	var authPolicy *AuthPolicy
+
+	var identity *Identity
+	if extJwt.UseExternalId {
+		authPolicy, identity, err = getAuthPolicyByExternalId(a.env, AuthMethodExtJwt, "", claimsId)
+	} else {
+		authPolicy, identity, err = getAuthPolicyByIdentityId(a.env, AuthMethodExtJwt, "", claimsId)
+	}
+
+	if err != nil {
+		logger.WithError(err).Error("encountered unhandled error during authentication")
+		return nil, apierror.NewInvalidAuth()
+	}
+
+	if authPolicy == nil {
+		logger.WithError(err).Error("encountered unhandled nil auth policy during authentication")
+		return nil, apierror.NewInvalidAuth()
+	}
+
+	if identity == nil {
+		logger.WithError(err).Error("encountered unhandled nil identity during authentication")
+		return nil, apierror.NewInvalidAuth()
+	}
+
+	if identity.Disabled {
+		logger.
+			WithField("disabledAt", identity.DisabledAt).
+			WithField("disabledUntil", identity.DisabledUntil).
+			Error("authentication failed, identity is disabled")
+		return nil, apierror.NewInvalidAuth()
+	}
+
+	if isPrimary {
+		err := a.verifyAsPrimary(authPolicy, extJwt)
+
+		if err != nil {
+			logger.WithError(err).Error("primary external jwt processing failed")
+			return nil, apierror.NewInvalidAuth()
+		}
+
+	} else {
+		if authPolicy.Secondary.RequiredExtJwtSigner == nil {
+			logger.Error("secondary external jwt authentication on auth policy is not configured")
+			return nil, apierror.NewInvalidAuth()
+		}
+
+		if extJwt.Id != *authPolicy.Secondary.RequiredExtJwtSigner {
+			logger.WithField("requiredExtJwtId", *authPolicy.Secondary.RequiredExtJwtSigner).
+				WithField("tokenExtJwtId", extJwt.Id).
+				Error("secondary external jwt authentication failed because the token did not match the required ext-jwt signer")
+			return nil, apierror.NewInvalidAuth()
+		}
+	}
+
+	result := &AuthResultJwt{
+		AuthResultBase: AuthResultBase{
+			authPolicyId: authPolicy.Id,
+			authPolicy:   authPolicy,
+			identity:     identity,
+			identityId:   identity.Id,
+			externalId:   stringz.OrEmpty(identity.ExternalId),
+			env:          a.env,
+		},
+		externalJwtSigner: extJwt,
+	}
+
+	return result, nil
 }
 
 func (a *AuthModuleExtJwt) onExternalSignerCreate(args ...interface{}) {
@@ -581,4 +513,117 @@ func (a *AuthModuleExtJwt) loadExistingSigners() {
 	if err != nil {
 		pfxlog.Logger().Errorf("error loading external jwt signerByIssuer: %v", err)
 	}
+}
+
+func (a *AuthModuleExtJwt) verifyAudience(expectedAudience *string, mapClaims jwt.MapClaims) error {
+
+	if expectedAudience == nil {
+		return errors.New("audience on ext-jwt signer is nil, audience is required")
+	}
+
+	audValues := mapClaims["aud"]
+
+	if audValues == nil {
+		return errors.New("audience field is missing or is empty in JWT")
+	}
+
+	audSlice, ok := audValues.([]string)
+
+	if !ok {
+		audISlice, ok := audValues.([]interface{})
+
+		if ok {
+			audSlice = []string{}
+			for _, aud := range audISlice {
+				audSlice = append(audSlice, aud.(string))
+			}
+		} else {
+			audString, ok := audValues.(string)
+
+			if !ok {
+				return errors.New("jwt audience field is not a string or an array of strings")
+			}
+
+			audSlice = []string{audString}
+		}
+	}
+
+	for _, validAud := range audSlice {
+		if validAud == *expectedAudience {
+			return nil
+		}
+	}
+
+	return errors.New("audience value is invalid, no audiences matched the expected audience")
+}
+
+func (a *AuthModuleExtJwt) verifyIssuer(expectedIssuer *string, mapClaims jwt.MapClaims) error {
+
+	if expectedIssuer == nil {
+		return errors.New("no issuer found for external jwt signer, issuer is required")
+	}
+
+	issuer := ""
+	if issuerVal, ok := mapClaims["iss"]; ok {
+		issuer, ok = issuerVal.(string)
+		if !ok {
+			return fmt.Errorf("issuer in claims was not a string, got %T", issuerVal)
+		}
+	}
+
+	if *expectedIssuer == issuer {
+		return nil
+	}
+
+	return fmt.Errorf("invalid issuer, got: %s", issuer)
+}
+
+func (a *AuthModuleExtJwt) getJwtFromAuthHeader(context AuthContext) (string, error) {
+	headers := map[string]interface{}{}
+
+	for key, value := range context.GetHeaders() {
+		headers[strings.ToLower(key)] = value
+	}
+
+	var authHeaders []string
+
+	if authHeaderVal, ok := headers["authorization"]; ok {
+		authHeaders = authHeaderVal.([]string)
+	}
+
+	if len(authHeaders) != 1 {
+		return "", fmt.Errorf("wrong number of authorization headers found got %d expected 1", len(authHeaders))
+	}
+
+	if !strings.HasPrefix(authHeaders[0], "Bearer ") {
+		return "", errors.New("invalid authorization header, missing Bearer prefix")
+	}
+
+	jwtStr := strings.Replace(authHeaders[0], "Bearer ", "", 1)
+	jwtStr = strings.TrimSpace(jwtStr)
+
+	if len(jwtStr) == 0 {
+		return "", errors.New("invalid authorization header, jwt after Bearer prefix is empty")
+	}
+
+	return jwtStr, nil
+}
+
+func (a *AuthModuleExtJwt) verifyAsPrimary(authPolicy *AuthPolicy, extJwt *db.ExternalJwtSigner) error {
+	if !authPolicy.Primary.ExtJwt.Allowed {
+		return errors.New("primary external jwt authentication on auth policy is disabled")
+	}
+
+	if len(authPolicy.Primary.ExtJwt.AllowedExtJwtSigners) == 0 {
+		//allow any valid JWT
+		return nil
+	}
+
+	for _, allowedId := range authPolicy.Primary.ExtJwt.AllowedExtJwtSigners {
+		if allowedId == extJwt.Id {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("allowed signers does not contain the external jwt id: %s, expected one of: %v", extJwt.Id, authPolicy.Primary.ExtJwt.AllowedExtJwtSigners)
 }

--- a/controller/model/authenticator_mod_updb.go
+++ b/controller/model/authenticator_mod_updb.go
@@ -150,7 +150,6 @@ func (module *AuthModuleUpdb) Process(context AuthContext) (AuthResult, error) {
 
 	return &AuthResultBase{
 		identity:        identity,
-		identityId:      updb.IdentityId,
 		authenticator:   authenticator,
 		authenticatorId: authenticator.Id,
 		env:             module.env,

--- a/controller/models/base_model.go
+++ b/controller/models/base_model.go
@@ -275,7 +275,7 @@ func (ctrl *BaseEntityManager[E]) ValidateNameOnUpdate(ctx boltz.MutateContext, 
 					return errorz.NewFieldError("name is must be unique", "name", namedEntity.GetName())
 				}
 			} else {
-				pfxlog.Logger().Errorf("entity of type %v is named, but store doesn't have name index", reflect.TypeOf(updatedEntity))
+				pfxlog.Logger().Errorf("entity of type %v is named, but store doesn't implement the NamedIndexStore interface", reflect.TypeOf(updatedEntity))
 			}
 		}
 	}
@@ -299,7 +299,7 @@ func (handler *BaseEntityManager[E]) ValidateNameOnCreate(tx *bbolt.Tx, entity i
 				return errorz.NewFieldError("name is must be unique", "name", namedEntity.GetName())
 			}
 		} else {
-			pfxlog.Logger().Errorf("entity of type %v is named, but store doesn't have name index", reflect.TypeOf(entity))
+			pfxlog.Logger().Errorf("entity of type %v is named, but store doesn't implement the NamedIndexStore interface", reflect.TypeOf(entity))
 		}
 	}
 	return nil

--- a/controller/oidc_auth/storage.go
+++ b/controller/oidc_auth/storage.go
@@ -208,7 +208,7 @@ func (s *HybridStorage) Authenticate(authCtx model.AuthContext, id string, confi
 		return nil, apierror.NewInvalidAuth()
 	}
 
-	authRequest.IdentityId = result.IdentityId()
+	authRequest.IdentityId = result.Identity().Id
 	authRequest.AddAmr(authCtx.GetMethod())
 
 	configTypeIds := s.env.GetManagers().ConfigType.MapConfigTypeNamesToIds(configTypes, authRequest.IdentityId)


### PR DESCRIPTION
...if ext-jwt primary wasn't enabled.

- fixes extra JWT processing on authentication endpoints (that would never pass)
- updates error message for missing NamedIndexStore implementations
- fixes ext-jwt store error stating that a named index is not present