### PR TITLE
feat: expose import / export features in the API

### DIFF
--- a/controller/internal/routes/ascode_router.go
+++ b/controller/internal/routes/ascode_router.go
@@ -1,0 +1,181 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package routes
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v2"
+
+	httptransport "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/strfmt"
+	mgmtclient "github.com/openziti/edge-api/rest_management_api_client"
+	ascodeops "github.com/openziti/edge-api/rest_management_api_server/operations/ascode"
+	"github.com/openziti/ziti/controller/env"
+	"github.com/openziti/ziti/controller/internal/permissions"
+	"github.com/openziti/ziti/controller/response"
+	"github.com/openziti/ziti/ziti/cmd/ascode/exporter"
+	"github.com/openziti/ziti/ziti/cmd/ascode/importer"
+)
+
+func init() {
+	r := &AscodeRouter{}
+	env.AddRouter(r)
+}
+
+type AscodeRouter struct{}
+
+func (r *AscodeRouter) Register(ae *env.AppEnv) {
+	ae.ManagementApi.AscodeExportAscodeHandler = ascodeops.ExportAscodeHandlerFunc(func(params ascodeops.ExportAscodeParams) middleware.Responder {
+		return ae.IsAllowed(func(ae *env.AppEnv, rc *response.RequestContext) {
+			r.Export(ae, rc, params)
+		}, params.HTTPRequest, "", "", permissions.IsAdmin())
+	})
+
+	ae.ManagementApi.AscodeImportAscodeHandler = ascodeops.ImportAscodeHandlerFunc(func(params ascodeops.ImportAscodeParams) middleware.Responder {
+		return ae.IsAllowed(func(ae *env.AppEnv, rc *response.RequestContext) {
+			r.Import(ae, rc, params)
+		}, params.HTTPRequest, "", "", permissions.IsAdmin())
+	})
+}
+
+func (r *AscodeRouter) Export(ae *env.AppEnv, rc *response.RequestContext, params ascodeops.ExportAscodeParams) {
+	var types []string
+	if params.ExportRequest.Types != "" {
+		types = strings.Split(params.ExportRequest.Types, ",")
+	}
+
+	format := "yaml"
+	if params.ExportRequest.Format != "" {
+		format = strings.ToLower(params.ExportRequest.Format)
+	}
+
+	address := ae.GetConfig().Edge.Api.Address
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	transport := httptransport.New(address, "/edge/management/v1", []string{"https", "http"})
+	transport.Transport = tr
+	token := rc.SessionToken
+	if rc.IsJwtToken {
+		transport.DefaultAuthentication = httptransport.BearerToken(token)
+	} else {
+		transport.DefaultAuthentication = httptransport.APIKeyAuth(env.ZitiSession, "header", token)
+	}
+	client := mgmtclient.New(transport, strfmt.Default)
+
+	var buf bytes.Buffer
+	exp := &exporter.Exporter{
+		Out:    *bufio.NewWriter(&buf),
+		Err:    io.Discard,
+		Client: client,
+	}
+	result, err := exp.Execute(types)
+	if err != nil {
+		rc.RespondWithError(err)
+		return
+	}
+
+	var output []byte
+	switch format {
+	case "json":
+		output, err = json.MarshalIndent(result, "", "  ")
+	case "yaml":
+		output, err = yaml.Marshal(result)
+	default:
+		rc.RespondWithError(fmt.Errorf("unsupported format %q", format))
+		return
+	}
+	if err != nil {
+		rc.RespondWithError(err)
+		return
+	}
+
+	filename := fmt.Sprintf("ziti-export-%s.%s", time.Now().UTC().Format("20060102-150405"), format)
+	rc.ResponseWriter.Header().Set("Content-Type", "application/"+format)
+	rc.ResponseWriter.Header().Set("Content-Disposition", `attachment; filename="`+filename+`"`)
+	rc.ResponseWriter.WriteHeader(http.StatusOK)
+	_, _ = rc.ResponseWriter.Write(output)
+}
+
+func (r *AscodeRouter) Import(ae *env.AppEnv, rc *response.RequestContext, params ascodeops.ImportAscodeParams) {
+	body, err := io.ReadAll(params.HTTPRequest.Body)
+	if err != nil {
+		rc.RespondWithError(err)
+		return
+	}
+
+	dryRun := params.DryRun != nil && *params.DryRun
+
+	format := "yaml"
+	if strings.Contains(params.HTTPRequest.Header.Get("Content-Type"), "json") {
+		format = "json"
+	}
+
+	data := map[string][]interface{}{}
+	switch format {
+	case "json":
+		if err := json.Unmarshal(body, &data); err != nil {
+			rc.RespondWithError(err)
+			return
+		}
+	default: // yaml
+		if err := yaml.Unmarshal(body, &data); err != nil {
+			rc.RespondWithError(err)
+			return
+		}
+	}
+
+	address := ae.GetConfig().Edge.Api.Address
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	transport := httptransport.New(address, "/edge/management/v1", []string{"https", "http"})
+	transport.Transport = tr
+	token := rc.SessionToken
+	if rc.IsJwtToken {
+		transport.DefaultAuthentication = httptransport.BearerToken(token)
+	} else {
+		transport.DefaultAuthentication = httptransport.APIKeyAuth(env.ZitiSession, "header", token)
+	}
+	client := mgmtclient.New(transport, strfmt.Default)
+
+	imp := &importer.Importer{
+		Out:    io.Discard,
+		Err:    io.Discard,
+		Client: client,
+		Data:   data,
+	}
+
+	if !dryRun {
+		if err := imp.Execute([]string{"all"}); err != nil {
+			rc.RespondWithError(err)
+			return
+		}
+	}
+
+	rc.ResponseWriter.WriteHeader(http.StatusNoContent)
+}

--- a/controller/specs/swagger.yml
+++ b/controller/specs/swagger.yml
@@ -873,6 +873,52 @@ paths:
         '503':
           $ref: '#/responses/serverUnavailableResponse'
 
+  '/ascode/export':
+    post:
+      tags: [ascode]
+      summary: Export the entire network (or a subset) as a YAML/JSON bundle
+      operationId: exportAscode
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                types:
+                  type: string
+                  description: List of resource types to export or "all"
+                format:
+                  type: string
+                  enum: [yaml, json]
+                  default: yaml
+      responses:
+        '200':
+          description: the exported bundle
+          content:
+            application/yaml: {}
+            application/json: {}
+
+  '/ascode/import':
+    post:
+      tags: [ascode]
+      summary: Import a YAML/JSON bundle produced by the exporter
+      operationId: importAscode
+      parameters:
+        - name: dryRun
+          in: query
+          schema: { type: boolean, default: false }
+          description: Validate only—do not mutate the network
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { type: object }
+      responses:
+        '204': { description: imported OK }
+        '422': { description: validation errors }
+
+
 #######################################################################################################################
 #
 # Parameters - Reusable parameters


### PR DESCRIPTION
This PR exposes the import / export CLI features in the edge management API for use by ZAC.

This PR depends on https://github.com/openziti/edge-api/pull/150.

Closes #3013.