### PR TITLE
Cluster operations should return 503 if there's no leader

### DIFF
--- a/controller/api/responder.go
+++ b/controller/api/responder.go
@@ -23,6 +23,7 @@ import (
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/foundation/v2/errorz"
 	"github.com/openziti/ziti/controller/apierror"
+	"github.com/openziti/ziti/controller/models"
 	"net/http"
 	"strconv"
 	"strings"
@@ -128,15 +129,12 @@ func (responder *ResponderImpl) RespondWithProducer(producer runtime.Producer, d
 }
 
 func (responder *ResponderImpl) RespondWithError(err error) {
-	var apiError *errorz.ApiError
-	var ok bool
-
-	if apiError, ok = err.(*errorz.ApiError); !ok {
+	apiErr := models.ToApiErrorWithDefault(err, func(err error) *errorz.ApiError {
 		pfxlog.Logger().WithField("uri", responder.rc.GetRequest().RequestURI).WithError(err).Error("unhandled error returned to REST API")
-		apiError = errorz.NewUnhandled(err)
-	}
+		return errorz.NewUnhandled(err)
+	})
 
-	responder.RespondWithApiError(apiError)
+	responder.RespondWithApiError(apiErr)
 }
 
 func (responder *ResponderImpl) RespondWithApiError(apiError *errorz.ApiError) {

--- a/controller/apierror/helpers.go
+++ b/controller/apierror/helpers.go
@@ -407,3 +407,13 @@ func NewClusterHasNoLeaderError() *errorz.ApiError {
 		Status:  ClusterHasNoLeaderStatus,
 	}
 }
+
+func NewTransferLeadershipError(err error) *errorz.ApiError {
+	return &errorz.ApiError{
+		Code:        TransferLeadershipErrorCode,
+		Message:     TransferLeadershipErrorMessage,
+		Status:      TransferLeadershipErrorStatus,
+		Cause:       err,
+		AppendCause: true,
+	}
+}

--- a/controller/config/config.go
+++ b/controller/config/config.go
@@ -224,7 +224,7 @@ func LoadConfig(path string) (*Config, error) {
 			if value, found := submap["dataDir"]; found {
 				controllerConfig.Raft.DataDir = value.(string)
 			} else {
-				return nil, errors.Errorf("raft dataDir configuration missing")
+				return nil, errors.Errorf("cluster dataDir configuration missing")
 			}
 
 			if value, found := submap["snapshotInterval"]; found {
@@ -326,7 +326,7 @@ func LoadConfig(path string) (*Config, error) {
 				}
 			}
 		} else {
-			return nil, errors.Errorf("invalid raft configuration")
+			return nil, errors.Errorf("invalid cluster configuration")
 		}
 	} else if value, found := cfgmap["db"]; found {
 		str, err := db.Open(value.(string))
@@ -335,7 +335,7 @@ func LoadConfig(path string) (*Config, error) {
 		}
 		controllerConfig.Db = str
 	} else {
-		panic("controllerConfig must provide [db] or [raft]")
+		panic("controllerConfig must provide [db] or [cluster]")
 	}
 
 	//SPIFFE Trust Domain

