### PR TITLE
add prometheus version to scrape target 

### DIFF
--- a/controller/webapis/metrics-api.go
+++ b/controller/webapis/metrics-api.go
@@ -142,6 +142,8 @@ func (metricsApi *MetricsApiHandler) ServeHTTP(writer http.ResponseWriter, reque
 
 func (metricsApi *MetricsApiHandler) newHandler() http.Handler {
 	handler := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		// Set Content-Type, see https://github.com/openziti/ziti/issues/2608
+		rw.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
 
 		if nil != metricsApi.scrapeCert {
 			certOk := false


### PR DESCRIPTION
closes #2608 

https://prometheus.io/docs/instrumenting/exposition_formats/ indicates the version should be present in the content-type. there don't seem to be many versions so simply hardcoding it into the header