### PR TITLE
Add verify traffic verify network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 * Includes a performance update ([Issue #2340](https://github.com/openziti/ziti/issues/2340)) which should improve
   connection ramp times. Previously circuits would start with a relatively low window size and ramp slowly. Circuits
   will now start with a large initial window size and scale back if they can't keep up
+* Added `ziti ops verify-network`. A command to aid when configuring the overlay network, this command will check config
+  files for obvious mistakes
+* Added `ziti ops verify-traffic`. Another command to aid when configuring the overlay network, this command will ensure
+  the overlay network is able to pass traffic
 
 ## Component Updates and Bug Fixes
 

--- a/internal/rest/mgmt/helpers.go
+++ b/internal/rest/mgmt/helpers.go
@@ -79,5 +79,5 @@ func ServicePolicyFromFilter(client *rest_management_api_client.ZitiEdgeManageme
 }
 
 func NameFilter(name string) string {
-	return "name=\"" + name + "\""
+	return `name="` + name + `"`
 }

--- a/internal/rest/mgmt/helpers.go
+++ b/internal/rest/mgmt/helpers.go
@@ -1,0 +1,83 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+package mgmt
+
+import (
+	"context"
+	"github.com/openziti/edge-api/rest_management_api_client"
+	"github.com/openziti/edge-api/rest_management_api_client/identity"
+	"github.com/openziti/edge-api/rest_management_api_client/service"
+	"github.com/openziti/edge-api/rest_management_api_client/service_policy"
+	"github.com/openziti/edge-api/rest_model"
+	log "github.com/sirupsen/logrus"
+	"time"
+)
+
+func IdentityFromFilter(client *rest_management_api_client.ZitiEdgeManagement, filter string) *rest_model.IdentityDetail {
+	params := &identity.ListIdentitiesParams{
+		Filter:  &filter,
+		Context: context.Background(),
+	}
+	params.SetTimeout(5 * time.Second)
+	resp, err := client.Identity.ListIdentities(params, nil)
+	if err != nil {
+		log.Debugf("Could not obtain an ID for the identity with filter %s: %v", filter, err)
+		return nil
+	}
+
+	if resp == nil || resp.Payload == nil || resp.Payload.Data == nil || len(resp.Payload.Data) == 0 {
+		return nil
+	}
+	return resp.Payload.Data[0]
+}
+
+func ServiceFromFilter(client *rest_management_api_client.ZitiEdgeManagement, filter string) *rest_model.ServiceDetail {
+	params := &service.ListServicesParams{
+		Filter:  &filter,
+		Context: context.Background(),
+	}
+	params.SetTimeout(5 * time.Second)
+	resp, err := client.Service.ListServices(params, nil)
+	if err != nil {
+		log.Debugf("Could not obtain an ID for the service with filter %s: %v", filter, err)
+		return nil
+	}
+	if resp == nil || resp.Payload == nil || resp.Payload.Data == nil || len(resp.Payload.Data) == 0 {
+		return nil
+	}
+	return resp.Payload.Data[0]
+}
+
+func ServicePolicyFromFilter(client *rest_management_api_client.ZitiEdgeManagement, filter string) *rest_model.ServicePolicyDetail {
+	params := &service_policy.ListServicePoliciesParams{
+		Filter:  &filter,
+		Context: context.Background(),
+	}
+	params.SetTimeout(5 * time.Second)
+	resp, err := client.ServicePolicy.ListServicePolicies(params, nil)
+	if err != nil {
+		log.Errorf("Could not obtain an ID for the service with filter %s: %v", filter, err)
+		return nil
+	}
+	if resp == nil || resp.Payload == nil || resp.Payload.Data == nil || len(resp.Payload.Data) == 0 {
+		return nil
+	}
+	return resp.Payload.Data[0]
+}
+
+func NameFilter(name string) string {
+	return "name=\"" + name + "\""
+}

--- a/ziti/cmd/cmd.go
+++ b/ziti/cmd/cmd.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	goflag "flag"
 	"fmt"
-	"github.com/openziti/ziti/ziti/cmd/verify"
 	"io"
 	"os"
 	"path/filepath"
@@ -34,6 +33,7 @@ import (
 	"github.com/openziti/ziti/ziti/cmd/fabric"
 	"github.com/openziti/ziti/ziti/cmd/pki"
 	"github.com/openziti/ziti/ziti/cmd/templates"
+	"github.com/openziti/ziti/ziti/cmd/verify"
 	c "github.com/openziti/ziti/ziti/constants"
 	"github.com/openziti/ziti/ziti/controller"
 	"github.com/openziti/ziti/ziti/internal/log"

--- a/ziti/cmd/cmd.go
+++ b/ziti/cmd/cmd.go
@@ -143,7 +143,7 @@ func NewCmdRoot(in io.Reader, out, err io.Writer, cmd *cobra.Command) *cobra.Com
 	opsCommands.AddCommand(NewCmdLogFormat(out, err))
 	opsCommands.AddCommand(NewUnwrapIdentityFileCommand(out, err))
 	opsCommands.AddCommand(verify.NewVerifyNetwork())
-	opsCommands.AddCommand(verify.NewVerifyTraffic(out, err))
+	opsCommands.AddCommand(verify.NewVerifyTraffic())
 
 	groups := templates.CommandGroups{
 		{

--- a/ziti/cmd/cmd.go
+++ b/ziti/cmd/cmd.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	goflag "flag"
 	"fmt"
+	"github.com/openziti/ziti/ziti/cmd/verify"
 	"io"
 	"os"
 	"path/filepath"
@@ -134,13 +135,15 @@ func NewCmdRoot(in io.Reader, out, err io.Writer, cmd *cobra.Command) *cobra.Com
 	demoCmd := demo.NewDemoCmd(p)
 
 	opsCommands := &cobra.Command{
-		Use:   "ops ",
+		Use: "ops",
 		Short: "Various utilities useful when operating a Ziti network",
 	}
 
 	opsCommands.AddCommand(database.NewCmdDb(out, err))
 	opsCommands.AddCommand(NewCmdLogFormat(out, err))
 	opsCommands.AddCommand(NewUnwrapIdentityFileCommand(out, err))
+	opsCommands.AddCommand(verify.NewVerifyNetwork())
+	opsCommands.AddCommand(verify.NewVerifyTraffic(out, err))
 
 	groups := templates.CommandGroups{
 		{

--- a/ziti/cmd/verify/common.go
+++ b/ziti/cmd/verify/common.go
@@ -20,6 +20,13 @@ import (
 	"runtime"
 )
 
+type controller struct {
+	user string
+	pass string
+	host string
+	port string
+}
+
 func configureLogFormat() {
 	log.SetFormatter(&log.TextFormatter{
 		ForceColors:               true,

--- a/ziti/cmd/verify/common.go
+++ b/ziti/cmd/verify/common.go
@@ -16,7 +16,7 @@
 package verify
 
 import (
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"runtime"
 )
 
@@ -27,8 +27,9 @@ type controller struct {
 	port string
 }
 
-func configureLogFormat() {
-	log.SetFormatter(&log.TextFormatter{
+func configureLogFormat(level logrus.Level) {
+	logrus.SetLevel(level)
+	logrus.SetFormatter(&logrus.TextFormatter{
 		ForceColors:               true,
 		DisableColors:             false,
 		ForceQuote:                false,

--- a/ziti/cmd/verify/common.go
+++ b/ziti/cmd/verify/common.go
@@ -1,0 +1,41 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+package verify
+
+import (
+	log "github.com/sirupsen/logrus"
+	"runtime"
+)
+
+func configureLogFormat() {
+	log.SetFormatter(&log.TextFormatter{
+		ForceColors:               true,
+		DisableColors:             false,
+		ForceQuote:                false,
+		DisableQuote:              false,
+		EnvironmentOverrideColors: false,
+		DisableTimestamp:          true,
+		FullTimestamp:             false,
+		TimestampFormat:           "",
+		DisableSorting:            true,
+		SortingFunc:               nil,
+		DisableLevelTruncation:    true,
+		PadLevelText:              true,
+		QuoteEmptyFields:          false,
+		FieldMap:                  nil,
+		CallerPrettyfier:          func(frame *runtime.Frame) (function string, file string) { return "", "" },
+	})
+}

--- a/ziti/cmd/verify/ops_verify_network.go
+++ b/ziti/cmd/verify/ops_verify_network.go
@@ -1,0 +1,262 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+package verify
+
+import (
+	"fmt"
+	"gopkg.in/yaml.v3"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/openziti/ziti/common"
+)
+
+type network struct {
+	controllerConfig string
+	routerConfig     string
+	verbose bool
+}
+
+func NewVerifyNetwork() *cobra.Command {
+	n := &network{}
+
+	cmd := &cobra.Command{
+		Use:   "verify-network",
+		Short: "Verifies the overlay is configured correctly",
+		Long:  "A tool to verify network configurations, checking controller and router ports or other common problems",
+		Run: func(cmd *cobra.Command, args []string) {
+			if n.verbose {
+				log.SetLevel(log.DebugLevel)
+			}
+			configureLogFormat()
+			anyFailure := false
+			if n.controllerConfig != "" {
+				log.Infof("Verifying controller config: %s", n.controllerConfig)
+				anyFailure = verifyControllerConfig(n.controllerConfig) || anyFailure
+				fmt.Println()
+			}
+			if n.routerConfig != "" {
+				log.Infof("Verifying router config: %s", n.routerConfig)
+				anyFailure = verifyRouterConfig(n.routerConfig) || anyFailure
+				fmt.Println()
+			}
+			if anyFailure {
+				log.Error("One or more error. Review the output above for errors.")
+			} else {
+				log.Info("All requested checks passed.")
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&n.controllerConfig, "controller-config-file", "c", "", "the controller config file verify")
+	cmd.Flags().StringVarP(&n.routerConfig, "router-config-file", "r", "", "the router config file to verify")
+	cmd.Flags().BoolVar(&n.verbose, "verbose", false, "Show additional output.")
+
+	return cmd
+}
+
+type StringMap map[string]interface{}
+
+func (m StringMap) mapFromKey(key string) StringMap {
+	if v, ok := m[key]; ok {
+		return v.(StringMap)
+	}
+	log.Fatalf("map didn't contain key %s", key)
+	return nil
+}
+
+type StringMapList []interface{}
+
+func (m StringMap) listFromKey(key string) StringMapList {
+	if v, ok := m[key]; ok {
+		return v.([]interface{})
+	}
+	log.Fatalf("map didn't contain key %s", key)
+	return nil
+}
+
+func (p ProtoHostPort) testPort(msg string) bool {
+	conn, err := net.DialTimeout("tcp", p.address(), 3*time.Second)
+	if err != nil {
+		log.Errorf("%s at %s cannot be reached.", msg, p.address())
+		return true
+	}
+	defer func(conn net.Conn) {
+		_ = conn.Close()
+	}(conn)
+	log.Infof("%s at %s is available.", msg, p.address())
+	return false
+}
+
+type ProtoHostPort struct {
+	proto string
+	host  string
+	port  string
+}
+
+func (p ProtoHostPort) address() string {
+	return p.host + ":" + p.port
+}
+
+func fromString(input string) *ProtoHostPort {
+	// input is expected to be in either "proto:host:port" format or "host:port" format
+	r := new(ProtoHostPort)
+	parts := strings.Split(input, ":")
+	if len(parts) > 2 {
+		r.proto = parts[0]
+		r.host = parts[1]
+		r.port = parts[2]
+	} else if len(parts) > 1 {
+		r.proto = "none"
+		r.host = parts[0]
+		r.port = parts[1]
+	} else {
+		panic("input is invalid: " + input)
+	}
+	return r
+}
+
+func verifyControllerConfig(controllerConfigFile string) bool {
+	if _, err := os.Stat(controllerConfigFile); err != nil {
+		log.Errorf("controller config file %s does not exist", controllerConfigFile)
+		return true
+	}
+	ctrlCfgBytes, err := os.ReadFile(controllerConfigFile)
+	if err != nil {
+		panic(err)
+	}
+	ctrlCfg := make(StringMap)
+	err = yaml.Unmarshal(ctrlCfgBytes, &ctrlCfg)
+	if err != nil {
+		panic(err)
+	}
+	advertiseAddress := stringOrNil(ctrlCfg.mapFromKey("ctrl").mapFromKey("options")["advertiseAddress"])
+	host := fromString(advertiseAddress)
+	anyFailure := host.testPort("controller advertise address")
+
+	web := ctrlCfg.listFromKey("web")
+
+	log.Infof("verifying %d web entries", len(web))
+	for _, item := range web {
+		webEntry := item.(StringMap)
+		webName := stringOrNil(webEntry["name"])
+		bps := webEntry.listFromKey("bindPoints")
+		log.Infof("verifying %d web bindPoints", len(bps))
+		bpPos := 0
+		for _, bpItem := range bps {
+			bp := bpItem.(StringMap)
+			bpInt := fromString(stringOrNil(bp["interface"]))
+			bpAddr := fromString(stringOrNil(bp["address"]))
+			if bpInt.port != bpAddr.port {
+				log.Warnf("web entry[%s], bindPoint[%d] ports differ. make sure this is intentional. interface port: %s, address port: %s", webName, bpPos, bpInt.port, bpAddr.port)
+			}
+
+			if bpAddr.testPort(fmt.Sprintf("web entry[%s], bindPoint[%d] %s", webName, bpPos, "address")) {
+				anyFailure = true
+			} else {
+				log.Infof("web entry[%s], bindPoint[%d] is valid", webName, bpPos)
+			}
+			bpPos++
+		}
+	}
+	return anyFailure
+}
+
+func verifyRouterConfig(routerConfigFile string) bool {
+	if _, err := os.Stat(routerConfigFile); err != nil {
+		log.Errorf("router config file %s does not exist", routerConfigFile)
+		return true
+	}
+	routerCfg := make(StringMap)
+	routerCfgBytes, err := os.ReadFile(routerConfigFile)
+	err = yaml.Unmarshal(routerCfgBytes, &routerCfg)
+	if err != nil {
+		panic(err)
+	}
+
+	controllerEndpoint := stringOrNil(routerCfg.mapFromKey("ctrl")["endpoint"])
+	routerCtrl := fromString(controllerEndpoint)
+	anyFailure := routerCtrl.testPort("ctrl endpoint")
+
+	link := routerCfg.mapFromKey("link")
+	linkListeners := link.listFromKey("listeners")
+	log.Infof("verifying %d web link listeners", len(linkListeners))
+	pos := 0
+	for _, item := range linkListeners {
+		listener := item.(StringMap)
+		if verifyLinkListener(fmt.Sprintf("link listener[%d]", pos), listener) {
+			anyFailure = true
+		} else {
+			log.Infof("link listener[%d] is valid", pos)
+		}
+		pos++
+	}
+
+	edgeListeners := routerCfg.listFromKey("listeners")
+	log.Infof("verifying %d web edge listeners", len(edgeListeners))
+	pos = 0
+	for _, item := range edgeListeners {
+		listener := item.(StringMap)
+		if verifyEdgeListener(fmt.Sprintf("listener binding[%d]", pos), listener) {
+			anyFailure = true
+		} else {
+			log.Infof("listener binding[%d] is valid", pos)
+		}
+		pos++
+	}
+	return anyFailure
+}
+
+func stringOrNil(input interface{}) string {
+	if str, ok := input.(string); ok {
+		return str
+	}
+	return ""
+}
+
+func verifyLinkListener(which string, listener StringMap) bool {
+	bind := fromString(stringOrNil(listener["bind"]))
+	adv := fromString(stringOrNil(listener["advertise"]))
+	if bind.port != adv.port {
+		log.Warnf("%s ports differ. make sure this is intentional. bind port: %s, advertise port: %s", which, bind.port, adv.port)
+	}
+	return adv.testPort(which)
+}
+
+func verifyEdgeListener(which string, listener StringMap) bool {
+	binding := stringOrNil(listener["binding"])
+	if binding == common.EdgeBinding {
+		address := stringOrNil(listener["address"])
+		opts := listener.mapFromKey("options")
+		advertise := stringOrNil(opts["advertise"])
+
+		add := fromString(address)
+		adv := fromString(advertise)
+		if add.port != adv.port {
+			log.Warnf("%s ports differ. make sure this is intentional. address port: %s, advertise port: %s", which, add.port, adv.port)
+		}
+		return adv.testPort(which)
+	} else {
+		// only verify "edge" for now
+		log.Infof("%s has binding %s and doesn't need to be verified", which, binding)
+	}
+	return false
+}

--- a/ziti/cmd/verify/ops_verify_network.go
+++ b/ziti/cmd/verify/ops_verify_network.go
@@ -30,6 +30,7 @@ import (
 )
 
 type network struct {
+	controller
 	controllerConfig string
 	routerConfig     string
 	verbose bool

--- a/ziti/cmd/verify/ops_verify_traffic.go
+++ b/ziti/cmd/verify/ops_verify_traffic.go
@@ -21,7 +21,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"github.com/openziti/foundation/v2/term"
-	"io"
 	"net"
 	"os"
 	"strings"
@@ -60,7 +59,7 @@ type traffic struct {
 	dialSPName   string
 }
 
-func NewVerifyTraffic(_ io.Writer, _ io.Writer) *cobra.Command {
+func NewVerifyTraffic() *cobra.Command {
 	t := &traffic{}
 	cmd := &cobra.Command{
 		Use:   "verify-traffic",

--- a/ziti/cmd/verify/ops_verify_traffic.go
+++ b/ziti/cmd/verify/ops_verify_traffic.go
@@ -1,0 +1,554 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+package verify
+
+import (
+	"bufio"
+	"context"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/openziti/edge-api/rest_management_api_client"
+	"github.com/openziti/edge-api/rest_management_api_client/identity"
+	"github.com/openziti/edge-api/rest_management_api_client/service"
+	"github.com/openziti/edge-api/rest_management_api_client/service_policy"
+	"github.com/openziti/edge-api/rest_management_api_client/terminator"
+	"github.com/openziti/edge-api/rest_model"
+	"github.com/openziti/edge-api/rest_util"
+	"github.com/openziti/sdk-golang/ziti"
+	"github.com/openziti/sdk-golang/ziti/enroll"
+	"github.com/openziti/ziti/internal/rest/mgmt"
+)
+
+
+type traffic struct {
+	prefix               string
+	role                 string
+	cleanup              bool
+	verbose              bool
+	allowMultipleServers bool
+
+	client       *rest_management_api_client.ZitiEdgeManagement
+	svcName      string
+	serverIdName string
+	clientIdName string
+	bindSPName   string
+	dialSPName   string
+}
+
+func NewVerifyTraffic(_ io.Writer, _ io.Writer) *cobra.Command {
+	t := &traffic{}
+	cmd := &cobra.Command{
+		Use:   "verify-traffic",
+		Short: "Verifies traffic",
+		Long:  "A tool to verify traffic can flow over the overlay properly. You must be authenticated to use this tool.",
+		Run: func(cmd *cobra.Command, args []string) {
+			if t.verbose {
+				log.SetLevel(log.DebugLevel)
+			}
+			configureLogFormat()
+			timePrefix := time.Now().Format("2006-01-02-1504")
+			if t.prefix == "" {
+				t.prefix = timePrefix
+			}
+			if t.role == "" {
+				t.role = "both"
+			}
+
+			t.svcName = t.prefix + ".verify-traffic"
+
+			t.serverIdName = t.prefix + ".server"
+			extraSeverIdName := ""
+			if t.allowMultipleServers {
+				extraSeverIdName = fmt.Sprintf("%d", time.Now().UnixNano())
+			}
+			t.serverIdName = fmt.Sprintf("%s.server%s", t.prefix, extraSeverIdName)
+			t.clientIdName = t.prefix + ".client"
+			t.bindSPName = t.prefix + ".bind"
+			t.dialSPName = t.prefix + ".dial"
+			client, err := newMgmtClient()
+			if err != nil {
+				panic(err)
+			}
+			t.client = client
+			if t.cleanup {
+				log.Info("attempting to cleanup based on parameters. this operation will disconnect the server if it's running.")
+				t.cleanupClient()
+				t.cleanupServer()
+				log.Info("cleanup complete. continuing")
+			}
+
+			if t.role == "both" {
+				t.doBoth()
+			} else if t.role == "server" {
+				t.doServer(context.Background(), true)
+			} else if t.role == "client" {
+				_, c := context.WithCancel(context.Background())
+				t.doClient(c)
+			} else {
+				panic("no role supplied? should have defaulted to 'both'")
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&t.prefix, "prefix", "p", "", "[optional] The prefix to apply to generated objects, necessary when not using the 'both' role.")
+	cmd.Flags().StringVarP(&t.role, "role", "r", "", "[optional, default 'both'] The role to perform: server, client, both.")
+	cmd.Flags().BoolVar(&t.cleanup, "cleanup", false, "Whether to perform cleanup.")
+	cmd.Flags().BoolVar(&t.verbose, "verbose", false, "Show additional output.")
+	cmd.Flags().BoolVar(&t.allowMultipleServers, "allow-multiple-servers", false, "Whether to allows the same server multiple times.")
+
+	return cmd
+}
+
+func startServer(ctx context.Context, serviceName string, zitiCfg *ziti.Config) error {
+	c, err := ziti.NewContext(zitiCfg)
+	if err != nil {
+		panic(err)
+	}
+	listener, err := c.Listen(serviceName)
+	if err != nil {
+		panic(err)
+	}
+	log.Infof("successfully bound service: %s.", serviceName)
+
+	connChan := make(chan net.Conn)
+	errChan := make(chan error)
+	go func() {
+		fmt.Println() // put a line in output for the humans
+		log.Info("Server is listening for a connection and will exit when one is received.")
+		conn, err := listener.Accept()
+		log.Info("Server has accepted a connection and will exit soon.")
+		if err != nil {
+			errChan <- err
+			return
+		}
+		connChan <- conn
+	}()
+
+	select {
+	case conn := <-connChan:
+		handleConnection(conn)
+	case err := <-errChan:
+		log.Errorf("Error accepting connection: %v", err)
+	case <-ctx.Done():
+		log.Info("Server shutting down")
+		return ctx.Err()
+	}
+	_ = listener.Close()
+	time.Sleep(1 * time.Second)
+	log.Info("Server complete. exiting")
+	return nil
+}
+
+func handleConnection(conn net.Conn) {
+	log.Debug("new connection accepted")
+
+	writer := bufio.NewWriter(conn)
+	reader := bufio.NewReader(conn)
+	rw := bufio.NewReadWriter(reader, writer)
+
+	line, err := rw.ReadString('\n')
+	if err != nil {
+		panic(err)
+	}
+	if strings.Contains(line, "verify-traffic test") {
+		log.Info("verify-traffic test successfully detected")
+	}
+	log.Debugf("read : %s", strings.TrimSpace(line))
+	resp := fmt.Sprintf("you sent me: %s", line)
+	_, _ = rw.WriteString(resp)
+	_ = rw.Flush()
+	log.Debugf("responding with : %s", strings.TrimSpace(resp))
+}
+
+func startClient(client *rest_management_api_client.ZitiEdgeManagement, serviceName string, zitiCfg *ziti.Config) error {
+	waitForTerminator(client, serviceName, 10*time.Second)
+	c, err := ziti.NewContext(zitiCfg)
+	if err != nil {
+		panic(err)
+	}
+
+	foundSvc, ok := c.GetService(serviceName)
+	if !ok {
+		panic("error when retrieving all the services for the provided config")
+	}
+	log.Infof("found service named: %s", *foundSvc.Name)
+
+	svc, err := c.Dial(serviceName) //dial the service using the given name
+	if err != nil {
+		log.Fatalf("error when dialing service name %s. %v", serviceName, err)
+	}
+	log.Infof("successfully dialed service: %s.", serviceName)
+
+	zitiReader := bufio.NewReader(svc)
+	zitiWriter := bufio.NewWriter(svc)
+
+	text := "verify-traffic test\n"
+	bytesRead, err := zitiWriter.WriteString(text)
+	_ = zitiWriter.Flush()
+	if err != nil {
+		panic(err)
+	} else {
+		log.Debugf("wrote %d bytes", bytesRead)
+	}
+	log.Debugf("sent : %s", text)
+	read, err := zitiReader.ReadString('\n')
+	if err != nil {
+		log.Errorf("error reading from reader: %v", err)
+	} else {
+		log.Debugf("Received: %s", strings.TrimSpace(read))
+	}
+	return nil
+}
+
+func terminatorExists(client *rest_management_api_client.ZitiEdgeManagement, serviceName string) bool {
+	filter := "service.name=\"" + serviceName + "\""
+	params := &terminator.ListTerminatorsParams{
+		Filter:  &filter,
+		Context: context.Background(),
+	}
+
+	resp, err := client.Terminator.ListTerminators(params, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	return len(resp.Payload.Data) > 0
+}
+
+func waitForTerminator(client *rest_management_api_client.ZitiEdgeManagement, serviceName string, timeout time.Duration) bool {
+	log.Infof("waiting %s for terminator for service: %s", timeout, serviceName)
+	startTime := time.Now()
+	for {
+		if terminatorExists(client, serviceName) {
+			log.Infof("found terminator for service: %s", serviceName)
+			return true
+		}
+		if time.Since(startTime) >= timeout {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	log.Fatalf("terminator not found for service: %s", serviceName)
+	return false
+}
+
+func newMgmtClient() (*rest_management_api_client.ZitiEdgeManagement, error) {
+	// Wait for the controller to become available
+	zitiAdminUsername := os.Getenv("ZITI_USER")
+	if zitiAdminUsername == "" {
+		zitiAdminUsername = "admin"
+	}
+	zitiAdminPassword := os.Getenv("ZITI_PWD")
+	if zitiAdminPassword == "" {
+		zitiAdminPassword = "admin"
+	}
+	advAddy := os.Getenv("ZITI_CTRL_EDGE_ADVERTISED_ADDRESS")
+	advPort := os.Getenv("ZITI_CTRL_EDGE_ADVERTISED_PORT")
+	if advAddy == "" {
+		advAddy = "ziti-edge-controller"
+	}
+	if advPort == "" {
+		advPort = "1280"
+	}
+	erName := os.Getenv("ZITI_ROUTER_NAME")
+	if erName == "" {
+		erName = "ziti-edge-router"
+	}
+
+	ctrlAddress := "https://" + advAddy + ":" + advPort
+
+	log.Infof("connecting with user %s to %s", zitiAdminUsername, ctrlAddress)
+	caCerts, err := rest_util.GetControllerWellKnownCas(ctrlAddress)
+	if err != nil {
+		panic(err)
+	}
+	caPool := x509.NewCertPool()
+	for _, ca := range caCerts {
+		caPool.AddCert(ca)
+	}
+	return rest_util.NewEdgeManagementClientWithUpdb(zitiAdminUsername, zitiAdminPassword, ctrlAddress, caPool)
+}
+
+func createIdentity(client *rest_management_api_client.ZitiEdgeManagement, name string, roleAttributes rest_model.Attributes) *identity.CreateIdentityCreated {
+	falseVar := false
+	usrType := rest_model.IdentityTypeUser
+	i := &rest_model.IdentityCreate{
+		Enrollment: &rest_model.IdentityCreateEnrollment{
+			Ott: true,
+		},
+		IsAdmin:                   &falseVar,
+		Name:                      &name,
+		RoleAttributes: &roleAttributes,
+		Type:           &usrType,
+	}
+	p := identity.NewCreateIdentityParams()
+	p.Identity = i
+
+	// Create the identity
+	ident, err := client.Identity.CreateIdentity(p, nil)
+	if err != nil {
+		id := mgmt.IdentityFromFilter(client, mgmt.NameFilter(name))
+		if id != nil {
+			log.Fatalf("Identity named %s exists. Remove the identity before trying again or use --cleanup.", name)
+		} else {
+			log.Fatalf("Failed to create the identity: %v", err)
+		}
+	}
+	return ident
+}
+
+func createServicePolicy(client *rest_management_api_client.ZitiEdgeManagement, name string, servType rest_model.DialBind, identityRoles rest_model.Roles, serviceRoles rest_model.Roles) *rest_model.CreateLocation {
+	defaultSemantic := rest_model.SemanticAllOf
+	servicePolicy := &rest_model.ServicePolicyCreate{
+		IdentityRoles: identityRoles,
+		Name:          &name,
+		Semantic:      &defaultSemantic,
+		ServiceRoles:  serviceRoles,
+		Type:          &servType,
+	}
+	params := &service_policy.CreateServicePolicyParams{
+		Policy:  servicePolicy,
+		Context: context.Background(),
+	}
+	params.SetTimeout(5 * time.Second)
+	resp, err := client.ServicePolicy.CreateServicePolicy(params, nil)
+	if resp == nil || err != nil {
+		log.Fatalf("Failed to create service policy: %s", name)
+		return nil
+	}
+	return resp.Payload.Data
+}
+
+func createService(client *rest_management_api_client.ZitiEdgeManagement, name string, serviceConfigs []string, roles rest_model.Attributes) *rest_model.CreateLocation {
+	encryptOn := true
+	serviceCreate := &rest_model.ServiceCreate{
+		Configs:            serviceConfigs,
+		EncryptionRequired: &encryptOn,
+		MaxIdleTimeMillis:  0,
+		Name:               &name,
+		RoleAttributes:     roles,
+		Tags:               nil,
+		TerminatorStrategy: "",
+	}
+	serviceParams := &service.CreateServiceParams{
+		Service: serviceCreate,
+		Context: context.Background(),
+	}
+	serviceParams.SetTimeout(5 * time.Second)
+	resp, err := client.Service.CreateService(serviceParams, nil)
+	if resp == nil || err != nil {
+		log.Fatalf("Failed to create service: %s", name)
+		return nil
+	}
+	return resp.Payload.Data
+}
+
+func deleteIdentity(client *rest_management_api_client.ZitiEdgeManagement, toDelete *rest_model.IdentityDetail) {
+	if toDelete == nil {
+		return
+	}
+	idToDel := *toDelete.ID
+	deleteParams := &identity.DeleteIdentityParams{
+		ID: idToDel,
+	}
+	deleteParams.SetTimeout(5 * time.Second)
+	_, err := client.Identity.DeleteIdentity(deleteParams, nil)
+	if err != nil {
+		log.Errorf("Failed to delete identity: %s. %v", idToDel, err)
+	}
+}
+
+func deleteService(client *rest_management_api_client.ZitiEdgeManagement, toDelete *rest_model.ServiceDetail) {
+	if toDelete == nil {
+		return
+	}
+	idToDel := *toDelete.ID
+	deleteParams := &service.DeleteServiceParams{
+		ID: idToDel,
+	}
+	deleteParams.SetTimeout(5 * time.Second)
+	_, err := client.Service.DeleteService(deleteParams, nil)
+	if err != nil {
+		log.Errorf("Failed to delete service: %s. %v", idToDel, err)
+	}
+}
+
+func deleteServicePolicy(client *rest_management_api_client.ZitiEdgeManagement, sp *rest_model.ServicePolicyDetail) {
+	if sp == nil {
+		return
+	}
+	id := *sp.ID
+	deleteParams := &service_policy.DeleteServicePolicyParams{
+		ID: id,
+	}
+	deleteParams.SetTimeout(5 * time.Second)
+	_, err := client.ServicePolicy.DeleteServicePolicy(deleteParams, nil)
+	if err != nil {
+		log.Errorf("Failed to delete the service policy: %s. %v", id, err)
+	}
+
+	return
+}
+
+func enrollIdentity(client *rest_management_api_client.ZitiEdgeManagement, id string) *ziti.Config {
+	// Get the identity object
+	params := &identity.DetailIdentityParams{
+		Context: context.Background(),
+		ID: id,
+	}
+	params.SetTimeout(5 * time.Second)
+	resp, err := client.Identity.DetailIdentity(params, nil)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Enroll the identity
+	tkn, _, err := enroll.ParseToken(resp.Payload.Data.Enrollment.Ott.JWT)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	flags := enroll.EnrollmentFlags{
+		Token:  tkn,
+		KeyAlg: "EC",
+	}
+	conf, err := enroll.Enroll(flags)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return conf
+}
+
+func (t *traffic) bindAttr() string {
+	return t.svcName + ".binders"
+}
+
+func (t *traffic) dialAttr() string {
+	return t.svcName + ".dialers"
+}
+
+func (t *traffic) svcAttr() string {
+	return t.svcName
+}
+
+func (t *traffic) configureService() {
+	svc := mgmt.ServiceFromFilter(t.client, mgmt.NameFilter(t.svcName))
+	if svc != nil && t.allowMultipleServers {
+		log.Debugf("service already exists. not creating: %s", t.svcName)
+	} else {
+		_ = createService(t.client, t.svcName, nil, []string{t.svcAttr()})
+	}
+
+	bind := mgmt.ServicePolicyFromFilter(t.client, mgmt.NameFilter(t.bindSPName))
+	if bind != nil && t.allowMultipleServers {
+		log.Debugf("service policy already exists. not creating: %s", t.bindSPName)
+	} else {
+		_ = createServicePolicy(t.client, t.bindSPName, rest_model.DialBindBind, rest_model.Roles{"#" + t.bindAttr()}, rest_model.Roles{"#" + t.svcAttr()})
+	}
+
+	dial := mgmt.ServicePolicyFromFilter(t.client, mgmt.NameFilter(t.dialSPName))
+	if dial != nil && t.allowMultipleServers {
+		log.Debugf("service policy already exists. not creating: %s", t.dialSPName)
+	} else {
+		_ = createServicePolicy(t.client, t.dialSPName, rest_model.DialBindDial, rest_model.Roles{"#" + t.dialAttr()}, rest_model.Roles{"#" + t.svcAttr()})
+	}
+}
+
+func (t *traffic) configureServer() *ziti.Config {
+	serverIdent := createIdentity(t.client, t.serverIdName, []string{t.bindAttr()})
+	return enrollIdentity(t.client, serverIdent.Payload.Data.ID)
+}
+
+func (t *traffic) configureClient() *ziti.Config {
+	clientIdent := createIdentity(t.client, t.clientIdName, []string{t.dialAttr()})
+	return enrollIdentity(t.client, clientIdent.Payload.Data.ID)
+}
+
+func (t *traffic) cleanupServer() {
+	if t.allowMultipleServers {
+		if terminatorExists(t.client, t.svcName) {
+			log.Debugf("found terminator for service: %s. cleanup will be skipped.", t.svcName)
+			return
+		}
+	}
+	dial := mgmt.ServicePolicyFromFilter(t.client, mgmt.NameFilter(t.dialSPName))
+	bind := mgmt.ServicePolicyFromFilter(t.client, mgmt.NameFilter(t.bindSPName))
+	deleteServicePolicy(t.client, dial)
+	deleteServicePolicy(t.client, bind)
+	svc := mgmt.ServiceFromFilter(t.client, mgmt.NameFilter(t.svcName))
+	deleteService(t.client, svc)
+
+	id := mgmt.IdentityFromFilter(t.client, mgmt.NameFilter(t.serverIdName))
+	deleteIdentity(t.client, id)
+}
+
+func (t *traffic) cleanupClient() {
+	id := mgmt.IdentityFromFilter(t.client, mgmt.NameFilter(t.clientIdName))
+	deleteIdentity(t.client, id)
+}
+
+func (t *traffic) doBoth() {
+	t.configureService()
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		defer wg.Done()
+		t.doServer(ctx, false)
+	}()
+	go func() {
+		defer wg.Done()
+		t.doClient(cancel)
+	}()
+	wg.Wait()
+}
+
+func (t *traffic) doServer(ctx context.Context, configureServices bool) {
+	if configureServices {
+		t.configureService()
+	}
+	serverCfg := t.configureServer()
+	defer t.cleanupServer()
+	if err := startServer(ctx, t.svcName, serverCfg); err != nil {
+		log.Fatal("unexpected error: %v", err)
+	}
+}
+
+func (t *traffic) doClient(cancel context.CancelFunc) {
+	clientCfg := t.configureClient()
+	defer t.cleanupClient()
+	if err := startClient(t.client, t.svcName, clientCfg); err != nil {
+		panic(err)
+	}
+
+	log.Debug("client received expected response. stopping server if it's running")
+	cancel() //end the server
+	time.Sleep(1 * time.Second)
+	log.Info("client complete")
+}

--- a/ziti/cmd/verify/ops_verify_traffic.go
+++ b/ziti/cmd/verify/ops_verify_traffic.go
@@ -20,14 +20,15 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
+	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/foundation/v2/term"
+	"github.com/sirupsen/logrus"
 	"net"
 	"os"
 	"strings"
 	"sync"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/openziti/edge-api/rest_management_api_client"
@@ -66,10 +67,14 @@ func NewVerifyTraffic() *cobra.Command {
 		Short: "Verifies traffic",
 		Long:  "A tool to verify traffic can flow over the overlay properly. You must be authenticated to use this tool.",
 		Run: func(cmd *cobra.Command, args []string) {
+			logLvl := logrus.InfoLevel
 			if t.verbose {
-				log.SetLevel(log.DebugLevel)
+				logLvl = logrus.DebugLevel
 			}
-			configureLogFormat()
+
+			pfxlog.GlobalInit(logLvl, pfxlog.DefaultOptions().Color())
+			configureLogFormat(logLvl)
+			
 			timePrefix := time.Now().Format("2006-01-02-1504")
 			if t.prefix == "" {
 				if t.mode != "both" {
@@ -430,8 +435,6 @@ func deleteServicePolicy(client *rest_management_api_client.ZitiEdgeManagement, 
 	if err != nil {
 		log.Errorf("Failed to delete the service policy: %s. %v", id, err)
 	}
-
-	return
 }
 
 func enrollIdentity(client *rest_management_api_client.ZitiEdgeManagement, id string) *ziti.Config {
@@ -557,7 +560,7 @@ func (t *traffic) doServer(ctx context.Context, configureServices bool) {
 	serverCfg := t.configureServer()
 	defer t.cleanupServer()
 	if err := startServer(ctx, t.svcName, serverCfg); err != nil {
-		log.Fatal("unexpected error: %v", err)
+		log.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/ziti/cmd/verify/ops_verify_traffic.go
+++ b/ziti/cmd/verify/ops_verify_traffic.go
@@ -73,6 +73,9 @@ func NewVerifyTraffic(_ io.Writer, _ io.Writer) *cobra.Command {
 			configureLogFormat()
 			timePrefix := time.Now().Format("2006-01-02-1504")
 			if t.prefix == "" {
+				if t.mode != "both" {
+					log.Warnf("no prefix and mode [%s] is not 'both'. default prefix of %s will be used", t.mode, timePrefix)
+				}
 				t.prefix = timePrefix
 			}
 			if t.mode == "" {


### PR DESCRIPTION
These two commands are nested under 'ops' and are meant to help people with verifying their configurations.

`verify-network` will allow you to specify config files which will then be probed and/or inspected looking for common issues such as unroutable addresses etc.

`verify-traffic` will test the deployed network making sure it can send traffic over the overlay. example output
![image](https://github.com/user-attachments/assets/96131010-623b-4ac0-a0ff-c2afe36438f5)
