### PR TITLE
Allow identity app data to be JSON structure. Allow setting from CLI.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## What's New
 
 * Multi-underlay links
+* Nested Identity App Data
 
 ## Multi-underlay Link
 
@@ -131,6 +132,28 @@ Link event example:
 2. New routers dialing older routers will still report link connections. See the second link in the list above.
 3. Old routers will not report connections.
 
+## Nested Identity App Data
+
+Identity app data may now be a full JSON document, rather than just a single layer map. There 
+are also some additional CLI methods to work with the data:
+
+```
+$ ziti edge create identity test --app-data foo=bar
+$ ziti edge create identity test --app-data-json '{ "foo" : "bar", "test" : { "nested" : true, "number" : 234 } }'
+$ ziti edge create identity test --app-data-json-file test-app-data.json 
+
+$ ziti edge update identity test --app-data foo=bar
+$ ziti edge update identity test --app-data-json '{ "foo" : "bar", "test" : { "nested" : true, "number" : 234 } }'
+$ ziti edge update identity test --app-data-json-file test-app-data.json 
+```
+
+## Component Updates and Bug Fixes
+
+* github.com/openziti/storage: [v0.4.20 -> v0.4.21](https://github.com/openziti/storage/compare/v0.4.20...v0.4.21)
+* github.com/openziti/ziti: [v1.6.5 -> v1.6.6](https://github.com/openziti/ziti/compare/v1.6.5...v1.6.6)
+    * [Issue #3161](https://github.com/openziti/ziti/issues/3161) - Allow setting structured data in identity appData from CLI
+    * [Issue #3169](https://github.com/openziti/ziti/issues/3169) - Allow identity app data to be a full JSON document, rather than just a flat map
+    * [Issue #3134](https://github.com/openziti/ziti/issues/3134) - Support multi-underlay links
 
 # Release 1.6.5
 

--- a/controller/db/identity_store.go
+++ b/controller/db/identity_store.go
@@ -319,7 +319,7 @@ func (store *identityStoreImpl) PersistEntity(entity *Identity, ctx *boltz.Persi
 	ctx.SetStringList(FieldRoleAttributes, entity.RoleAttributes)
 	ctx.SetInt32(FieldIdentityDefaultHostingPrecedence, int32(entity.DefaultHostingPrecedence))
 	ctx.SetInt32(FieldIdentityDefaultHostingCost, int32(entity.DefaultHostingCost))
-	ctx.Bucket.PutMap(FieldIdentityAppData, entity.AppData, ctx.FieldChecker, false)
+	ctx.Bucket.PutMap(FieldIdentityAppData, entity.AppData, ctx.FieldChecker, true)
 
 	ctx.SetTimeP(FieldIdentityDisabledAt, entity.DisabledAt)
 	ctx.SetTimeP(FieldIdentityDisabledUntil, entity.DisabledUntil)

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/openziti/runzmd v1.0.76
 	github.com/openziti/sdk-golang v1.1.2
 	github.com/openziti/secretstream v0.1.36
-	github.com/openziti/storage v0.4.20
+	github.com/openziti/storage v0.4.21
 	github.com/openziti/transport/v2 v2.0.180
 	github.com/openziti/x509-claims v1.0.3
 	github.com/openziti/xweb/v2 v2.3.4

--- a/go.sum
+++ b/go.sum
@@ -591,8 +591,8 @@ github.com/openziti/sdk-golang v1.1.2 h1:Q7YqFcAjfkH9ZZp+yYPIAvEWt/DOhhOxBx1drXy
 github.com/openziti/sdk-golang v1.1.2/go.mod h1:sXLPdy/Q0Zor5ef08H+W60EEy6ofEDpeZFlP4SWwc4w=
 github.com/openziti/secretstream v0.1.36 h1:4mr377v+ucLMaa5DG8cQE5hrunfueWIdR8We55D2GL0=
 github.com/openziti/secretstream v0.1.36/go.mod h1:aAcEcGkbUeD7rBvQlkrHourEb1Y+YQT6edA7e7+Imfw=
-github.com/openziti/storage v0.4.20 h1:+j+SvofcOfhhG6dfv2uLhyxmnQUoBcCyf2rM486vMs8=
-github.com/openziti/storage v0.4.20/go.mod h1:Ir67mINB6bVCSz90VLAMvxcpV/zvMl7F3EVOaC8wMic=
+github.com/openziti/storage v0.4.21 h1:3nvNF3pcMf5aYiAWbm9zqftlS7r8cjOD5liicvLsgHw=
+github.com/openziti/storage v0.4.21/go.mod h1:8/Pv2qOdE+k3gjBrNxlSX1NnQ1FTN8f6XHhGlmqm4cU=
 github.com/openziti/transport/v2 v2.0.180 h1:7lo8wMRtrJ5o1rRLADhPf+mkDkwaw0myZPMgU4uQfJI=
 github.com/openziti/transport/v2 v2.0.180/go.mod h1:o7dnKA2wE9HPk3SD4Gyoyl0N4k5X1WdiHqI0TvDZmEM=
 github.com/openziti/x509-claims v1.0.3 h1:HNdQ8Nf1agB3lBs1gahcO6zfkeS4S5xoQ2/PkY4HRX0=

--- a/zititest/go.mod
+++ b/zititest/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/openziti/identity v1.0.108
 	github.com/openziti/metrics v1.4.2
 	github.com/openziti/sdk-golang v1.1.2
-	github.com/openziti/storage v0.4.20
+	github.com/openziti/storage v0.4.21
 	github.com/openziti/transport/v2 v2.0.180
 	github.com/openziti/ziti v1.6.2
 	github.com/orcaman/concurrent-map/v2 v2.0.1

--- a/zititest/go.sum
+++ b/zititest/go.sum
@@ -610,8 +610,8 @@ github.com/openziti/sdk-golang v1.1.2 h1:Q7YqFcAjfkH9ZZp+yYPIAvEWt/DOhhOxBx1drXy
 github.com/openziti/sdk-golang v1.1.2/go.mod h1:sXLPdy/Q0Zor5ef08H+W60EEy6ofEDpeZFlP4SWwc4w=
 github.com/openziti/secretstream v0.1.36 h1:4mr377v+ucLMaa5DG8cQE5hrunfueWIdR8We55D2GL0=
 github.com/openziti/secretstream v0.1.36/go.mod h1:aAcEcGkbUeD7rBvQlkrHourEb1Y+YQT6edA7e7+Imfw=
-github.com/openziti/storage v0.4.20 h1:+j+SvofcOfhhG6dfv2uLhyxmnQUoBcCyf2rM486vMs8=
-github.com/openziti/storage v0.4.20/go.mod h1:Ir67mINB6bVCSz90VLAMvxcpV/zvMl7F3EVOaC8wMic=
+github.com/openziti/storage v0.4.21 h1:3nvNF3pcMf5aYiAWbm9zqftlS7r8cjOD5liicvLsgHw=
+github.com/openziti/storage v0.4.21/go.mod h1:8/Pv2qOdE+k3gjBrNxlSX1NnQ1FTN8f6XHhGlmqm4cU=
 github.com/openziti/transport/v2 v2.0.180 h1:7lo8wMRtrJ5o1rRLADhPf+mkDkwaw0myZPMgU4uQfJI=
 github.com/openziti/transport/v2 v2.0.180/go.mod h1:o7dnKA2wE9HPk3SD4Gyoyl0N4k5X1WdiHqI0TvDZmEM=
 github.com/openziti/x509-claims v1.0.3 h1:HNdQ8Nf1agB3lBs1gahcO6zfkeS4S5xoQ2/PkY4HRX0=


### PR DESCRIPTION
- **Allow identity app data to a full map. Fixes #3169**
- **Allow specify json or json file for identity app data. Fixes #3161**
