### PR TITLE
set Linux package architecture for 32-bit ARM

### DIFF
--- a/.github/workflows/publish-linux-packages.yml
+++ b/.github/workflows/publish-linux-packages.yml
@@ -29,8 +29,8 @@ jobs:
             rpm: aarch64
           - goreleaser: armv7
             gox: arm
-            deb: armv7
-            rpm: armv7
+            deb: armhf
+            rpm: armv7hl
         packager:
           - rpm
           - deb
@@ -41,7 +41,7 @@ jobs:
       ZITI_MAINTAINER: "OpenZiti Maintainers <developers@openziti.org>"
       ZITI_HOMEPAGE: "https://openziti.io"
       ZITI_VENDOR: "NetFoundry Inc."
-      GOARCH: ${{ matrix.arch.goreleaser }}
+      TARGETARCH: ${{ matrix.packager == 'deb' && matrix.arch.deb || matrix.arch.rpm }}
       MINIMUM_SYSTEMD_VERSION: 232
       ZITI_DEB_TEST_REPO: ${{ vars.ZITI_DEB_TEST_REPO || 'zitipax-openziti-deb-test' }}
       ZITI_RPM_TEST_REPO: ${{ vars.ZITI_RPM_TEST_REPO || 'zitipax-openziti-rpm-test' }}

--- a/.github/workflows/test-deployments.yml
+++ b/.github/workflows/test-deployments.yml
@@ -64,7 +64,7 @@ jobs:
           ZITI_MAINTAINER: "OpenZiti Maintainers <developers@openziti.org>"
           ZITI_HOMEPAGE: "https://openziti.io"
           ZITI_VENDOR: "NetFoundry Inc."
-          GOARCH: ${{ matrix.arch.goreleaser }}
+          TARGETARCH: ${{ matrix.arch.goreleaser }}
           MINIMUM_SYSTEMD_VERSION: 232
 
       - name: Upload Package to Build Summary

--- a/dist/dist-packages/linux/nfpm-openziti-controller.yaml
+++ b/dist/dist-packages/linux/nfpm-openziti-controller.yaml
@@ -3,7 +3,7 @@
 # check https://nfpm.goreleaser.com/configuration for detailed usage
 #
 name: openziti-controller
-arch: ${GOARCH}
+arch: ${TARGETARCH}
 platform: linux
 version: ${ZITI_VERSION}
 prerelease: ${ZITI_REV}

--- a/dist/dist-packages/linux/nfpm-openziti-router.yaml
+++ b/dist/dist-packages/linux/nfpm-openziti-router.yaml
@@ -3,7 +3,7 @@
 # check https://nfpm.goreleaser.com/configuration for detailed usage
 #
 name: openziti-router
-arch: ${GOARCH}
+arch: ${TARGETARCH}
 platform: linux
 version: ${ZITI_VERSION}
 prerelease: ${ZITI_REV}

--- a/dist/dist-packages/linux/nfpm-openziti.yaml
+++ b/dist/dist-packages/linux/nfpm-openziti.yaml
@@ -3,7 +3,7 @@
 # check https://nfpm.goreleaser.com/configuration for detailed usage
 #
 name: openziti
-arch: ${GOARCH}
+arch: ${TARGETARCH}
 platform: linux
 version: ${ZITI_VERSION}
 prerelease: ${ZITI_REV}


### PR DESCRIPTION

Set Linux package metadata to reflect the target architecture of the 32-bit ARM executable: ARM v7 w/ hardware floating point, aka "hard float."

- DEB targets `armhf`
- RPM targets `armv7hl`