--- a/controller/models/errors.go
+++ b/controller/models/errors.go
@@ -1,13 +1,19 @@
 package models
 
 import (
+	"errors"
 	"github.com/openziti/foundation/v2/errorz"
 	"github.com/openziti/storage/boltz"
 	"github.com/openziti/ziti/controller/apierror"
 )
 
 func ToApiError(err error) *errorz.ApiError {
-	if apiErr, ok := err.(*errorz.ApiError); ok {
+	return ToApiErrorWithDefault(err, errorz.NewUnhandled)
+}
+
+func ToApiErrorWithDefault(err error, f func(err error) *errorz.ApiError) *errorz.ApiError {
+	var apiErr *errorz.ApiError
+	if errors.As(err, &apiErr) {
 		return apiErr
 	}
 
@@ -17,13 +23,15 @@ func ToApiError(err error) *errorz.ApiError {
 		return result
 	}
 
-	if fe, ok := err.(*errorz.FieldError); ok {
+	var fe *errorz.FieldError
+	if errors.As(err, &fe) {
 		return errorz.NewFieldApiError(fe)
 	}
 
-	if sve, ok := err.(*apierror.ValidationErrors); ok {
+	var sve *apierror.ValidationErrors
+	if errors.As(err, &sve) {
 		return errorz.NewCouldNotValidate(sve)
 	}
 
-	return errorz.NewUnhandled(err)
+	return f(err)
 }

--- a/controller/raft/member.go
+++ b/controller/raft/member.go
@@ -17,6 +17,7 @@
 package raft
 
 import (
+	"github.com/openziti/ziti/controller/apierror"
 	"time"
 
 	"github.com/openziti/channel/v3/protobufs"
@@ -210,7 +211,7 @@ func (self *Controller) HandleTransferLeadership(req *cmd_pb.TransferLeadershipR
 func (self *Controller) forwardToLeader(req protobufs.TypedMessage) error {
 	leader := self.GetLeaderAddr()
 	if leader == "" {
-		return errors.New("no leader, unable to forward request")
+		return apierror.NewClusterHasNoLeaderError()
 	}
 
 	return self.ForwardToAddr(leader, req)

--- a/controller/rest_client/circuit/delete_circuit_responses.go
+++ b/controller/rest_client/circuit/delete_circuit_responses.go
@@ -77,6 +77,12 @@ func (o *DeleteCircuitReader) ReadResponse(response runtime.ClientResponse, cons
 			return nil, err
 		}
 		return nil, result
+	case 503:
+		result := NewDeleteCircuitServiceUnavailable()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	default:
 		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
@@ -231,6 +237,38 @@ func (o *DeleteCircuitTooManyRequests) GetPayload() *rest_model.APIErrorEnvelope
 }
 
 func (o *DeleteCircuitTooManyRequests) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(rest_model.APIErrorEnvelope)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewDeleteCircuitServiceUnavailable creates a DeleteCircuitServiceUnavailable with default headers values
+func NewDeleteCircuitServiceUnavailable() *DeleteCircuitServiceUnavailable {
+	return &DeleteCircuitServiceUnavailable{}
+}
+
+/* DeleteCircuitServiceUnavailable describes a response with status code 503, with default header values.
+
+The request could not be completed due to the server being busy or in a temporarily bad state
+*/
+type DeleteCircuitServiceUnavailable struct {
+	Payload *rest_model.APIErrorEnvelope
+}
+
+func (o *DeleteCircuitServiceUnavailable) Error() string {
+	return fmt.Sprintf("[DELETE /circuits/{id}][%d] deleteCircuitServiceUnavailable  %+v", 503, o.Payload)
+}
+func (o *DeleteCircuitServiceUnavailable) GetPayload() *rest_model.APIErrorEnvelope {
+	return o.Payload
+}
+
+func (o *DeleteCircuitServiceUnavailable) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(rest_model.APIErrorEnvelope)
 

--- a/controller/rest_client/cluster/cluster_member_add_responses.go
+++ b/controller/rest_client/cluster/cluster_member_add_responses.go
@@ -71,6 +71,12 @@ func (o *ClusterMemberAddReader) ReadResponse(response runtime.ClientResponse, c
 			return nil, err
 		}
 		return nil, result
+	case 503:
+		result := NewClusterMemberAddServiceUnavailable()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	default:
 		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
@@ -193,6 +199,38 @@ func (o *ClusterMemberAddTooManyRequests) GetPayload() *rest_model.APIErrorEnvel
 }
 
 func (o *ClusterMemberAddTooManyRequests) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(rest_model.APIErrorEnvelope)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewClusterMemberAddServiceUnavailable creates a ClusterMemberAddServiceUnavailable with default headers values
+func NewClusterMemberAddServiceUnavailable() *ClusterMemberAddServiceUnavailable {
+	return &ClusterMemberAddServiceUnavailable{}
+}
+
+/* ClusterMemberAddServiceUnavailable describes a response with status code 503, with default header values.
+
+The request could not be completed due to the server being busy or in a temporarily bad state
+*/
+type ClusterMemberAddServiceUnavailable struct {
+	Payload *rest_model.APIErrorEnvelope
+}
+
+func (o *ClusterMemberAddServiceUnavailable) Error() string {
+	return fmt.Sprintf("[POST /cluster/add-member][%d] clusterMemberAddServiceUnavailable  %+v", 503, o.Payload)
+}
+func (o *ClusterMemberAddServiceUnavailable) GetPayload() *rest_model.APIErrorEnvelope {
+	return o.Payload
+}
+
+func (o *ClusterMemberAddServiceUnavailable) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(rest_model.APIErrorEnvelope)
 

--- a/controller/rest_client/cluster/cluster_member_remove_responses.go
+++ b/controller/rest_client/cluster/cluster_member_remove_responses.go
@@ -77,6 +77,12 @@ func (o *ClusterMemberRemoveReader) ReadResponse(response runtime.ClientResponse
 			return nil, err
 		}
 		return nil, result
+	case 503:
+		result := NewClusterMemberRemoveServiceUnavailable()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	default:
 		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
@@ -231,6 +237,38 @@ func (o *ClusterMemberRemoveTooManyRequests) GetPayload() *rest_model.APIErrorEn
 }
 
 func (o *ClusterMemberRemoveTooManyRequests) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(rest_model.APIErrorEnvelope)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewClusterMemberRemoveServiceUnavailable creates a ClusterMemberRemoveServiceUnavailable with default headers values
+func NewClusterMemberRemoveServiceUnavailable() *ClusterMemberRemoveServiceUnavailable {
+	return &ClusterMemberRemoveServiceUnavailable{}
+}
+
+/* ClusterMemberRemoveServiceUnavailable describes a response with status code 503, with default header values.
+
+The request could not be completed due to the server being busy or in a temporarily bad state
+*/
+type ClusterMemberRemoveServiceUnavailable struct {
+	Payload *rest_model.APIErrorEnvelope
+}
+
+func (o *ClusterMemberRemoveServiceUnavailable) Error() string {
+	return fmt.Sprintf("[POST /cluster/remove-member][%d] clusterMemberRemoveServiceUnavailable  %+v", 503, o.Payload)
+}
+func (o *ClusterMemberRemoveServiceUnavailable) GetPayload() *rest_model.APIErrorEnvelope {
+	return o.Payload
+}
+
+func (o *ClusterMemberRemoveServiceUnavailable) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(rest_model.APIErrorEnvelope)
 

--- a/controller/rest_client/cluster/cluster_transfer_leadership_responses.go
+++ b/controller/rest_client/cluster/cluster_transfer_leadership_responses.go
@@ -77,6 +77,12 @@ func (o *ClusterTransferLeadershipReader) ReadResponse(response runtime.ClientRe
 			return nil, err
 		}
 		return nil, result
+	case 503:
+		result := NewClusterTransferLeadershipServiceUnavailable()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	default:
 		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
@@ -231,6 +237,38 @@ func (o *ClusterTransferLeadershipInternalServerError) GetPayload() *rest_model.
 }
 
 func (o *ClusterTransferLeadershipInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(rest_model.APIErrorEnvelope)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewClusterTransferLeadershipServiceUnavailable creates a ClusterTransferLeadershipServiceUnavailable with default headers values
+func NewClusterTransferLeadershipServiceUnavailable() *ClusterTransferLeadershipServiceUnavailable {
+	return &ClusterTransferLeadershipServiceUnavailable{}
+}
+
+/* ClusterTransferLeadershipServiceUnavailable describes a response with status code 503, with default header values.
+
+The request could not be completed due to the server being busy or in a temporarily bad state
+*/
+type ClusterTransferLeadershipServiceUnavailable struct {
+	Payload *rest_model.APIErrorEnvelope
+}
+
+func (o *ClusterTransferLeadershipServiceUnavailable) Error() string {
+	return fmt.Sprintf("[POST /cluster/transfer-leadership][%d] clusterTransferLeadershipServiceUnavailable  %+v", 503, o.Payload)
+}
+func (o *ClusterTransferLeadershipServiceUnavailable) GetPayload() *rest_model.APIErrorEnvelope {
+	return o.Payload
+}
+
+func (o *ClusterTransferLeadershipServiceUnavailable) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(rest_model.APIErrorEnvelope)
 

--- a/controller/rest_client/link/delete_link_responses.go
+++ b/controller/rest_client/link/delete_link_responses.go
@@ -71,6 +71,12 @@ func (o *DeleteLinkReader) ReadResponse(response runtime.ClientResponse, consume
 			return nil, err
 		}
 		return nil, result
+	case 503:
+		result := NewDeleteLinkServiceUnavailable()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	default:
 		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
@@ -193,6 +199,38 @@ func (o *DeleteLinkTooManyRequests) GetPayload() *rest_model.APIErrorEnvelope {
 }
 
 func (o *DeleteLinkTooManyRequests) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(rest_model.APIErrorEnvelope)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewDeleteLinkServiceUnavailable creates a DeleteLinkServiceUnavailable with default headers values
+func NewDeleteLinkServiceUnavailable() *DeleteLinkServiceUnavailable {
+	return &DeleteLinkServiceUnavailable{}
+}
+
+/* DeleteLinkServiceUnavailable describes a response with status code 503, with default header values.
+
+The request could not be completed due to the server being busy or in a temporarily bad state
+*/
+type DeleteLinkServiceUnavailable struct {
+	Payload *rest_model.APIErrorEnvelope
+}
+
+func (o *DeleteLinkServiceUnavailable) Error() string {
+	return fmt.Sprintf("[DELETE /links/{id}][%d] deleteLinkServiceUnavailable  %+v", 503, o.Payload)
+}
+func (o *DeleteLinkServiceUnavailable) GetPayload() *rest_model.APIErrorEnvelope {
+	return o.Payload
+}
+
+func (o *DeleteLinkServiceUnavailable) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(rest_model.APIErrorEnvelope)
 

--- a/controller/rest_client/link/patch_link_responses.go
+++ b/controller/rest_client/link/patch_link_responses.go
@@ -77,6 +77,12 @@ func (o *PatchLinkReader) ReadResponse(response runtime.ClientResponse, consumer
 			return nil, err
 		}
 		return nil, result
+	case 503:
+		result := NewPatchLinkServiceUnavailable()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	default:
 		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
@@ -231,6 +237,38 @@ func (o *PatchLinkTooManyRequests) GetPayload() *rest_model.APIErrorEnvelope {
 }
 
 func (o *PatchLinkTooManyRequests) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(rest_model.APIErrorEnvelope)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewPatchLinkServiceUnavailable creates a PatchLinkServiceUnavailable with default headers values
+func NewPatchLinkServiceUnavailable() *PatchLinkServiceUnavailable {
+	return &PatchLinkServiceUnavailable{}
+}
+
+/* PatchLinkServiceUnavailable describes a response with status code 503, with default header values.
+
+The request could not be completed due to the server being busy or in a temporarily bad state
+*/
+type PatchLinkServiceUnavailable struct {
+	Payload *rest_model.APIErrorEnvelope
+}
+
+func (o *PatchLinkServiceUnavailable) Error() string {
+	return fmt.Sprintf("[PATCH /links/{id}][%d] patchLinkServiceUnavailable  %+v", 503, o.Payload)
+}
+func (o *PatchLinkServiceUnavailable) GetPayload() *rest_model.APIErrorEnvelope {
+	return o.Payload
+}
+
+func (o *PatchLinkServiceUnavailable) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(rest_model.APIErrorEnvelope)
 

--- a/controller/rest_client/router/create_router_responses.go
+++ b/controller/rest_client/router/create_router_responses.go
@@ -71,6 +71,12 @@ func (o *CreateRouterReader) ReadResponse(response runtime.ClientResponse, consu
 			return nil, err
 		}
 		return nil, result
+	case 503:
+		result := NewCreateRouterServiceUnavailable()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	default:
 		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
@@ -193,6 +199,38 @@ func (o *CreateRouterTooManyRequests) GetPayload() *rest_model.APIErrorEnvelope 
 }
 
 func (o *CreateRouterTooManyRequests) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(rest_model.APIErrorEnvelope)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewCreateRouterServiceUnavailable creates a CreateRouterServiceUnavailable with default headers values
+func NewCreateRouterServiceUnavailable() *CreateRouterServiceUnavailable {
+	return &CreateRouterServiceUnavailable{}
+}
+
+/* CreateRouterServiceUnavailable describes a response with status code 503, with default header values.
+
+The request could not be completed due to the server being busy or in a temporarily bad state
+*/
+type CreateRouterServiceUnavailable struct {
+	Payload *rest_model.APIErrorEnvelope
+}
+
+func (o *CreateRouterServiceUnavailable) Error() string {
+	return fmt.Sprintf("[POST /routers][%d] createRouterServiceUnavailable  %+v", 503, o.Payload)
+}
+func (o *CreateRouterServiceUnavailable) GetPayload() *rest_model.APIErrorEnvelope {
+	return o.Payload
+}
+
+func (o *CreateRouterServiceUnavailable) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(rest_model.APIErrorEnvelope)
 

--- a/controller/rest_client/router/delete_router_responses.go
+++ b/controller/rest_client/router/delete_router_responses.go
@@ -77,6 +77,12 @@ func (o *DeleteRouterReader) ReadResponse(response runtime.ClientResponse, consu
 			return nil, err
 		}
 		return nil, result
+	case 503:
+		result := NewDeleteRouterServiceUnavailable()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	default:
 		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
@@ -231,6 +237,38 @@ func (o *DeleteRouterTooManyRequests) GetPayload() *rest_model.APIErrorEnvelope 
 }
 
 func (o *DeleteRouterTooManyRequests) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(rest_model.APIErrorEnvelope)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewDeleteRouterServiceUnavailable creates a DeleteRouterServiceUnavailable with default headers values
+func NewDeleteRouterServiceUnavailable() *DeleteRouterServiceUnavailable {
+	return &DeleteRouterServiceUnavailable{}
+}
+
+/* DeleteRouterServiceUnavailable describes a response with status code 503, with default header values.
+
+The request could not be completed due to the server being busy or in a temporarily bad state
+*/
+type DeleteRouterServiceUnavailable struct {
+	Payload *rest_model.APIErrorEnvelope
+}
+
+func (o *DeleteRouterServiceUnavailable) Error() string {
+	return fmt.Sprintf("[DELETE /routers/{id}][%d] deleteRouterServiceUnavailable  %+v", 503, o.Payload)
+}
+func (o *DeleteRouterServiceUnavailable) GetPayload() *rest_model.APIErrorEnvelope {
+	return o.Payload
+}
+
+func (o *DeleteRouterServiceUnavailable) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(rest_model.APIErrorEnvelope)
 

--- a/controller/rest_client/router/patch_router_responses.go
+++ b/controller/rest_client/router/patch_router_responses.go
@@ -77,6 +77,12 @@ func (o *PatchRouterReader) ReadResponse(response runtime.ClientResponse, consum
 			return nil, err
 		}
 		return nil, result
+	case 503:
+		result := NewPatchRouterServiceUnavailable()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	default:
 		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
@@ -231,6 +237,38 @@ func (o *PatchRouterTooManyRequests) GetPayload() *rest_model.APIErrorEnvelope {
 }
 
 func (o *PatchRouterTooManyRequests) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(rest_model.APIErrorEnvelope)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewPatchRouterServiceUnavailable creates a PatchRouterServiceUnavailable with default headers values
+func NewPatchRouterServiceUnavailable() *PatchRouterServiceUnavailable {
+	return &PatchRouterServiceUnavailable{}
+}
+
+/* PatchRouterServiceUnavailable describes a response with status code 503, with default header values.
+
+The request could not be completed due to the server being busy or in a temporarily bad state
+*/
+type PatchRouterServiceUnavailable struct {
+	Payload *rest_model.APIErrorEnvelope
+}
+
+func (o *PatchRouterServiceUnavailable) Error() string {
+	return fmt.Sprintf("[PATCH /routers/{id}][%d] patchRouterServiceUnavailable  %+v", 503, o.Payload)
+}
+func (o *PatchRouterServiceUnavailable) GetPayload() *rest_model.APIErrorEnvelope {
+	return o.Payload
+}
+
+func (o *PatchRouterServiceUnavailable) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(rest_model.APIErrorEnvelope)
 

--- a/controller/rest_client/router/update_router_responses.go
+++ b/controller/rest_client/router/update_router_responses.go
@@ -77,6 +77,12 @@ func (o *UpdateRouterReader) ReadResponse(response runtime.ClientResponse, consu
 			return nil, err
 		}
 		return nil, result
+	case 503:
+		result := NewUpdateRouterServiceUnavailable()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	default:
 		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
@@ -231,6 +237,38 @@ func (o *UpdateRouterTooManyRequests) GetPayload() *rest_model.APIErrorEnvelope 
 }
 
 func (o *UpdateRouterTooManyRequests) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(rest_model.APIErrorEnvelope)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewUpdateRouterServiceUnavailable creates a UpdateRouterServiceUnavailable with default headers values
