### PR TITLE
closes #2860 - add validation from controller/router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Release 1.4.2
+
+* Bug fixes
+
+## Component Updates and Bug Fixes
+
+* github.com/openziti/ziti: [v1.4.1 -> v1.4.2](https://github.com/openziti/ziti/compare/v1.4.1...v1.4.2)
+    * [Issue #2860](https://github.com/openziti/ziti/issues/2860) - router healtcheck with invalid address logs error but still doesn't listen
+    
 # Release 1.4.1
 
 ## What's New

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/openziti/storage v0.4.5
 	github.com/openziti/transport/v2 v2.0.165
 	github.com/openziti/x509-claims v1.0.3
-	github.com/openziti/xweb/v2 v2.2.1
+	github.com/openziti/xweb/v2 v2.3.0
 	github.com/openziti/ziti-db-explorer v1.1.3
 	github.com/orcaman/concurrent-map/v2 v2.0.1
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -617,6 +617,8 @@ github.com/openziti/x509-claims v1.0.3 h1:HNdQ8Nf1agB3lBs1gahcO6zfkeS4S5xoQ2/PkY
 github.com/openziti/x509-claims v1.0.3/go.mod h1:Z0WIpBm6c4ecrpRKrou6Gk2wrLWxJO/+tuUwKh8VewE=
 github.com/openziti/xweb/v2 v2.2.1 h1:vPHASmyTlWB75GLIEIvWSSs2ZQgZDsr7do0IXeHf6Ww=
 github.com/openziti/xweb/v2 v2.2.1/go.mod h1:44Jk2F3kdovYXopVWk8BbvnP+156g6f0BhwUWWSBZjs=
+github.com/openziti/xweb/v2 v2.3.0 h1:KWCHvDp2nzFD0pnq2a2pEjaHvUQF42hR/3J+XWYDAQY=
+github.com/openziti/xweb/v2 v2.3.0/go.mod h1:pISANxAUfIjaswSotq7XPnI9q28wMEXLsSrEy0xwIXk=
 github.com/openziti/ziti-db-explorer v1.1.3 h1:9JER16MJzagtYPdGEhgDcw2p/BXNCVbf9IgA/sMB52w=
 github.com/openziti/ziti-db-explorer v1.1.3/go.mod h1:pMIMNJoTRSTbkO2e7cZWiBokA3jMdeiGAILP3QhU+v8=
 github.com/orcaman/concurrent-map/v2 v2.0.1 h1:jOJ5Pg2w1oeB6PeDurIYf6k9PQ+aTITr/6lP/L/zp6c=

--- a/router/router.go
+++ b/router/router.go
@@ -103,7 +103,6 @@ type Router struct {
 	agentBindHandlers   []channel.BindHandler
 	rdmRequired         atomic.Bool
 	indexWatchers       env.IndexWatchers
-	failOnAddress       bool
 }
 
 func (self *Router) GetRouterId() *identity.TokenId {
@@ -229,7 +228,6 @@ func Create(cfg *Config, versionProvider versions.VersionProvider) *Router {
 		ctrlRateLimiter:     command.NewAdaptiveRateLimitTracker(cfg.Ctrl.RateLimit, metricsRegistry, closeNotify),
 		rdmEnabled:          config.NewConfigValue[bool](),
 		indexWatchers:       env.NewIndexWatchers(),
-		failOnAddress:       false,
 	}
 
 	router.ctrls = env.NewNetworkControllers(cfg.Ctrl.DefaultRequestTimeout, router.connectToController, &cfg.Ctrl.Heartbeats)


### PR DESCRIPTION
closes #2860 moved extra validation outside of xweb itself via passing validators
continues to allow routers to have misconfigured xweb section for healthchecks