### PR TITLE
makes OIDC issuer dynamic based on xweb bind point address

### DIFF
--- a/controller/oidc_auth/config.go
+++ b/controller/oidc_auth/config.go
@@ -10,7 +10,7 @@ import (
 
 // Config represents the configuration necessary to operate an OIDC Provider
 type Config struct {
-	Issuer               string
+	Issuers              []string
 	TokenSecret          string
 	Storage              Storage
 	Certificate          *x509.Certificate
@@ -25,9 +25,9 @@ type Config struct {
 }
 
 // NewConfig will create a Config with default values
-func NewConfig(issuer string, cert *x509.Certificate, key crypto.PrivateKey) Config {
+func NewConfig(issuers []string, cert *x509.Certificate, key crypto.PrivateKey) Config {
 	return Config{
-		Issuer:               issuer,
+		Issuers:              issuers,
 		Certificate:          cert,
 		PrivateKey:           key,
 		RefreshTokenDuration: common.DefaultRefreshTokenDuration,

--- a/controller/oidc_auth/storage.go
+++ b/controller/oidc_auth/storage.go
@@ -91,6 +91,7 @@ type HybridStorage struct {
 	serviceUsers cmap.ConcurrentMap[string, *Client]
 
 	startOnce sync.Once
+	issuer    string
 	config    *Config
 
 	keys cmap.ConcurrentMap[string, *pubKey]
@@ -429,7 +430,7 @@ func (s *HybridStorage) createAccessToken(ctx context.Context, request op.TokenR
 		AccessTokenClaims: oidc.AccessTokenClaims{
 			TokenClaims: oidc.TokenClaims{
 				JWTID:      uuid.NewString(),
-				Issuer:     s.config.Issuer,
+				Issuer:     op.IssuerFromContext(ctx),
 				Subject:    request.GetSubject(),
 				Audience:   request.GetAudience(),
 				Expiration: oidc.Time(now.Add(s.config.AccessTokenDuration).Unix()),

--- a/controller/webapis/oidc-api.go
+++ b/controller/webapis/oidc-api.go
@@ -108,8 +108,12 @@ func NewOidcApiHandler(serverConfig *xweb.ServerConfig, ae *env.AppEnv, options 
 	cert := serverCert[0].Leaf
 	key := serverCert[0].PrivateKey
 
-	issuer := ae.OidcIssuer()
-	oidcConfig := oidc_auth.NewConfig(issuer, cert, key)
+	var issuers []string
+
+	for _, bindPoint := range serverConfig.BindPoints {
+		issuers = append(issuers, bindPoint.Address)
+	}
+	oidcConfig := oidc_auth.NewConfig(issuers, cert, key)
 
 	if secretVal, ok := options["secret"]; ok {
 		if secret, ok := secretVal.(string); ok {


### PR DESCRIPTION
This makes each OIDC API exposure use its xweb bind point address as the hostname of the issuer rather than defaulting to the `edge.api.address` configuration value. The result is that the bind point address will be used in the well-known OIDC configuration.