+func NewUpdateRouterServiceUnavailable() *UpdateRouterServiceUnavailable {
+	return &UpdateRouterServiceUnavailable{}
+}
+
+/* UpdateRouterServiceUnavailable describes a response with status code 503, with default header values.
+
+The request could not be completed due to the server being busy or in a temporarily bad state
+*/
+type UpdateRouterServiceUnavailable struct {
+	Payload *rest_model.APIErrorEnvelope
+}
+
+func (o *UpdateRouterServiceUnavailable) Error() string {
+	return fmt.Sprintf("[PUT /routers/{id}][%d] updateRouterServiceUnavailable  %+v", 503, o.Payload)
+}
+func (o *UpdateRouterServiceUnavailable) GetPayload() *rest_model.APIErrorEnvelope {
+	return o.Payload
+}
+
+func (o *UpdateRouterServiceUnavailable) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(rest_model.APIErrorEnvelope)
 

--- a/controller/rest_client/service/create_service_responses.go
+++ b/controller/rest_client/service/create_service_responses.go
@@ -71,6 +71,12 @@ func (o *CreateServiceReader) ReadResponse(response runtime.ClientResponse, cons
 			return nil, err
 		}
 		return nil, result
+	case 503:
+		result := NewCreateServiceServiceUnavailable()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	default:
 		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
@@ -193,6 +199,38 @@ func (o *CreateServiceTooManyRequests) GetPayload() *rest_model.APIErrorEnvelope
 }
 
 func (o *CreateServiceTooManyRequests) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(rest_model.APIErrorEnvelope)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewCreateServiceServiceUnavailable creates a CreateServiceServiceUnavailable with default headers values
+func NewCreateServiceServiceUnavailable() *CreateServiceServiceUnavailable {
+	return &CreateServiceServiceUnavailable{}
+}
+
+/* CreateServiceServiceUnavailable describes a response with status code 503, with default header values.
+
+The request could not be completed due to the server being busy or in a temporarily bad state
+*/
+type CreateServiceServiceUnavailable struct {
+	Payload *rest_model.APIErrorEnvelope
+}
+
+func (o *CreateServiceServiceUnavailable) Error() string {
+	return fmt.Sprintf("[POST /services][%d] createServiceServiceUnavailable  %+v", 503, o.Payload)
+}
+func (o *CreateServiceServiceUnavailable) GetPayload() *rest_model.APIErrorEnvelope {
+	return o.Payload
+}
+
+func (o *CreateServiceServiceUnavailable) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(rest_model.APIErrorEnvelope)
 

--- a/controller/rest_client/service/delete_service_responses.go
+++ b/controller/rest_client/service/delete_service_responses.go
@@ -77,6 +77,12 @@ func (o *DeleteServiceReader) ReadResponse(response runtime.ClientResponse, cons
 			return nil, err
 		}
 		return nil, result
+	case 503:
+		result := NewDeleteServiceServiceUnavailable()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	default:
 		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
@@ -231,6 +237,38 @@ func (o *DeleteServiceTooManyRequests) GetPayload() *rest_model.APIErrorEnvelope
 }
 
 func (o *DeleteServiceTooManyRequests) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(rest_model.APIErrorEnvelope)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewDeleteServiceServiceUnavailable creates a DeleteServiceServiceUnavailable with default headers values
+func NewDeleteServiceServiceUnavailable() *DeleteServiceServiceUnavailable {
+	return &DeleteServiceServiceUnavailable{}
+}
+
+/* DeleteServiceServiceUnavailable describes a response with status code 503, with default header values.
+
+The request could not be completed due to the server being busy or in a temporarily bad state
+*/
+type DeleteServiceServiceUnavailable struct {
+	Payload *rest_model.APIErrorEnvelope
+}
+
+func (o *DeleteServiceServiceUnavailable) Error() string {
+	return fmt.Sprintf("[DELETE /services/{id}][%d] deleteServiceServiceUnavailable  %+v", 503, o.Payload)
+}
+func (o *DeleteServiceServiceUnavailable) GetPayload() *rest_model.APIErrorEnvelope {
+	return o.Payload
+}
+
+func (o *DeleteServiceServiceUnavailable) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(rest_model.APIErrorEnvelope)
 

--- a/controller/rest_client/service/patch_service_responses.go
+++ b/controller/rest_client/service/patch_service_responses.go
@@ -77,6 +77,12 @@ func (o *PatchServiceReader) ReadResponse(response runtime.ClientResponse, consu
 			return nil, err
 		}
 		return nil, result
+	case 503:
+		result := NewPatchServiceServiceUnavailable()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	default:
 		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
@@ -231,6 +237,38 @@ func (o *PatchServiceTooManyRequests) GetPayload() *rest_model.APIErrorEnvelope 
 }
 
 func (o *PatchServiceTooManyRequests) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(rest_model.APIErrorEnvelope)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewPatchServiceServiceUnavailable creates a PatchServiceServiceUnavailable with default headers values
+func NewPatchServiceServiceUnavailable() *PatchServiceServiceUnavailable {
+	return &PatchServiceServiceUnavailable{}
+}
+
+/* PatchServiceServiceUnavailable describes a response with status code 503, with default header values.
+
+The request could not be completed due to the server being busy or in a temporarily bad state
+*/
+type PatchServiceServiceUnavailable struct {
+	Payload *rest_model.APIErrorEnvelope
+}
+
+func (o *PatchServiceServiceUnavailable) Error() string {
+	return fmt.Sprintf("[PATCH /services/{id}][%d] patchServiceServiceUnavailable  %+v", 503, o.Payload)
+}
+func (o *PatchServiceServiceUnavailable) GetPayload() *rest_model.APIErrorEnvelope {
+	return o.Payload
+}
+
+func (o *PatchServiceServiceUnavailable) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(rest_model.APIErrorEnvelope)
 

--- a/controller/rest_client/service/update_service_responses.go
+++ b/controller/rest_client/service/update_service_responses.go
@@ -77,6 +77,12 @@ func (o *UpdateServiceReader) ReadResponse(response runtime.ClientResponse, cons
 			return nil, err
 		}
 		return nil, result
+	case 503:
+		result := NewUpdateServiceServiceUnavailable()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	default:
 		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
@@ -231,6 +237,38 @@ func (o *UpdateServiceTooManyRequests) GetPayload() *rest_model.APIErrorEnvelope
 }
 
 func (o *UpdateServiceTooManyRequests) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(rest_model.APIErrorEnvelope)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewUpdateServiceServiceUnavailable creates a UpdateServiceServiceUnavailable with default headers values
+func NewUpdateServiceServiceUnavailable() *UpdateServiceServiceUnavailable {
+	return &UpdateServiceServiceUnavailable{}
+}
+
+/* UpdateServiceServiceUnavailable describes a response with status code 503, with default header values.
+
+The request could not be completed due to the server being busy or in a temporarily bad state
+*/
+type UpdateServiceServiceUnavailable struct {
+	Payload *rest_model.APIErrorEnvelope
+}
+
+func (o *UpdateServiceServiceUnavailable) Error() string {
+	return fmt.Sprintf("[PUT /services/{id}][%d] updateServiceServiceUnavailable  %+v", 503, o.Payload)
+}
+func (o *UpdateServiceServiceUnavailable) GetPayload() *rest_model.APIErrorEnvelope {
+	return o.Payload
+}
+
+func (o *UpdateServiceServiceUnavailable) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(rest_model.APIErrorEnvelope)
 

--- a/controller/rest_client/terminator/create_terminator_responses.go
+++ b/controller/rest_client/terminator/create_terminator_responses.go
@@ -71,6 +71,12 @@ func (o *CreateTerminatorReader) ReadResponse(response runtime.ClientResponse, c
 			return nil, err
 		}
 		return nil, result
+	case 503:
+		result := NewCreateTerminatorServiceUnavailable()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	default:
 		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
@@ -193,6 +199,38 @@ func (o *CreateTerminatorTooManyRequests) GetPayload() *rest_model.APIErrorEnvel
 }
 
 func (o *CreateTerminatorTooManyRequests) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(rest_model.APIErrorEnvelope)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewCreateTerminatorServiceUnavailable creates a CreateTerminatorServiceUnavailable with default headers values
+func NewCreateTerminatorServiceUnavailable() *CreateTerminatorServiceUnavailable {
+	return &CreateTerminatorServiceUnavailable{}
+}
+
+/* CreateTerminatorServiceUnavailable describes a response with status code 503, with default header values.
+
+The request could not be completed due to the server being busy or in a temporarily bad state
+*/
+type CreateTerminatorServiceUnavailable struct {
+	Payload *rest_model.APIErrorEnvelope
+}
+
+func (o *CreateTerminatorServiceUnavailable) Error() string {
+	return fmt.Sprintf("[POST /terminators][%d] createTerminatorServiceUnavailable  %+v", 503, o.Payload)
+}
+func (o *CreateTerminatorServiceUnavailable) GetPayload() *rest_model.APIErrorEnvelope {
+	return o.Payload
+}
+
+func (o *CreateTerminatorServiceUnavailable) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(rest_model.APIErrorEnvelope)
 

