### PR TITLE
fixes #2674 default port and local address routing for oidc auth

### DIFF
--- a/controller/oidc_auth/provider.go
+++ b/controller/oidc_auth/provider.go
@@ -111,7 +111,17 @@ func getHandledHostnames(issuer string) []string {
 
 	shouldHandleDefaultPort := port == DefaultTlsPort
 	if shouldHandleDefaultPort {
-		hostsToHandle[hostWithoutPort] = struct{}{}
+
+		ip := net.ParseIP(hostWithoutPort)
+		isIpv6 := ip != nil && ip.To4() == nil
+
+		if isIpv6 {
+			//ipv6 in urls always requires brackets even w/ default ports
+			hostsToHandle["["+hostWithoutPort+"]"] = struct{}{}
+		} else {
+			hostsToHandle[hostWithoutPort] = struct{}{}
+		}
+
 	}
 
 	//local address in use, translate as needed
@@ -123,7 +133,10 @@ func getHandledHostnames(issuer string) []string {
 		if shouldHandleDefaultPort {
 			hostsToHandle[LocalhostName] = struct{}{}
 			hostsToHandle[LocalhostIpv4] = struct{}{}
-			hostsToHandle[LocalhostIpv6] = struct{}{}
+
+			//ipv6 in urls always requires brackets even w/ default ports
+			hostsToHandle["["+LocalhostIpv6+"]"] = struct{}{}
+
 		}
 	}
 

--- a/controller/oidc_auth/provider.go
+++ b/controller/oidc_auth/provider.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/zitadel/oidc/v2/pkg/op"
 	"golang.org/x/text/language"
+	"net"
 	"net/http"
 )
 
@@ -67,7 +68,11 @@ func NewNativeOnlyOP(ctx context.Context, env model.Env, config Config) (http.Ha
 			oidcHandler.ServeHTTP(writer, r)
 		})
 
-		handlers[issuer] = handler
+		hostsToHandle := getHandledHostnames(issuer)
+
+		for _, hostToHandle := range hostsToHandle {
+			handlers[hostToHandle] = handler
+		}
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -81,6 +86,53 @@ func NewNativeOnlyOP(ctx context.Context, env model.Env, config Config) (http.Ha
 		handler.ServeHTTP(w, r)
 	}), nil
 
+}
+
+func getHandledHostnames(issuer string) []string {
+	const (
+		DefaultTlsPort = "443"
+		LocalhostName  = "localhost"
+		LocalhostIpv4  = "127.0.0.1"
+		LocalhostIpv6  = "::1"
+	)
+	hostsToHandle := map[string]struct{}{
+		issuer: {},
+	}
+
+	hostWithoutPort, port, err := net.SplitHostPort(issuer)
+	if err != nil {
+		var ret []string
+		for host := range hostsToHandle {
+			ret = append(ret, host)
+		}
+
+		return ret
+	}
+
+	shouldHandleDefaultPort := port == DefaultTlsPort
+	if shouldHandleDefaultPort {
+		hostsToHandle[hostWithoutPort] = struct{}{}
+	}
+
+	//local address in use, translate as needed
+	if hostWithoutPort == LocalhostName || hostWithoutPort == LocalhostIpv4 || hostWithoutPort == "::1" {
+		hostsToHandle[net.JoinHostPort(LocalhostName, port)] = struct{}{}
+		hostsToHandle[net.JoinHostPort(LocalhostIpv4, port)] = struct{}{}
+		hostsToHandle[net.JoinHostPort(LocalhostIpv6, port)] = struct{}{}
+
+		if shouldHandleDefaultPort {
+			hostsToHandle[LocalhostName] = struct{}{}
+			hostsToHandle[LocalhostIpv4] = struct{}{}
+			hostsToHandle[LocalhostIpv6] = struct{}{}
+		}
+	}
+
+	var ret []string
+	for host := range hostsToHandle {
+		ret = append(ret, host)
+	}
+
+	return ret
 }
 
 // newHttpRouter creates an OIDC HTTP router

