### PR TITLE
fixes #2997 adds authenticator ids for OIDC jwts

### DIFF
--- a/common/oidc_tokens.go
+++ b/common/oidc_tokens.go
@@ -37,6 +37,7 @@ const (
 	CustomClaimIsAdmin           = "z_ia"
 	CustomClaimsConfigTypes      = "z_ct"
 	CustomClaimsCertFingerprints = "z_cfs"
+	CustomClaimsAuthenticatorId  = "z_authid"
 
 	// CustomClaimsTokenType and other constants below may not appear as referenced, but are used in `json: ""` tags. Provided here for external use.
 	CustomClaimsTokenType       = "z_t"
@@ -68,6 +69,7 @@ type CustomClaims struct {
 	EnvInfo          *rest_model.EnvInfo `json:"z_env"`
 	RemoteAddress    string              `json:"z_ra"`
 	IsCertExtendable bool                `json:"z_ice"`
+	AuthenticatorId  string              `json:"z_authid,omitempty"`
 }
 
 func (c *CustomClaims) ToMap() (map[string]any, error) {

--- a/controller/env/appenv.go
+++ b/controller/env/appenv.go
@@ -652,7 +652,7 @@ func (ae *AppEnv) ProcessJwt(rc *response.RequestContext, token *jwt.Token) erro
 		ExpiresAt:          rc.Claims.Expiration.AsTime(),
 		ExpirationDuration: time.Until(rc.Claims.Expiration.AsTime()),
 		LastActivityAt:     time.Now(),
-		AuthenticatorId:    "oidc",
+		AuthenticatorId:    rc.Claims.AuthenticatorId,
 		IsCertExtendable:   rc.Claims.IsCertExtendable,
 	}
 

--- a/controller/oidc_auth/requests.go
+++ b/controller/oidc_auth/requests.go
@@ -49,6 +49,7 @@ type AuthRequest struct {
 	EnvInfo             *rest_model.EnvInfo
 	RemoteAddress       string
 	IsCertExtendable    bool
+	AuthenticatorId     string
 }
 
 // GetID returns an AuthRequest's ID and implements op.AuthRequest

--- a/controller/oidc_auth/storage.go
+++ b/controller/oidc_auth/storage.go
@@ -263,6 +263,8 @@ func (s *HybridStorage) Authenticate(authCtx model.AuthContext, id string, confi
 		}
 	}
 
+	authRequest.AuthenticatorId = result.AuthenticatorId()
+
 	return authRequest, nil
 }
 
