### PR TITLE
fixes #2455 uses std base64 decoding for x5c property per RFC

### DIFF
--- a/controller/model/authenticator_mod_ext_jwt.go
+++ b/controller/model/authenticator_mod_ext_jwt.go
@@ -185,7 +185,9 @@ func (r *signerRecord) Resolve(force bool) error {
 		for _, key := range jwksResponse.Keys {
 			//if we have an x509chain the first must be the signing key
 			if len(key.X509Chain) != 0 {
-				x509Der, err := base64.RawURLEncoding.DecodeString(key.X509Chain[0])
+				// x5c is the only attribute with padding according to
+				// RFC 7517 Section-4.7 "x5c" (X.509 Certificate Chain) Parameter
+				x509Der, err := base64.StdEncoding.DecodeString(key.X509Chain[0])
 
 				if err != nil {
 					return fmt.Errorf("could not parse JWKS keys: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/openziti/edge-api v0.26.30
 	github.com/openziti/foundation/v2 v2.0.49
 	github.com/openziti/identity v1.0.85
-	github.com/openziti/jwks v1.0.5
+	github.com/openziti/jwks v1.0.6
 	github.com/openziti/metrics v1.2.58
 	github.com/openziti/runzmd v1.0.51
 	github.com/openziti/sdk-golang v0.23.42

--- a/go.sum
+++ b/go.sum
@@ -582,8 +582,8 @@ github.com/openziti/foundation/v2 v2.0.49 h1:aQ5I/lMhkHQ6urhRpLwrWP+7YtoeUitCfY/
 github.com/openziti/foundation/v2 v2.0.49/go.mod h1:tFk7wg5WE/nDDur5jSVQTROugKDXQkFvmqRSV4pvWp0=
 github.com/openziti/identity v1.0.85 h1:jphDHrUCXCJGdbVTMBqsdtS0Ei/vhDH337DMNMYzLro=
 github.com/openziti/identity v1.0.85/go.mod h1:beIXWNDImEjZn93XPOorJzyuQCQUYOvKFQ0fWhLN2qM=
-github.com/openziti/jwks v1.0.5 h1:JVoOeccqLEtKBc9GcyJODVZYVk50YwEaDTocm+KgKbI=
-github.com/openziti/jwks v1.0.5/go.mod h1:t4xxq8vlXGsPn29kiQVnZBBDDnEoOFqtJoHibkJunQQ=
+github.com/openziti/jwks v1.0.6 h1:PR+9OVaMO8oHEoVQmHqeUBExWwLWyODEGJQK2DXHaqE=
+github.com/openziti/jwks v1.0.6/go.mod h1:t4xxq8vlXGsPn29kiQVnZBBDDnEoOFqtJoHibkJunQQ=
 github.com/openziti/metrics v1.2.58 h1:AbHSTMKHP/o6r6fh7a08c486Y/5f5xjkZQbcyn3w1tM=
 github.com/openziti/metrics v1.2.58/go.mod h1:zGLMrLvVFOxo9tXUf8svcUsASxsPjhW9foW92FUzmDs=
 github.com/openziti/runzmd v1.0.51 h1:Vz+2nfF9AyKQGyKwBUnpL2DH/4cL+3rOuLWj8lkNDBc=

--- a/tests/auth_external_jwt_signer_test.go
+++ b/tests/auth_external_jwt_signer_test.go
@@ -125,7 +125,7 @@ func (js *jwksServer) handleJWKS(w http.ResponseWriter, _ *http.Request) {
 	var keys []jsonWebKey
 	for _, cert := range js.certificates {
 
-		certBase64 := base64.RawURLEncoding.EncodeToString(cert.Raw)
+		certBase64 := base64.StdEncoding.EncodeToString(cert.Raw)
 		key := jsonWebKey{
 			Kid: cert.Subject.CommonName,
 			X5C: []string{certBase64},

--- a/zititest/go.mod
+++ b/zititest/go.mod
@@ -141,7 +141,7 @@ require (
 	github.com/openziti-incubator/cf v0.0.3 // indirect
 	github.com/openziti/cobra-to-md v1.0.1 // indirect
 	github.com/openziti/dilithium v0.3.5 // indirect
-	github.com/openziti/jwks v1.0.5 // indirect
+	github.com/openziti/jwks v1.0.6 // indirect
 	github.com/openziti/metrics v1.2.58 // indirect
 	github.com/openziti/runzmd v1.0.51 // indirect
 	github.com/openziti/secretstream v0.1.24 // indirect

--- a/zititest/go.sum
+++ b/zititest/go.sum
@@ -606,8 +606,8 @@ github.com/openziti/foundation/v2 v2.0.49 h1:aQ5I/lMhkHQ6urhRpLwrWP+7YtoeUitCfY/
 github.com/openziti/foundation/v2 v2.0.49/go.mod h1:tFk7wg5WE/nDDur5jSVQTROugKDXQkFvmqRSV4pvWp0=
 github.com/openziti/identity v1.0.85 h1:jphDHrUCXCJGdbVTMBqsdtS0Ei/vhDH337DMNMYzLro=
 github.com/openziti/identity v1.0.85/go.mod h1:beIXWNDImEjZn93XPOorJzyuQCQUYOvKFQ0fWhLN2qM=
-github.com/openziti/jwks v1.0.5 h1:JVoOeccqLEtKBc9GcyJODVZYVk50YwEaDTocm+KgKbI=
-github.com/openziti/jwks v1.0.5/go.mod h1:t4xxq8vlXGsPn29kiQVnZBBDDnEoOFqtJoHibkJunQQ=
+github.com/openziti/jwks v1.0.6 h1:PR+9OVaMO8oHEoVQmHqeUBExWwLWyODEGJQK2DXHaqE=
+github.com/openziti/jwks v1.0.6/go.mod h1:t4xxq8vlXGsPn29kiQVnZBBDDnEoOFqtJoHibkJunQQ=
 github.com/openziti/metrics v1.2.58 h1:AbHSTMKHP/o6r6fh7a08c486Y/5f5xjkZQbcyn3w1tM=
 github.com/openziti/metrics v1.2.58/go.mod h1:zGLMrLvVFOxo9tXUf8svcUsASxsPjhW9foW92FUzmDs=
 github.com/openziti/runzmd v1.0.51 h1:Vz+2nfF9AyKQGyKwBUnpL2DH/4cL+3rOuLWj8lkNDBc=


### PR DESCRIPTION
Tests on this will fail until the jwks dep is updated: https://github.com/openziti/jwks/pull/11/files

