### PR TITLE
fixes #2796 generated clients for enrollment do not work

### DIFF
--- a/controller/env/appenv.go
+++ b/controller/env/appenv.go
@@ -845,8 +845,7 @@ func NewAppEnv(host HostController) (*AppEnv, error) {
 
 	//enrollment consumer, leave content unread, allow modules to read
 	clientApi.ApplicationXPemFileConsumer = noOpConsumer
-	clientApi.ApplicationPkcs10Consumer = noOpConsumer
-	clientApi.ApplicationXPemFileProducer = &PemProducer{}
+	clientApi.ApplicationPkcs7Consumer = noOpConsumer
 	clientApi.TextYamlProducer = &YamlProducer{}
 
 	clientApi.Oauth2Auth = func(token string, scopes []string) (principal interface{}, err error) {

--- a/controller/env/helpers.go
+++ b/controller/env/helpers.go
@@ -3,8 +3,8 @@ package env
 import (
 	openApiErrors "github.com/go-openapi/errors"
 	"github.com/michaelquigley/pfxlog"
-	"github.com/openziti/ziti/controller/apierror"
 	"github.com/openziti/foundation/v2/errorz"
+	"github.com/openziti/ziti/controller/apierror"
 	"net/http"
 )
 
@@ -25,6 +25,7 @@ func ServeError(rw http.ResponseWriter, r *http.Request, inErr error) {
 					//validation errors
 					if validationError, ok := compositeError.Errors[0].(*openApiErrors.Validation); ok {
 						newApiError = errorz.NewCouldNotValidate(validationError)
+						newApiError.Status = int(validationError.Code())
 					}
 				}
 			}

--- a/controller/env/producers.go
+++ b/controller/env/producers.go
@@ -17,30 +17,9 @@
 package env
 
 import (
-	"fmt"
 	"gopkg.in/yaml.v3"
 	"io"
 )
-
-type PemProducer struct{}
-
-func (p PemProducer) Produce(writer io.Writer, i interface{}) error {
-	if buffer, ok := i.([]byte); ok {
-		_, err := writer.Write(buffer)
-		return err
-	} else if reader, ok := i.(io.Reader); ok {
-		buffer, err := io.ReadAll(reader)
-		if err != nil {
-			return err
-		}
-		_, err = writer.Write(buffer)
-		return err
-	} else if buffer, ok := i.(string); ok {
-		_, err := writer.Write([]byte(buffer))
-		return err
-	}
-	return fmt.Errorf("unsupported type for PEM producer: %T", i)
-}
 
 type YamlProducer struct{}
 

--- a/controller/env/routers.go
+++ b/controller/env/routers.go
@@ -16,7 +16,7 @@
 
 package env
 
-var routerFuncs []AddRouterFunc
+var routers []ApiRouter
 
 type AddRouterFunc func(ae *AppEnv)
 
@@ -24,10 +24,14 @@ type ApiRouter interface {
 	Register(ae *AppEnv)
 }
 
-func AddRouter(rf ApiRouter) {
-	routerFuncs = append(routerFuncs, rf.Register)
+type ApiRouterMiddleware interface {
+	AddMiddleware(ae *AppEnv)
 }
 
-func GetRouters() []AddRouterFunc {
-	return routerFuncs
+func AddRouter(rf ApiRouter) {
+	routers = append(routers, rf)
+}
+
+func GetRouters() []ApiRouter {
+	return routers
 }

--- a/controller/internal/routes/enroll_router.go
+++ b/controller/internal/routes/enroll_router.go
@@ -275,6 +275,11 @@ func (ro *EnrollRouter) legacyGenericEnrollPemHandler(ae *env.AppEnv, rc *respon
 	enrollContext := &model.EnrollmentContextHttp{}
 	err := enrollContext.FillFromHttpRequest(rc.Request, rc.NewChangeContext())
 
+	if err != nil {
+		rc.RespondWithError(err)
+		return
+	}
+
 	body, err := io.ReadAll(rc.Request.Body)
 
 	if err != nil {

--- a/controller/internal/routes/enrollment_router.go
+++ b/controller/internal/routes/enrollment_router.go
@@ -20,11 +20,11 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/openziti/edge-api/rest_management_api_server/operations/enrollment"
 	"github.com/openziti/edge-api/rest_model"
+	"github.com/openziti/foundation/v2/errorz"
 	"github.com/openziti/ziti/controller/env"
 	"github.com/openziti/ziti/controller/internal/permissions"
 	"github.com/openziti/ziti/controller/model"
 	"github.com/openziti/ziti/controller/response"
-	"github.com/openziti/foundation/v2/errorz"
 	"time"
 )
 

--- a/controller/model/enrollment_manager.go
+++ b/controller/model/enrollment_manager.go
@@ -161,6 +161,12 @@ func (self *EnrollmentManager) getEnrollmentMethod(ctx EnrollmentContext) (strin
 		return "", apierror.NewInvalidEnrollmentToken()
 	}
 
+	// if we have an explicit enroll method we are targeting, ensure it is valid
+	// the enroll method may be blank for the generic enroll endpoint
+	if ctx.GetMethod() != "" && ctx.GetMethod() != enrollment.Method {
+		return "", apierror.NewInvalidEnrollMethod()
+	}
+
 	method = enrollment.Method
 
 	return method, nil

--- a/controller/model/enrollment_mod_ca.go
+++ b/controller/model/enrollment_mod_ca.go
@@ -155,15 +155,7 @@ func (module *EnrollModuleCa) completeCertAuthenticatorEnrollment(log *logrus.En
 	}
 
 	identityId := eid.New()
-	requestedName := ""
-
-	log = log.WithField("identityId", identityId)
-
-	if context.GetDataAsMap() != nil {
-		if dataName, ok := context.GetDataAsMap()["name"]; ok {
-			requestedName = dataName.(string)
-		}
-	}
+	requestedName := context.GetData().RequestedName
 
 	if requestedName == "" {
 		requestedName = identityId
@@ -224,13 +216,7 @@ func (module *EnrollModuleCa) completeExternalIdEnrollment(log *logrus.Entry, co
 
 	log = log.WithField("identityId", identityId).WithField("subMethod", "externalId")
 
-	requestedName := ""
-
-	if context.GetDataAsMap() != nil {
-		if dataName, ok := context.GetDataAsMap()["name"]; ok {
-			requestedName = dataName.(string)
-		}
-	}
+	requestedName := context.GetData().RequestedName
 
 	if requestedName == "" {
 		requestedName = identityId

--- a/controller/model/enrollment_mod_erott.go
+++ b/controller/model/enrollment_mod_erott.go
@@ -77,21 +77,21 @@ func (module *EnrollModuleEr) Process(context EnrollmentContext) (*EnrollmentRes
 		return nil, apierror.NewEnrollmentExpired()
 	}
 
-	enrollData := context.GetDataAsMap()
+	enrollData := context.GetData()
 
-	serverCertCsrPem, ok := enrollData["serverCertCsr"]
+	serverCertCsrPem := enrollData.ServerCsrPem
 
-	if !ok || serverCertCsrPem == nil {
+	if serverCertCsrPem == nil || len(serverCertCsrPem) == 0 {
 		return nil, apierror.NewInvalidEnrollmentMissingCsr(errors.New("invalid server CSR"))
 	}
 
-	clientCertCsrPem, ok := enrollData["certCsr"]
+	clientCertCsrPem := enrollData.ClientCsrPem
 
-	if !ok || clientCertCsrPem == nil {
+	if clientCertCsrPem == nil || len(clientCertCsrPem) == 0 {
 		return nil, apierror.NewInvalidEnrollmentMissingCsr(errors.New("invalid client CSR"))
 	}
 
-	serverCertRaw, err := module.ProcessServerCsrPem([]byte(serverCertCsrPem.(string)))
+	serverCertRaw, err := module.ProcessServerCsrPem(serverCertCsrPem)
 
 	if err != nil {
 		apiError := apierror.NewCouldNotProcessCsr()
@@ -99,7 +99,7 @@ func (module *EnrollModuleEr) Process(context EnrollmentContext) (*EnrollmentRes
 		return nil, apiError
 	}
 
-	clientCertRaw, err := module.ProcessClientCsrPem([]byte(clientCertCsrPem.(string)), edgeRouter.Id)
+	clientCertRaw, err := module.ProcessClientCsrPem(clientCertCsrPem, edgeRouter.Id)
 
 	if err != nil {
 		apiError := apierror.NewCouldNotProcessCsr()
@@ -142,7 +142,7 @@ func (module *EnrollModuleEr) Process(context EnrollmentContext) (*EnrollmentRes
 	content := &rest_model.EnrollmentCerts{
 		Ca:         string(module.env.GetConfig().Edge.CaPems()),
 		Cert:       clientChainPem,
-		ServerCert: string(serverCertPem),
+		ServerCert: serverCertPem,
 	}
 
 	return &EnrollmentResult{

--- a/controller/model/enrollment_mod_erott.go
+++ b/controller/model/enrollment_mod_erott.go
@@ -81,13 +81,13 @@ func (module *EnrollModuleEr) Process(context EnrollmentContext) (*EnrollmentRes
 
 	serverCertCsrPem := enrollData.ServerCsrPem
 
-	if serverCertCsrPem == nil || len(serverCertCsrPem) == 0 {
+	if len(serverCertCsrPem) == 0 {
 		return nil, apierror.NewInvalidEnrollmentMissingCsr(errors.New("invalid server CSR"))
 	}
 
 	clientCertCsrPem := enrollData.ClientCsrPem
 
-	if clientCertCsrPem == nil || len(clientCertCsrPem) == 0 {
+	if len(clientCertCsrPem) == 0 {
 		return nil, apierror.NewInvalidEnrollmentMissingCsr(errors.New("invalid client CSR"))
 	}
 

--- a/controller/model/enrollment_mod_ott.go
+++ b/controller/model/enrollment_mod_ott.go
@@ -75,7 +75,7 @@ func (module *EnrollModuleOtt) Process(ctx EnrollmentContext) (*EnrollmentResult
 		SetChangeAuthorId(identity.Id).
 		SetChangeAuthorName(identity.Name)
 
-	csrPem := ctx.GetDataAsByteArray()
+	csrPem := ctx.GetData().ClientCsrPem
 
 	csr, err := cert.ParseCsrPem(csrPem)
 

--- a/controller/model/enrollment_mod_trott.go
+++ b/controller/model/enrollment_mod_trott.go
@@ -72,9 +72,9 @@ func (module *EnrollModuleRouterOtt) Process(context EnrollmentContext) (*Enroll
 	if time.Now().After(*enrollment.ExpiresAt) {
 		return nil, apierror.NewEnrollmentExpired()
 	}
-	enrollData := context.GetDataAsMap()
+	enrollData := context.GetData()
 
-	serverCsr, err := cert.ParseCsrPem([]byte(enrollData["serverCertCsr"].(string)))
+	serverCsr, err := cert.ParseCsrPem(enrollData.ServerCsrPem)
 
 	if err != nil {
 		apiErr := apierror.NewCouldNotProcessCsr()
@@ -102,7 +102,7 @@ func (module *EnrollModuleRouterOtt) Process(context EnrollmentContext) (*Enroll
 		return nil, apierror.NewCouldNotProcessCsr()
 	}
 
-	clientCsr, err := cert.ParseCsrPem([]byte(enrollData["certCsr"].(string)))
+	clientCsr, err := cert.ParseCsrPem(enrollData.ClientCsrPem)
 
 	if err != nil {
 		return nil, apierror.NewCouldNotProcessCsr()
@@ -150,7 +150,7 @@ func (module *EnrollModuleRouterOtt) Process(context EnrollmentContext) (*Enroll
 	content := &rest_model.EnrollmentCerts{
 		Ca:         string(module.env.GetConfig().Edge.CaPems()),
 		Cert:       clientChainPem,
-		ServerCert: string(srvPem),
+		ServerCert: srvPem,
 	}
 
 	return &EnrollmentResult{

--- a/controller/model/enrollment_mod_updb.go
+++ b/controller/model/enrollment_mod_updb.go
@@ -76,17 +76,13 @@ func (module *EnrollModuleUpdb) Process(ctx EnrollmentContext) (*EnrollmentResul
 		SetChangeAuthorId(identity.Id).
 		SetChangeAuthorName(identity.Name)
 
-	data := ctx.GetDataAsMap()
+	data := ctx.GetData()
 
-	password := ""
-
-	val, ok := data["password"]
-	if !ok {
+	if len(data.Password) == 0 {
 		return nil, errorz.NewUnhandled(errors.New("password expected for updb enrollment"))
 	}
-	password = val.(string)
 
-	hash := Hash(password)
+	hash := Hash(data.Password)
 
 	encodedPassword := base64.StdEncoding.EncodeToString(hash.Hash)
 	encodedSalt := base64.StdEncoding.EncodeToString(hash.Salt)

--- a/controller/server/controller.go
+++ b/controller/server/controller.go
@@ -215,8 +215,14 @@ func (c *Controller) Run() {
 	log.Info("starting edge")
 
 	//after InitPersistence
-	for _, rf := range env.GetRouters() {
-		rf(c.AppEnv)
+	for _, router := range env.GetRouters() {
+		router.Register(c.AppEnv)
+	}
+	// middleware has to be added after all routes are added due to caching mechanisms in the generated code
+	for _, router := range env.GetRouters() {
+		if apiRouterMiddleware, ok := router.(env.ApiRouterMiddleware); ok {
+			apiRouterMiddleware.AddMiddleware(c.AppEnv)
+		}
 	}
 
 	go c.checkEdgeInitialized()

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/openziti/agent v1.0.26
 	github.com/openziti/channel/v3 v3.0.37
 	github.com/openziti/cobra-to-md v1.0.1
-	github.com/openziti/edge-api v0.26.41
+	github.com/openziti/edge-api v0.26.42
 	github.com/openziti/foundation/v2 v2.0.58
 	github.com/openziti/identity v1.0.100
 	github.com/openziti/jwks v1.0.6

--- a/go.sum
+++ b/go.sum
@@ -593,8 +593,8 @@ github.com/openziti/cobra-to-md v1.0.1 h1:WRinNoIRmwWUSJm+pSNXMjOrtU48oxXDZgeCYQ
 github.com/openziti/cobra-to-md v1.0.1/go.mod h1:FjCpk/yzHF7/r28oSTNr5P57yN5VolpdAtS/g7KNi2c=
 github.com/openziti/dilithium v0.3.5 h1:+envGNzxc3OyVPiuvtxivQmCsOjdZjtOMLpQBeMz7eM=
 github.com/openziti/dilithium v0.3.5/go.mod h1:XONq1iK6te/WwNzkgZHfIDHordMPqb0hMwJ8bs9EfSk=
-github.com/openziti/edge-api v0.26.41 h1:JL2gDqinD5GILTKct+z3YG0YcU8jIDAstW572Bq7nNY=
-github.com/openziti/edge-api v0.26.41/go.mod h1:sYHVpm26Jr1u7VooNJzTb2b2nGSlmCHMnbGC8XfWSng=
+github.com/openziti/edge-api v0.26.42 h1:Wi/BUttSUvedT9XGht7vi/zI/TNGc3ApvjkAviWhauA=
+github.com/openziti/edge-api v0.26.42/go.mod h1:sYHVpm26Jr1u7VooNJzTb2b2nGSlmCHMnbGC8XfWSng=
 github.com/openziti/foundation/v2 v2.0.58 h1:U3+EfX3EdYfmcaEX2wROfrxX75xVoIZ9gZfiPQd6HCs=
 github.com/openziti/foundation/v2 v2.0.58/go.mod h1:9pC2rMvKgCjiWmga6RFvYG8ck03yrTTsp0uDiwmHbMk=
 github.com/openziti/identity v1.0.100 h1:FTkbhykDCMw1z/wxEeDfmq1aBp2tLRjZ3ggioRT4pg8=

--- a/tests/api_error_test.go
+++ b/tests/api_error_test.go
@@ -103,7 +103,7 @@ func Test_Api_Errors(t *testing.T) {
 		standardErrorJsonResponseTests(resp, "INVALID_ENROLLMENT_TOKEN", http.StatusBadRequest, t)
 	})
 
-	t.Run("empty body expected on error for an accept of application/x-pem-file", func(t *testing.T) {
+	t.Run("406 not acceptable type for accept of application/x-pem-file", func(t *testing.T) {
 		ctx.testContextChanged(t)
 		madeUpToken := uuid.New().String()
 
@@ -112,12 +112,6 @@ func Test_Api_Errors(t *testing.T) {
 			Post("enroll?token=" + madeUpToken)
 
 		ctx.Req.NoError(err)
-
-		contentTypeHeaders := resp.Header().Values("content-type")
-
-		ctx.Req.NotEmpty(contentTypeHeaders)
-		ctx.Req.Equal("application/x-pem-file", contentTypeHeaders[0])
-
-		ctx.Req.Empty(resp.Body())
+		ctx.Req.Equal(http.StatusNotAcceptable, resp.StatusCode())
 	})
 }

--- a/tests/context.go
+++ b/tests/context.go
@@ -209,18 +209,22 @@ func (ctx *TestContext) ControllerCaPool() *x509.CertPool {
 	return ctx.ControllerConfig.Id.CA()
 }
 
-func (ctx *TestContext) NewEdgeClientApi(totpProvider func(chan string)) *edge_apis.ClientApiClient {
+func (ctx *TestContext) NewEdgeClientApi(totpProvider func(chan string)) *ClientHelperClient {
 	if totpProvider == nil {
 		totpProvider = func(chan string) {}
 	}
-	return edge_apis.NewClientApiClient([]*url.URL{ctx.ClientApiUrl()}, ctx.ControllerCaPool(), totpProvider)
+	client := edge_apis.NewClientApiClient([]*url.URL{ctx.ClientApiUrl()}, ctx.ControllerCaPool(), totpProvider)
+
+	return &ClientHelperClient{client}
 }
 
-func (ctx *TestContext) NewEdgeManagementApi(totpProvider func(chan string)) *edge_apis.ManagementApiClient {
+func (ctx *TestContext) NewEdgeManagementApi(totpProvider func(chan string)) *ManagementHelperClient {
 	if totpProvider == nil {
 		totpProvider = func(chan string) {}
 	}
-	return edge_apis.NewManagementApiClient([]*url.URL{ctx.ClientApiUrl()}, ctx.ControllerCaPool(), totpProvider)
+	client := edge_apis.NewManagementApiClient([]*url.URL{ctx.ManagementApiUrl()}, ctx.ControllerCaPool(), totpProvider)
+
+	return &ManagementHelperClient{client}
 }
 
 func (ctx *TestContext) NewTransportWithIdentity(i idlib.Identity) *http.Transport {
@@ -669,8 +673,6 @@ func (ctx *TestContext) completeOttCaEnrollment(certAuth *certAuthenticator) {
 	client.SetHostURL("https://" + ctx.ApiHost + EdgeClientApiPath)
 
 	resp, err := client.NewRequest().
-		SetBody("{}").
-		SetHeader("content-type", "application/x-pem-file").
 		Post("enroll?method=ca")
 	ctx.Req.NoError(err)
 	ctx.logJson(resp.Body())

--- a/tests/endpoint_test.go
+++ b/tests/endpoint_test.go
@@ -37,9 +37,7 @@ func Test_Endpoints(t *testing.T) {
 		resp, err := rootPathClient.R().Post("https://" + ctx.ApiHost + "/authenticate")
 
 		ctx.Req.NoError(err)
-		ctx.Req.Equal(400, resp.StatusCode())
-		ctx.Req.Equal("application/json", resp.Header().Get("Content-Type"))
-		ctx.Req.NotEmpty(resp.Body())
+		ctx.Req.NotEqual(404, resp.StatusCode())
 	})
 
 	t.Run("oidc-configuration does not work on root .well-known", func(t *testing.T) {

--- a/tests/enrollment_ca_auto_specific_test.go
+++ b/tests/enrollment_ca_auto_specific_test.go
@@ -29,8 +29,8 @@ import (
 	"testing"
 )
 
-// Test_EnrollmetnCaAuto uses the generic enrollment endpoint
-func Test_EnrollmetnCaAuto(t *testing.T) {
+// Test_EnrollmetnCaAutoSpecific uses the ca specific enrollment endpoint rather than the generic enroll endpoint.
+func Test_EnrollmetnCaAutoSpecific(t *testing.T) {
 	ctx := NewTestContext(t)
 	defer ctx.Teardown()
 	ctx.StartServer()

--- a/tests/enrollment_ott_specific_test.go
+++ b/tests/enrollment_ott_specific_test.go
@@ -1,0 +1,527 @@
+//go:build apitests
+
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package tests
+
+import (
+	"crypto/x509"
+	"github.com/openziti/edge-api/rest_model"
+	edge_apis "github.com/openziti/sdk-golang/edge-apis"
+	"github.com/openziti/ziti/common/eid"
+	"testing"
+	"time"
+)
+
+// Test_EnrollmentOttSpecific uses the /enroll/ott specific endpoint.
+func Test_EnrollmentOttSpecific(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+	ctx.RequireAdminManagementApiLogin()
+
+	t.Run("can create an OTT enrollment", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		managementApiClient := ctx.NewEdgeManagementApi(nil)
+		ctx.Req.NotNil(managementApiClient)
+
+		adminCreds := edge_apis.NewUpdbCredentials(ctx.AdminAuthenticator.Username, ctx.AdminAuthenticator.Password)
+		adminManApiSession, err := managementApiClient.Authenticate(adminCreds, nil)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(adminManApiSession)
+
+		newIdentityLoc, err := managementApiClient.CreateIdentity(eid.New(), false)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(newIdentityLoc)
+		ctx.Req.NotEmpty(newIdentityLoc.ID)
+
+		newIdentity, err := managementApiClient.GetIdentity(newIdentityLoc.ID)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(newIdentity)
+
+		newEnrollmentExpiresAt := time.Now().Add(10 * time.Minute).UTC()
+		newEnrollmentLoc, err := managementApiClient.NewEnrollmentOtt(newIdentity.ID, &newEnrollmentExpiresAt)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(newEnrollmentLoc)
+
+		newEnrollment, err := managementApiClient.GetEnrollment(newEnrollmentLoc.ID)
+		ctx.NoError(err)
+		ctx.NotNil(newEnrollment)
+
+		t.Run("enrollment has the proper values", func(t *testing.T) {
+			ctx.testContextChanged(t)
+
+			ctx.NotNil(newEnrollment.ID)
+			ctx.NotNil(newEnrollment.Method)
+			ctx.NotNil(newEnrollment.ExpiresAt)
+			ctx.NotNil(newEnrollment.Identity)
+			ctx.NotNil(newEnrollment.Token)
+			ctx.NotEmpty(*newEnrollment.Token)
+			ctx.NotEmpty(newEnrollment.IdentityID)
+			ctx.NotEmpty(newEnrollment.JWT)
+
+			ctx.Equal(rest_model.EnrollmentCreateMethodOtt, *newEnrollment.Method)
+
+			//API time date format conversions reduce fidelity, truncate to MS comparison
+			ctx.Equal(newEnrollmentExpiresAt.Truncate(time.Millisecond), time.Time(*newEnrollment.ExpiresAt).Truncate(time.Millisecond))
+			ctx.Equal(newIdentityLoc.ID, newEnrollment.IdentityID)
+		})
+
+		t.Run("can enroll", func(t *testing.T) {
+			ctx.testContextChanged(t)
+
+			clientApiClient := ctx.NewEdgeClientApi(nil)
+
+			newIdentityCertAuth, err := clientApiClient.CompleteOttEnrollment(*newEnrollment.Token)
+			ctx.Req.NoError(err)
+			ctx.Req.NotNil(newIdentityCertAuth)
+		})
+	})
+
+	t.Run("can not enroll with an expired enrollment", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		managementApiClient := ctx.NewEdgeManagementApi(nil)
+		ctx.Req.NotNil(managementApiClient)
+
+		adminCreds := edge_apis.NewUpdbCredentials(ctx.AdminAuthenticator.Username, ctx.AdminAuthenticator.Password)
+		adminManApiSession, err := managementApiClient.Authenticate(adminCreds, nil)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(adminManApiSession)
+
+		newIdentityLoc, err := managementApiClient.CreateIdentity(eid.New(), false)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(newIdentityLoc)
+		ctx.Req.NotEmpty(newIdentityLoc.ID)
+
+		newIdentity, err := managementApiClient.GetIdentity(newIdentityLoc.ID)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(newIdentity)
+
+		newEnrollmentExpiresAt := time.Now().Add(2 * time.Second).UTC()
+		newEnrollmentLoc, err := managementApiClient.NewEnrollmentOtt(newIdentity.ID, &newEnrollmentExpiresAt)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(newEnrollmentLoc)
+
+		newEnrollment, err := managementApiClient.GetEnrollment(newEnrollmentLoc.ID)
+		ctx.NoError(err)
+		ctx.NotNil(newEnrollment)
+
+		t.Run("enrollment has the proper values", func(t *testing.T) {
+			ctx.testContextChanged(t)
+
+			ctx.NotNil(newEnrollment.ID)
+			ctx.NotNil(newEnrollment.Method)
+			ctx.NotNil(newEnrollment.ExpiresAt)
+			ctx.NotNil(newEnrollment.Identity)
+			ctx.NotNil(newEnrollment.Token)
+			ctx.NotEmpty(*newEnrollment.Token)
+			ctx.NotEmpty(newEnrollment.IdentityID)
+			ctx.NotEmpty(newEnrollment.JWT)
+
+			ctx.Equal(rest_model.EnrollmentCreateMethodOtt, *newEnrollment.Method)
+
+			//API time date format conversions reduce fidelity, truncate to MS comparison
+			ctx.Equal(newEnrollmentExpiresAt.Truncate(time.Millisecond), time.Time(*newEnrollment.ExpiresAt).Truncate(time.Millisecond))
+			ctx.Equal(newIdentityLoc.ID, newEnrollment.IdentityID)
+		})
+
+		t.Run("can not enroll", func(t *testing.T) {
+			ctx.testContextChanged(t)
+
+			waitDuration := time.Until(newEnrollmentExpiresAt)
+
+			if waitDuration > 0 {
+				time.Sleep(waitDuration)
+			}
+
+			clientApiClient := ctx.NewEdgeClientApi(nil)
+
+			newIdentityCertAuth, err := clientApiClient.CompleteOttEnrollment(*newEnrollment.Token)
+			ctx.Req.Error(err)
+			ctx.Req.Nil(newIdentityCertAuth)
+		})
+	})
+
+	t.Run("can not create two OTT enrollments", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		managementApiClient := ctx.NewEdgeManagementApi(nil)
+		ctx.Req.NotNil(managementApiClient)
+
+		adminCreds := edge_apis.NewUpdbCredentials(ctx.AdminAuthenticator.Username, ctx.AdminAuthenticator.Password)
+		adminManApiSession, err := managementApiClient.Authenticate(adminCreds, nil)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(adminManApiSession)
+
+		newIdentityLoc, err := managementApiClient.CreateIdentity(eid.New(), false)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(newIdentityLoc)
+		ctx.Req.NotEmpty(newIdentityLoc.ID)
+
+		newIdentity, err := managementApiClient.GetIdentity(newIdentityLoc.ID)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(newIdentity)
+
+		newEnrollmentExpiresAt := time.Now().Add(5 * time.Second).UTC()
+		newEnrollmentLoc, err := managementApiClient.NewEnrollmentOtt(newIdentity.ID, &newEnrollmentExpiresAt)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(newEnrollmentLoc)
+
+		newEnrollment, err := managementApiClient.GetEnrollment(newEnrollmentLoc.ID)
+		ctx.NoError(err)
+		ctx.NotNil(newEnrollment)
+
+		t.Run("creating second OTT enrollment fails", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			secondEnrollmentExpiresAt := time.Now().Add(5 * time.Second).UTC()
+			secondEnrollmentLoc, err := managementApiClient.NewEnrollmentOtt(newIdentity.ID, &secondEnrollmentExpiresAt)
+			ctx.Req.Error(err)
+			ctx.Req.Nil(secondEnrollmentLoc)
+		})
+	})
+
+	t.Run("can not create an OTT enrollment with invalid identity id", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		managementApiClient := ctx.NewEdgeManagementApi(nil)
+		ctx.Req.NotNil(managementApiClient)
+
+		adminCreds := edge_apis.NewUpdbCredentials(ctx.AdminAuthenticator.Username, ctx.AdminAuthenticator.Password)
+		adminManApiSession, err := managementApiClient.Authenticate(adminCreds, nil)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(adminManApiSession)
+
+		newEnrollmentExpiresAt := time.Now().Add(5 * time.Second).UTC()
+		newEnrollmentLoc, err := managementApiClient.NewEnrollmentOtt(ToPtr("i-do-not-exist"), &newEnrollmentExpiresAt)
+		ctx.Req.Error(err)
+		ctx.Req.Nil(newEnrollmentLoc)
+	})
+
+	t.Run("can not create an OTT enrollment with nil identity id", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		managementApiClient := ctx.NewEdgeManagementApi(nil)
+		ctx.Req.NotNil(managementApiClient)
+
+		adminCreds := edge_apis.NewUpdbCredentials(ctx.AdminAuthenticator.Username, ctx.AdminAuthenticator.Password)
+		adminManApiSession, err := managementApiClient.Authenticate(adminCreds, nil)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(adminManApiSession)
+
+		newEnrollmentExpiresAt := time.Now().Add(5 * time.Second).UTC()
+		newEnrollmentLoc, err := managementApiClient.NewEnrollmentOtt(nil, &newEnrollmentExpiresAt)
+		ctx.Req.Error(err)
+		ctx.Req.Nil(newEnrollmentLoc)
+	})
+
+	t.Run("can not create an OTT enrollment with an expiresAt in the past", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		managementApiClient := ctx.NewEdgeManagementApi(nil)
+		ctx.Req.NotNil(managementApiClient)
+
+		adminCreds := edge_apis.NewUpdbCredentials(ctx.AdminAuthenticator.Username, ctx.AdminAuthenticator.Password)
+		adminManApiSession, err := managementApiClient.Authenticate(adminCreds, nil)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(adminManApiSession)
+
+		newIdentityLoc, err := managementApiClient.CreateIdentity(eid.New(), false)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(newIdentityLoc)
+		ctx.Req.NotEmpty(newIdentityLoc.ID)
+
+		newIdentity, err := managementApiClient.GetIdentity(newIdentityLoc.ID)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(newIdentity)
+
+		newEnrollmentExpiresAt := time.Now().Add(-5 * time.Hour).UTC()
+		newEnrollmentLoc, err := managementApiClient.NewEnrollmentOtt(newIdentity.ID, &newEnrollmentExpiresAt)
+		ctx.Req.Error(err)
+		ctx.Req.Nil(newEnrollmentLoc)
+	})
+
+	t.Run("can not create an OTT enrollment with a nil expiresAt", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		managementApiClient := ctx.NewEdgeManagementApi(nil)
+		ctx.Req.NotNil(managementApiClient)
+
+		adminCreds := edge_apis.NewUpdbCredentials(ctx.AdminAuthenticator.Username, ctx.AdminAuthenticator.Password)
+		adminManApiSession, err := managementApiClient.Authenticate(adminCreds, nil)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(adminManApiSession)
+
+		newIdentityLoc, err := managementApiClient.CreateIdentity(eid.New(), false)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(newIdentityLoc)
+		ctx.Req.NotEmpty(newIdentityLoc.ID)
+
+		newIdentity, err := managementApiClient.GetIdentity(newIdentityLoc.ID)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(newIdentity)
+
+		newEnrollmentLoc, err := managementApiClient.NewEnrollmentOtt(newIdentity.ID, nil)
+		ctx.Req.Error(err)
+		ctx.Req.Nil(newEnrollmentLoc)
+	})
+
+	t.Run("can create an OTTCA enrollment", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		managementApiClient := ctx.NewEdgeManagementApi(nil)
+		ctx.Req.NotNil(managementApiClient)
+
+		adminCreds := edge_apis.NewUpdbCredentials(ctx.AdminAuthenticator.Username, ctx.AdminAuthenticator.Password)
+		adminManApiSession, err := managementApiClient.Authenticate(adminCreds, nil)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(adminManApiSession)
+
+		newIdentityLoc, err := managementApiClient.CreateIdentity(eid.New(), false)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(newIdentityLoc)
+		ctx.Req.NotEmpty(newIdentityLoc.ID)
+
+		newIdentity, err := managementApiClient.GetIdentity(newIdentityLoc.ID)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(newIdentity)
+
+		testCa := newTestCa()
+
+		newCaLoc, err := managementApiClient.CreateCa(testCa)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(newCaLoc)
+		ctx.Req.NotEmpty(newCaLoc.ID)
+
+		newCa, err := managementApiClient.GetCa(newCaLoc.ID)
+		ctx.NoError(err)
+		ctx.NotNil(newCa)
+		ctx.NotEmpty(newCa.VerificationToken)
+
+		err = managementApiClient.VerifyCa(*newCa.ID, newCa.VerificationToken.String(), testCa.publicCert, testCa.privateKey)
+		ctx.Req.NoError(err)
+
+		newEnrollmentExpiresAt := time.Now().Add(10 * time.Minute).UTC()
+		newEnrollmentLoc, err := managementApiClient.NewEnrollmentOttCa(newIdentity.ID, newCa.ID, &newEnrollmentExpiresAt)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(newEnrollmentLoc)
+
+		newEnrollment, err := managementApiClient.GetEnrollment(newEnrollmentLoc.ID)
+		ctx.NoError(err)
+		ctx.NotNil(newEnrollment)
+
+		t.Run("enrollment has the proper values", func(t *testing.T) {
+			ctx.testContextChanged(t)
+
+			ctx.NotNil(newEnrollment.ID)
+			ctx.NotNil(newEnrollment.Method)
+			ctx.NotNil(newEnrollment.ExpiresAt)
+			ctx.NotNil(newEnrollment.Identity)
+			ctx.NotNil(newEnrollment.Token)
+			ctx.NotNil(newEnrollment.CaID)
+			ctx.NotEmpty(*newEnrollment.Token)
+			ctx.NotEmpty(newEnrollment.IdentityID)
+			ctx.NotEmpty(newEnrollment.JWT)
+
+			ctx.Equal(rest_model.EnrollmentCreateMethodOttca, *newEnrollment.Method)
+
+			//API time date format conversions reduce fidelity, truncate to MS comparison
+			ctx.Equal(newEnrollmentExpiresAt.Truncate(time.Millisecond), time.Time(*newEnrollment.ExpiresAt).Truncate(time.Millisecond))
+			ctx.Equal(newIdentityLoc.ID, newEnrollment.IdentityID)
+			ctx.Equal(newCaLoc.ID, *newEnrollment.CaID)
+		})
+
+		t.Run("can enroll", func(t *testing.T) {
+			ctx.testContextChanged(t)
+
+			clientApiClient := ctx.NewEdgeClientApi(nil)
+
+			certAuth := testCa.CreateSignedCert(eid.New())
+
+			_, err := clientApiClient.CompleteOttCaEnrollment(*newEnrollment.Token, []*x509.Certificate{certAuth.cert}, certAuth.key)
+			ctx.Req.NoError(err)
+
+		})
+	})
+
+	t.Run("can not enroll with an expired OTTCA enrollment", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		managementApiClient := ctx.NewEdgeManagementApi(nil)
+		ctx.Req.NotNil(managementApiClient)
+
+		adminCreds := edge_apis.NewUpdbCredentials(ctx.AdminAuthenticator.Username, ctx.AdminAuthenticator.Password)
+		adminManApiSession, err := managementApiClient.Authenticate(adminCreds, nil)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(adminManApiSession)
+
+		newIdentityLoc, err := managementApiClient.CreateIdentity(eid.New(), false)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(newIdentityLoc)
+		ctx.Req.NotEmpty(newIdentityLoc.ID)
+
+		newIdentity, err := managementApiClient.GetIdentity(newIdentityLoc.ID)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(newIdentity)
+
+		testCa := newTestCa()
+
+		newCaLoc, err := managementApiClient.CreateCa(testCa)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(newCaLoc)
+		ctx.Req.NotEmpty(newCaLoc.ID)
+
+		newCa, err := managementApiClient.GetCa(newCaLoc.ID)
+		ctx.NoError(err)
+		ctx.NotNil(newCa)
+		ctx.NotEmpty(newCa.VerificationToken)
+
+		err = managementApiClient.VerifyCa(*newCa.ID, newCa.VerificationToken.String(), testCa.publicCert, testCa.privateKey)
+		ctx.Req.NoError(err)
+
+		newEnrollmentExpiresAt := time.Now().Add(5 * time.Second).UTC()
+		newEnrollmentLoc, err := managementApiClient.NewEnrollmentOttCa(newIdentity.ID, newCa.ID, &newEnrollmentExpiresAt)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(newEnrollmentLoc)
+
+		newEnrollment, err := managementApiClient.GetEnrollment(newEnrollmentLoc.ID)
+		ctx.NoError(err)
+		ctx.NotNil(newEnrollment)
+
+		t.Run("can not enroll", func(t *testing.T) {
+			ctx.testContextChanged(t)
+
+			duration := time.Until(newEnrollmentExpiresAt)
+
+			if duration > 0 {
+				time.Sleep(duration)
+			}
+
+			ctx.testContextChanged(t)
+
+			clientApiClient := ctx.NewEdgeClientApi(nil)
+
+			certAuth := testCa.CreateSignedCert(eid.New())
+
+			_, err := clientApiClient.CompleteOttCaEnrollment(*newEnrollment.Token, []*x509.Certificate{certAuth.cert}, certAuth.key)
+			ctx.Req.Error(err)
+		})
+	})
+
+	t.Run("can not create two OTTCA enrollments", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		managementApiClient := ctx.NewEdgeManagementApi(nil)
+		ctx.Req.NotNil(managementApiClient)
+
+		adminCreds := edge_apis.NewUpdbCredentials(ctx.AdminAuthenticator.Username, ctx.AdminAuthenticator.Password)
+		adminManApiSession, err := managementApiClient.Authenticate(adminCreds, nil)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(adminManApiSession)
+
+		newIdentityLoc, err := managementApiClient.CreateIdentity(eid.New(), false)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(newIdentityLoc)
+		ctx.Req.NotEmpty(newIdentityLoc.ID)
+
+		newIdentity, err := managementApiClient.GetIdentity(newIdentityLoc.ID)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(newIdentity)
+
+		testCa := newTestCa()
+
+		newCaLoc, err := managementApiClient.CreateCa(testCa)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(newCaLoc)
+		ctx.Req.NotEmpty(newCaLoc.ID)
+
+		newCa, err := managementApiClient.GetCa(newCaLoc.ID)
+		ctx.NoError(err)
+		ctx.NotNil(newCa)
+		ctx.NotEmpty(newCa.VerificationToken)
+
+		err = managementApiClient.VerifyCa(*newCa.ID, newCa.VerificationToken.String(), testCa.publicCert, testCa.privateKey)
+		ctx.Req.NoError(err)
+
+		newEnrollmentExpiresAt := time.Now().Add(5 * time.Hour).UTC()
+		newEnrollmentLoc, err := managementApiClient.NewEnrollmentOttCa(newIdentity.ID, newCa.ID, &newEnrollmentExpiresAt)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(newEnrollmentLoc)
+
+		t.Run("creating second OTTCA enrollment fails", func(t *testing.T) {
+			ctx.testContextChanged(t)
+
+			secondEnrollmentExpiresAt := time.Now().Add(5 * time.Hour).UTC()
+			secondEnrollmentLoc, err := managementApiClient.NewEnrollmentOttCa(newIdentity.ID, newCa.ID, &secondEnrollmentExpiresAt)
+			ctx.Req.Error(err)
+			ctx.Req.Nil(secondEnrollmentLoc)
+		})
+	})
+
+	t.Run("can not create an OTTCA enrollment with an invalid caId", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		managementApiClient := ctx.NewEdgeManagementApi(nil)
+		ctx.Req.NotNil(managementApiClient)
+
+		adminCreds := edge_apis.NewUpdbCredentials(ctx.AdminAuthenticator.Username, ctx.AdminAuthenticator.Password)
+		adminManApiSession, err := managementApiClient.Authenticate(adminCreds, nil)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(adminManApiSession)
+
+		newIdentityLoc, err := managementApiClient.CreateIdentity(eid.New(), false)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(newIdentityLoc)
+		ctx.Req.NotEmpty(newIdentityLoc.ID)
+
+		newIdentity, err := managementApiClient.GetIdentity(newIdentityLoc.ID)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(newIdentity)
+
+		newEnrollmentExpiresAt := time.Now().Add(5 * time.Hour).UTC()
+		newEnrollmentLoc, err := managementApiClient.NewEnrollmentOttCa(newIdentity.ID, ToPtr("i-do-not-exist"), &newEnrollmentExpiresAt)
+		ctx.Req.Error(err)
+		ctx.Req.Nil(newEnrollmentLoc)
+	})
+
+	t.Run("can not create an OTTCA enrollment with a nil caId", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		managementApiClient := ctx.NewEdgeManagementApi(nil)
+		ctx.Req.NotNil(managementApiClient)
+
+		adminCreds := edge_apis.NewUpdbCredentials(ctx.AdminAuthenticator.Username, ctx.AdminAuthenticator.Password)
+		adminManApiSession, err := managementApiClient.Authenticate(adminCreds, nil)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(adminManApiSession)
+
+		newIdentityLoc, err := managementApiClient.CreateIdentity(eid.New(), false)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(newIdentityLoc)
+		ctx.Req.NotEmpty(newIdentityLoc.ID)
+
+		newIdentity, err := managementApiClient.GetIdentity(newIdentityLoc.ID)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(newIdentity)
+
+		newEnrollmentExpiresAt := time.Now().Add(5 * time.Hour).UTC()
+		newEnrollmentLoc, err := managementApiClient.NewEnrollmentOttCa(newIdentity.ID, nil, &newEnrollmentExpiresAt)
+		ctx.Req.Error(err)
+		ctx.Req.Nil(newEnrollmentLoc)
+	})
+}

--- a/tests/enrollment_ott_test.go
+++ b/tests/enrollment_ott_test.go
@@ -19,22 +19,16 @@
 package tests
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
-	cryptoTls "crypto/tls"
-	"crypto/x509"
 	"encoding/pem"
-	"fmt"
 	"github.com/openziti/edge-api/rest_model"
-	"github.com/openziti/identity/certtools"
 	"github.com/openziti/ziti/common/eid"
-	"gopkg.in/resty.v1"
 	"net/http"
 	"testing"
 	"time"
 )
 
+// Test_EnrollmentOtt uses the generic legacy and deprecated /enroll endpoint. These test ensure it remains
+// functioning as is as the OpenAPI 2.0 spec and generated clients cannot model it properly.
 func Test_EnrollmentOtt(t *testing.T) {
 	ctx := NewTestContext(t)
 	defer ctx.Teardown()
@@ -88,89 +82,6 @@ func Test_EnrollmentOtt(t *testing.T) {
 			ctx.testContextChanged(t)
 			authenticator := ctx.completeOttEnrollment(identity.Id)
 			ctx.Req.NotNil(authenticator)
-		})
-	})
-
-	t.Run("can not enroll with an expired enrollment", func(t *testing.T) {
-		ctx.testContextChanged(t)
-
-		identity := ctx.AdminManagementSession.requireNewIdentity(false)
-
-		expiresAt := time.Now().Add(5 * time.Second).UTC()
-		enrollmentCreate := &rest_model.EnrollmentCreate{
-			IdentityID: &identity.Id,
-			Method:     S(rest_model.EnrollmentCreateMethodOtt),
-			ExpiresAt:  ST(expiresAt),
-		}
-
-		enrollmentCreateResp := &rest_model.CreateEnvelope{}
-
-		resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(enrollmentCreate).SetResult(enrollmentCreateResp).Post("/enrollments")
-		ctx.NoError(err)
-		ctx.Equal(http.StatusCreated, resp.StatusCode(), string(resp.Body()))
-		ctx.NotNil(enrollmentCreateResp)
-		ctx.NotNil(enrollmentCreateResp.Data)
-		ctx.NotEmpty(enrollmentCreateResp.Data.ID)
-
-		t.Run("enrollment has the proper values", func(t *testing.T) {
-			ctx.testContextChanged(t)
-			enrollmentGetResp := &rest_model.DetailEnrollmentEnvelope{}
-
-			resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetResult(enrollmentGetResp).Get("/enrollments/" + enrollmentCreateResp.Data.ID)
-			ctx.NoError(err)
-			ctx.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body()))
-			ctx.NotNil(enrollmentGetResp)
-			ctx.NotNil(enrollmentGetResp.Data)
-			ctx.NotNil(enrollmentGetResp.Data.ID)
-			ctx.NotNil(enrollmentGetResp.Data.Method)
-			ctx.NotNil(enrollmentGetResp.Data.ExpiresAt)
-			ctx.NotNil(enrollmentGetResp.Data.Identity)
-			ctx.NotNil(enrollmentGetResp.Data.Token)
-			ctx.NotEmpty(*enrollmentGetResp.Data.Token)
-			ctx.NotEmpty(enrollmentGetResp.Data.IdentityID)
-			ctx.NotEmpty(enrollmentGetResp.Data.JWT)
-
-			ctx.Equal(*enrollmentCreate.Method, *enrollmentGetResp.Data.Method)
-			ctx.Equal(enrollmentCreate.ExpiresAt.String(), enrollmentGetResp.Data.ExpiresAt.String())
-			ctx.Equal(*enrollmentCreate.IdentityID, enrollmentGetResp.Data.IdentityID)
-		})
-
-		t.Run("can not enroll", func(t *testing.T) {
-			ctx.testContextChanged(t)
-			duration := time.Until(expiresAt)
-
-			if duration > 0 {
-				time.Sleep(duration)
-			}
-
-			result := ctx.AdminManagementSession.requireQuery(fmt.Sprintf("identities/%v", identity.Id))
-
-			tokenValue := result.Path("data.enrollment.ott.token")
-
-			ctx.Req.NotNil(tokenValue)
-			token, ok := tokenValue.Data().(string)
-			ctx.Req.True(ok)
-
-			privateKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
-			ctx.Req.NoError(err)
-
-			request, err := certtools.NewCertRequest(map[string]string{
-				"C": "US", "O": "NetFoundry-API-Test", "CN": identity.Id,
-			}, nil)
-			ctx.Req.NoError(err)
-
-			csr, err := x509.CreateCertificateRequest(rand.Reader, request, privateKey)
-			ctx.Req.NoError(err)
-
-			csrPem := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csr})
-
-			enrollResp, err := ctx.newAnonymousClientApiRequest().
-				SetBody(csrPem).
-				SetHeader("content-type", "application/x-pem-file").
-				SetHeader("accept", "application/json").
-				Post("enroll?token=" + token)
-			ctx.Req.NoError(err)
-			ctx.Req.Equal(http.StatusBadRequest, enrollResp.StatusCode())
 		})
 	})
 
@@ -273,17 +184,17 @@ func Test_EnrollmentOtt(t *testing.T) {
 	t.Run("can create an OTTCA enrollment", func(t *testing.T) {
 		ctx.testContextChanged(t)
 
-		testIdentity := ctx.AdminManagementSession.requireNewIdentity(false)
-		testCa := newTestCa()
+		identity := ctx.AdminManagementSession.requireNewIdentity(false)
+		ca := newTestCa()
 
 		caCreate := &rest_model.CaCreate{
-			CertPem:                   &testCa.certPem,
-			IdentityNameFormat:        testCa.identityNameFormat,
-			IdentityRoles:             testCa.identityRoles,
-			IsAuthEnabled:             &testCa.isAuthEnabled,
-			IsAutoCaEnrollmentEnabled: &testCa.isAutoCaEnrollmentEnabled,
-			IsOttCaEnrollmentEnabled:  &testCa.isOttCaEnrollmentEnabled,
-			Name:                      &testCa.name,
+			CertPem:                   &ca.certPem,
+			IdentityNameFormat:        ca.identityNameFormat,
+			IdentityRoles:             ca.identityRoles,
+			IsAuthEnabled:             &ca.isAuthEnabled,
+			IsAutoCaEnrollmentEnabled: &ca.isAutoCaEnrollmentEnabled,
+			IsOttCaEnrollmentEnabled:  &ca.isOttCaEnrollmentEnabled,
+			Name:                      &ca.name,
 		}
 
 		caCreateResp := &rest_model.CreateEnvelope{}
@@ -305,7 +216,7 @@ func Test_EnrollmentOtt(t *testing.T) {
 		ctx.NotNil(caGetResp.Data.ID)
 		ctx.NotEmpty(caGetResp.Data.VerificationToken)
 
-		verifyCert, _, err := generateCaSignedClientCert(testCa.publicCert, testCa.privateKey, caGetResp.Data.VerificationToken.String())
+		verifyCert, _, err := generateCaSignedClientCert(ca.publicCert, ca.privateKey, caGetResp.Data.VerificationToken.String())
 		ctx.Req.NoError(err)
 
 		verificationBlock := &pem.Block{
@@ -319,7 +230,7 @@ func Test_EnrollmentOtt(t *testing.T) {
 		standardJsonResponseTests(resp, http.StatusOK, t)
 
 		enrollmentCreate := &rest_model.EnrollmentCreate{
-			IdentityID: &testIdentity.Id,
+			IdentityID: &identity.Id,
 			CaID:       S(caCreateResp.Data.ID),
 			Method:     S(rest_model.EnrollmentCreateMethodOttca),
 			ExpiresAt:  ST(time.Now().Add(1 * time.Hour).UTC()),
@@ -361,132 +272,10 @@ func Test_EnrollmentOtt(t *testing.T) {
 		t.Run("can enroll", func(t *testing.T) {
 			ctx.testContextChanged(t)
 
-			clientAuthenticator := testCa.CreateSignedCert(eid.New())
+			clientAuthenticator := ca.CreateSignedCert(eid.New())
 
 			ctx.completeOttCaEnrollment(clientAuthenticator)
 		})
-	})
-
-	t.Run("can not enroll with an expired OTTCA enrollment", func(t *testing.T) {
-		ctx.testContextChanged(t)
-
-		testId := ctx.AdminManagementSession.requireNewIdentity(false)
-		testCa := newTestCa()
-
-		caCreate := &rest_model.CaCreate{
-			CertPem:                   &testCa.certPem,
-			IdentityNameFormat:        testCa.identityNameFormat,
-			IdentityRoles:             testCa.identityRoles,
-			IsAuthEnabled:             &testCa.isAuthEnabled,
-			IsAutoCaEnrollmentEnabled: &testCa.isAutoCaEnrollmentEnabled,
-			IsOttCaEnrollmentEnabled:  &testCa.isOttCaEnrollmentEnabled,
-			Name:                      &testCa.name,
-		}
-
-		caCreateResp := &rest_model.CreateEnvelope{}
-
-		resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(caCreate).SetResult(caCreateResp).Post("cas/")
-		ctx.NoError(err)
-		ctx.Equal(http.StatusCreated, resp.StatusCode(), string(resp.Body()))
-		ctx.NotNil(caCreateResp)
-		ctx.NotNil(caCreateResp.Data)
-		ctx.NotEmpty(caCreateResp.Data.ID)
-
-		caGetResp := &rest_model.DetailCaEnvelope{}
-
-		resp, err = ctx.AdminManagementSession.newAuthenticatedRequest().SetResult(caGetResp).Get("/cas/" + caCreateResp.Data.ID)
-		ctx.NoError(err)
-		ctx.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body()))
-		ctx.NotNil(caGetResp)
-		ctx.NotNil(caGetResp.Data)
-		ctx.NotNil(caGetResp.Data.ID)
-		ctx.NotEmpty(caGetResp.Data.VerificationToken)
-
-		verifyCert, _, err := generateCaSignedClientCert(testCa.publicCert, testCa.privateKey, caGetResp.Data.VerificationToken.String())
-		ctx.Req.NoError(err)
-
-		verificationBlock := &pem.Block{
-			Type:  "CERTIFICATE",
-			Bytes: verifyCert.Raw,
-		}
-		verifyPem := pem.EncodeToMemory(verificationBlock)
-
-		resp, err = ctx.AdminManagementSession.newAuthenticatedRequest().SetHeader("content-type", "text/plain").SetBody(verifyPem).Post("cas/" + caCreateResp.Data.ID + "/verify")
-		ctx.Req.NoError(err)
-		standardJsonResponseTests(resp, http.StatusOK, t)
-
-		expiresAt := time.Now().Add(5 * time.Second).UTC()
-		enrollmentCreate := &rest_model.EnrollmentCreate{
-			IdentityID: &testId.Id,
-			CaID:       S(caCreateResp.Data.ID),
-			Method:     S(rest_model.EnrollmentCreateMethodOttca),
-			ExpiresAt:  ST(expiresAt),
-		}
-
-		enrollmentCreateResp := &rest_model.CreateEnvelope{}
-
-		resp, err = ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(enrollmentCreate).SetResult(enrollmentCreateResp).Post("/enrollments")
-		ctx.NoError(err)
-		ctx.Equal(http.StatusCreated, resp.StatusCode(), string(resp.Body()))
-		ctx.NotNil(enrollmentCreateResp)
-		ctx.NotNil(enrollmentCreateResp.Data)
-		ctx.NotEmpty(enrollmentCreateResp.Data.ID)
-
-		t.Run("enrollment has the proper values", func(t *testing.T) {
-			ctx.testContextChanged(t)
-			enrollmentGetResp := &rest_model.DetailEnrollmentEnvelope{}
-
-			resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetResult(enrollmentGetResp).Get("/enrollments/" + enrollmentCreateResp.Data.ID)
-			ctx.NoError(err)
-			ctx.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body()))
-			ctx.NotNil(enrollmentGetResp)
-			ctx.NotNil(enrollmentGetResp.Data)
-			ctx.NotNil(enrollmentGetResp.Data.ID)
-			ctx.NotNil(enrollmentGetResp.Data.Method)
-			ctx.NotNil(enrollmentGetResp.Data.ExpiresAt)
-			ctx.NotNil(enrollmentGetResp.Data.Identity)
-			ctx.NotNil(enrollmentGetResp.Data.Token)
-			ctx.NotEmpty(*enrollmentGetResp.Data.Token)
-			ctx.NotEmpty(enrollmentGetResp.Data.IdentityID)
-			ctx.NotEmpty(enrollmentGetResp.Data.JWT)
-
-			ctx.Equal(*enrollmentCreate.Method, *enrollmentGetResp.Data.Method)
-			ctx.Equal(enrollmentCreate.ExpiresAt.String(), enrollmentGetResp.Data.ExpiresAt.String())
-			ctx.Equal(*enrollmentCreate.IdentityID, enrollmentGetResp.Data.IdentityID)
-			ctx.Equal(*enrollmentCreate.CaID, *enrollmentGetResp.Data.CaID)
-
-			t.Run("can not enroll", func(t *testing.T) {
-				ctx.testContextChanged(t)
-
-				clientAuthenticator := testCa.CreateSignedCert(eid.New())
-
-				ctx.completeOttCaEnrollment(clientAuthenticator)
-
-				trans := ctx.NewTransport()
-				trans.TLSClientConfig.Certificates = []cryptoTls.Certificate{
-					{
-						Certificate: [][]byte{clientAuthenticator.cert.Raw},
-						PrivateKey:  clientAuthenticator.key,
-					},
-				}
-				client := resty.NewWithClient(ctx.NewHttpClient(trans))
-				client.SetHostURL("https://" + ctx.ApiHost + EdgeClientApiPath)
-
-				duration := time.Until(expiresAt)
-
-				if duration > 0 {
-					time.Sleep(duration)
-				}
-
-				enrollResp, err := client.NewRequest().
-					SetBody("{}").
-					SetHeader("content-type", "application/x-pem-file").
-					Post("enroll?method=ottca&token=" + *enrollmentGetResp.Data.Token)
-				ctx.Req.NoError(err)
-				ctx.Req.Equal(http.StatusBadRequest, enrollResp.StatusCode())
-			})
-		})
-
 	})
 
 	t.Run("can not create two OTTCA enrollments", func(t *testing.T) {

--- a/tests/enrollment_router_test.go
+++ b/tests/enrollment_router_test.go
@@ -167,7 +167,7 @@ func Test_RouterEnrollment(t *testing.T) {
 				resp, err := ctx.newAnonymousClientApiRequest().SetBody(bodyContainer.String()).Post("/enroll?method=erott&token=" + enrollmentToken)
 				ctx.Req.NoError(err)
 
-				standardErrorJsonResponseTests(resp, "COULD_NOT_PROCESS_CSR", http.StatusBadRequest, t)
+				standardErrorJsonResponseTests(resp, "MISSING_OR_INVALID_CSR", http.StatusBadRequest, t)
 			})
 
 			t.Run("and with empty server and client CSR fields fails", func(t *testing.T) {
@@ -181,7 +181,7 @@ func Test_RouterEnrollment(t *testing.T) {
 				resp, err := ctx.newAnonymousClientApiRequest().SetBody(bodyContainer.String()).Post("/enroll?method=erott&token=" + enrollmentToken)
 				ctx.Req.NoError(err)
 
-				standardErrorJsonResponseTests(resp, "COULD_NOT_PROCESS_CSR", http.StatusBadRequest, t)
+				standardErrorJsonResponseTests(resp, "MISSING_OR_INVALID_CSR", http.StatusBadRequest, t)
 			})
 
 			t.Run("and with valid client and missing server CSR fields fails", func(t *testing.T) {
@@ -218,7 +218,7 @@ func Test_RouterEnrollment(t *testing.T) {
 				resp, err := ctx.newAnonymousClientApiRequest().SetBody(bodyContainer.String()).Post("/enroll?method=erott&token=" + enrollmentToken)
 				ctx.Req.NoError(err)
 
-				standardErrorJsonResponseTests(resp, "COULD_NOT_PROCESS_CSR", http.StatusBadRequest, t)
+				standardErrorJsonResponseTests(resp, "MISSING_OR_INVALID_CSR", http.StatusBadRequest, t)
 			})
 
 			t.Run("and with valid server and missing client CSR fields fails", func(t *testing.T) {
@@ -255,7 +255,7 @@ func Test_RouterEnrollment(t *testing.T) {
 				resp, err := ctx.newAnonymousClientApiRequest().SetBody(bodyContainer.String()).Post("/enroll?method=erott&token=" + enrollmentToken)
 				ctx.Req.NoError(err)
 
-				standardErrorJsonResponseTests(resp, "COULD_NOT_PROCESS_CSR", http.StatusBadRequest, t)
+				standardErrorJsonResponseTests(resp, "MISSING_OR_INVALID_CSR", http.StatusBadRequest, t)
 			})
 
 			t.Run("and with valid client and server CSR fields succeeds", func(t *testing.T) {

--- a/tests/enrollment_updb_specific_test.go
+++ b/tests/enrollment_updb_specific_test.go
@@ -1,0 +1,95 @@
+//go:build apitests
+
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package tests
+
+import (
+	edge_apis "github.com/openziti/sdk-golang/edge-apis"
+	"github.com/openziti/ziti/common/eid"
+	"testing"
+	"time"
+)
+
+// Test_EnrollmentOttSpecific uses the /enroll/updb specific endpoint.
+func Test_EnrollmentUpdbSpecific(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+	ctx.RequireAdminManagementApiLogin()
+
+	t.Run("a updb enrolling identity can be created", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		managementApiClient := ctx.NewEdgeManagementApi(nil)
+		ctx.Req.NotNil(managementApiClient)
+
+		adminCreds := edge_apis.NewUpdbCredentials(ctx.AdminAuthenticator.Username, ctx.AdminAuthenticator.Password)
+		adminManApiSession, err := managementApiClient.Authenticate(adminCreds, nil)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(adminManApiSession)
+
+		newIdentityLoc, err := managementApiClient.CreateIdentity(eid.New(), false)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(newIdentityLoc)
+		ctx.Req.NotEmpty(newIdentityLoc.ID)
+
+		newEnrollmentExpiresAt := time.Now().Add(10 * time.Minute).UTC()
+		username := eid.New()
+		newEnrollmentLoc, err := managementApiClient.NewEnrollmentUpdb(&newIdentityLoc.ID, &username, &newEnrollmentExpiresAt)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(newEnrollmentLoc)
+
+		newEnrollment, err := managementApiClient.GetEnrollment(newEnrollmentLoc.ID)
+		ctx.NoError(err)
+		ctx.NotNil(newEnrollment)
+
+		newIdentity, err := managementApiClient.GetIdentity(newIdentityLoc.ID)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(newIdentity)
+
+		t.Run("created updb identity has a UPDB JWT", func(t *testing.T) {
+			ctx.testContextChanged(t)
+
+			ctx.Req.NotNil(newIdentity.Enrollment)
+			ctx.Req.NotNil(newIdentity.Enrollment.Updb)
+			ctx.Req.NotEmpty(newIdentity.Enrollment.Updb.JWT)
+			ctx.Req.NotEmpty(newIdentity.Enrollment.Updb.Token)
+
+			t.Run("updb JWT can enroll", func(t *testing.T) {
+				ctx.testContextChanged(t)
+
+				clientApiClient := ctx.NewEdgeClientApi(nil)
+
+				password := eid.New()
+
+				newIdentityUpdbAuth, err := clientApiClient.CompleteUpdbEnrollment(*newEnrollment.Token, username, password)
+				ctx.Req.NoError(err)
+				ctx.Req.NotNil(newIdentityUpdbAuth)
+
+				t.Run("can authenticate after updb enrollment", func(t *testing.T) {
+					ctx.testContextChanged(t)
+
+					apiSesion, err := clientApiClient.Authenticate(newIdentityUpdbAuth, nil)
+					ctx.Req.NoError(err)
+					ctx.Req.NotNil(apiSesion)
+
+				})
+			})
+		})
+	})
+}

--- a/tests/enrollment_updb_test.go
+++ b/tests/enrollment_updb_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 )
 
+// Test_EnrollmentUpdb uses the generic legacy and deprecated /enroll endpoint. These test ensure it remains
+// functioning as is as the OpenAPI 2.0 spec and generated clients cannot model it properly.
 func Test_EnrollmentUpdb(t *testing.T) {
 	ctx := NewTestContext(t)
 	defer ctx.Teardown()

--- a/tests/generated_client_helpers.go
+++ b/tests/generated_client_helpers.go
@@ -238,6 +238,11 @@ func (helper *ClientHelperClient) CompleteOttEnrollment(enrollmentToken string) 
 	}
 
 	privateKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+
+	if err != nil {
+		return nil, err
+	}
+
 	template := &x509.CertificateRequest{}
 
 	csr, err := x509.CreateCertificateRequest(rand.Reader, template, privateKey)
@@ -289,6 +294,11 @@ func (helper *ClientHelperClient) CompleteOttGenericEnrollment(enrollmentToken s
 	}
 
 	privateKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+
+	if err != nil {
+		return nil, err
+	}
+	
 	template := &x509.CertificateRequest{}
 
 	csr, err := x509.CreateCertificateRequest(rand.Reader, template, privateKey)

--- a/tests/generated_client_helpers.go
+++ b/tests/generated_client_helpers.go
@@ -1,0 +1,442 @@
+package tests
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
+	"github.com/golang-jwt/jwt/v5"
+	clientEnroll "github.com/openziti/edge-api/rest_client_api_client/enroll"
+	"github.com/openziti/edge-api/rest_management_api_client/certificate_authority"
+	managementEnrollment "github.com/openziti/edge-api/rest_management_api_client/enrollment"
+	managementIdentity "github.com/openziti/edge-api/rest_management_api_client/identity"
+	"github.com/openziti/edge-api/rest_model"
+	"github.com/openziti/edge-api/rest_util"
+	nfPem "github.com/openziti/foundation/v2/pem"
+	edge_apis "github.com/openziti/sdk-golang/edge-apis"
+	"github.com/openziti/sdk-golang/ziti"
+	"math/big"
+	"strings"
+	"time"
+)
+
+type ManagementHelperClient struct {
+	*edge_apis.ManagementApiClient
+}
+
+func (helper *ManagementHelperClient) CreateIdentity(name string, isAdmin bool, roleAttributes ...string) (*rest_model.CreateLocation, error) {
+	newIdentity := &rest_model.IdentityCreate{
+		Name:           ToPtr(name),
+		Type:           ToPtr(rest_model.IdentityTypeDefault),
+		IsAdmin:        ToPtr(isAdmin),
+		RoleAttributes: ToPtr(rest_model.Attributes(roleAttributes)),
+	}
+
+	newIdentityParams := &managementIdentity.CreateIdentityParams{
+		Identity: newIdentity,
+	}
+
+	resp, err := helper.API.Identity.CreateIdentity(newIdentityParams, nil)
+
+	if err != nil {
+		return nil, rest_util.WrapErr(err)
+	}
+
+	return resp.Payload.Data, nil
+}
+
+func (helper *ManagementHelperClient) GetIdentity(identityId string) (*rest_model.IdentityDetail, error) {
+	getParams := &managementIdentity.DetailIdentityParams{
+		ID: identityId,
+	}
+
+	resp, err := helper.API.Identity.DetailIdentity(getParams, nil)
+
+	if err != nil {
+		return nil, rest_util.WrapErr(err)
+	}
+
+	return resp.Payload.Data, nil
+}
+
+func (helper *ManagementHelperClient) NewEnrollmentOtt(identityId *string, expiresAt *time.Time) (*rest_model.CreateLocation, error) {
+	var expAt *strfmt.DateTime
+
+	if expiresAt != nil {
+		expAt = ToPtr(strfmt.DateTime(*expiresAt))
+	}
+
+	createParams := &managementEnrollment.CreateEnrollmentParams{
+		Enrollment: &rest_model.EnrollmentCreate{
+			IdentityID: identityId,
+			ExpiresAt:  expAt,
+			Method:     ToPtr(rest_model.EnrollmentCreateMethodOtt),
+		},
+	}
+
+	resp, err := helper.API.Enrollment.CreateEnrollment(createParams, nil)
+
+	if err != nil {
+		return nil, rest_util.WrapErr(err)
+	}
+
+	return resp.Payload.Data, nil
+}
+
+func (helper *ManagementHelperClient) GetEnrollment(enrollmentId string) (*rest_model.EnrollmentDetail, error) {
+	getParams := &managementEnrollment.DetailEnrollmentParams{
+		ID: enrollmentId,
+	}
+
+	resp, err := helper.API.Enrollment.DetailEnrollment(getParams, nil)
+
+	if err != nil {
+		return nil, rest_util.WrapErr(err)
+	}
+
+	return resp.Payload.Data, nil
+}
+
+func (helper *ManagementHelperClient) CreateCa(testCa *ca) (*rest_model.CreateLocation, error) {
+	caCreate := &rest_model.CaCreate{
+		CertPem:                   &testCa.certPem,
+		IdentityNameFormat:        testCa.identityNameFormat,
+		IdentityRoles:             testCa.identityRoles,
+		IsAuthEnabled:             &testCa.isAuthEnabled,
+		IsAutoCaEnrollmentEnabled: &testCa.isAutoCaEnrollmentEnabled,
+		IsOttCaEnrollmentEnabled:  &testCa.isOttCaEnrollmentEnabled,
+		Name:                      &testCa.name,
+	}
+
+	createParams := &certificate_authority.CreateCaParams{
+		Ca: caCreate,
+	}
+
+	resp, err := helper.API.CertificateAuthority.CreateCa(createParams, nil)
+
+	if err != nil {
+		return nil, rest_util.WrapErr(err)
+	}
+
+	return resp.Payload.Data, nil
+}
+
+func (helper *ManagementHelperClient) NewEnrollmentOttCa(identityId *string, caId *string, expiresAt *time.Time) (*rest_model.CreateLocation, error) {
+	var expAt *strfmt.DateTime
+
+	if expiresAt != nil {
+		expAt = ToPtr(strfmt.DateTime(*expiresAt))
+	}
+
+	createParams := &managementEnrollment.CreateEnrollmentParams{
+		Enrollment: &rest_model.EnrollmentCreate{
+			IdentityID: identityId,
+			ExpiresAt:  expAt,
+			CaID:       caId,
+			Method:     ToPtr(rest_model.EnrollmentCreateMethodOttca),
+		},
+	}
+
+	resp, err := helper.API.Enrollment.CreateEnrollment(createParams, nil)
+
+	if err != nil {
+		return nil, rest_util.WrapErr(err)
+	}
+
+	return resp.Payload.Data, nil
+}
+
+func (helper *ManagementHelperClient) GetCa(caId string) (*rest_model.CaDetail, error) {
+	getParams := &certificate_authority.DetailCaParams{
+		ID: caId,
+	}
+
+	resp, err := helper.API.CertificateAuthority.DetailCa(getParams, nil)
+
+	if err != nil {
+		return nil, rest_util.WrapErr(err)
+	}
+
+	return resp.Payload.Data, nil
+}
+
+func (helper *ManagementHelperClient) VerifyCa(id string, token string, cert *x509.Certificate, key crypto.Signer) error {
+	verifyCert, _, err := generateCaSignedClientCert(cert, key, token)
+
+	if err != nil {
+		return fmt.Errorf("could not generate verification certificate: %w", err)
+	}
+
+	verificationBlock := &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: verifyCert.Raw,
+	}
+	verifyPem := pem.EncodeToMemory(verificationBlock)
+
+	verifyParams := &certificate_authority.VerifyCaParams{
+		Certificate: string(verifyPem),
+		ID:          id,
+	}
+
+	_, err = helper.API.CertificateAuthority.VerifyCa(verifyParams, nil)
+
+	if err != nil {
+		return fmt.Errorf("could not verify certificate: %w", rest_util.WrapErr(err))
+	}
+
+	return nil
+}
+
+func (helper *ManagementHelperClient) NewEnrollmentUpdb(identityId *string, username *string, expiresAt *time.Time) (*rest_model.CreateLocation, error) {
+	var expAt *strfmt.DateTime
+
+	if expiresAt != nil {
+		expAt = ToPtr(strfmt.DateTime(*expiresAt))
+	}
+
+	createParams := &managementEnrollment.CreateEnrollmentParams{
+		Enrollment: &rest_model.EnrollmentCreate{
+			IdentityID: identityId,
+			ExpiresAt:  expAt,
+			Username:   username,
+			Method:     ToPtr(rest_model.EnrollmentCreateMethodUpdb),
+		},
+	}
+
+	resp, err := helper.API.Enrollment.CreateEnrollment(createParams, nil)
+
+	if err != nil {
+		return nil, rest_util.WrapErr(err)
+	}
+
+	return resp.Payload.Data, nil
+}
+
+type ClientHelperClient struct {
+	*edge_apis.ClientApiClient
+}
+
+func (helper *ClientHelperClient) CompleteOttEnrollment(enrollmentToken string) (*edge_apis.CertCredentials, error) {
+	token := enrollmentToken
+
+	if IsJwt(token) {
+		jwtParser := jwt.NewParser()
+		enrollmentClaims := &ziti.EnrollmentClaims{}
+		_, _, err := jwtParser.ParseUnverified(token, enrollmentClaims)
+
+		if err != nil {
+			return nil, fmt.Errorf("could not parse enrollment JWT: %w", rest_util.WrapErr(err))
+		}
+
+		token = enrollmentClaims.ID
+	}
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	template := &x509.CertificateRequest{}
+
+	csr, err := x509.CreateCertificateRequest(rand.Reader, template, privateKey)
+
+	if err != nil {
+		return nil, rest_util.WrapErr(err)
+	}
+
+	csrPem := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csr})
+
+	params := clientEnroll.NewEnrollOttParams()
+	params.OttEnrollmentRequest = &rest_model.OttEnrollmentRequest{
+		ClientCsr: string(csrPem),
+		Token:     token,
+	}
+
+	resp, err := helper.API.Enroll.EnrollOtt(params)
+
+	if err != nil {
+		return nil, rest_util.WrapErr(err)
+	}
+
+	certs := nfPem.PemStringToCertificates(resp.Payload.Data.Cert)
+
+	if len(certs) == 0 {
+		return nil, fmt.Errorf("no certificates returned from enrollment")
+	}
+
+	return &edge_apis.CertCredentials{
+		BaseCredentials: edge_apis.BaseCredentials{},
+		Certs:           certs,
+		Key:             privateKey,
+	}, nil
+}
+
+func (helper *ClientHelperClient) CompleteOttGenericEnrollment(enrollmentToken string) (*edge_apis.CertCredentials, error) {
+	token := enrollmentToken
+
+	if IsJwt(token) {
+		jwtParser := jwt.NewParser()
+		enrollmentClaims := &ziti.EnrollmentClaims{}
+		_, _, err := jwtParser.ParseUnverified(token, enrollmentClaims)
+
+		if err != nil {
+			return nil, fmt.Errorf("could not parse enrollment JWT: %w", rest_util.WrapErr(err))
+		}
+
+		token = enrollmentClaims.ID
+	}
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	template := &x509.CertificateRequest{}
+
+	csr, err := x509.CreateCertificateRequest(rand.Reader, template, privateKey)
+
+	if err != nil {
+		return nil, rest_util.WrapErr(err)
+	}
+
+	csrPem := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csr})
+
+	params := clientEnroll.NewEnrollParams()
+	params.Method = ToPtr(rest_model.EnrollmentCreateMethodOtt)
+	params.Token = ToPtr(strfmt.UUID(token))
+	params.Body = &rest_model.GenericEnroll{
+		ClientCsr: string(csrPem),
+	}
+
+	resp, err := helper.API.Enroll.Enroll(params, func(operation *runtime.ClientOperation) {
+		operation.ConsumesMediaTypes = []string{"text/plain"}
+	})
+
+	if err != nil {
+		return nil, rest_util.WrapErr(err)
+	}
+
+	certs := nfPem.PemStringToCertificates(resp.Payload.Data.Cert)
+
+	if len(certs) == 0 {
+		return nil, fmt.Errorf("no certificates returned from enrollment")
+	}
+
+	return &edge_apis.CertCredentials{
+		BaseCredentials: edge_apis.BaseCredentials{},
+		Certs:           certs,
+		Key:             privateKey,
+	}, nil
+}
+
+func (helper *ClientHelperClient) CompleteOttCaEnrollment(enrollmentToken string, clientCert []*x509.Certificate, clientKey crypto.PrivateKey) (*edge_apis.CertCredentials, error) {
+	token := enrollmentToken
+
+	if IsJwt(token) {
+		jwtParser := jwt.NewParser()
+		enrollmentClaims := &ziti.EnrollmentClaims{}
+		_, _, err := jwtParser.ParseUnverified(token, enrollmentClaims)
+
+		if err != nil {
+			return nil, fmt.Errorf("could not parse enrollment JWT: %w", rest_util.WrapErr(err))
+		}
+
+		token = enrollmentClaims.ID
+	}
+
+	params := clientEnroll.NewEnrollOttCaParams()
+	params.OttEnrollmentRequest = &rest_model.OttEnrollmentRequest{
+		Token: token,
+	}
+
+	certCreds := &edge_apis.CertCredentials{
+		BaseCredentials: edge_apis.BaseCredentials{},
+		Certs:           clientCert,
+		Key:             clientKey,
+	}
+
+	helper.Credentials = certCreds
+
+	_, err := helper.API.Enroll.EnrollOttCa(params)
+
+	if err != nil {
+		return nil, rest_util.WrapErr(err)
+	}
+
+	return certCreds, nil
+}
+
+func (helper *ClientHelperClient) CompleteUpdbEnrollment(enrollmentToken string, username string, password string) (*edge_apis.UpdbCredentials, error) {
+	token := enrollmentToken
+
+	if IsJwt(token) {
+		jwtParser := jwt.NewParser()
+		enrollmentClaims := &ziti.EnrollmentClaims{}
+		_, _, err := jwtParser.ParseUnverified(token, enrollmentClaims)
+
+		if err != nil {
+			return nil, fmt.Errorf("could not parse enrollment JWT: %w", rest_util.WrapErr(err))
+		}
+
+		token = enrollmentClaims.ID
+	}
+
+	params := clientEnroll.NewEnrollUpdbParams()
+	params.Token = strfmt.UUID(token)
+	params.UpdbCredentials = clientEnroll.EnrollUpdbBody{
+		Password: rest_model.Password(password),
+		Username: rest_model.Username(username),
+	}
+
+	_, err := helper.API.Enroll.EnrollUpdb(params)
+
+	if err != nil {
+		return nil, rest_util.WrapErr(err)
+	}
+
+	return &edge_apis.UpdbCredentials{
+		BaseCredentials: edge_apis.BaseCredentials{},
+		Username:        username,
+		Password:        password,
+	}, nil
+}
+
+func generateCaSignedClientCert(caCert *x509.Certificate, caSigner crypto.Signer, commonName string) (*x509.Certificate, crypto.Signer, error) {
+	id, _ := rand.Int(rand.Reader, big.NewInt(100000000000000000))
+	verificationCert := &x509.Certificate{
+		SerialNumber: id,
+		Subject: pkix.Name{
+			CommonName:   commonName,
+			Organization: []string{"Ziti CLI Generated API Test Cert"},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(time.Minute * 10),
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+	}
+
+	verificationKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not generate private key for certificate (%v)", err)
+	}
+
+	signedCertBytes, err := x509.CreateCertificate(rand.Reader, verificationCert, caCert, verificationKey.Public(), caSigner)
+
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not sign certificate with CA (%v)", err)
+	}
+
+	verificationCert, _ = x509.ParseCertificate(signedCertBytes)
+
+	return verificationCert, verificationKey, nil
+}
+
+func IsJwt(token string) bool {
+	if strings.HasPrefix(token, "eY") {
+		parts := strings.Split(token, ",")
+		return len(parts) == 3 && len(parts[0]) > 0 && len(parts[1]) > 0 && len(parts[2]) > 0
+	}
+
+	return false
+}

--- a/zititest/go.mod
+++ b/zititest/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/michaelquigley/pfxlog v0.6.10
 	github.com/openziti/agent v1.0.26
 	github.com/openziti/channel/v3 v3.0.37
-	github.com/openziti/edge-api v0.26.41
+	github.com/openziti/edge-api v0.26.42
 	github.com/openziti/fablab v0.5.83
 	github.com/openziti/foundation/v2 v2.0.58
 	github.com/openziti/identity v1.0.100

--- a/zititest/go.sum
+++ b/zititest/go.sum
@@ -609,8 +609,8 @@ github.com/openziti/cobra-to-md v1.0.1 h1:WRinNoIRmwWUSJm+pSNXMjOrtU48oxXDZgeCYQ
 github.com/openziti/cobra-to-md v1.0.1/go.mod h1:FjCpk/yzHF7/r28oSTNr5P57yN5VolpdAtS/g7KNi2c=
 github.com/openziti/dilithium v0.3.5 h1:+envGNzxc3OyVPiuvtxivQmCsOjdZjtOMLpQBeMz7eM=
 github.com/openziti/dilithium v0.3.5/go.mod h1:XONq1iK6te/WwNzkgZHfIDHordMPqb0hMwJ8bs9EfSk=
-github.com/openziti/edge-api v0.26.41 h1:JL2gDqinD5GILTKct+z3YG0YcU8jIDAstW572Bq7nNY=
-github.com/openziti/edge-api v0.26.41/go.mod h1:sYHVpm26Jr1u7VooNJzTb2b2nGSlmCHMnbGC8XfWSng=
+github.com/openziti/edge-api v0.26.42 h1:Wi/BUttSUvedT9XGht7vi/zI/TNGc3ApvjkAviWhauA=
+github.com/openziti/edge-api v0.26.42/go.mod h1:sYHVpm26Jr1u7VooNJzTb2b2nGSlmCHMnbGC8XfWSng=
 github.com/openziti/fablab v0.5.83 h1:O0GHGtYV56oziaPg0hPgbXcNfE+fyoKA+mmdb4xZ5/s=
 github.com/openziti/fablab v0.5.83/go.mod h1:r1tz45RA2u8x1iF/tgKN+B6hSR5FBR61kaq/bCne4zc=
 github.com/openziti/foundation/v2 v2.0.58 h1:U3+EfX3EdYfmcaEX2wROfrxX75xVoIZ9gZfiPQd6HCs=


### PR DESCRIPTION
- default behavior complies with OpenAPI spec, but allows for legacy PEM handling through middleware intervention
- adds test for generic enrollment endpoint and for specific enrollment endpoints