### PR TITLE
linux, docker, k8s router - fix auto-renewal

### DIFF
--- a/dist/dist-packages/linux/openziti-router/bootstrap.bash
+++ b/dist/dist-packages/linux/openziti-router/bootstrap.bash
@@ -31,12 +31,6 @@ makeConfig() {
           ZITI_ROUTER_PORT \
           ZITI_ROUTER_LISTENER_BIND_PORT="${ZITI_ROUTER_PORT}"
 
-  if [[ "${ZITI_ROUTER_ADVERTISED_ADDRESS}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "DEBUG: ZITI_ROUTER_ADVERTISED_ADDRESS is an IPv4 address, setting ZITI_ROUTER_IP_OVERRIDE" >&3
-    export ZITI_ROUTER_IP_OVERRIDE="${ZITI_ROUTER_ADVERTISED_ADDRESS}"
-    unset ZITI_ROUTER_ADVERTISED_ADDRESS
-  fi
-
   if [[ ! -s "${_config_file}" || "${1:-}" == --force ]]; then
     # build config command
     local -a _command=("ziti create config router ${ZITI_ROUTER_TYPE}" \
@@ -62,6 +56,7 @@ makeConfig() {
       echo "INFO: recreating config file: ${_config_file}"
       mv --no-clobber "${_config_file}"{,".${ZITI_BOOTSTRAP_NOW}.old"}
     fi
+
 
     exportZitiVars                # export all ZITI_ vars to be used in bootstrap
     # shellcheck disable=SC2068

--- a/dist/dist-packages/linux/openziti-router/bootstrap.bash
+++ b/dist/dist-packages/linux/openziti-router/bootstrap.bash
@@ -31,6 +31,12 @@ makeConfig() {
           ZITI_ROUTER_PORT \
           ZITI_ROUTER_LISTENER_BIND_PORT="${ZITI_ROUTER_PORT}"
 
+  if [[ "${ZITI_ROUTER_ADVERTISED_ADDRESS}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "DEBUG: ZITI_ROUTER_ADVERTISED_ADDRESS is an IPv4 address, setting ZITI_ROUTER_IP_OVERRIDE" >&3
+    export ZITI_ROUTER_IP_OVERRIDE="${ZITI_ROUTER_ADVERTISED_ADDRESS}"
+    unset ZITI_ROUTER_ADVERTISED_ADDRESS
+  fi
+
   if [[ ! -s "${_config_file}" || "${1:-}" == --force ]]; then
     # build config command
     local -a _command=("ziti create config router ${ZITI_ROUTER_TYPE}" \
@@ -56,7 +62,6 @@ makeConfig() {
       echo "INFO: recreating config file: ${_config_file}"
       mv --no-clobber "${_config_file}"{,".${ZITI_BOOTSTRAP_NOW}.old"}
     fi
-
 
     exportZitiVars                # export all ZITI_ vars to be used in bootstrap
     # shellcheck disable=SC2068

--- a/dist/dist-packages/linux/openziti-router/service.env
+++ b/dist/dist-packages/linux/openziti-router/service.env
@@ -13,8 +13,5 @@ ZITI_BOOTSTRAP_ENROLLMENT='true'
 # BASH script that defines function bootstrap()
 ZITI_ROUTER_BOOTSTRAP_BASH='/opt/openziti/etc/router/bootstrap.bash'
 
-# renew server and client certificates every startup
-ZITI_AUTO_RENEW_CERTS='true'
-
 # additional arguments to the ExecStart command must be a non-empty string
-ZITI_ARGS='--'
+ZITI_ARGS='--extend'


### PR DESCRIPTION
- fix for missing IP SAN issue reported in Discourse: https://openziti.discourse.group/t/can-zrok-be-used-to-expose-local-mqtt-broker-to-internet/3126/39?u=qrkourier
- fix for Linux router failing to auto-renew identity certs