--- a/controller/rest_client/terminator/delete_terminator_responses.go
+++ b/controller/rest_client/terminator/delete_terminator_responses.go
@@ -77,6 +77,12 @@ func (o *DeleteTerminatorReader) ReadResponse(response runtime.ClientResponse, c
 			return nil, err
 		}
 		return nil, result
+	case 503:
+		result := NewDeleteTerminatorServiceUnavailable()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	default:
 		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
@@ -231,6 +237,38 @@ func (o *DeleteTerminatorTooManyRequests) GetPayload() *rest_model.APIErrorEnvel
 }
 
 func (o *DeleteTerminatorTooManyRequests) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(rest_model.APIErrorEnvelope)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewDeleteTerminatorServiceUnavailable creates a DeleteTerminatorServiceUnavailable with default headers values
+func NewDeleteTerminatorServiceUnavailable() *DeleteTerminatorServiceUnavailable {
+	return &DeleteTerminatorServiceUnavailable{}
+}
+
+/* DeleteTerminatorServiceUnavailable describes a response with status code 503, with default header values.
+
+The request could not be completed due to the server being busy or in a temporarily bad state
+*/
+type DeleteTerminatorServiceUnavailable struct {
+	Payload *rest_model.APIErrorEnvelope
+}
+
+func (o *DeleteTerminatorServiceUnavailable) Error() string {
+	return fmt.Sprintf("[DELETE /terminators/{id}][%d] deleteTerminatorServiceUnavailable  %+v", 503, o.Payload)
+}
+func (o *DeleteTerminatorServiceUnavailable) GetPayload() *rest_model.APIErrorEnvelope {
+	return o.Payload
+}
+
+func (o *DeleteTerminatorServiceUnavailable) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(rest_model.APIErrorEnvelope)
 

--- a/controller/rest_client/terminator/patch_terminator_responses.go
+++ b/controller/rest_client/terminator/patch_terminator_responses.go
@@ -77,6 +77,12 @@ func (o *PatchTerminatorReader) ReadResponse(response runtime.ClientResponse, co
 			return nil, err
 		}
 		return nil, result
+	case 503:
+		result := NewPatchTerminatorServiceUnavailable()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	default:
 		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
@@ -231,6 +237,38 @@ func (o *PatchTerminatorTooManyRequests) GetPayload() *rest_model.APIErrorEnvelo
 }
 
 func (o *PatchTerminatorTooManyRequests) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(rest_model.APIErrorEnvelope)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewPatchTerminatorServiceUnavailable creates a PatchTerminatorServiceUnavailable with default headers values
+func NewPatchTerminatorServiceUnavailable() *PatchTerminatorServiceUnavailable {
+	return &PatchTerminatorServiceUnavailable{}
+}
+
+/* PatchTerminatorServiceUnavailable describes a response with status code 503, with default header values.
+
+The request could not be completed due to the server being busy or in a temporarily bad state
+*/
+type PatchTerminatorServiceUnavailable struct {
+	Payload *rest_model.APIErrorEnvelope
+}
+
+func (o *PatchTerminatorServiceUnavailable) Error() string {
+	return fmt.Sprintf("[PATCH /terminators/{id}][%d] patchTerminatorServiceUnavailable  %+v", 503, o.Payload)
+}
+func (o *PatchTerminatorServiceUnavailable) GetPayload() *rest_model.APIErrorEnvelope {
+	return o.Payload
+}
+
+func (o *PatchTerminatorServiceUnavailable) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(rest_model.APIErrorEnvelope)
 

--- a/controller/rest_client/terminator/update_terminator_responses.go
+++ b/controller/rest_client/terminator/update_terminator_responses.go
@@ -77,6 +77,12 @@ func (o *UpdateTerminatorReader) ReadResponse(response runtime.ClientResponse, c
 			return nil, err
 		}
 		return nil, result
+	case 503:
+		result := NewUpdateTerminatorServiceUnavailable()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	default:
 		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
@@ -231,6 +237,38 @@ func (o *UpdateTerminatorTooManyRequests) GetPayload() *rest_model.APIErrorEnvel
 }
 
 func (o *UpdateTerminatorTooManyRequests) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(rest_model.APIErrorEnvelope)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewUpdateTerminatorServiceUnavailable creates a UpdateTerminatorServiceUnavailable with default headers values
+func NewUpdateTerminatorServiceUnavailable() *UpdateTerminatorServiceUnavailable {
+	return &UpdateTerminatorServiceUnavailable{}
+}
+
+/* UpdateTerminatorServiceUnavailable describes a response with status code 503, with default header values.
+
+The request could not be completed due to the server being busy or in a temporarily bad state
+*/
+type UpdateTerminatorServiceUnavailable struct {
+	Payload *rest_model.APIErrorEnvelope
+}
+
+func (o *UpdateTerminatorServiceUnavailable) Error() string {
+	return fmt.Sprintf("[PUT /terminators/{id}][%d] updateTerminatorServiceUnavailable  %+v", 503, o.Payload)
+}
+func (o *UpdateTerminatorServiceUnavailable) GetPayload() *rest_model.APIErrorEnvelope {
+	return o.Payload
+}
+
+func (o *UpdateTerminatorServiceUnavailable) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(rest_model.APIErrorEnvelope)
 

--- a/controller/rest_server/embedded_spec.go
+++ b/controller/rest_server/embedded_spec.go
@@ -156,6 +156,9 @@ func init() {
           },
           "429": {
             "$ref": "#/responses/rateLimitedResponse"
+          },
+          "503": {
+            "$ref": "#/responses/serverUnavailableResponse"
           }
         }
       },
@@ -196,6 +199,9 @@ func init() {
           },
           "429": {
             "$ref": "#/responses/rateLimitedResponse"
+          },
+          "503": {
+            "$ref": "#/responses/serverUnavailableResponse"
           }
         }
       }
@@ -258,6 +264,9 @@ func init() {
           },
           "429": {
             "$ref": "#/responses/rateLimitedResponse"
+          },
+          "503": {
+            "$ref": "#/responses/serverUnavailableResponse"
           }
         }
       }
@@ -296,6 +305,9 @@ func init() {
           },
           "500": {
             "$ref": "#/responses/badRequestResponse"
+          },
+          "503": {
+            "$ref": "#/responses/serverUnavailableResponse"
           }
         }
       }
@@ -542,6 +554,9 @@ func init() {
           },
           "429": {
             "$ref": "#/responses/rateLimitedResponse"
+          },
+          "503": {
+            "$ref": "#/responses/serverUnavailableResponse"
           }
         }
       },
@@ -578,6 +593,9 @@ func init() {
           },
           "429": {
             "$ref": "#/responses/rateLimitedResponse"
+          },
+          "503": {
+            "$ref": "#/responses/serverUnavailableResponse"
           }
         }
       },
@@ -648,6 +666,9 @@ func init() {
           },
           "429": {
             "$ref": "#/responses/rateLimitedResponse"
+          },
+          "503": {
+            "$ref": "#/responses/serverUnavailableResponse"
           }
         }
       }
@@ -708,6 +729,9 @@ func init() {
           },
           "429": {
             "$ref": "#/responses/rateLimitedResponse"
+          },
+          "503": {
+            "$ref": "#/responses/serverUnavailableResponse"
           }
         }
       },
@@ -733,6 +757,9 @@ func init() {
           },
           "429": {
             "$ref": "#/responses/rateLimitedResponse"
+          },
+          "503": {
+            "$ref": "#/responses/serverUnavailableResponse"
           }
         }
       },
@@ -769,6 +796,9 @@ func init() {
           },
           "429": {
             "$ref": "#/responses/rateLimitedResponse"
+          },
+          "503": {
+            "$ref": "#/responses/serverUnavailableResponse"
           }
         }
       },
@@ -879,6 +909,9 @@ func init() {
           },
           "429": {
             "$ref": "#/responses/rateLimitedResponse"
+          },
+          "503": {
+            "$ref": "#/responses/serverUnavailableResponse"
           }
         }
       }
@@ -939,6 +972,9 @@ func init() {
           },
           "429": {
             "$ref": "#/responses/rateLimitedResponse"
+          },
+          "503": {
+            "$ref": "#/responses/serverUnavailableResponse"
           }
         }
       },
@@ -964,6 +1000,9 @@ func init() {
           },
           "429": {
             "$ref": "#/responses/rateLimitedResponse"
+          },
+          "503": {
+            "$ref": "#/responses/serverUnavailableResponse"
           }
         }
       },
@@ -1000,6 +1039,9 @@ func init() {
           },
           "429": {
             "$ref": "#/responses/rateLimitedResponse"
+          },
+          "503": {
+            "$ref": "#/responses/serverUnavailableResponse"
           }
         }
       },
@@ -1113,6 +1155,9 @@ func init() {
           },
           "429": {
             "$ref": "#/responses/rateLimitedResponse"
+          },
+          "503": {
+            "$ref": "#/responses/serverUnavailableResponse"
           }
         }
       }
@@ -1173,6 +1218,9 @@ func init() {
           },
           "429": {
             "$ref": "#/responses/rateLimitedResponse"
+          },
+          "503": {
+            "$ref": "#/responses/serverUnavailableResponse"
           }
         }
       },
@@ -1198,6 +1246,9 @@ func init() {
           },
           "429": {
             "$ref": "#/responses/rateLimitedResponse"
+          },
+          "503": {
+            "$ref": "#/responses/serverUnavailableResponse"
           }
         }
       },
@@ -1234,6 +1285,9 @@ func init() {
           },
           "429": {
             "$ref": "#/responses/rateLimitedResponse"
+          },
+          "503": {
+            "$ref": "#/responses/serverUnavailableResponse"
           }
         }
       },
@@ -2749,6 +2803,12 @@ func init() {
         }
       }
     },
