### PR TITLE
refinements to ops verify-traffic to integrate and work with ziti edge login

### DIFF
--- a/controller/oidc_auth/storage.go
+++ b/controller/oidc_auth/storage.go
@@ -91,7 +91,7 @@ type HybridStorage struct {
 	serviceUsers cmap.ConcurrentMap[string, *Client]
 
 	startOnce sync.Once
-	issuer    string
+//linter issue	issuer    string
 	config    *Config
 
 	keys cmap.ConcurrentMap[string, *pubKey]

--- a/ziti/cmd/cmd.go
+++ b/ziti/cmd/cmd.go
@@ -143,8 +143,8 @@ func NewCmdRoot(in io.Reader, out, err io.Writer, cmd *cobra.Command) *cobra.Com
 	opsCommands.AddCommand(database.NewCmdDb(out, err))
 	opsCommands.AddCommand(NewCmdLogFormat(out, err))
 	opsCommands.AddCommand(NewUnwrapIdentityFileCommand(out, err))
-	opsCommands.AddCommand(verify.NewVerifyNetwork())
-	opsCommands.AddCommand(verify.NewVerifyTraffic())
+	opsCommands.AddCommand(verify.NewVerifyNetwork(out, err))
+	opsCommands.AddCommand(verify.NewVerifyTraffic(out, err))
 
 	groups := templates.CommandGroups{
 		{

--- a/ziti/cmd/edge/login.go
+++ b/ziti/cmd/edge/login.go
@@ -56,6 +56,25 @@ type LoginOptions struct {
 	FileCertCreds *edge_apis.IdentityCredentials
 }
 
+func AddLoginFlags(cmd *cobra.Command, options *LoginOptions) {
+	// allow interspersing positional args and flags
+	cmd.Flags().SetInterspersed(true)
+
+	cmd.Flags().StringVarP(&options.Username, "username", "u", "", "username to use for authenticating to the Ziti Edge Controller ")
+	cmd.Flags().StringVarP(&options.Password, "password", "p", "", "password to use for authenticating to the Ziti Edge Controller, if -u is supplied and -p is not, a value will be prompted for")
+	cmd.Flags().StringVarP(&options.Token, "token", "t", "", "if an api token has already been acquired, it can be set in the config with this option. This will set the session to read only by default")
+	cmd.Flags().StringVarP(&options.CaCert, "ca", "", "", "additional root certificates used by the Ziti Edge Controller")
+	cmd.Flags().BoolVar(&options.ReadOnly, "read-only", false, "marks this login as read-only. Note: this is not a guarantee that nothing can be changed on the server. Care should still be taken!")
+	cmd.Flags().BoolVarP(&options.Yes, "yes", "y", false, "If set, responds to prompts with yes. This will result in untrusted certs being accepted or updated.")
+	cmd.Flags().BoolVar(&options.IgnoreConfig, "ignore-config", false, "If set, does not use value from the config file for hostname or username. Values must be entered or will be prompted for.")
+	cmd.Flags().StringVarP(&options.ClientCert, "client-cert", "c", "", "A certificate used to authenticate")
+	cmd.Flags().StringVarP(&options.ClientKey, "client-key", "k", "", "The key to use with certificate authentication")
+	cmd.Flags().StringVarP(&options.ExtJwt, "ext-jwt", "e", "", "A file containing a JWT from an external provider to be used for authentication")
+	cmd.Flags().StringVarP(&options.File, "file", "f", "", "An identity file to use for authentication")
+
+	options.AddCommonFlags(cmd)
+}
+
 // NewLoginCmd creates the command
 func NewLoginCmd(out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &LoginOptions{
@@ -77,23 +96,8 @@ func NewLoginCmd(out io.Writer, errOut io.Writer) *cobra.Command {
 		},
 		SuggestFor: []string{},
 	}
-
-	// allow interspersing positional args and flags
-	cmd.Flags().SetInterspersed(true)
-
-	cmd.Flags().StringVarP(&options.Username, "username", "u", "", "username to use for authenticating to the Ziti Edge Controller ")
-	cmd.Flags().StringVarP(&options.Password, "password", "p", "", "password to use for authenticating to the Ziti Edge Controller, if -u is supplied and -p is not, a value will be prompted for")
-	cmd.Flags().StringVarP(&options.Token, "token", "t", "", "if an api token has already been acquired, it can be set in the config with this option. This will set the session to read only by default")
-	cmd.Flags().StringVarP(&options.CaCert, "ca", "", "", "additional root certificates used by the Ziti Edge Controller")
-	cmd.Flags().BoolVar(&options.ReadOnly, "read-only", false, "marks this login as read-only. Note: this is not a guarantee that nothing can be changed on the server. Care should still be taken!")
-	cmd.Flags().BoolVarP(&options.Yes, "yes", "y", false, "If set, responds to prompts with yes. This will result in untrusted certs being accepted or updated.")
-	cmd.Flags().BoolVar(&options.IgnoreConfig, "ignore-config", false, "If set, does not use value from the config file for hostname or username. Values must be entered or will be prompted for.")
-	cmd.Flags().StringVarP(&options.ClientCert, "client-cert", "c", "", "A certificate used to authenticate")
-	cmd.Flags().StringVarP(&options.ClientKey, "client-key", "k", "", "The key to use with certificate authentication")
-	cmd.Flags().StringVarP(&options.ExtJwt, "ext-jwt", "e", "", "A file containing a JWT from an external provider to be used for authentication")
-	cmd.Flags().StringVarP(&options.File, "file", "f", "", "An identity file to use for authentication")
-
-	options.AddCommonFlags(cmd)
+	
+	AddLoginFlags(cmd, options)
 
 	return cmd
 }

--- a/ziti/cmd/verify/common.go
+++ b/ziti/cmd/verify/common.go
@@ -20,13 +20,6 @@ import (
 	"runtime"
 )
 
-type controller struct {
-	user string
-	pass string
-	host string
-	port string
-}
-
 func configureLogFormat(level logrus.Level) {
 	logrus.SetLevel(level)
 	logrus.SetFormatter(&logrus.TextFormatter{

--- a/ziti/cmd/verify/ops_verify_network.go
+++ b/ziti/cmd/verify/ops_verify_network.go
@@ -17,6 +17,7 @@ package verify
 
 import (
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"strings"
@@ -48,7 +49,7 @@ type stringMapList []interface{}
 
 type StringMap map[string]interface{}
 
-func NewVerifyNetwork() *cobra.Command {
+func NewVerifyNetwork(_ io.Writer, _ io.Writer) *cobra.Command {
 	n := &network{}
 
 	cmd := &cobra.Command{

--- a/ziti/cmd/verify/ops_verify_traffic.go
+++ b/ziti/cmd/verify/ops_verify_traffic.go
@@ -43,7 +43,7 @@ import (
 
 
 type traffic struct {
-	loginOpts			 edge.LoginOptions
+	loginOpts            edge.LoginOptions
 	prefix               string
 	mode                 string
 	cleanup              bool

--- a/ziti/cmd/verify/ops_verify_traffic.go
+++ b/ziti/cmd/verify/ops_verify_traffic.go
@@ -43,7 +43,6 @@ import (
 
 
 type traffic struct {
-	controller
 	loginOpts			 edge.LoginOptions
 	prefix               string
 	mode                 string
@@ -136,9 +135,6 @@ func NewVerifyTraffic(out io.Writer, errOut io.Writer) *cobra.Command {
 	edge.AddLoginFlags(cmd, &t.loginOpts)
 	t.loginOpts.Out = out
 	t.loginOpts.Err = errOut
-	
-	cmd.Flags().StringVar(&t.host, "host", "", "the controller host")
-	cmd.Flags().StringVar(&t.port, "port", "", "the controller port")
 
 	return cmd
 }


### PR DESCRIPTION
the existing ziti ops verify-traffic were not integrated with the ziti edge login functionality. Jens needs/wants an example of how to integrate better with ziti login but apparently we haven't done that yet when using the edge-apis library.

This should provide a mechanism to obtain a new management client from the edge-apis library while integrating with ziti edge login as well. This will allow not only for updb style login but also enables cert/key/file-based login:
```
ziti ops verify-traffic --cleanup --file testadmin.json
```

Using an identity file greatly simplifies the command and is more secure than shipping a user/pwd. example:
![image](https://github.com/user-attachments/assets/266c27b6-9f9c-40c7-be9f-bd1a5ae29193)
