### PR TITLE
closes #2825 - use the client chain going forward

### DIFF
--- a/.github/workflows/test-quickstart.yml
+++ b/.github/workflows/test-quickstart.yml
@@ -109,10 +109,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
-      - name: Install xtail
-        shell: bash
-        run: sudo apt-get update && sudo apt-get install --yes xtail
-
       - name: Build ziti executable
         shell: bash
         run: |

--- a/quickstart/test/ha-test.sh
+++ b/quickstart/test/ha-test.sh
@@ -147,6 +147,8 @@ kill $pid1 $pid2 $pid3
 # Wait for both processes to finish
 wait $pid1 $pid2 $pid3
 
+TRAP - EXIT ERR
+
 echo "all processes have exited: $pid1 $pid2 $pid3"
 echo "Test exited with code $test_exit_code"
 exit $test_exit_code  # Fail script if test fails

--- a/quickstart/test/ha-test.sh
+++ b/quickstart/test/ha-test.sh
@@ -81,27 +81,6 @@ for BIN in "${BINS[@]}"; do
     _check_command "$BIN"
 done
 
-function start_instance() {
-    local instance_id=$1
-    local ctrl_port=$2
-    local router_port=$3
-
-    "${BUILD_DIR}/ziti" edge quickstart ha \
-        --ctrl-address="127.0.0.1" \
-        --router-address="127.0.0.1" \
-        --home="${ziti_home}" \
-        --trust-domain="quickstart-ha-test" \
-        --instance-id="${instance_id}" \
-        --ctrl-port="${ctrl_port}" \
-        --router-port="${router_port}" \
-        > >(while IFS= read -r line; do echo "${instance_id}: $line"; done) 2>&1 &
-
-    echo $!  # Return the PID
-}
-
-#pid1=$(start_instance "inst1" 2001 3001)
-
-
 "${BUILD_DIR}/ziti" edge quickstart ha \
     --ctrl-address="127.0.0.1" \
     --router-address="127.0.0.1" \

--- a/quickstart/test/ha-test.sh
+++ b/quickstart/test/ha-test.sh
@@ -147,7 +147,7 @@ kill $pid1 $pid2 $pid3
 # Wait for both processes to finish
 wait $pid1 $pid2 $pid3
 
-TRAP - EXIT ERR
+trap - EXIT ERR
 
 echo "all processes have exited: $pid1 $pid2 $pid3"
 echo "Test exited with code $test_exit_code"

--- a/quickstart/test/ha-test.sh
+++ b/quickstart/test/ha-test.sh
@@ -9,10 +9,12 @@ set -o pipefail
 : "${BUILD_DIR:=./build}"
 : "${PFXLOG_NO_JSON:=true}"; export PFXLOG_NO_JSON  # disable JSON log format
 : "${VERBOSE:=1}"  # 0: no instance logs printed, 1: print instance logs to stdout