+    "serverUnavailableResponse": {
+      "description": "The request could not be completed due to the server being busy or in a temporarily bad state",
+      "schema": {
+        "$ref": "#/definitions/apiErrorEnvelope"
+      }
+    },
     "unauthorizedResponse": {
       "description": "The currently supplied session does not have the correct access rights to request this resource",
       "schema": {
@@ -3113,6 +3173,12 @@ func init() {
                 }
               }
             }
+          },
+          "503": {
+            "description": "The request could not be completed due to the server being busy or in a temporarily bad state",
+            "schema": {
+              "$ref": "#/definitions/apiErrorEnvelope"
+            }
           }
         }
       },
@@ -3234,6 +3300,12 @@ func init() {
                   "apiVersion": "0.0.1"
                 }
               }
+            }
+          },
+          "503": {
+            "description": "The request could not be completed due to the server being busy or in a temporarily bad state",
+            "schema": {
+              "$ref": "#/definitions/apiErrorEnvelope"
             }
           }
         }
@@ -3476,6 +3548,12 @@ func init() {
                 }
               }
             }
+          },
+          "503": {
+            "description": "The request could not be completed due to the server being busy or in a temporarily bad state",
+            "schema": {
+              "$ref": "#/definitions/apiErrorEnvelope"
+            }
           }
         }
       }
@@ -3614,6 +3692,12 @@ func init() {
                   "apiVersion": "0.0.1"
                 }
               }
+            }
+          },
+          "503": {
+            "description": "The request could not be completed due to the server being busy or in a temporarily bad state",
+            "schema": {
+              "$ref": "#/definitions/apiErrorEnvelope"
             }
           }
         }
@@ -4320,6 +4404,12 @@ func init() {
                 }
               }
             }
+          },
+          "503": {
+            "description": "The request could not be completed due to the server being busy or in a temporarily bad state",
+            "schema": {
+              "$ref": "#/definitions/apiErrorEnvelope"
+            }
           }
         }
       },
@@ -4456,6 +4546,12 @@ func init() {
                   "apiVersion": "0.0.1"
                 }
               }
+            }
+          },
+          "503": {
+            "description": "The request could not be completed due to the server being busy or in a temporarily bad state",
+            "schema": {
+              "$ref": "#/definitions/apiErrorEnvelope"
             }
           }
         }
@@ -4658,6 +4754,12 @@ func init() {
                   "apiVersion": "0.0.1"
                 }
               }
+            }
+          },
+          "503": {
+            "description": "The request could not be completed due to the server being busy or in a temporarily bad state",
+            "schema": {
+              "$ref": "#/definitions/apiErrorEnvelope"
             }
           }
         }
@@ -4887,6 +4989,12 @@ func init() {
                 }
               }
             }
+          },
+          "503": {
+            "description": "The request could not be completed due to the server being busy or in a temporarily bad state",
+            "schema": {
+              "$ref": "#/definitions/apiErrorEnvelope"
+            }
           }
         }
       },
@@ -5011,6 +5119,12 @@ func init() {
                   "apiVersion": "0.0.1"
                 }
               }
+            }
+          },
+          "503": {
+            "description": "The request could not be completed due to the server being busy or in a temporarily bad state",
+            "schema": {
+              "$ref": "#/definitions/apiErrorEnvelope"
             }
           }
         }
@@ -5148,6 +5262,12 @@ func init() {
                   "apiVersion": "0.0.1"
                 }
               }
+            }
+          },
+          "503": {
+            "description": "The request could not be completed due to the server being busy or in a temporarily bad state",
+            "schema": {
+              "$ref": "#/definitions/apiErrorEnvelope"
             }
           }
         }
@@ -5479,6 +5599,12 @@ func init() {
                 }
               }
             }
+          },
+          "503": {
+            "description": "The request could not be completed due to the server being busy or in a temporarily bad state",
+            "schema": {
+              "$ref": "#/definitions/apiErrorEnvelope"
+            }
           }
         }
       }
@@ -5707,6 +5833,12 @@ func init() {
                 }
               }
             }
+          },
+          "503": {
+            "description": "The request could not be completed due to the server being busy or in a temporarily bad state",
+            "schema": {
+              "$ref": "#/definitions/apiErrorEnvelope"
+            }
           }
         }
       },
@@ -5831,6 +5963,12 @@ func init() {
                   "apiVersion": "0.0.1"
                 }
               }
+            }
+          },
+          "503": {
+            "description": "The request could not be completed due to the server being busy or in a temporarily bad state",
+            "schema": {
+              "$ref": "#/definitions/apiErrorEnvelope"
             }
           }
         }
@@ -5968,6 +6106,12 @@ func init() {
                   "apiVersion": "0.0.1"
                 }
               }
+            }
+          },
+          "503": {
+            "description": "The request could not be completed due to the server being busy or in a temporarily bad state",
+            "schema": {
+              "$ref": "#/definitions/apiErrorEnvelope"
             }
           }
         }
@@ -6336,6 +6480,12 @@ func init() {
                 }
               }
             }
+          },
+          "503": {
+            "description": "The request could not be completed due to the server being busy or in a temporarily bad state",
+            "schema": {
+              "$ref": "#/definitions/apiErrorEnvelope"
+            }
           }
         }
       }
@@ -6564,6 +6714,12 @@ func init() {
                 }
               }
             }
+          },
+          "503": {
+            "description": "The request could not be completed due to the server being busy or in a temporarily bad state",
+            "schema": {
+              "$ref": "#/definitions/apiErrorEnvelope"
+            }
           }
         }
       },
@@ -6688,6 +6844,12 @@ func init() {
                   "apiVersion": "0.0.1"
                 }
               }
+            }
+          },
+          "503": {
+            "description": "The request could not be completed due to the server being busy or in a temporarily bad state",
+            "schema": {
+              "$ref": "#/definitions/apiErrorEnvelope"
             }
           }
         }
@@ -6825,6 +6987,12 @@ func init() {
                   "apiVersion": "0.0.1"
                 }
               }
+            }
+          },
+          "503": {
+            "description": "The request could not be completed due to the server being busy or in a temporarily bad state",
+            "schema": {
+              "$ref": "#/definitions/apiErrorEnvelope"
             }
           }
         }
@@ -8348,6 +8516,12 @@ func init() {
             "apiVersion": "0.0.1"
           }
         }
+      }
+    },
+    "serverUnavailableResponse": {
+      "description": "The request could not be completed due to the server being busy or in a temporarily bad state",
+      "schema": {
+        "$ref": "#/definitions/apiErrorEnvelope"
       }
     },
     "unauthorizedResponse": {

--- a/controller/rest_server/operations/circuit/delete_circuit_responses.go
+++ b/controller/rest_server/operations/circuit/delete_circuit_responses.go
@@ -256,3 +256,47 @@ func (o *DeleteCircuitTooManyRequests) WriteResponse(rw http.ResponseWriter, pro
 		}
 	}
 }
+
+// DeleteCircuitServiceUnavailableCode is the HTTP code returned for type DeleteCircuitServiceUnavailable
+const DeleteCircuitServiceUnavailableCode int = 503
+
+/*DeleteCircuitServiceUnavailable The request could not be completed due to the server being busy or in a temporarily bad state
+
+swagger:response deleteCircuitServiceUnavailable
+*/
+type DeleteCircuitServiceUnavailable struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *rest_model.APIErrorEnvelope `json:"body,omitempty"`
+}
+
+// NewDeleteCircuitServiceUnavailable creates DeleteCircuitServiceUnavailable with default headers values
+func NewDeleteCircuitServiceUnavailable() *DeleteCircuitServiceUnavailable {
+
+	return &DeleteCircuitServiceUnavailable{}
+}
+
+// WithPayload adds the payload to the delete circuit service unavailable response
+func (o *DeleteCircuitServiceUnavailable) WithPayload(payload *rest_model.APIErrorEnvelope) *DeleteCircuitServiceUnavailable {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the delete circuit service unavailable response
+func (o *DeleteCircuitServiceUnavailable) SetPayload(payload *rest_model.APIErrorEnvelope) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *DeleteCircuitServiceUnavailable) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(503)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}

--- a/controller/rest_server/operations/cluster/cluster_member_add_responses.go
+++ b/controller/rest_server/operations/cluster/cluster_member_add_responses.go
@@ -212,3 +212,47 @@ func (o *ClusterMemberAddTooManyRequests) WriteResponse(rw http.ResponseWriter, 
 		}
 	}
 }
+
+// ClusterMemberAddServiceUnavailableCode is the HTTP code returned for type ClusterMemberAddServiceUnavailable
+const ClusterMemberAddServiceUnavailableCode int = 503
+
+/*ClusterMemberAddServiceUnavailable The request could not be completed due to the server being busy or in a temporarily bad state
+
+swagger:response clusterMemberAddServiceUnavailable
+*/
+type ClusterMemberAddServiceUnavailable struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *rest_model.APIErrorEnvelope `json:"body,omitempty"`
+}
+
+// NewClusterMemberAddServiceUnavailable creates ClusterMemberAddServiceUnavailable with default headers values
+func NewClusterMemberAddServiceUnavailable() *ClusterMemberAddServiceUnavailable {
+
+	return &ClusterMemberAddServiceUnavailable{}
+}
+
+// WithPayload adds the payload to the cluster member add service unavailable response
+func (o *ClusterMemberAddServiceUnavailable) WithPayload(payload *rest_model.APIErrorEnvelope) *ClusterMemberAddServiceUnavailable {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the cluster member add service unavailable response
+func (o *ClusterMemberAddServiceUnavailable) SetPayload(payload *rest_model.APIErrorEnvelope) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *ClusterMemberAddServiceUnavailable) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(503)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}

--- a/controller/rest_server/operations/cluster/cluster_member_remove_responses.go
+++ b/controller/rest_server/operations/cluster/cluster_member_remove_responses.go
@@ -256,3 +256,47 @@ func (o *ClusterMemberRemoveTooManyRequests) WriteResponse(rw http.ResponseWrite
 		}
 	}
 }