--- a/controller/oidc_auth/provider_test.go
+++ b/controller/oidc_auth/provider_test.go
@@ -1,0 +1,81 @@
+package oidc_auth
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func Test_GetHandledHostNames(t *testing.T) {
+
+	t.Run("localhost:443 returns all local addresses and supports implicit 443 port", func(t *testing.T) {
+		result := getHandledHostnames("localhost:443")
+
+		req := require.New(t)
+
+		req.Len(result, 6)
+		req.Contains(result, "localhost:443")
+		req.Contains(result, "localhost")
+		req.Contains(result, "127.0.0.1:443")
+		req.Contains(result, "127.0.0.1")
+		req.Contains(result, "::1")
+		req.Contains(result, "[::1]:443")
+	})
+	t.Run("localhost:1234 returns all local addresses", func(t *testing.T) {
+		result := getHandledHostnames("localhost:1234")
+
+		req := require.New(t)
+
+		req.Len(result, 3)
+		req.Contains(result, "localhost:1234")
+		req.Contains(result, "127.0.0.1:1234")
+		req.Contains(result, "[::1]:1234")
+	})
+
+	t.Run("127.0.0.1:443 returns all local addresses and supports implicit 443 port", func(t *testing.T) {
+		result := getHandledHostnames("127.0.0.1:443")
+
+		req := require.New(t)
+
+		req.Len(result, 6)
+		req.Contains(result, "localhost:443")
+		req.Contains(result, "localhost")
+		req.Contains(result, "127.0.0.1:443")
+		req.Contains(result, "127.0.0.1")
+		req.Contains(result, "::1")
+		req.Contains(result, "[::1]:443")
+	})
+	t.Run("127.0.0.1:1234 returns all local addresses", func(t *testing.T) {
+		result := getHandledHostnames("127.0.0.1:1234")
+
+		req := require.New(t)
+
+		req.Len(result, 3)
+		req.Contains(result, "localhost:1234")
+		req.Contains(result, "127.0.0.1:1234")
+		req.Contains(result, "[::1]:1234")
+	})
+
+	t.Run("[::1]:443 returns all local addresses and supports implicit 443 port", func(t *testing.T) {
+		result := getHandledHostnames("[::1]:443")
+
+		req := require.New(t)
+
+		req.Len(result, 6)
+		req.Contains(result, "localhost:443")
+		req.Contains(result, "localhost")
+		req.Contains(result, "127.0.0.1:443")
+		req.Contains(result, "127.0.0.1")
+		req.Contains(result, "::1")
+		req.Contains(result, "[::1]:443")
+	})
+	t.Run("[::1]:1234 returns all local addresses", func(t *testing.T) {
+		result := getHandledHostnames("[::1]:1234")
+
+		req := require.New(t)
+
+		req.Len(result, 3)
+		req.Contains(result, "localhost:1234")
+		req.Contains(result, "127.0.0.1:1234")
+		req.Contains(result, "[::1]:1234")
+	})
+}

