### PR TITLE
when cross-building locally, use go.work if defined in ziti project

### DIFF
--- a/dist/docker-images/cross-build/Dockerfile
+++ b/dist/docker-images/cross-build/Dockerfile
@@ -31,5 +31,5 @@ ENV GOCACHE=${go_cache}
 ENV PATH=${go_path}/bin:${go_root}/bin:$PATH
 ENV CGO_ENABLED=1
 RUN go install github.com/mitchellh/gox@latest
-WORKDIR /mnt
+WORKDIR /mnt/ziti
 ENTRYPOINT ["linux-build.sh"]


### PR DESCRIPTION
the cross-build image and script supports local development and testing by emulating the CI and cloud environments.