+
+// ClusterMemberRemoveServiceUnavailableCode is the HTTP code returned for type ClusterMemberRemoveServiceUnavailable
+const ClusterMemberRemoveServiceUnavailableCode int = 503
+
+/*ClusterMemberRemoveServiceUnavailable The request could not be completed due to the server being busy or in a temporarily bad state
+
+swagger:response clusterMemberRemoveServiceUnavailable
+*/
+type ClusterMemberRemoveServiceUnavailable struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *rest_model.APIErrorEnvelope `json:"body,omitempty"`
+}
+
+// NewClusterMemberRemoveServiceUnavailable creates ClusterMemberRemoveServiceUnavailable with default headers values
+func NewClusterMemberRemoveServiceUnavailable() *ClusterMemberRemoveServiceUnavailable {
+
+	return &ClusterMemberRemoveServiceUnavailable{}
+}
+
+// WithPayload adds the payload to the cluster member remove service unavailable response
+func (o *ClusterMemberRemoveServiceUnavailable) WithPayload(payload *rest_model.APIErrorEnvelope) *ClusterMemberRemoveServiceUnavailable {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the cluster member remove service unavailable response
+func (o *ClusterMemberRemoveServiceUnavailable) SetPayload(payload *rest_model.APIErrorEnvelope) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *ClusterMemberRemoveServiceUnavailable) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(503)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}

--- a/controller/rest_server/operations/cluster/cluster_transfer_leadership_responses.go
+++ b/controller/rest_server/operations/cluster/cluster_transfer_leadership_responses.go
@@ -256,3 +256,47 @@ func (o *ClusterTransferLeadershipInternalServerError) WriteResponse(rw http.Res
 		}
 	}
 }
+
+// ClusterTransferLeadershipServiceUnavailableCode is the HTTP code returned for type ClusterTransferLeadershipServiceUnavailable
+const ClusterTransferLeadershipServiceUnavailableCode int = 503
+
+/*ClusterTransferLeadershipServiceUnavailable The request could not be completed due to the server being busy or in a temporarily bad state
+
+swagger:response clusterTransferLeadershipServiceUnavailable
+*/
+type ClusterTransferLeadershipServiceUnavailable struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *rest_model.APIErrorEnvelope `json:"body,omitempty"`
+}
+
+// NewClusterTransferLeadershipServiceUnavailable creates ClusterTransferLeadershipServiceUnavailable with default headers values
+func NewClusterTransferLeadershipServiceUnavailable() *ClusterTransferLeadershipServiceUnavailable {
+
+	return &ClusterTransferLeadershipServiceUnavailable{}
+}
+
+// WithPayload adds the payload to the cluster transfer leadership service unavailable response
+func (o *ClusterTransferLeadershipServiceUnavailable) WithPayload(payload *rest_model.APIErrorEnvelope) *ClusterTransferLeadershipServiceUnavailable {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the cluster transfer leadership service unavailable response
+func (o *ClusterTransferLeadershipServiceUnavailable) SetPayload(payload *rest_model.APIErrorEnvelope) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *ClusterTransferLeadershipServiceUnavailable) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(503)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}

--- a/controller/rest_server/operations/link/delete_link_responses.go
+++ b/controller/rest_server/operations/link/delete_link_responses.go
@@ -212,3 +212,47 @@ func (o *DeleteLinkTooManyRequests) WriteResponse(rw http.ResponseWriter, produc
 		}
 	}
 }
+
+// DeleteLinkServiceUnavailableCode is the HTTP code returned for type DeleteLinkServiceUnavailable
+const DeleteLinkServiceUnavailableCode int = 503
+
+/*DeleteLinkServiceUnavailable The request could not be completed due to the server being busy or in a temporarily bad state
+
+swagger:response deleteLinkServiceUnavailable
+*/
+type DeleteLinkServiceUnavailable struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *rest_model.APIErrorEnvelope `json:"body,omitempty"`
+}
+
+// NewDeleteLinkServiceUnavailable creates DeleteLinkServiceUnavailable with default headers values
+func NewDeleteLinkServiceUnavailable() *DeleteLinkServiceUnavailable {
+
+	return &DeleteLinkServiceUnavailable{}
+}
+
+// WithPayload adds the payload to the delete link service unavailable response
+func (o *DeleteLinkServiceUnavailable) WithPayload(payload *rest_model.APIErrorEnvelope) *DeleteLinkServiceUnavailable {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the delete link service unavailable response
+func (o *DeleteLinkServiceUnavailable) SetPayload(payload *rest_model.APIErrorEnvelope) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *DeleteLinkServiceUnavailable) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(503)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}

--- a/controller/rest_server/operations/link/patch_link_responses.go
+++ b/controller/rest_server/operations/link/patch_link_responses.go
@@ -256,3 +256,47 @@ func (o *PatchLinkTooManyRequests) WriteResponse(rw http.ResponseWriter, produce
 		}
 	}
 }
+
+// PatchLinkServiceUnavailableCode is the HTTP code returned for type PatchLinkServiceUnavailable
+const PatchLinkServiceUnavailableCode int = 503
+
+/*PatchLinkServiceUnavailable The request could not be completed due to the server being busy or in a temporarily bad state
+
+swagger:response patchLinkServiceUnavailable
+*/
+type PatchLinkServiceUnavailable struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *rest_model.APIErrorEnvelope `json:"body,omitempty"`
+}
+
+// NewPatchLinkServiceUnavailable creates PatchLinkServiceUnavailable with default headers values
+func NewPatchLinkServiceUnavailable() *PatchLinkServiceUnavailable {
+
+	return &PatchLinkServiceUnavailable{}
+}
+
+// WithPayload adds the payload to the patch link service unavailable response
+func (o *PatchLinkServiceUnavailable) WithPayload(payload *rest_model.APIErrorEnvelope) *PatchLinkServiceUnavailable {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the patch link service unavailable response
+func (o *PatchLinkServiceUnavailable) SetPayload(payload *rest_model.APIErrorEnvelope) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *PatchLinkServiceUnavailable) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(503)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}

--- a/controller/rest_server/operations/router/create_router_responses.go
+++ b/controller/rest_server/operations/router/create_router_responses.go
@@ -212,3 +212,47 @@ func (o *CreateRouterTooManyRequests) WriteResponse(rw http.ResponseWriter, prod
 		}
 	}
 }
+
+// CreateRouterServiceUnavailableCode is the HTTP code returned for type CreateRouterServiceUnavailable
+const CreateRouterServiceUnavailableCode int = 503
+
+/*CreateRouterServiceUnavailable The request could not be completed due to the server being busy or in a temporarily bad state
+
+swagger:response createRouterServiceUnavailable
+*/
+type CreateRouterServiceUnavailable struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *rest_model.APIErrorEnvelope `json:"body,omitempty"`
+}
+
+// NewCreateRouterServiceUnavailable creates CreateRouterServiceUnavailable with default headers values
+func NewCreateRouterServiceUnavailable() *CreateRouterServiceUnavailable {
+
+	return &CreateRouterServiceUnavailable{}
+}
+
+// WithPayload adds the payload to the create router service unavailable response
+func (o *CreateRouterServiceUnavailable) WithPayload(payload *rest_model.APIErrorEnvelope) *CreateRouterServiceUnavailable {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the create router service unavailable response
+func (o *CreateRouterServiceUnavailable) SetPayload(payload *rest_model.APIErrorEnvelope) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *CreateRouterServiceUnavailable) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(503)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}

--- a/controller/rest_server/operations/router/delete_router_responses.go
+++ b/controller/rest_server/operations/router/delete_router_responses.go
@@ -256,3 +256,47 @@ func (o *DeleteRouterTooManyRequests) WriteResponse(rw http.ResponseWriter, prod
 		}
 	}
 }
+
+// DeleteRouterServiceUnavailableCode is the HTTP code returned for type DeleteRouterServiceUnavailable
+const DeleteRouterServiceUnavailableCode int = 503
+
+/*DeleteRouterServiceUnavailable The request could not be completed due to the server being busy or in a temporarily bad state
+
+swagger:response deleteRouterServiceUnavailable
+*/
+type DeleteRouterServiceUnavailable struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *rest_model.APIErrorEnvelope `json:"body,omitempty"`
+}
+
+// NewDeleteRouterServiceUnavailable creates DeleteRouterServiceUnavailable with default headers values
+func NewDeleteRouterServiceUnavailable() *DeleteRouterServiceUnavailable {
+
+	return &DeleteRouterServiceUnavailable{}
+}
+
+// WithPayload adds the payload to the delete router service unavailable response
+func (o *DeleteRouterServiceUnavailable) WithPayload(payload *rest_model.APIErrorEnvelope) *DeleteRouterServiceUnavailable {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the delete router service unavailable response
+func (o *DeleteRouterServiceUnavailable) SetPayload(payload *rest_model.APIErrorEnvelope) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *DeleteRouterServiceUnavailable) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(503)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}

--- a/controller/rest_server/operations/router/patch_router_responses.go
+++ b/controller/rest_server/operations/router/patch_router_responses.go
@@ -256,3 +256,47 @@ func (o *PatchRouterTooManyRequests) WriteResponse(rw http.ResponseWriter, produ
 		}
 	}
 }
+
+// PatchRouterServiceUnavailableCode is the HTTP code returned for type PatchRouterServiceUnavailable
+const PatchRouterServiceUnavailableCode int = 503
+
+/*PatchRouterServiceUnavailable The request could not be completed due to the server being busy or in a temporarily bad state
+
+swagger:response patchRouterServiceUnavailable
+*/
+type PatchRouterServiceUnavailable struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *rest_model.APIErrorEnvelope `json:"body,omitempty"`
+}
+
+// NewPatchRouterServiceUnavailable creates PatchRouterServiceUnavailable with default headers values
+func NewPatchRouterServiceUnavailable() *PatchRouterServiceUnavailable {
+
+	return &PatchRouterServiceUnavailable{}
+}
+
+// WithPayload adds the payload to the patch router service unavailable response
+func (o *PatchRouterServiceUnavailable) WithPayload(payload *rest_model.APIErrorEnvelope) *PatchRouterServiceUnavailable {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the patch router service unavailable response
+func (o *PatchRouterServiceUnavailable) SetPayload(payload *rest_model.APIErrorEnvelope) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *PatchRouterServiceUnavailable) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(503)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}

