### PR TITLE
reconcile ziti-tunnel entrypoint script with ziti-edge-tunnel's

### DIFF
--- a/dist/docker-images/cross-build/Dockerfile
+++ b/dist/docker-images/cross-build/Dockerfile
@@ -5,7 +5,7 @@ FROM debian:bullseye-slim
 #
 
 ARG TARGETARCH
-ARG golang_version=1.22.1
+ARG golang_version=1.23.2
 ARG go_distribution_file=go${golang_version}.linux-${TARGETARCH}.tar.gz
 ARG go_path=/usr/share/go
 ARG go_root=/usr/local/go
@@ -32,4 +32,3 @@ ENV PATH=${go_path}/bin:${go_root}/bin:$PATH
 RUN go install github.com/mitchellh/gox@latest
 WORKDIR /mnt
 ENTRYPOINT ["linux-build.sh"]
-

--- a/dist/docker-images/ziti-tunnel/entrypoint.sh
+++ b/dist/docker-images/ziti-tunnel/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright 2023 NetFoundry Inc.
+# Copyright 2025 NetFoundry Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-set -e -u -o pipefail
+set -o errexit -o nounset -o pipefail
 
 function alldone() {
     # if successfully sent to background then send SIGTERM to trigger a cleanup
@@ -29,75 +29,85 @@ function alldone() {
 }
 trap alldone SIGTERM SIGINT EXIT
 
-IDENTITIES_DIR="/netfoundry"
-if ! [[ -d "${IDENTITIES_DIR}" ]]; then
-    echo "ERROR: need directory ${IDENTITIES_DIR} to find tokens and identities" >&2
-    exit 1
-fi
+unset \
+    ZITI_IDENTITY_DIR \
+    IDENTITY_FILE \
+    JSON_FILES \
+    JWT_CANDIDATE \
+    JWT_FILE \
+    TUNNEL_OPTS \
+    TUNNEL_RUN_MODE
 
-if ! mountpoint "${IDENTITIES_DIR}" &>/dev/null; then
-    echo "WARN: the identities directory is only available inside this container because ${IDENTITIES_DIR} is not a mounted volume. Be careful to not publish this image with identity inside or lose access to the identity by removing the image prematurely." >&2
-else
-    if [[ -n "${ZITI_IDENTITY_JSON:-}" ]]; then
-        echo "WARNING: you supplied the Ziti identity as an env var and you mounted a volume on the identities dir. You may avoid this warning and future errors by not mounting a volume on ${IDENTITIES_DIR} when ZITI_IDENTITY_JSON is defined." >&2
+# adapt deprecated NF_REG_* env vars to undefined ZITI_* env vars
+if [[ -z "${ZITI_IDENTITY_BASENAME:-}" ]]; then
+    if [[ -n "${NF_REG_NAME:-}" ]]; then
+        echo "WARN: replacing deprecated NF_REG_NAME with ZITI_IDENTITY_BASENAME=${NF_REG_NAME}"
+        ZITI_IDENTITY_BASENAME="${NF_REG_NAME}"
+    elif [[ -n "${IOTEDGE_DEVICEID:-}" ]]; then
+        echo "WARN: replacing deprecated IOTEDGE_DEVICEID with ZITI_IDENTITY_BASENAME=${IOTEDGE_DEVICEID}"
+        ZITI_IDENTITY_BASENAME="${IOTEDGE_DEVICEID}"
     fi
 fi
-
-#
-## Map the preferred, Ziti var names to legacy NF names. This allows us to begin using the preferred vars right away 
-##  while minimizing immediate differences to the main control structure. This eases code review. Later, the legacy
-##  names can be retired and replaced.
-#
-if [[ -n "${ZITI_IDENTITY_BASENAME:-}" ]]; then
-    echo "INFO: setting NF_REG_NAME to \${ZITI_IDENTITY_BASENAME} (${ZITI_IDENTITY_BASENAME})"
-    NF_REG_NAME="${ZITI_IDENTITY_BASENAME}"
+if [[ -z "${ZITI_ENROLL_TOKEN:-}" && -n "${NF_REG_TOKEN:-}" ]]; then
+    echo "WARN: replacing deprecated NF_REG_TOKEN with ZITI_ENROLL_TOKEN=${NF_REG_TOKEN}"
+    ZITI_ENROLL_TOKEN="${NF_REG_TOKEN}"
 fi
-if [[ -n "${ZITI_ENROLL_TOKEN:-}" ]]; then
-    echo "INFO: setting NF_REG_TOKEN to \${ZITI_ENROLL_TOKEN} (${ZITI_ENROLL_TOKEN})"
-    NF_REG_TOKEN="${ZITI_ENROLL_TOKEN}"
-fi
-if [[ -n "${ZITI_IDENTITY_WAIT:-}" ]]; then
-    echo "INFO: setting NF_REG_WAIT to \${ZITI_IDENTITY_WAIT} (${ZITI_IDENTITY_WAIT})"
-    NF_REG_WAIT="${ZITI_IDENTITY_WAIT}"
+if [[ -z "${ZITI_IDENTITY_WAIT:-}" && -n "${NF_REG_WAIT:-}" ]]; then
+    echo "WARN: replacing deprecated var NF_REG_WAIT with ZITI_IDENTITY_WAIT=${NF_REG_WAIT}"
+    ZITI_IDENTITY_WAIT="${NF_REG_WAIT}"
 fi
 
-# treat IOTEDGE_DEVICEID, a standard var assigned by Azure IoT, as an alias for NF_REG_NAME
-if [[ -z "${NF_REG_NAME:-}" ]]; then
-    if [[ -n "${IOTEDGE_DEVICEID:-}" ]]; then
-        echo "INFO: setting NF_REG_NAME to \${IOTEDGE_DEVICEID} (${IOTEDGE_DEVICEID})"
-        NF_REG_NAME="${IOTEDGE_DEVICEID}"
-    fi
-fi
+# assign default identity dir if not set in parent env; this is a writeable path within the container image
+: "${ZITI_IDENTITY_DIR:="/netfoundry"}"
 
-# if identity JSON var is defined then write to a file
+# if enrolled identity JSON is provided then write it to a file in the identities dir
 if [[ -n "${ZITI_IDENTITY_JSON:-}" ]]; then
-    # if the basename is not defined then use a default basename to write JSON to a file
-    if [[ -z "${NF_REG_NAME:-}" ]]; then
-        NF_REG_NAME="ziti_id"
+    if [[ -z "${ZITI_IDENTITY_BASENAME:-}" ]]; then
+        ZITI_IDENTITY_BASENAME="ziti_id"
     fi
-    if [[ -s "${IDENTITIES_DIR}/${NF_REG_NAME}.json" ]]; then
-        echo "ERROR: refusing to clobber non-empty Ziti identity file ${NF_REG_NAME}.json with contents of env var ZITI_IDENTITY_JSON!" >&2
+    IDENTITY_FILE="${ZITI_IDENTITY_DIR}/${ZITI_IDENTITY_BASENAME}.json"
+    if [[ -s "${IDENTITY_FILE}" ]]; then
+        echo "WARN: clobbering non-empty Ziti identity file ${IDENTITY_FILE} with contents of env var ZITI_IDENTITY_JSON" >&2
+    fi
+    echo "${ZITI_IDENTITY_JSON}" > "${IDENTITY_FILE}"
+# if an enrollment token is provided then write it to a file in the identities dir so it will be found in the next step
+# and used to enroll
+elif [[ -n "${ZITI_ENROLL_TOKEN:-}" ]]; then
+    if [[ -z "${ZITI_IDENTITY_BASENAME:-}" ]]; then
+        ZITI_IDENTITY_BASENAME="ziti_id"
+    fi
+    JWT_FILE="${ZITI_IDENTITY_DIR}/${ZITI_IDENTITY_BASENAME}.jwt"
+    if [[ -s "${JWT_FILE}" ]]; then
+        echo "WARN: clobbering non-empty Ziti enrollment token file ${JWT_FILE} with contents of env var ZITI_ENROLL_TOKEN" >&2
+    fi
+    echo "${ZITI_ENROLL_TOKEN}" > "${JWT_FILE}"
+# otherwise, assume the identities dir is a mounted volume with identity files or tokens
+else
+    if ! [[ -d "${ZITI_IDENTITY_DIR}" ]]; then
+        echo "ERROR: need directory ${ZITI_IDENTITY_DIR} to find tokens and identities" >&2
         exit 1
-    else
-        echo "${ZITI_IDENTITY_JSON}" > "${IDENTITIES_DIR}/${NF_REG_NAME}.json"
     fi
 fi
 
 typeset -a TUNNEL_OPTS
-# if identity file, else multiple identities dir
-if [[ -n "${NF_REG_NAME:-}" ]]; then
-    IDENTITY_FILE="${IDENTITIES_DIR}/${NF_REG_NAME}.json"
+# if identity basename is specified then look for an identity file with that name, else load all identities in the
+# identities dir mountpoint
+if [[ -n "${ZITI_IDENTITY_BASENAME:-}" ]]; then
+    IDENTITY_FILE="${ZITI_IDENTITY_DIR}/${ZITI_IDENTITY_BASENAME}.json"
     TUNNEL_OPTS=("--identity" "${IDENTITY_FILE}")
-    : ${NF_REG_WAIT:=1}
-    if [[ "${NF_REG_WAIT}" =~ ^[0-9]+$ ]]; then
-        echo "DEBUG: waiting ${NF_REG_WAIT}s for ${IDENTITY_FILE} (or token) to appear"
-    elif (( "${NF_REG_WAIT}" < 0 )); then
+
+    # if wait is specified then wait for the identity file or token to appear
+    : "${ZITI_IDENTITY_WAIT:=3}"
+    if [[ "${ZITI_IDENTITY_WAIT}" =~ ^[0-9]+$ ]]; then
+        echo "DEBUG: waiting ${ZITI_IDENTITY_WAIT}s for ${IDENTITY_FILE} (or token) to appear"
+    elif (( "${ZITI_IDENTITY_WAIT}" < 0 )); then
         echo "DEBUG: waiting forever for ${IDENTITY_FILE} (or token) to appear"
     else
-        echo "ERROR: need integer for NF_REG_WAIT" >&2
+        echo "ERROR: need integer for ZITI_IDENTITY_WAIT" >&2
         exit 1
     fi
-    while (( $NF_REG_WAIT > 0 || $NF_REG_WAIT < 0)); do
+
+    while (( ZITI_IDENTITY_WAIT > 0 || ZITI_IDENTITY_WAIT < 0 )); do
         # if non-empty identity file
         if [[ -s "${IDENTITY_FILE}" ]]; then
             echo "INFO: found identity file ${IDENTITY_FILE}"
@@ -105,10 +115,10 @@ if [[ -n "${NF_REG_NAME:-}" ]]; then
         # look for enrollment token
         else
             echo "INFO: identity file ${IDENTITY_FILE} does not exist"
-            for dir in  "/var/run/secrets/netfoundry.io/enrollment-token" \
-                        "/enrollment-token" \
-                        "${IDENTITIES_DIR}"; do
-                JWT_CANDIDATE="${dir}/${NF_REG_NAME}.jwt"
+            for dir in "/var/run/secrets/netfoundry.io/enrollment-token" \
+                      "/enrollment-token" \
+                      "${ZITI_IDENTITY_DIR}"; do
+                JWT_CANDIDATE="${dir}/${ZITI_IDENTITY_BASENAME}.jwt"
                 echo "INFO: looking for ${JWT_CANDIDATE}"
                 if [[ -s "${JWT_CANDIDATE}" ]]; then
                     JWT_FILE="${JWT_CANDIDATE}"
@@ -121,32 +131,21 @@ if [[ -n "${NF_REG_NAME:-}" ]]; then
                     echo "ERROR: failed to enroll with token from ${JWT_FILE} ($(wc -c < "${JWT_FILE}")B)" >&2
                     exit 1
                 }