-declare -a ctrl_ports=(2001 2002 2003)
-declare -a router_ports=(3001 3002 3003)
-: "${ziti_home:=$(mktemp -d)}"
-: "${trust_domain:="quickstart-ha-test"}"
+BASE_TMP_DIR="/tmp/ha-quickstart-test"
+mkdir -p "$BASE_TMP_DIR"
+: "${ziti_home:=$(mktemp -d "$BASE_TMP_DIR/ziti_home_XXXXXX")}"
+
+trap 'rm -rf "/tmp/ha-quickstart-test"' EXIT ERR
+trap 'echo "Cleaning up..."; [[ -n "${pid1-}" ]] && kill $pid1 2>/dev/null; [[ -n "${pid2-}" ]] && kill $pid2 2>/dev/null; [[ -n "${pid3-}" ]] && kill $pid3 2>/dev/null' EXIT ERR
 
 function _wait_for_controller {
     local advertised_host_port="127.0.0.1:${1}"
@@ -32,22 +34,21 @@ function _wait_for_controller {
         (( elapsed += 3 ))
     done
     echo "CONTROLLER ONLINE AT: https://${advertised_host_port}"
-}
-
-function _term_background_pids {
-    echo -n "terminating background pids: "
-    for name in "${!PIDS[@]}"; do
-        echo -n "${name}=${PIDS[$name]} "
+    
+    echo "Waiting five seconds for the controller to be chill...."
+    sleep 5
+    
+    while ! "${BUILD_DIR}/ziti" edge login -u admin -p admin "${advertised_host_port}" -y; do
+        if (( elapsed >= timeout )); then
+            echo "Login failed after $timeout seconds, exiting."
+            exit 1
+        fi
+        echo "Login failed, retrying..."
+        sleep 1
+        ((elapsed++))
     done
-    echo -e "\n"
-    kill "${PIDS[@]}" 2>/dev/null
-    for instance in "${!PIDS[@]}"; do
-        while kill -0 "${PIDS[${instance}]}" 2>/dev/null; do
-            echo "Waiting for ${instance} process ${PIDS[${instance}]} to stop..."
-            sleep 1
-        done
-        echo "Process ${PIDS[${instance}]} has stopped."
-    done
+    
+    echo "Login to ${advertised_host_port} successful!"
 }
 
 function _check_command() {
@@ -57,149 +58,116 @@ function _check_command() {
     fi
 }
 
+function _wait_for_leader() {
+  local timeout=10  # Maximum wait time in seconds
+  local elapsed=0
+  
+  while [ "$elapsed" -lt "$timeout" ]; do
+    if "${BUILD_DIR}/ziti" ops cluster list | awk -F'│' 'NR>3 {print $3, $5}' | grep -q "true"; then
+      echo "Leader found"
+      return 0  # Success
+    fi
+    echo "leader not found. waiting for leader..."
+    sleep 1
+    ((elapsed++))
+  done
+
+  echo "No leader found after $timeout seconds"
+  return 1  # Failure
+}
+
 declare -a BINS=(awk grep jq "${BUILD_DIR}/ziti")
 for BIN in "${BINS[@]}"; do
     _check_command "$BIN"
 done
 
-trap '_term_background_pids' EXIT
+function start_instance() {
+    local instance_id=$1
+    local ctrl_port=$2
+    local router_port=$3
 
-# initialize an array of instance names
-declare -a INSTANCE_NAMES=(inst001 inst002 inst003)
-# initialize a map of name=pid
-declare -A PIDS
+    "${BUILD_DIR}/ziti" edge quickstart ha \
+        --ctrl-address="127.0.0.1" \
+        --router-address="127.0.0.1" \
+        --home="${ziti_home}" \
+        --trust-domain="quickstart-ha-test" \
+        --instance-id="${instance_id}" \
+        --ctrl-port="${ctrl_port}" \
+        --router-port="${router_port}" \
+        > >(while IFS= read -r line; do echo "${instance_id}: $line"; done) 2>&1 &
 
-if (( VERBOSE )); then
-    # print from the top and follow instance logs with filename separators
-    xtail "${ziti_home}/" &
-    # add the tail PID to background pids to clean up
-    PIDS["logtail"]=$!
-fi
+    echo $!  # Return the PID
+}
+
+#pid1=$(start_instance "inst1" 2001 3001)
 
 
-echo "${BUILD_DIR}/ziti" edge quickstart ha \
+"${BUILD_DIR}/ziti" edge quickstart ha \
     --ctrl-address="127.0.0.1" \
     --router-address="127.0.0.1" \
     --home="${ziti_home}" \
-    --trust-domain="${trust_domain}" \
-    --instance-id="${INSTANCE_NAMES[0]}" \
-    --ctrl-port="${ctrl_ports[0]}" \
-    --router-port="${router_ports[0]}" \
-    > /tmp/ha-test.cmds
+    --trust-domain="quickstart-ha-test" \
+    --instance-id="inst1" \
+    --ctrl-port="2001" \
+    --router-port="3001" \
+    > >(while IFS= read -r line; do echo "inst1: $line"; done) 2>&1 &
+pid1=$!
 
-nohup "${BUILD_DIR}/ziti" edge quickstart ha \
+_wait_for_controller "2001"
+_wait_for_leader
+
+"${BUILD_DIR}/ziti" edge quickstart join \
     --ctrl-address="127.0.0.1" \
     --router-address="127.0.0.1" \
     --home="${ziti_home}" \
-    --trust-domain="${trust_domain}" \
-    --instance-id="${INSTANCE_NAMES[0]}" \
-    --ctrl-port="${ctrl_ports[0]}" \
-    --router-port="${router_ports[0]}" \
-    &> "${ziti_home}/${INSTANCE_NAMES[0]}.log" &
-PIDS["${INSTANCE_NAMES[0]}"]=$!
+    --trust-domain="quickstart-ha-test" \
+    --ctrl-port="2002" \
+    --router-port="3002" \
+    --instance-id="inst2" \
+    --cluster-member="tls:127.0.0.1:2001" \
+    > >(while IFS= read -r line; do echo "inst2: $line"; done) 2>&1 &
+pid2=$!
 
-_wait_for_controller "${ctrl_ports[0]}"
-sleep 5
-echo "controller online"
+sleep 3
+_wait_for_controller "2002"
+_wait_for_leader
 
-echo "${BUILD_DIR}/ziti" edge quickstart join \
+"${BUILD_DIR}/ziti" edge quickstart join \
     --ctrl-address="127.0.0.1" \
     --router-address="127.0.0.1" \
     --home="${ziti_home}" \
-    --trust-domain="${trust_domain}" \
-    --ctrl-port="${ctrl_ports[1]}" \
-    --router-port="${router_ports[1]}" \
-    --instance-id="${INSTANCE_NAMES[1]}" \
-    --cluster-member="tls:127.0.0.1:${ctrl_ports[0]}" \
-    >> /tmp/ha-test.cmds
+    --trust-domain="quickstart-ha-test" \
+    --ctrl-port="2003" \
+    --router-port="3003" \
+    --instance-id="inst3" \
+    --cluster-member="tls:127.0.0.1:2001" \
+    > >(while IFS= read -r line; do echo "inst3: $line"; done) 2>&1 &
+pid3=$!
 
-nohup "${BUILD_DIR}/ziti" edge quickstart join \
-    --ctrl-address="127.0.0.1" \
-    --router-address="127.0.0.1" \
-    --home="${ziti_home}" \
-    --trust-domain="${trust_domain}" \
-    --ctrl-port="${ctrl_ports[1]}" \
-    --router-port="${router_ports[1]}" \
-    --instance-id="${INSTANCE_NAMES[1]}" \
-    --cluster-member="tls:127.0.0.1:${ctrl_ports[0]}" \
-    &> "${ziti_home}/${INSTANCE_NAMES[1]}.log" &
-PIDS["${INSTANCE_NAMES[1]}"]=$!
+sleep 3
+_wait_for_controller "2003"
 
-echo "${BUILD_DIR}/ziti" edge quickstart join \
-    --ctrl-address="127.0.0.1" \
-    --router-address="127.0.0.1" \
-    --home="${ziti_home}" \
-    --trust-domain="${trust_domain}" \
-    --ctrl-port="${ctrl_ports[2]}" \
-    --router-port="${router_ports[2]}" \
-    --instance-id="${INSTANCE_NAMES[2]}" \
-    --cluster-member="tls:127.0.0.1:${ctrl_ports[0]}" \
-    >> /tmp/ha-test.cmds
-
-nohup "${BUILD_DIR}/ziti" edge quickstart join \
-    --ctrl-address="127.0.0.1" \
-    --router-address="127.0.0.1" \
-    --home="${ziti_home}" \
-    --trust-domain="${trust_domain}" \
-    --ctrl-port="${ctrl_ports[2]}" \
-    --router-port="${router_ports[2]}" \
-    --instance-id="${INSTANCE_NAMES[2]}" \
-    --cluster-member="tls:127.0.0.1:${ctrl_ports[0]}" \
-    &> "${ziti_home}/${INSTANCE_NAMES[2]}.log" &
-PIDS["${INSTANCE_NAMES[2]}"]=$!
-
-count=0
-: "${timeout:=60}"  # Timeout in seconds
-elapsed=0
-
-while [[ ${count} -lt 3 ]]; do
-    results=$("${BUILD_DIR}/ziti" fabric list links -j | jq -r '.data[].state')
-    connected_count=$(echo "${results}" | grep -c "Connected" || true)
-
-    if [[ ${connected_count} -eq 3 ]]; then
-        echo "All three are connected."
-        break
-    else
-        echo "Waiting for three router links before continuing..."
-        sleep 6
-        ((elapsed+=6))
-        
-        if [[ ${elapsed} -ge ${timeout} ]]; then
-            "${BUILD_DIR}/ziti" fabric list routers
-            "${BUILD_DIR}/ziti" fabric list links
-            echo "Timeout reached; not all connections are 'Connected'."
-            exit 1
-        fi
-    fi
-done
-
-# three links == things are ready -- tests start below
-output=$("${BUILD_DIR}/ziti" agent cluster list --pid "${PIDS["${INSTANCE_NAMES[0]}"]}")
-
+echo "========================================================="
+echo "HA Cluster should now be online"
+"${BUILD_DIR}/ziti" ops cluster list
 echo ""
-echo "${output}"
-echo ""
+echo "Building and running quickstart test"
+echo "========================================================="
+"${BUILD_DIR}/ziti" ops verify traffic -u admin -p admin --controller-url localhost:2001 -y \
+  > >(while IFS= read -r line; do echo "traffic: $line"; done) 2>&1
 
-# Extract the columns for LEADER and CONNECTED
-leaders=$(echo "${output}" | grep inst | awk -F '│' '{print $5}')
-connected=$(echo "${output}" | grep inst | awk -F '/│' '{print $6}')
+ZITI_CTRL_EDGE_ADVERTISED_ADDRESS=localhost \
+ZITI_CTRL_EDGE_ADVERTISED_PORT=2001 \
+ZITI_ROUTER_NAME="router-inst1" \
+go test -tags "quickstart manual" ziti/cmd/edge/quickstart_manual_test.go ziti/cmd/edge/quickstart_shared_test.go
+test_exit_code=$?
 
-# Check there is only one leader
-leader_count=$(echo "${leaders}" | grep -c "true")
-if [[ ${leader_count} -ne 1 ]]; then
-    echo "Test failed: Expected 1 leader, found ${leader_count}"
-    _term_background_pids
-    exit 1
-fi
+echo "waiting for processes to exit: $pid1 $pid2 $pid3"
+kill $pid1 $pid2 $pid3
 
-# Check all are connected
-disconnected_count=$(echo "${connected}" | grep -c "false" || true)
-if [[ ${disconnected_count} -ne 0 ]]; then
-    echo "Test failed: Some instances are not connected"
-    _term_background_pids
-    exit 1
-fi
+# Wait for both processes to finish
+wait $pid1 $pid2 $pid3
 
-echo "Test passed: One leader found and all instances are connected"
-trap - EXIT
-_term_background_pids
+echo "all processes have exited: $pid1 $pid2 $pid3"
+echo "Test exited with code $test_exit_code"
+exit $test_exit_code  # Fail script if test fails

--- a/ziti/cmd/create/create_config_controller.go
+++ b/ziti/cmd/create/create_config_controller.go
@@ -203,7 +203,7 @@ func SetControllerIdentity(data *ControllerTemplateValues) {
 func SetControllerIdentityCert(c *ControllerTemplateValues) {
 	val := os.Getenv(constants.PkiCtrlCertVarName)
 	if val == "" {
-		val = helpers.GetZitiHome() + "/" + helpers.HostnameOrNetworkName() + ".cert" // default
+		val = helpers.GetZitiHome() + "/" + helpers.HostnameOrNetworkName() + "client.chain.cert" // default
 	}
 	c.Identity.Cert = helpers.NormalizePath(val)
 }

--- a/ziti/cmd/create/create_config_controller_test.go
+++ b/ziti/cmd/create/create_config_controller_test.go
@@ -255,7 +255,7 @@ func TestCtrlConfigDefaultsWhenUnset(t *testing.T) {
 
 	// identity:
 	t.Run("TestPKICert", func(t *testing.T) {
-		expectedValue := cmdhelper.GetZitiHome() + "/" + cmdhelper.HostnameOrNetworkName() + ".cert"
+		expectedValue := cmdhelper.GetZitiHome() + "/" + cmdhelper.HostnameOrNetworkName() + "client.chain.cert"
 
 		assert.Equal(t, expectedValue, data.Controller.Identity.Cert)
 		assert.Equal(t, expectedValue, ctrlConfig.Identity.Cert)
@@ -469,7 +469,7 @@ func TestCtrlConfigDefaultsWhenEmpty(t *testing.T) {
 
 	// identity:
 	t.Run("TestPKICert", func(t *testing.T) {
-		expectedValue := cmdhelper.GetZitiHome() + "/" + cmdhelper.HostnameOrNetworkName() + ".cert"
+		expectedValue := cmdhelper.GetZitiHome() + "/" + cmdhelper.HostnameOrNetworkName() + "client.chain.cert"
 
 		assert.Equal(t, expectedValue, data.Controller.Identity.Cert)
 		assert.Equal(t, expectedValue, ctrlConfig.Identity.Cert)

--- a/ziti/cmd/edge/quickstart_shared_test.go
+++ b/ziti/cmd/edge/quickstart_shared_test.go
@@ -518,7 +518,7 @@ func performQuickstartTest(t *testing.T) {
 	defer func() { _ = deleteServicePolicyByID(client, dialSP.ID) }()
 
 	// Test connectivity with private edge router, wait some time for the terminator to be created
-	terminatorFilter := "router.name=\"" + hostingRouterName + "\""
+	terminatorFilter := "service.name=\"" + serviceName + "\""
 	termCntReached := waitForTerminatorCount(client, terminatorFilter, 1, 30*time.Second)
 	if !termCntReached {
 		t.Fatal("Unable to detect a terminator for the edge router")

--- a/ziti/cmd/edge/quickstart_shared_test.go
+++ b/ziti/cmd/edge/quickstart_shared_test.go
@@ -296,8 +296,10 @@ func getTerminatorsByFilter(client *rest_management_api_client.ZitiEdgeManagemen
 
 func waitForTerminatorCount(client *rest_management_api_client.ZitiEdgeManagement, filter string, count int, timeout time.Duration) bool {
 	startTime := time.Now()
+	var found int
 	for {
-		if len(getTerminatorsByFilter(client, filter)) == count {
+		found = len(getTerminatorsByFilter(client, filter))
+		if found == count {
 			return true
 		}
 		if time.Since(startTime) >= timeout {
@@ -305,6 +307,8 @@ func waitForTerminatorCount(client *rest_management_api_client.ZitiEdgeManagemen
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
+
+	log.Infof("waitForTerminatorCount found %d, expected %d for %s", found, count, filter)
 	return false
 }
 


### PR DESCRIPTION
closes #2825 

- use client chain for identity blocks, not the leaf. necessary for clustered controllers when connecting to other controllers
- get the quickstart test to successfully run again
- return errors instead of log.fatal for better test failures