--- a/controller/rest_server/operations/router/update_router_responses.go
+++ b/controller/rest_server/operations/router/update_router_responses.go
@@ -256,3 +256,47 @@ func (o *UpdateRouterTooManyRequests) WriteResponse(rw http.ResponseWriter, prod
 		}
 	}
 }
+
+// UpdateRouterServiceUnavailableCode is the HTTP code returned for type UpdateRouterServiceUnavailable
+const UpdateRouterServiceUnavailableCode int = 503
+
+/*UpdateRouterServiceUnavailable The request could not be completed due to the server being busy or in a temporarily bad state
+
+swagger:response updateRouterServiceUnavailable
+*/
+type UpdateRouterServiceUnavailable struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *rest_model.APIErrorEnvelope `json:"body,omitempty"`
+}
+
+// NewUpdateRouterServiceUnavailable creates UpdateRouterServiceUnavailable with default headers values
+func NewUpdateRouterServiceUnavailable() *UpdateRouterServiceUnavailable {
+
+	return &UpdateRouterServiceUnavailable{}
+}
+
+// WithPayload adds the payload to the update router service unavailable response
+func (o *UpdateRouterServiceUnavailable) WithPayload(payload *rest_model.APIErrorEnvelope) *UpdateRouterServiceUnavailable {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the update router service unavailable response
+func (o *UpdateRouterServiceUnavailable) SetPayload(payload *rest_model.APIErrorEnvelope) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *UpdateRouterServiceUnavailable) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(503)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}

--- a/controller/rest_server/operations/service/create_service_responses.go
+++ b/controller/rest_server/operations/service/create_service_responses.go
@@ -212,3 +212,47 @@ func (o *CreateServiceTooManyRequests) WriteResponse(rw http.ResponseWriter, pro
 		}
 	}
 }
+
+// CreateServiceServiceUnavailableCode is the HTTP code returned for type CreateServiceServiceUnavailable
+const CreateServiceServiceUnavailableCode int = 503
+
+/*CreateServiceServiceUnavailable The request could not be completed due to the server being busy or in a temporarily bad state
+
+swagger:response createServiceServiceUnavailable
+*/
+type CreateServiceServiceUnavailable struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *rest_model.APIErrorEnvelope `json:"body,omitempty"`
+}
+
+// NewCreateServiceServiceUnavailable creates CreateServiceServiceUnavailable with default headers values
+func NewCreateServiceServiceUnavailable() *CreateServiceServiceUnavailable {
+
+	return &CreateServiceServiceUnavailable{}
+}
+
+// WithPayload adds the payload to the create service service unavailable response
+func (o *CreateServiceServiceUnavailable) WithPayload(payload *rest_model.APIErrorEnvelope) *CreateServiceServiceUnavailable {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the create service service unavailable response
+func (o *CreateServiceServiceUnavailable) SetPayload(payload *rest_model.APIErrorEnvelope) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *CreateServiceServiceUnavailable) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(503)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}

--- a/controller/rest_server/operations/service/delete_service_responses.go
+++ b/controller/rest_server/operations/service/delete_service_responses.go
@@ -256,3 +256,47 @@ func (o *DeleteServiceTooManyRequests) WriteResponse(rw http.ResponseWriter, pro
 		}
 	}
 }
+
+// DeleteServiceServiceUnavailableCode is the HTTP code returned for type DeleteServiceServiceUnavailable
+const DeleteServiceServiceUnavailableCode int = 503
+
+/*DeleteServiceServiceUnavailable The request could not be completed due to the server being busy or in a temporarily bad state
+
+swagger:response deleteServiceServiceUnavailable
+*/
+type DeleteServiceServiceUnavailable struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *rest_model.APIErrorEnvelope `json:"body,omitempty"`
+}
+
+// NewDeleteServiceServiceUnavailable creates DeleteServiceServiceUnavailable with default headers values
+func NewDeleteServiceServiceUnavailable() *DeleteServiceServiceUnavailable {
+
+	return &DeleteServiceServiceUnavailable{}
+}
+
+// WithPayload adds the payload to the delete service service unavailable response
+func (o *DeleteServiceServiceUnavailable) WithPayload(payload *rest_model.APIErrorEnvelope) *DeleteServiceServiceUnavailable {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the delete service service unavailable response
+func (o *DeleteServiceServiceUnavailable) SetPayload(payload *rest_model.APIErrorEnvelope) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *DeleteServiceServiceUnavailable) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(503)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}

--- a/controller/rest_server/operations/service/patch_service_responses.go
+++ b/controller/rest_server/operations/service/patch_service_responses.go
@@ -256,3 +256,47 @@ func (o *PatchServiceTooManyRequests) WriteResponse(rw http.ResponseWriter, prod
 		}
 	}
 }
+
+// PatchServiceServiceUnavailableCode is the HTTP code returned for type PatchServiceServiceUnavailable
+const PatchServiceServiceUnavailableCode int = 503
+
+/*PatchServiceServiceUnavailable The request could not be completed due to the server being busy or in a temporarily bad state
+
+swagger:response patchServiceServiceUnavailable
+*/
+type PatchServiceServiceUnavailable struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *rest_model.APIErrorEnvelope `json:"body,omitempty"`
+}
+
+// NewPatchServiceServiceUnavailable creates PatchServiceServiceUnavailable with default headers values
+func NewPatchServiceServiceUnavailable() *PatchServiceServiceUnavailable {
+
+	return &PatchServiceServiceUnavailable{}
+}
+
+// WithPayload adds the payload to the patch service service unavailable response
+func (o *PatchServiceServiceUnavailable) WithPayload(payload *rest_model.APIErrorEnvelope) *PatchServiceServiceUnavailable {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the patch service service unavailable response
+func (o *PatchServiceServiceUnavailable) SetPayload(payload *rest_model.APIErrorEnvelope) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *PatchServiceServiceUnavailable) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(503)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}

--- a/controller/rest_server/operations/service/update_service_responses.go
+++ b/controller/rest_server/operations/service/update_service_responses.go
@@ -256,3 +256,47 @@ func (o *UpdateServiceTooManyRequests) WriteResponse(rw http.ResponseWriter, pro
 		}
 	}
 }
+
+// UpdateServiceServiceUnavailableCode is the HTTP code returned for type UpdateServiceServiceUnavailable
+const UpdateServiceServiceUnavailableCode int = 503
+
+/*UpdateServiceServiceUnavailable The request could not be completed due to the server being busy or in a temporarily bad state
+
+swagger:response updateServiceServiceUnavailable
+*/
+type UpdateServiceServiceUnavailable struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *rest_model.APIErrorEnvelope `json:"body,omitempty"`
+}
+
+// NewUpdateServiceServiceUnavailable creates UpdateServiceServiceUnavailable with default headers values
+func NewUpdateServiceServiceUnavailable() *UpdateServiceServiceUnavailable {
+
+	return &UpdateServiceServiceUnavailable{}
+}
+
+// WithPayload adds the payload to the update service service unavailable response
+func (o *UpdateServiceServiceUnavailable) WithPayload(payload *rest_model.APIErrorEnvelope) *UpdateServiceServiceUnavailable {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the update service service unavailable response
+func (o *UpdateServiceServiceUnavailable) SetPayload(payload *rest_model.APIErrorEnvelope) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *UpdateServiceServiceUnavailable) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(503)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}

--- a/controller/rest_server/operations/terminator/create_terminator_responses.go
+++ b/controller/rest_server/operations/terminator/create_terminator_responses.go
@@ -212,3 +212,47 @@ func (o *CreateTerminatorTooManyRequests) WriteResponse(rw http.ResponseWriter, 
 		}
 	}
 }
+
+// CreateTerminatorServiceUnavailableCode is the HTTP code returned for type CreateTerminatorServiceUnavailable
+const CreateTerminatorServiceUnavailableCode int = 503
+
+/*CreateTerminatorServiceUnavailable The request could not be completed due to the server being busy or in a temporarily bad state
+
+swagger:response createTerminatorServiceUnavailable
+*/
+type CreateTerminatorServiceUnavailable struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *rest_model.APIErrorEnvelope `json:"body,omitempty"`
+}
+
+// NewCreateTerminatorServiceUnavailable creates CreateTerminatorServiceUnavailable with default headers values
+func NewCreateTerminatorServiceUnavailable() *CreateTerminatorServiceUnavailable {
+
+	return &CreateTerminatorServiceUnavailable{}
+}
+
+// WithPayload adds the payload to the create terminator service unavailable response
+func (o *CreateTerminatorServiceUnavailable) WithPayload(payload *rest_model.APIErrorEnvelope) *CreateTerminatorServiceUnavailable {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the create terminator service unavailable response
+func (o *CreateTerminatorServiceUnavailable) SetPayload(payload *rest_model.APIErrorEnvelope) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *CreateTerminatorServiceUnavailable) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(503)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}

--- a/controller/rest_server/operations/terminator/delete_terminator_responses.go
+++ b/controller/rest_server/operations/terminator/delete_terminator_responses.go
@@ -256,3 +256,47 @@ func (o *DeleteTerminatorTooManyRequests) WriteResponse(rw http.ResponseWriter, 
 		}
 	}
 }
+
+// DeleteTerminatorServiceUnavailableCode is the HTTP code returned for type DeleteTerminatorServiceUnavailable
+const DeleteTerminatorServiceUnavailableCode int = 503
+
+/*DeleteTerminatorServiceUnavailable The request could not be completed due to the server being busy or in a temporarily bad state
+
+swagger:response deleteTerminatorServiceUnavailable
+*/
+type DeleteTerminatorServiceUnavailable struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *rest_model.APIErrorEnvelope `json:"body,omitempty"`
+}
+
+// NewDeleteTerminatorServiceUnavailable creates DeleteTerminatorServiceUnavailable with default headers values
+func NewDeleteTerminatorServiceUnavailable() *DeleteTerminatorServiceUnavailable {
+
+	return &DeleteTerminatorServiceUnavailable{}
+}
+
+// WithPayload adds the payload to the delete terminator service unavailable response
+func (o *DeleteTerminatorServiceUnavailable) WithPayload(payload *rest_model.APIErrorEnvelope) *DeleteTerminatorServiceUnavailable {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the delete terminator service unavailable response
+func (o *DeleteTerminatorServiceUnavailable) SetPayload(payload *rest_model.APIErrorEnvelope) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *DeleteTerminatorServiceUnavailable) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(503)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}