-            elif [[ -n "${NF_REG_TOKEN:-}" ]]; then
-                echo "INFO: attempting enrollment with NF_REG_TOKEN"
-                if [[ -s "${IDENTITIES_DIR}/${NF_REG_NAME}.jwt" ]]; then
-                    echo "ERROR: refusing to clobber non-empty enrollment OTP file ${NF_REG_NAME}.jwt with contents of env var NF_REG_TOKEN!" >&2
-                    exit 1
-                else
-                    echo "${NF_REG_TOKEN}" > "${IDENTITIES_DIR}/${NF_REG_NAME}.jwt"
-                fi
-                ziti edge enroll --jwt "${IDENTITIES_DIR}/${NF_REG_NAME}.jwt" --out "${IDENTITY_FILE}" || {
-                    echo "ERROR: failed to enroll with token from NF_REG_TOKEN ($(wc -c <<<"${NF_REG_TOKEN}")B)" >&2
-                    exit 1
-                }
+                break 1
             fi
         fi
         # decrement the wait seconds until zero or forever if negative
-        (( NF_REG_WAIT-- ))
+        (( ZITI_IDENTITY_WAIT-- ))
         sleep 1
     done
 else
     typeset -a JSON_FILES
-    mapfile -t JSON_FILES < <(ls -1 "${IDENTITIES_DIR}"/*.json)
+    mapfile -t JSON_FILES < <(ls -1 "${ZITI_IDENTITY_DIR}"/*.json 2>/dev/null || true)
     if [[ ${#JSON_FILES[*]} -gt 0 ]]; then
-        echo "INFO: NF_REG_NAME not set, loading ${#JSON_FILES[*]} identities from ${IDENTITIES_DIR}"
-        TUNNEL_OPTS=("--identity-dir" "${IDENTITIES_DIR}")
+        echo "INFO: ZITI_IDENTITY_BASENAME not set, loading ${#JSON_FILES[*]} identities from ${ZITI_IDENTITY_DIR}"
+        TUNNEL_OPTS=("--identity-dir" "${ZITI_IDENTITY_DIR}")
     else
-        echo "ERROR: NF_REG_NAME not set and zero identities found in ${IDENTITIES_DIR}" >&2
+        echo "ERROR: ZITI_IDENTITY_BASENAME not set and zero identities found in ${ZITI_IDENTITY_DIR}" >&2
         exit 1
     fi
 fi
@@ -156,7 +155,7 @@ if (( ${#} )) && [[ ${1} =~ t?proxy|host ]]; then
     TUNNEL_RUN_MODE=${1}
     shift
 else
-    TUNNEL_RUN_MODE=run
+    TUNNEL_RUN_MODE=tproxy
 fi
 
 echo "INFO: running \"ziti tunnel ${TUNNEL_RUN_MODE} ${TUNNEL_OPTS[*]} ${*}\""


### PR DESCRIPTION

The main reason for this is to enable the ziti-tunnel image to enroll and run with only an enrollment token env var.

