### PR TITLE
fixes #2468 locates the correct server certificate for enrollments

### DIFF
--- a/controller/env/appenv.go
+++ b/controller/env/appenv.go
@@ -296,7 +296,7 @@ func (ae *AppEnv) getEnrollmentTlsCert() (*tls.Certificate, error) {
 				tlsCert.Leaf, err = x509.ParseCertificate(tlsCert.Certificate[0])
 
 				if err != nil {
-					pfxlog.Logger().Warnf("failed to parse leading certificate in a tls configuration while determining enrollment certificate, entry at index %d is skipped, processing other certificates: %w", i, err)
+					pfxlog.Logger().Warnf("failed to parse leading certificate in a tls configuration while determining enrollment certificate, entry at index %d is skipped, processing other certificates: %s", i, err)
 					continue
 				}
 			}

--- a/controller/model/enrollment_model.go
+++ b/controller/model/enrollment_model.go
@@ -76,8 +76,13 @@ func (entity *Enrollment) FillJwtInfoWithExpiresAt(env Env, subject string, expi
 			Subject:   subject,
 		},
 	}
+	signer, err := env.GetEnrollmentJwtSigner()
 
-	signedJwt, err := env.GetServerJwtSigner().Generate(enrollmentClaims)
+	if err != nil {
+		return fmt.Errorf("could not get enrollment signer: %v", err)
+	}
+
+	signedJwt, err := signer.Generate(enrollmentClaims)
 
 	if err != nil {
 		return err

--- a/controller/model/env.go
+++ b/controller/model/env.go
@@ -48,6 +48,8 @@ type Env interface {
 	GetFingerprintGenerator() cert.FingerprintGenerator
 	HandleServiceUpdatedEventForIdentityId(identityId string)
 
+	GetEnrollmentJwtSigner() (jwtsigner.Signer, error)
+
 	GetServerJwtSigner() jwtsigner.Signer
 	GetServerCert() (*tls.Certificate, string, jwt.SigningMethod)
 	JwtSignerKeyFunc(token *jwt.Token) (interface{}, error)

--- a/controller/model/testing.go
+++ b/controller/model/testing.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"errors"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/openziti/identity"
@@ -49,6 +50,10 @@ type TestContext struct {
 	metricsRegistry metrics.Registry
 	closeNotify     chan struct{}
 	dispatcher      command.Dispatcher
+}
+
+func (ctx *TestContext) GetEnrollmentJwtSigner() (jwtsigner.Signer, error) {
+	return nil, errors.New("not implemented")
 }
 
 func (ctx *TestContext) GetEventDispatcher() event.Dispatcher {

--- a/controller/model/testing.go
+++ b/controller/model/testing.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 	"time"
 
-	"errors"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/openziti/identity"
@@ -53,7 +52,7 @@ type TestContext struct {
 }
 
 func (ctx *TestContext) GetEnrollmentJwtSigner() (jwtsigner.Signer, error) {
-	return nil, errors.New("not implemented")
+	return ctx, nil
 }
 
 func (ctx *TestContext) GetEventDispatcher() event.Dispatcher {


### PR DESCRIPTION
- determines certificate for signing based on all identity server certs
- does not cache as certificates may reload