@@ -471,6 +473,7 @@ func (s *HybridStorage) createAccessToken(ctx context.Context, request op.TokenR
 		claims.CustomClaims.SdkInfo = req.SdkInfo
 		claims.CustomClaims.RemoteAddress = req.RemoteAddress
 		claims.CustomClaims.IsCertExtendable = req.IsCertExtendable
+		claims.CustomClaims.AuthenticatorId = req.AuthenticatorId
 		claims.AuthTime = oidc.Time(req.AuthTime.Unix())
 		claims.AccessTokenClaims.AuthenticationMethodsReferences = req.GetAMR()
 		claims.ClientID = req.ClientID
@@ -797,7 +800,7 @@ func (s *HybridStorage) GetPrivateClaimsFromScopes(ctx context.Context, identity
 	return s.getPrivateClaims(ctx, identityId, clientID, scopes)
 }
 
-func (s *HybridStorage) getPrivateClaims(ctx context.Context, _, clientId string, scopes []string) (claims map[string]interface{}, err error) {
+func (s *HybridStorage) getPrivateClaims(ctx context.Context, _, _ string, _ []string) (claims map[string]interface{}, err error) {
 	tokenState, err := TokenStateFromContext(ctx)
 
 	if err != nil {
@@ -928,7 +931,7 @@ func tokenTypeToName(oidcType oidc.TokenType) string {
 }
 
 // ValidateTokenExchangeRequest implements the op.TokenExchangeStorage interface
-func (s *HybridStorage) ValidateTokenExchangeRequest(ctx context.Context, request op.TokenExchangeRequest) error {
+func (s *HybridStorage) ValidateTokenExchangeRequest(_ context.Context, request op.TokenExchangeRequest) error {
 	if request.GetRequestedTokenType() == "" {
 		request.SetRequestedTokenType(oidc.RefreshTokenType)
 	}
@@ -972,7 +975,7 @@ func (s *HybridStorage) ValidateTokenExchangeRequest(ctx context.Context, reques
 	return nil
 }
 
-func (s *HybridStorage) CreateTokenExchangeRequest(_ context.Context, req op.TokenExchangeRequest) error {
+func (s *HybridStorage) CreateTokenExchangeRequest(_ context.Context, _ op.TokenExchangeRequest) error {
 	return nil
 }
 

--- a/tests/auth_oidc_test.go
+++ b/tests/auth_oidc_test.go
@@ -199,6 +199,24 @@ func Test_Authenticate_OIDC_Auth(t *testing.T) {
 		ctx.Req.NotEmpty(outTokens.IDTokenClaims)
 		ctx.Req.NotEmpty(outTokens.AccessToken)
 		ctx.Req.NotEmpty(outTokens.RefreshToken)
+
+		t.Run("access token has expected values", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			parser := jwt.NewParser()
+
+			accessClaims := &common.AccessClaims{}
+
+			_, _, err := parser.ParseUnverified(outTokens.AccessToken, accessClaims)
+
+			ctx.Req.NoError(err)
+			ctx.Req.NotEmpty(accessClaims.AuthenticatorId)
+			ctx.Req.False(accessClaims.IsCertExtendable)
+			ctx.Req.True(accessClaims.IsAdmin)
+			ctx.Req.NotEmpty(accessClaims.ApiSessionId)
+			ctx.Req.NotEmpty(accessClaims.JWTID)
+			ctx.Req.Equal(common.TokenTypeAccess, accessClaims.Type)
+			ctx.Req.NotEmpty(accessClaims.Subject)
+		})
 	})
 
 	t.Run("updb with auth request id in query string", func(t *testing.T) {
@@ -235,6 +253,24 @@ func Test_Authenticate_OIDC_Auth(t *testing.T) {
 		ctx.Req.NotEmpty(outTokens.IDTokenClaims)
 		ctx.Req.NotEmpty(outTokens.AccessToken)
 		ctx.Req.NotEmpty(outTokens.RefreshToken)
+
+		t.Run("access token has expected values", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			parser := jwt.NewParser()
+
+			accessClaims := &common.AccessClaims{}
+
+			_, _, err := parser.ParseUnverified(outTokens.AccessToken, accessClaims)
+
+			ctx.Req.NoError(err)
+			ctx.Req.NotEmpty(accessClaims.AuthenticatorId)
+			ctx.Req.False(accessClaims.IsCertExtendable)
+			ctx.Req.True(accessClaims.IsAdmin)
+			ctx.Req.NotEmpty(accessClaims.ApiSessionId)
+			ctx.Req.NotEmpty(accessClaims.JWTID)
+			ctx.Req.Equal(common.TokenTypeAccess, accessClaims.Type)
+			ctx.Req.NotEmpty(accessClaims.Subject)
+		})
 	})
 
 	t.Run("updb with id in query string", func(t *testing.T) {
@@ -271,6 +307,24 @@ func Test_Authenticate_OIDC_Auth(t *testing.T) {
 		ctx.Req.NotEmpty(outTokens.IDTokenClaims)
 		ctx.Req.NotEmpty(outTokens.AccessToken)
 		ctx.Req.NotEmpty(outTokens.RefreshToken)
+
+		t.Run("access token has expected values", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			parser := jwt.NewParser()
+
+			accessClaims := &common.AccessClaims{}
+
+			_, _, err := parser.ParseUnverified(outTokens.AccessToken, accessClaims)
+
+			ctx.Req.NoError(err)
+			ctx.Req.NotEmpty(accessClaims.AuthenticatorId)
+			ctx.Req.False(accessClaims.IsCertExtendable)
+			ctx.Req.True(accessClaims.IsAdmin)
+			ctx.Req.NotEmpty(accessClaims.ApiSessionId)
+			ctx.Req.NotEmpty(accessClaims.JWTID)
+			ctx.Req.Equal(common.TokenTypeAccess, accessClaims.Type)
+			ctx.Req.NotEmpty(accessClaims.Subject)
+		})
 	})
 
 	t.Run("cert", func(t *testing.T) {
@@ -312,16 +366,22 @@ func Test_Authenticate_OIDC_Auth(t *testing.T) {
 		ctx.Req.NotEmpty(outTokens.AccessToken)
 		ctx.Req.NotEmpty(outTokens.RefreshToken)
 
-		t.Run("first party cert authentication should have isCertExtendable", func(t *testing.T) {
+		t.Run("access token has expected values", func(t *testing.T) {
 			ctx.testContextChanged(t)
+			parser := jwt.NewParser()
 
 			accessClaims := &common.AccessClaims{}
 
-			parser := jwt.NewParser()
 			_, _, err := parser.ParseUnverified(outTokens.AccessToken, accessClaims)
 
 			ctx.Req.NoError(err)
-			ctx.Req.True(accessClaims.IsCertExtendable, "expected isCertExtendable to be true for first party cert auth")
+			ctx.Req.NotEmpty(accessClaims.AuthenticatorId)
+			ctx.Req.True(accessClaims.IsCertExtendable)
+			ctx.Req.False(accessClaims.IsAdmin)
+			ctx.Req.NotEmpty(accessClaims.ApiSessionId)
+			ctx.Req.NotEmpty(accessClaims.JWTID)
+			ctx.Req.Equal(common.TokenTypeAccess, accessClaims.Type)
+			ctx.Req.NotEmpty(accessClaims.Subject)
 		})
 	})
 


### PR DESCRIPTION
- updates current-api session logic to use new value
- sets z_authid in access/refresh tokens
- updates tests to ensure authenticator id is set on access/refres