### PR TITLE
adds support for ${TMP} ${TEMP} and ${TMPDIR} in configs

### DIFF
--- a/common/config/env.go
+++ b/common/config/env.go
@@ -19,30 +19,13 @@ package config
 import (
 	"github.com/michaelquigley/pfxlog"
 	"os"
-	"runtime"
 	"sync"
 )
 
 var ensureTmpDirEnvOnce sync.Once
 
 func EnsureTempDirEnv() {
-	defaultTemp := "/tmp"
-
-	if runtime.GOOS == "windows" {
-		defaultTemp = os.Getenv("TEMP")
-
-		if defaultTemp == "" {
-			defaultTemp = "C:\\temp"
-		}
-	}
-
-	if os.Getenv("TEMP") != "" {
-		defaultTemp = os.Getenv("TEMP")
-	} else if os.Getenv("TMP") != "" {
-		defaultTemp = os.Getenv("TMP")
-	} else if os.Getenv("TMPDIR") != "" {
-		defaultTemp = os.Getenv("TMPDIR")
-	}
+	defaultTemp := os.TempDir()
 
 	err := os.Setenv("TMP", defaultTemp)
 
@@ -65,7 +48,7 @@ func EnsureTempDirEnv() {
 
 func InjectEnv(config map[interface{}]interface{}) {
 	ensureTmpDirEnvOnce.Do(EnsureTempDirEnv)
-
+	
 	for key, v := range config {
 		if str, ok := v.(string); ok {
 			config[key] = os.ExpandEnv(str)

--- a/etc/ctrl.with.edge.yml
+++ b/etc/ctrl.with.edge.yml
@@ -45,7 +45,7 @@ additionalTrustDomains: []
 
 profile:
 #   cpu:
-#       path: /home/plorenz/tmp/ctrl.cpu.pprof
+#       path: ${TMPDIR}/ziti.ctrl.cpu.pprof
 #  memory:
 #    path: ctrl.memprof
 
@@ -108,7 +108,7 @@ events:
     handler:
       type: file
       format: json
-      path: /tmp/ziti-events.log
+      path: ${TMPDIR}/ziti-events.log
 #  usageLogger:
 #    subscriptions:
 #      - type: fabric.usage

--- a/zititest/go.mod
+++ b/zititest/go.mod
@@ -80,7 +80,7 @@ require (
 	github.com/go-openapi/strfmt v0.23.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-openapi/validate v0.24.0 // indirect
-	github.com/go-resty/resty/v2 v2.16.2 // indirect
+	github.com/go-resty/resty/v2 v2.16.3 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/gomarkdown/markdown v0.0.0-20230922112808-5421fefb8386 // indirect
@@ -96,7 +96,7 @@ require (
 	github.com/hashicorp/golang-lru v0.6.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
-	github.com/hashicorp/raft v1.7.1 // indirect
+	github.com/hashicorp/raft v1.7.2 // indirect
 	github.com/hashicorp/raft-boltdb v0.0.0-20220329195025-15018e9b97e0 // indirect
 	github.com/iancoleman/strcase v0.1.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/zititest/go.sum
+++ b/zititest/go.sum
@@ -248,6 +248,7 @@ github.com/go-openapi/validate v0.24.0 h1:LdfDKwNbpB6Vn40xhTdNZAnfLECL81w+VX3Bum
 github.com/go-openapi/validate v0.24.0/go.mod h1:iyeX1sEufmv3nPbBdX3ieNviWnOZaJ1+zquzJEf2BAQ=
 github.com/go-resty/resty/v2 v2.16.2 h1:CpRqTjIzq/rweXUt9+GxzzQdlkqMdt8Lm/fuK/CAbAg=
 github.com/go-resty/resty/v2 v2.16.2/go.mod h1:0fHAoK7JoBy/Ch36N8VFeMsK7xQOHhvWaC3iOktwmIU=
+github.com/go-resty/resty/v2 v2.16.3/go.mod h1:hkJtXbA2iKHzJheXYvQ8snQES5ZLGKMwQ07xAwp/fiA=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -395,6 +396,7 @@ github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/raft v1.1.0/go.mod h1:4Ak7FSPnuvmb0GV6vgIAJ4vYT4bek9bb6Q+7HVbyzqM=
 github.com/hashicorp/raft v1.7.1 h1:ytxsNx4baHsRZrhUcbt3+79zc4ly8qm7pi0393pSchY=
 github.com/hashicorp/raft v1.7.1/go.mod h1:hUeiEwQQR/Nk2iKDD0dkEhklSsu3jcAcqvPzPoZSAEM=
+github.com/hashicorp/raft v1.7.2/go.mod h1:DfvCGFxpAUPE0L4Uc8JLlTPtc3GzSbdH0MTJCLgnmJQ=
 github.com/hashicorp/raft-boltdb v0.0.0-20220329195025-15018e9b97e0 h1:CO8dBMLH6dvE1jTn/30ZZw3iuPsNfajshWoJTnVc5cc=
 github.com/hashicorp/raft-boltdb v0.0.0-20220329195025-15018e9b97e0/go.mod h1:nTakvJ4XYq45UXtn0DbwR4aU9ZdjlnIenpbs6Cd+FM0=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=


### PR DESCRIPTION
- TMP/TEMP/TMPDIR are standards from windows, macOs, bsd, and linux
- TMP/TEMP/TMPDIR are set for all oses to allow cross platform configs
- Priotity order for selection is TMP/TEMP/TMPDIR
- For windows if TMP/TEMP are not set C:\temp is the default