### PR TITLE
set spiffe id when generating a controller pki

### DIFF
--- a/dist/dist-packages/linux/openziti-controller/bootstrap.bash
+++ b/dist/dist-packages/linux/openziti-controller/bootstrap.bash
@@ -85,9 +85,9 @@ issueLeafCerts() {
 
     # fall back to renewing without SPIFFE ID if issuer cert lacks trust domain in URI SAN
     "${_create_server[@]}" --spiffe-id "/controller/${ZITI_SERVER_FILE}" >&3 || {
-      echo "DEBUG: renewing server cert without SPIFFE ID" >&3
+      echo "DEBUG: renewing server cert without SPIFFE ID"
       "${_create_server[@]}"
-    } >&3 # write to debug fd because this runs every startup
+    } >&3
   fi
 
   # client cert
@@ -105,10 +105,10 @@ issueLeafCerts() {
     )
 
     # fall back to renewing without SPIFFE ID if issuer cert lacks trust domain in URI SAN
-    "${_create_client[@]}" --spiffe-id "/controller/${ZITI_CLIENT_FILE}" || {
-      echo "DEBUG: renewing client cert without SPIFFE ID" >&3
+    "${_create_client[@]}" --spiffe-id "/controller/${ZITI_CLIENT_FILE}" >&3 || {
+      echo "DEBUG: renewing client cert without SPIFFE ID"
       "${_create_client[@]}"
-    } >&3 # write to debug fd because this runs every startup
+    } >&3
   fi
 
 }

--- a/dist/dist-packages/linux/openziti-controller/bootstrap.bash
+++ b/dist/dist-packages/linux/openziti-controller/bootstrap.bash
@@ -82,13 +82,11 @@ issueLeafCerts() {
       --ip "127.0.0.1,::1" \
       --allow-overwrite
     )
-    {
-      # fall back to renewing without SPIFFE ID if issuer cert lacks trust domain in URI SAN
-      "${_create_server[@]}" --spiffe-id "/controller/${ZITI_SERVER_FILE}" >&3 \
-      || {
-        echo "DEBUG: renewing server cert without SPIFFE ID" >&3
-        "${_create_server[@]}"
-      }
+
+    # fall back to renewing without SPIFFE ID if issuer cert lacks trust domain in URI SAN
+    "${_create_server[@]}" --spiffe-id "/controller/${ZITI_SERVER_FILE}" >&3 || {
+      echo "DEBUG: renewing server cert without SPIFFE ID" >&3
+      "${_create_server[@]}"
     } >&3 # write to debug fd because this runs every startup
   fi
 
@@ -105,13 +103,13 @@ issueLeafCerts() {
       --client-file "${ZITI_CLIENT_FILE}" \
       --allow-overwrite
     )
-  fi
-      # fall back to renewing without SPIFFE ID if issuer cert lacks trust domain in URI SAN
-      "${_create_client[@]}" --spiffe-id "/controller/${ZITI_CLIENT_FILE}" || {
-        echo "DEBUG: renewing client cert without SPIFFE ID" >&3
-        "${_create_client[@]}"
-      }
+
+    # fall back to renewing without SPIFFE ID if issuer cert lacks trust domain in URI SAN
+    "${_create_client[@]}" --spiffe-id "/controller/${ZITI_CLIENT_FILE}" || {
+      echo "DEBUG: renewing client cert without SPIFFE ID" >&3
+      "${_create_client[@]}"
     } >&3 # write to debug fd because this runs every startup
+  fi
 
 }
 

--- a/dist/dist-packages/linux/openziti-controller/bootstrap.bash
+++ b/dist/dist-packages/linux/openziti-controller/bootstrap.bash
@@ -25,7 +25,8 @@ makePki() {
   if [[ ! -s "${ZITI_CA_CERT}" ]]; then
     ziti pki create ca \
       --pki-root "${ZITI_PKI_ROOT}" \
-      --ca-file "${ZITI_CA_FILE}"
+      --ca-file "${ZITI_CA_FILE}" \
+      --trust-domain "${ZITI_CTRL_ADVERTISED_ADDRESS}"
   fi
 
   ZITI_PKI_SIGNER_CERT="${ZITI_PKI_ROOT}/${ZITI_INTERMEDIATE_FILE}/certs/${ZITI_INTERMEDIATE_FILE}.cert"
@@ -78,6 +79,7 @@ issueLeafCerts() {
       --server-file "${ZITI_SERVER_FILE}" \
       --dns "localhost,${ZITI_CTRL_ADVERTISED_ADDRESS}" \
       --ip "127.0.0.1,::1" \
+      --spiffe-id "/controller/${ZITI_SERVER_FILE}" \
       --allow-overwrite >&3  # write to debug fd because this runs every startup
   fi
 
@@ -91,6 +93,7 @@ issueLeafCerts() {
       --ca-name "${ZITI_INTERMEDIATE_FILE}" \
       --key-file "${ZITI_SERVER_FILE}" \
       --client-file "${ZITI_CLIENT_FILE}" \
+      --spiffe-id "/controller/${ZITI_CLIENT_FILE}" \
       --allow-overwrite >&3  # write to debug fd because this runs every startup
   fi
 


### PR DESCRIPTION
Add SPIFFE ID to the Linux and Docker controller's certs