### PR TITLE
set read only path to console files

### DIFF
--- a/dist/dist-packages/linux/openziti-controller/ziti-controller.service
+++ b/dist/dist-packages/linux/openziti-controller/ziti-controller.service
@@ -14,6 +14,7 @@ EnvironmentFile=/opt/openziti/etc/controller/service.env
 # relative to /var/lib
 StateDirectory=ziti-controller
 WorkingDirectory=/var/lib/ziti-controller
+ReadOnlyPaths=/opt/openziti/share/console
 
 ExecStartPre=/opt/openziti/etc/controller/entrypoint.bash check config.yml
 ExecStart=/opt/openziti/bin/ziti controller run config.yml ${ZITI_ARGS}


### PR DESCRIPTION
ensure systemd mounts the default console files path in the controller's filesystem namespace