--- a/controller/oidc_auth/provider_test.go
+++ b/controller/oidc_auth/provider_test.go
@@ -17,7 +17,7 @@ func Test_GetHandledHostNames(t *testing.T) {
 		req.Contains(result, "localhost")
 		req.Contains(result, "127.0.0.1:443")
 		req.Contains(result, "127.0.0.1")
-		req.Contains(result, "::1")
+		req.Contains(result, "[::1]")
 		req.Contains(result, "[::1]:443")
 	})
 	t.Run("localhost:1234 returns all local addresses", func(t *testing.T) {
@@ -41,7 +41,7 @@ func Test_GetHandledHostNames(t *testing.T) {
 		req.Contains(result, "localhost")
 		req.Contains(result, "127.0.0.1:443")
 		req.Contains(result, "127.0.0.1")
-		req.Contains(result, "::1")
+		req.Contains(result, "[::1]")
 		req.Contains(result, "[::1]:443")
 	})
 	t.Run("127.0.0.1:1234 returns all local addresses", func(t *testing.T) {
@@ -65,7 +65,7 @@ func Test_GetHandledHostNames(t *testing.T) {
 		req.Contains(result, "localhost")
 		req.Contains(result, "127.0.0.1:443")
 		req.Contains(result, "127.0.0.1")
-		req.Contains(result, "::1")
+		req.Contains(result, "[::1]")
 		req.Contains(result, "[::1]:443")
 	})
 	t.Run("[::1]:1234 returns all local addresses", func(t *testing.T) {

--- a/controller/webapis/oidc-api.go
+++ b/controller/webapis/oidc-api.go
@@ -86,7 +86,7 @@ func (h OidcApiHandler) RootPath() string {
 }
 
 func (h OidcApiHandler) IsHandler(r *http.Request) bool {
-	return strings.HasPrefix(r.URL.Path, h.RootPath()) || strings.HasPrefix(r.URL.Path, oidc_auth.WellKnownOidcConfiguration)
+	return strings.HasPrefix(r.URL.Path, h.RootPath()) || r.URL.Path == oidc_auth.WellKnownOidcConfiguration
 }
 
 func (h OidcApiHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {

--- a/etc/ctrl.with.edge.yml
+++ b/etc/ctrl.with.edge.yml
@@ -164,7 +164,7 @@ edge:
     # address - required
     # The default address (host:port) to use for enrollment for the Client API. This value must match one of the addresses
     # defined in a bind point's address field for the `edge-client` API in the web section.
-    address: 127.0.0.1:1280
+    address: "[::1]:443"
   # enrollment - required
   # A section containing settings pertaining to enrollment.
   enrollment:
@@ -206,18 +206,18 @@ web:
     bindPoints:
       #interface - required
       # A host:port string on which network interface to listen on. 0.0.0.0 will listen on all interfaces
-      - interface: 127.0.0.1:1280
+      - interface: "[::1]:443"
 
         # address - required
         # The public address that external incoming requests will be able to resolve. Used in request processing and
         # response content that requires full host:port/path addresses.
-        address: 127.0.0.1:1280
+        address: "[::1]:443"
 
         # newAddress - optional
         # A host:port string which will be sent out as an HTTP header "ziti-new-address" if specified. If the header
         # is present, clients should update location configuration to immediately use the new address for future
         # connections. The value of newAddress must be resolvable both via DNS and validate via certificates
-        newAddress: localhost:1280
+        newAddress: "[::1]:443"
     # identity - optional
     # Allows the webListener to have a specific identity instead of defaulting to the root `identity` section.
     #    identity:

--- a/etc/ctrl.with.edge.yml
+++ b/etc/ctrl.with.edge.yml
@@ -164,7 +164,7 @@ edge:
     # address - required
     # The default address (host:port) to use for enrollment for the Client API. This value must match one of the addresses
     # defined in a bind point's address field for the `edge-client` API in the web section.
-    address: "[::1]:443"
+    address: 127.0.0.1:1280
   # enrollment - required
   # A section containing settings pertaining to enrollment.
   enrollment:
@@ -206,18 +206,18 @@ web:
     bindPoints:
       #interface - required
       # A host:port string on which network interface to listen on. 0.0.0.0 will listen on all interfaces
-      - interface: "[::1]:443"
+      - interface: 127.0.0.1:1280
 
         # address - required
         # The public address that external incoming requests will be able to resolve. Used in request processing and
         # response content that requires full host:port/path addresses.
-        address: "[::1]:443"
+        address: 127.0.0.1:1280
 
         # newAddress - optional
         # A host:port string which will be sent out as an HTTP header "ziti-new-address" if specified. If the header
         # is present, clients should update location configuration to immediately use the new address for future
         # connections. The value of newAddress must be resolvable both via DNS and validate via certificates
-        newAddress: "[::1]:443"
+        newAddress: localhost:1280
     # identity - optional
     # Allows the webListener to have a specific identity instead of defaulting to the root `identity` section.
     #    identity:


### PR DESCRIPTION
- fixes :443 default port calls from clients (e.g. https and :443 left off)
- fixes localhost vs 127.0.0.1 vs ::1 bindings