### PR TITLE
fixes #3059 keep JWT enrollment secrets sync'ed during refresh

### DIFF
--- a/controller/model/enrollment_manager.go
+++ b/controller/model/enrollment_manager.go
@@ -294,11 +294,12 @@ func (self *EnrollmentManager) RefreshJwt(id string, expiresAt time.Time, ctx *c
 		return errorz.NewFieldError("must be after the current date and time", "expiresAt", expiresAt)
 	}
 
+	enrollment.Token = uuid.New().String()
+
 	if err = enrollment.FillJwtInfoWithExpiresAt(self.env, *enrollment.IdentityId, expiresAt); err != nil {
 		return err
 	}
 
-	enrollment.Token = uuid.New().String()
 	return self.Update(enrollment, fields.UpdatedFieldsMap{
 		db.FieldEnrollmentToken:     struct{}{},
 		db.FieldEnrollmentJwt:       struct{}{},

--- a/tests/generated_client_helpers.go
+++ b/tests/generated_client_helpers.go
@@ -260,10 +260,33 @@ func (helper *ManagementHelperClient) GetIdentityAuthenticators(identityId strin
 	resp, err := helper.API.Identity.GetIdentityAuthenticators(getIdAuthenticatorsParams, nil)
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve identity authenticators: %w", err)
+		return nil, fmt.Errorf("failed to retrieve identity authenticators: %w", rest_util.WrapErr(err))
 	}
 
 	return resp.Payload.Data, nil
+}
+
+func (helper *ManagementHelperClient) RefreshEnrollmentJwt(id string) (*rest_model.EnrollmentDetail, error) {
+	refreshParams := &managementEnrollment.RefreshEnrollmentParams{
+		ID: id,
+		Refresh: &rest_model.EnrollmentRefresh{
+			ExpiresAt: ToPtr(strfmt.DateTime(time.Now().Add(time.Hour * 24))),
+		},
+	}
+	_, err := helper.API.Enrollment.RefreshEnrollment(refreshParams, nil)
+
+	if err != nil {
+		return nil, rest_util.WrapErr(err)
+	}
+
+	detail, err := helper.GetEnrollment(id)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return detail, nil
+
 }
 
 type ClientHelperClient struct {


### PR DESCRIPTION
- adds tests for desync'ed secrets