### PR TITLE
set appropriate filemodes on unwrapped identity files

### DIFF
--- a/ziti/cmd/file_mode_unix.go
+++ b/ziti/cmd/file_mode_unix.go
@@ -1,5 +1,22 @@
 //go:build !windows
 
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+
 package cmd
 
 import (

--- a/ziti/cmd/file_mode_unix.go
+++ b/ziti/cmd/file_mode_unix.go
@@ -1,0 +1,27 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"os"
+	"syscall"
+)
+
+func getFileMode(isPrivateKey bool) os.FileMode {
+	// Default modes before umask:
+	// - Private keys: 0600 (rw-------)
+	// - Public files: 0644 (rw-r--r--)
+	mode := os.FileMode(0644)
+	if isPrivateKey {
+		mode = os.FileMode(0600)
+	}
+
+	// Get current umask
+	oldMask := syscall.Umask(0)
+	syscall.Umask(oldMask) // Restore original umask
+
+	// Apply umask to our default mode
+	mode &= ^os.FileMode(oldMask)
+
+	return mode
+}

--- a/ziti/cmd/file_mode_windows.go
+++ b/ziti/cmd/file_mode_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package cmd
+
+import "os"
+
+func getFileMode(isPrivateKey bool) os.FileMode {
+	// Default modes for Windows:
+	// - Private keys: 0600 (rw-------)
+	// - Public files: 0644 (rw-r--r--)
+	if isPrivateKey {
+		return os.FileMode(0600)
+	}
+	return os.FileMode(0644)
+}

--- a/ziti/cmd/file_mode_windows.go
+++ b/ziti/cmd/file_mode_windows.go
@@ -1,5 +1,21 @@
 //go:build windows
 
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
 package cmd
 
 import "os"

--- a/ziti/cmd/unwrap_identity.go
+++ b/ziti/cmd/unwrap_identity.go
@@ -1,3 +1,19 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
 package cmd
 
 import (

--- a/ziti/cmd/unwrap_identity.go
+++ b/ziti/cmd/unwrap_identity.go
@@ -7,7 +7,9 @@ import (
 	"github.com/spf13/cobra"
 	"io"
 	"os"
+	"runtime"
 	"strings"
+	"syscall"
 )
 
 type IdentityConfigFile struct {
@@ -57,7 +59,7 @@ func NewUnwrapIdentityFileCommand(out io.Writer, errOut io.Writer) *cobra.Comman
 
 			if strings.HasPrefix(config.ID.Cert, "pem:") {
 				data := strings.TrimPrefix(config.ID.Cert, "pem:")
-				if err := os.WriteFile(outCertFile, []byte(data), 0); err != nil {
+				if err := os.WriteFile(outCertFile, []byte(data), getFileMode(false)); err != nil {
 					_, _ = fmt.Fprintf(errOut, "error writing certificate to file [%s]: %v\n", outCertFile, err)
 					return
 				}
@@ -67,7 +69,7 @@ func NewUnwrapIdentityFileCommand(out io.Writer, errOut io.Writer) *cobra.Comman
 
 			if strings.HasPrefix(config.ID.Key, "pem:") {
 				data := strings.TrimPrefix(config.ID.Key, "pem:")
-				if err := os.WriteFile(outKeyFile, []byte(data), 0); err != nil {
+				if err := os.WriteFile(outKeyFile, []byte(data), getFileMode(true)); err != nil {
 					_, _ = fmt.Fprintf(errOut, "error writing private key to file [%s]: %v\n", outKeyFile, err)
 					return
 				}
@@ -75,14 +77,14 @@ func NewUnwrapIdentityFileCommand(out io.Writer, errOut io.Writer) *cobra.Comman
 				_, _ = fmt.Fprintf(errOut, "error writing private key to file [%s]: missing pem prefix, type is unsupported\n", outKeyFile)
 			}
 
-			if strings.HasPrefix(config.ID.Key, "pem:") {
+			if strings.HasPrefix(config.ID.CA, "pem:") {
 				data := strings.TrimPrefix(config.ID.CA, "pem:")
-				if err := os.WriteFile(outCaFile, []byte(data), 0); err != nil {
+				if err := os.WriteFile(outCaFile, []byte(data), getFileMode(false)); err != nil {
 					_, _ = fmt.Fprintf(errOut, "error writing CAs to file [%s]: %v\n", outCaFile, err)
 					return
 				}
 			} else {
-				_, _ = fmt.Fprintf(errOut, "error writing CAs to file [%s]: missing pem prefix, type is unsupported\n", outKeyFile)
+				_, _ = fmt.Fprintf(errOut, "error writing CAs to file [%s]: missing pem prefix, type is unsupported\n", outCaFile)
 			}
 		},
 	}
@@ -92,4 +94,25 @@ func NewUnwrapIdentityFileCommand(out io.Writer, errOut io.Writer) *cobra.Comman
 	cmd.Flags().StringVarP(&outCaFile, "ca", "", "", "output ca bundle file, defaults to ./<root>.ca")
 
 	return cmd
+}
+
+func getFileMode(isPrivateKey bool) os.FileMode {
+	// Default modes before umask:
+	// - Private keys: 0600 (rw-------)
+	// - Public files: 0644 (rw-r--r--)
+	mode := os.FileMode(0644)
+	if isPrivateKey {
+		mode = os.FileMode(0600)
+	}
+
+	if runtime.GOOS != "windows" {
+		// Get current umask
+		oldMask := syscall.Umask(0)
+		syscall.Umask(oldMask) // Restore original umask
+
+		// Apply umask to our default mode
+		mode &= ^os.FileMode(oldMask)
+	}
+
+	return mode
 }

--- a/ziti/cmd/unwrap_identity.go
+++ b/ziti/cmd/unwrap_identity.go
@@ -7,9 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"io"
 	"os"
-	"runtime"
 	"strings"
-	"syscall"
 )
 
 type IdentityConfigFile struct {
@@ -94,25 +92,4 @@ func NewUnwrapIdentityFileCommand(out io.Writer, errOut io.Writer) *cobra.Comman
 	cmd.Flags().StringVarP(&outCaFile, "ca", "", "", "output ca bundle file, defaults to ./<root>.ca")
 
 	return cmd
-}
-
-func getFileMode(isPrivateKey bool) os.FileMode {
-	// Default modes before umask:
-	// - Private keys: 0600 (rw-------)
-	// - Public files: 0644 (rw-r--r--)
-	mode := os.FileMode(0644)
-	if isPrivateKey {
-		mode = os.FileMode(0600)
-	}
-
-	if runtime.GOOS != "windows" {
-		// Get current umask
-		oldMask := syscall.Umask(0)
-		syscall.Umask(oldMask) // Restore original umask
-
-		// Apply umask to our default mode
-		mode &= ^os.FileMode(oldMask)
-	}
-
-	return mode
 }


### PR DESCRIPTION
On `!windows` systems, it's currently necessary to correct the filemode on unwrapped files. This respects the filemode mask on POSIX systems with appropriate defaults and always sets the default mode on Windows: 

- owner: read+write on key, cert, ca
- group, others: read-only on cert, ca