--- a/controller/rest_server/operations/terminator/patch_terminator_responses.go
+++ b/controller/rest_server/operations/terminator/patch_terminator_responses.go
@@ -256,3 +256,47 @@ func (o *PatchTerminatorTooManyRequests) WriteResponse(rw http.ResponseWriter, p
 		}
 	}
 }
+
+// PatchTerminatorServiceUnavailableCode is the HTTP code returned for type PatchTerminatorServiceUnavailable
+const PatchTerminatorServiceUnavailableCode int = 503
+
+/*PatchTerminatorServiceUnavailable The request could not be completed due to the server being busy or in a temporarily bad state
+
+swagger:response patchTerminatorServiceUnavailable
+*/
+type PatchTerminatorServiceUnavailable struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *rest_model.APIErrorEnvelope `json:"body,omitempty"`
+}
+
+// NewPatchTerminatorServiceUnavailable creates PatchTerminatorServiceUnavailable with default headers values
+func NewPatchTerminatorServiceUnavailable() *PatchTerminatorServiceUnavailable {
+
+	return &PatchTerminatorServiceUnavailable{}
+}
+
+// WithPayload adds the payload to the patch terminator service unavailable response
+func (o *PatchTerminatorServiceUnavailable) WithPayload(payload *rest_model.APIErrorEnvelope) *PatchTerminatorServiceUnavailable {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the patch terminator service unavailable response
+func (o *PatchTerminatorServiceUnavailable) SetPayload(payload *rest_model.APIErrorEnvelope) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *PatchTerminatorServiceUnavailable) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(503)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}

--- a/controller/rest_server/operations/terminator/update_terminator_responses.go
+++ b/controller/rest_server/operations/terminator/update_terminator_responses.go
@@ -256,3 +256,47 @@ func (o *UpdateTerminatorTooManyRequests) WriteResponse(rw http.ResponseWriter, 
 		}
 	}
 }
+
+// UpdateTerminatorServiceUnavailableCode is the HTTP code returned for type UpdateTerminatorServiceUnavailable
+const UpdateTerminatorServiceUnavailableCode int = 503
+
+/*UpdateTerminatorServiceUnavailable The request could not be completed due to the server being busy or in a temporarily bad state
+
+swagger:response updateTerminatorServiceUnavailable
+*/
+type UpdateTerminatorServiceUnavailable struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *rest_model.APIErrorEnvelope `json:"body,omitempty"`
+}
+
+// NewUpdateTerminatorServiceUnavailable creates UpdateTerminatorServiceUnavailable with default headers values
+func NewUpdateTerminatorServiceUnavailable() *UpdateTerminatorServiceUnavailable {
+
+	return &UpdateTerminatorServiceUnavailable{}
+}
+
+// WithPayload adds the payload to the update terminator service unavailable response
+func (o *UpdateTerminatorServiceUnavailable) WithPayload(payload *rest_model.APIErrorEnvelope) *UpdateTerminatorServiceUnavailable {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the update terminator service unavailable response
+func (o *UpdateTerminatorServiceUnavailable) SetPayload(payload *rest_model.APIErrorEnvelope) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *UpdateTerminatorServiceUnavailable) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(503)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}

--- a/controller/specs/swagger.yml
+++ b/controller/specs/swagger.yml
@@ -71,6 +71,8 @@ paths:
           $ref: '#/responses/unauthorizedResponse'
         '429':
           $ref: '#/responses/rateLimitedResponse'
+        '503':
+          $ref: '#/responses/serverUnavailableResponse'
 
   '/services/{id}':
     parameters:
@@ -115,6 +117,8 @@ paths:
           $ref: '#/responses/unauthorizedResponse'
         '429':
           $ref: '#/responses/rateLimitedResponse'
+        '503':
+          $ref: '#/responses/serverUnavailableResponse'
 
     patch:
       summary: Update the supplied fields on a service
@@ -140,6 +144,8 @@ paths:
           $ref: '#/responses/unauthorizedResponse'
         '429':
           $ref: '#/responses/rateLimitedResponse'
+        '503':
+          $ref: '#/responses/serverUnavailableResponse'
 
     delete:
       summary: Delete a service
@@ -158,6 +164,8 @@ paths:
           $ref: '#/responses/cannotDeleteReferencedResourceResponse'
         '429':
           $ref: '#/responses/rateLimitedResponse'
+        '503':
+          $ref: '#/responses/serverUnavailableResponse'
 
   '/services/{id}/terminators':
     parameters:
@@ -228,6 +236,8 @@ paths:
           $ref: '#/responses/unauthorizedResponse'
         '429':
           $ref: '#/responses/rateLimitedResponse'
+        '503':
+          $ref: '#/responses/serverUnavailableResponse'
 
   '/routers/{id}':
     parameters:
@@ -272,6 +282,8 @@ paths:
           $ref: '#/responses/unauthorizedResponse'
         '429':
           $ref: '#/responses/rateLimitedResponse'
+        '503':
+          $ref: '#/responses/serverUnavailableResponse'
 
     patch:
       summary: Update the supplied fields on a router
@@ -297,6 +309,8 @@ paths:
           $ref: '#/responses/unauthorizedResponse'
         '429':
           $ref: '#/responses/rateLimitedResponse'
+        '503':
+          $ref: '#/responses/serverUnavailableResponse'
 
     delete:
       summary: Delete a router
@@ -315,6 +329,8 @@ paths:
           $ref: '#/responses/cannotDeleteReferencedResourceResponse'
         '429':
           $ref: '#/responses/rateLimitedResponse'
+        '503':
+          $ref: '#/responses/serverUnavailableResponse'
 
   '/routers/{id}/terminators':
     parameters:
@@ -387,6 +403,8 @@ paths:
           $ref: '#/responses/unauthorizedResponse'
         '429':
           $ref: '#/responses/rateLimitedResponse'
+        '503':
+          $ref: '#/responses/serverUnavailableResponse'
 
   '/terminators/{id}':
     parameters:
@@ -431,6 +449,8 @@ paths:
           $ref: '#/responses/unauthorizedResponse'
         '429':
           $ref: '#/responses/rateLimitedResponse'
+        '503':
+          $ref: '#/responses/serverUnavailableResponse'
 
     patch:
       summary: Update the supplied fields on a terminator
@@ -456,6 +476,8 @@ paths:
           $ref: '#/responses/unauthorizedResponse'
         '429':
           $ref: '#/responses/rateLimitedResponse'
+        '503':
+          $ref: '#/responses/serverUnavailableResponse'
 
     delete:
       summary: Delete a terminator
@@ -474,6 +496,8 @@ paths:
           $ref: '#/responses/cannotDeleteReferencedResourceResponse'
         '429':
           $ref: '#/responses/rateLimitedResponse'
+        '503':
+          $ref: '#/responses/serverUnavailableResponse'
 
   ###################################################################
   # Links
@@ -541,6 +565,8 @@ paths:
           $ref: '#/responses/unauthorizedResponse'
         '429':
           $ref: '#/responses/rateLimitedResponse'
+        '503':
+          $ref: '#/responses/serverUnavailableResponse'
 
     delete:
       summary: Delete a link
@@ -557,6 +583,8 @@ paths:
           $ref: '#/responses/unauthorizedResponse'
         '429':
           $ref: '#/responses/rateLimitedResponse'
+        '503':
+          $ref: '#/responses/serverUnavailableResponse'
 
   ###################################################################
   # Circuits
@@ -624,6 +652,8 @@ paths:
           $ref: '#/responses/cannotDeleteReferencedResourceResponse'
         '429':
           $ref: '#/responses/rateLimitedResponse'
+        '503':
+          $ref: '#/responses/serverUnavailableResponse'
 
   ###################################################################
   # Inspections
@@ -784,6 +814,8 @@ paths:
           $ref: '#/responses/unauthorizedResponse'
         '429':
           $ref: '#/responses/rateLimitedResponse'
+        '503':
+          $ref: '#/responses/serverUnavailableResponse'
 
   '/cluster/remove-member':
     post:
@@ -810,6 +842,8 @@ paths:
           $ref: '#/responses/notFoundResponse'
         '429':
           $ref: '#/responses/rateLimitedResponse'
+        '503':
+          $ref: '#/responses/serverUnavailableResponse'
 
   '/cluster/transfer-leadership':
     post:
@@ -836,6 +870,8 @@ paths:
           $ref: '#/responses/rateLimitedResponse'
         '500':
           $ref: '#/responses/badRequestResponse'
+        '503':
+          $ref: '#/responses/serverUnavailableResponse'
 
 #######################################################################################################################
 #
@@ -1008,6 +1044,11 @@ responses:
     description: The create request was successful and the resource has been added at the following location
     schema:
       $ref: '#/definitions/createEnvelope'
+  serverUnavailableResponse:
+    description: The request could not be completed due to the server being busy or in a temporarily bad state
+    schema:
+      $ref: '#/definitions/apiErrorEnvelope'
+
   ###################################################################
   # Services
   ##################################################################

--- a/zititest/models/smoke/smoketest.go
+++ b/zititest/models/smoke/smoketest.go
@@ -38,7 +38,7 @@ import (
 	"time"
 )
 
-const ZitiEdgeTunnelVersion = "v1.2.9"
+const ZitiEdgeTunnelVersion = "v1.5.0"
 const ZitiCtrlVersion = ""
 const ZitiRouterVersion = ""
 


### PR DESCRIPTION
Cluster operations should return 503 if there's no leader. Also add 503s for other operations where appropriate. Fixes #2738
