### PR TITLE
do nothing and exit non-error if check mode 

### DIFF
--- a/dist/dist-packages/linux/openziti-controller/entrypoint.bash
+++ b/dist/dist-packages/linux/openziti-controller/entrypoint.bash
@@ -46,7 +46,8 @@ elif [[ "${1}" =~ check ]]; then
     issueLeafCerts
     exit
   else
-    exit
+    # if check mode and no bootstrap then noop
+    exit 0
   fi
 fi
 

--- a/dist/dist-packages/linux/openziti-router/entrypoint.bash
+++ b/dist/dist-packages/linux/openziti-router/entrypoint.bash
@@ -42,8 +42,9 @@ elif [[ "${1}" =~ check ]]; then
     hintLinuxBootstrap "${PWD}"
     exit 1
   else
+    # if check mode and config.yml exists then noop
     echo "DEBUG: ${2} exists and is not empty" >&3
-    exit
+    exit 0
   fi
 fi
 


### PR DESCRIPTION
If the Linux service for controller or router calls entrypoint.bash with "check" then it must perform only pre-flight checks and exit 0 if they succeed and >0 if failed.

This fixes a bug where checks appeared to fail, aborting the service, when bootstrapping was explicitly disabled.
