### PR TITLE
fix #3178 apis missing from controllers

### DIFF
--- a/controller/db/controller_store.go
+++ b/controller/db/controller_store.go
@@ -133,7 +133,7 @@ func (store *controllerStoreImpl) PersistEntity(entity *Controller, ctx *boltz.P
 	ctx.SetBool(FieldControllerIsOnline, entity.IsOnline)
 	ctx.SetTimeP(FieldControllerLastJoinedAt, &entity.LastJoinedAt)
 
-	if ctx.ProceedWithSet(FieldControllerApiAddresses) && ctx.ProceedWithSet(FieldControllerApiAddressUrl) && ctx.ProceedWithSet(FieldControllerApiAddressVersion) {
+	if ctx.ProceedWithSet(FieldControllerApiAddresses) && (ctx.ProceedWithSet(FieldControllerApiAddressUrl) || ctx.ProceedWithSet(FieldControllerApiAddressVersion)) {
 		apiListBucket, err := ctx.Bucket.EmptyBucket(FieldControllerApiAddresses)
 		if err != nil {
 			ctx.Bucket.SetError(err)

--- a/controller/db/controller_store.go
+++ b/controller/db/controller_store.go
@@ -133,18 +133,20 @@ func (store *controllerStoreImpl) PersistEntity(entity *Controller, ctx *boltz.P
 	ctx.SetBool(FieldControllerIsOnline, entity.IsOnline)
 	ctx.SetTimeP(FieldControllerLastJoinedAt, &entity.LastJoinedAt)
 
-	apiListBucket, err := ctx.Bucket.EmptyBucket(FieldControllerApiAddresses)
-	if err != nil {
-		ctx.Bucket.SetError(err)
-		return
-	}
+	if ctx.ProceedWithSet(FieldControllerApiAddresses) && ctx.ProceedWithSet(FieldControllerApiAddressUrl) && ctx.ProceedWithSet(FieldControllerApiAddressVersion) {
+		apiListBucket, err := ctx.Bucket.EmptyBucket(FieldControllerApiAddresses)
+		if err != nil {
+			ctx.Bucket.SetError(err)
+			return
+		}
 
-	for apiKey, apis := range entity.ApiAddresses {
-		apiBucket, _ := apiListBucket.EmptyBucket(apiKey)
-		for i, instance := range apis {
-			instanceBucket := apiBucket.GetOrCreateBucket(strconv.Itoa(i))
-			instanceBucket.SetString(FieldControllerApiAddressUrl, instance.Url, ctx.FieldChecker)
-			instanceBucket.SetString(FieldControllerApiAddressVersion, instance.Version, ctx.FieldChecker)
+		for apiKey, apis := range entity.ApiAddresses {
+			apiBucket, _ := apiListBucket.EmptyBucket(apiKey)
+			for i, instance := range apis {
+				instanceBucket := apiBucket.GetOrCreateBucket(strconv.Itoa(i))
+				instanceBucket.SetString(FieldControllerApiAddressUrl, instance.Url, ctx.FieldChecker)
+				instanceBucket.SetString(FieldControllerApiAddressVersion, instance.Version, ctx.FieldChecker)
+			}
 		}
 	}
 }

--- a/controller/db/controller_store_test.go
+++ b/controller/db/controller_store_test.go
@@ -1,0 +1,275 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package db
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha1"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"github.com/google/uuid"
+	"github.com/openziti/storage/boltz"
+	"github.com/openziti/storage/boltztest"
+	"github.com/openziti/ziti/common/eid"
+	"go.etcd.io/bbolt"
+	"math/big"
+	"testing"
+	"time"
+)
+
+func Test_ControllerStore(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Cleanup()
+	ctx.Init()
+
+	t.Run("create controller saves all values", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		testControllerCert, err := newTestSelfSignedCert()
+		ctx.NoError(err)
+		ctx.NotNil(testControllerCert)
+
+		newController := &Controller{
+			BaseExtEntity: boltz.BaseExtEntity{Id: eid.New()},
+			Name:          "test-controller-" + uuid.NewString(),
+			CtrlAddress:   "test.controller.example.com:1234",
+			CertPem:       testControllerCert.certPem,
+			Fingerprint:   testControllerCert.fingerprint,
+			IsOnline:      true,
+			LastJoinedAt:  time.Now(),
+			ApiAddresses: map[string][]ApiAddress{
+				"v1": {
+					{
+						Url:     "https://test.controller.example.com:1234/v1",
+						Version: "v1",
+					},
+				},
+				"v2": {
+					{
+						Url:     "https://test.controller.example.com:1234/v2",
+						Version: "v2",
+					},
+				},
+			},
+		}
+
+		boltztest.RequireCreate(ctx, newController)
+
+		t.Run("has the proper values", func(t *testing.T) {
+			ctx.NextTest(t)
+
+			boltztest.ValidateBaseline(ctx, newController)
+
+			err = ctx.GetDb().View(func(tx *bbolt.Tx) error {
+				readController, err := ctx.stores.Controller.LoadById(tx, newController.Id)
+				ctx.NoError(err)
+				ctx.NotNil(readController)
+				ctx.Equal(newController.Name, readController.Name)
+				ctx.Equal(newController.CtrlAddress, readController.CtrlAddress)
+				ctx.Equal(newController.Fingerprint, readController.Fingerprint)
+				ctx.Equal(newController.IsOnline, readController.IsOnline)
+				ctx.Equal(newController.LastJoinedAt.UTC(), readController.LastJoinedAt.UTC())
+				ctx.Equal(newController.CertPem, readController.CertPem)
+				ctx.Equal(len(newController.ApiAddresses), len(readController.ApiAddresses))
+
+				for apiKey, newApiList := range newController.ApiAddresses {
+					readApiList, ok := readController.ApiAddresses[apiKey]
+					ctx.True(ok)
+					ctx.Equal(len(newApiList), len(readApiList))
+
+					for i, newApi := range newApiList {
+						readApi := readApiList[i]
+						ctx.Equal(newApi.Url, readApi.Url)
+						ctx.Equal(newApi.Version, readApi.Version)
+					}
+				}
+
+				return nil
+			})
+
+			t.Run("updating isOnline after create only updates isOnline", func(t *testing.T) {
+				ctx.NextTest(t)
+
+				updateController := &Controller{
+					BaseExtEntity: boltz.BaseExtEntity{Id: newController.Id},
+					IsOnline:      false,
+				}
+
+				fieldChecker := boltz.MapFieldChecker{
+					FieldControllerIsOnline: struct{}{},
+				}
+
+				boltztest.RequirePatch(ctx, updateController, fieldChecker)
+
+				t.Run("only isOnline was changed", func(t *testing.T) {
+					ctx.NextTest(t)
+
+					err = ctx.GetDb().View(func(tx *bbolt.Tx) error {
+						readController, err := ctx.stores.Controller.LoadById(tx, newController.Id)
+						ctx.NoError(err)
+						ctx.NotNil(readController)
+
+						//changed
+						ctx.Equal(false, readController.IsOnline)
+
+						//no change
+						ctx.Equal(newController.Name, readController.Name)
+						ctx.Equal(newController.CtrlAddress, readController.CtrlAddress)
+						ctx.Equal(newController.Fingerprint, readController.Fingerprint)
+
+						ctx.Equal(newController.LastJoinedAt.UTC(), readController.LastJoinedAt.UTC())
+						ctx.Equal(newController.CertPem, readController.CertPem)
+						ctx.Equal(len(newController.ApiAddresses), len(readController.ApiAddresses))
+
+						for apiKey, newApiList := range newController.ApiAddresses {
+							readApiList, ok := readController.ApiAddresses[apiKey]
+							ctx.True(ok)
+							ctx.Equal(len(newApiList), len(readApiList))
+
+							for i, newApi := range newApiList {
+								readApi := readApiList[i]
+								ctx.Equal(newApi.Url, readApi.Url)
+								ctx.Equal(newApi.Version, readApi.Version)
+							}
+						}
+
+						return nil
+					})
+				})
+			})
+
+			t.Run("updating api address after create only updates api addresses", func(t *testing.T) {
+				ctx.NextTest(t)
+
+				updateController := &Controller{
+					BaseExtEntity: boltz.BaseExtEntity{Id: newController.Id},
+					ApiAddresses: map[string][]ApiAddress{
+						"v1000": {
+							{
+								Url:     "https://test.controller.example.com:1000/v1",
+								Version: "v1000",
+							},
+						},
+						"v2000": {
+							{
+								Url:     "https://test.controller.example.com:2000/v2",
+								Version: "v2000",
+							},
+						},
+					},
+				}
+
+				fieldChecker := boltz.MapFieldChecker{
+					FieldControllerApiAddresses:      struct{}{},
+					FieldControllerApiAddressUrl:     struct{}{},
+					FieldControllerApiAddressVersion: struct{}{},
+				}
+
+				boltztest.RequirePatch(ctx, updateController, fieldChecker)
+
+				t.Run("only isOnline was changed", func(t *testing.T) {
+					ctx.NextTest(t)
+
+					err = ctx.GetDb().View(func(tx *bbolt.Tx) error {
+						readController, err := ctx.stores.Controller.LoadById(tx, newController.Id)
+						ctx.NoError(err)
+						ctx.NotNil(readController)
+
+						//changed
+						ctx.Equal(len(updateController.ApiAddresses), len(readController.ApiAddresses))
+
+						for updateApiKey, updateApiList := range updateController.ApiAddresses {
+							readApiList, ok := readController.ApiAddresses[updateApiKey]
+							ctx.True(ok)
+							ctx.Equal(len(updateApiList), len(readApiList))
+
+							for i, updateApi := range updateApiList {
+								readApi := readApiList[i]
+								ctx.Equal(updateApi.Url, readApi.Url)
+								ctx.Equal(updateApi.Version, readApi.Version)
+							}
+						}
+
+						//no change
+						ctx.Equal(false, readController.IsOnline) //false from previous test setting to false
+						ctx.Equal(newController.Name, readController.Name)
+						ctx.Equal(newController.CtrlAddress, readController.CtrlAddress)
+						ctx.Equal(newController.Fingerprint, readController.Fingerprint)
+						ctx.Equal(newController.LastJoinedAt.UTC(), readController.LastJoinedAt.UTC())
+						ctx.Equal(newController.CertPem, readController.CertPem)
+
+						return nil
+					})
+				})
+			})
+		})
+	})
+
+}
+
+type testCert struct {
+	certPem     string
+	fingerprint string
+	key         crypto.PrivateKey
+}
+
+func newTestSelfSignedCert() (*testCert, error) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate private key: %s", err)
+	}
+
+	notBefore := time.Now()
+	notAfter := notBefore.Add(365 * 1 * time.Hour)
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate serial number: %s", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Controller Store Test Org"},
+			CommonName:   "test.controller.store.example.com",
+		},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  false,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create certificate: %s", err)
+	}
+
+	certPemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+
+	return &testCert{
+		certPem:     string(certPemBytes),
+		fingerprint: fmt.Sprintf("%x", sha1.Sum(certPemBytes)),
+		key:         priv,
+	}, nil
+}

--- a/controller/env/appenv.go
+++ b/controller/env/appenv.go
@@ -746,7 +746,14 @@ func ProcessAuthQueries(ae *AppEnv, rc *response.RequestContext) {
 	totpRequired := rc.ApiSession.MfaRequired || rc.AuthPolicy.Secondary.RequireTotp
 
 	if totpRequired && !rc.ApiSession.MfaComplete {
-		rc.AuthQueries = append(rc.AuthQueries, NewAuthQueryZitiMfa())
+		totpAuthQuery := NewAuthQueryZitiMfa()
+
+		mfaDetail, err := ae.Managers.Mfa.ReadOneByIdentityId(rc.ApiSession.IdentityId)
+
+		if err == nil && mfaDetail != nil {
+			totpAuthQuery.IsTotpEnrolled = mfaDetail.IsVerified
+		}
+		rc.AuthQueries = append(rc.AuthQueries, totpAuthQuery)
 	}
 
 	if rc.AuthPolicy.Secondary.RequiredExtJwtSigner != nil {

--- a/controller/env/broker.go
+++ b/controller/env/broker.go
@@ -96,6 +96,9 @@ func (broker *Broker) GetRouterDataModel() *common.RouterDataModel {
 func (broker *Broker) AcceptClusterEvent(clusterEvent *event.ClusterEvent) {
 	if clusterEvent.EventType == event.ClusterLeadershipGained {
 		broker.ae.Managers.Controller.UpdateControllerState(clusterEvent.Peers, false)
+	} else if clusterEvent.EventType == event.ClusterHasLeader && !broker.ae.HostController.IsRaftLeader() {
+		//gained a leader and it isn't us
+		broker.ae.Managers.Controller.UpdateSelfOnNewLeader()
 	}
 
 	if broker.ae.HostController.IsRaftLeader() {

--- a/controller/model/mfa_manager.go
+++ b/controller/model/mfa_manager.go
@@ -165,6 +165,7 @@ func (self *MfaManager) ReadOneByIdentityId(identityId string) (*Mfa, error) {
 	return resultList.Mfas[0], nil
 }
 
+// Verify will attempt to check a code (recovery or totp) against the current secret.
 func (self *MfaManager) Verify(mfa *Mfa, code string, ctx *change.Context) (bool, error) {
 	//check recovery codes
 	for i, recoveryCode := range mfa.RecoveryCodes {

--- a/controller/oidc_auth/parse.go
+++ b/controller/oidc_auth/parse.go
@@ -28,7 +28,7 @@ import (
 	"unicode/utf8"
 )
 
-type Totp struct {
+type TotpRequestBody struct {
 	AuthRequestBody
 	Code string `json:"code"`
 }

--- a/controller/oidc_auth/parse_test.go
+++ b/controller/oidc_auth/parse_test.go
@@ -42,7 +42,7 @@ func Test_Map(t *testing.T) {
 	)
 
 	t.Run("totp id/code payload", func(t *testing.T) {
-		dstTotp := &Totp{}
+		dstTotp := &TotpRequestBody{}
 
 		srcMap := map[string][]string{
 			"id":   {"123"},

--- a/controller/oidc_auth/requests.go
+++ b/controller/oidc_auth/requests.go
@@ -37,6 +37,7 @@ type AuthRequest struct {
 	IdentityId            string
 	AuthTime              time.Time
 	ApiSessionId          string
+	IsTotpEnrolled        bool
 	SecondaryTotpRequired bool
 	SecondaryExtJwtSigner *model.ExternalJwtSigner
 	ConfigTypes           []string
@@ -198,13 +199,14 @@ func (a *AuthRequest) GetAuthQueries() []*rest_model.AuthQueryDetail {
 	if a.NeedsTotp() {
 		provider := rest_model.MfaProvidersZiti
 		authQueries = append(authQueries, &rest_model.AuthQueryDetail{
-			Format:     rest_model.MfaFormatsNumeric,
-			HTTPMethod: "POST",
-			HTTPURL:    "./oidc/login/totp",
-			MaxLength:  8,
-			MinLength:  6,
-			Provider:   &provider,
-			TypeID:     rest_model.AuthQueryTypeTOTP,
+			Format:         rest_model.MfaFormatsNumeric,
+			HTTPMethod:     "POST",
+			HTTPURL:        "./oidc/login/totp",
+			MaxLength:      8,
+			MinLength:      6,
+			Provider:       &provider,
+			TypeID:         rest_model.AuthQueryTypeTOTP,
+			IsTotpEnrolled: a.IsTotpEnrolled,
 		})
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/openziti/agent v1.0.30
 	github.com/openziti/channel/v4 v4.2.18
 	github.com/openziti/cobra-to-md v1.0.1
-	github.com/openziti/edge-api v0.26.46
+	github.com/openziti/edge-api v0.26.47
 	github.com/openziti/foundation/v2 v2.0.70
 	github.com/openziti/identity v1.0.109
 	github.com/openziti/jwks v1.0.6

--- a/go.sum
+++ b/go.sum
@@ -575,8 +575,8 @@ github.com/openziti/cobra-to-md v1.0.1 h1:WRinNoIRmwWUSJm+pSNXMjOrtU48oxXDZgeCYQ
 github.com/openziti/cobra-to-md v1.0.1/go.mod h1:FjCpk/yzHF7/r28oSTNr5P57yN5VolpdAtS/g7KNi2c=
 github.com/openziti/dilithium v0.3.5 h1:+envGNzxc3OyVPiuvtxivQmCsOjdZjtOMLpQBeMz7eM=
 github.com/openziti/dilithium v0.3.5/go.mod h1:XONq1iK6te/WwNzkgZHfIDHordMPqb0hMwJ8bs9EfSk=
-github.com/openziti/edge-api v0.26.46 h1:cFOGXTIMXmxTgcM/bGd50OqZES/yT37MriojGJxozzo=
-github.com/openziti/edge-api v0.26.46/go.mod h1:sYHVpm26Jr1u7VooNJzTb2b2nGSlmCHMnbGC8XfWSng=
+github.com/openziti/edge-api v0.26.47 h1:5QZeqhD4HFtox7FS5z816M1+MpJED1DdS6oOH128nI8=
+github.com/openziti/edge-api v0.26.47/go.mod h1:sYHVpm26Jr1u7VooNJzTb2b2nGSlmCHMnbGC8XfWSng=
 github.com/openziti/foundation/v2 v2.0.70 h1:1g4jIl7nIdqW8oCgRcwlbNvK8dwk4mPyrwjjtjH1tp8=
 github.com/openziti/foundation/v2 v2.0.70/go.mod h1:7U2lINqfYrwOIcprl/spFA8EmCFvzegHMc/nhpPyXyM=
 github.com/openziti/identity v1.0.109 h1:FFMbcdbD0igP6fygpbqsix6BuRLlIzoTX9qp3BUqfh0=

--- a/tests/context.go
+++ b/tests/context.go
@@ -172,12 +172,17 @@ func GetTestContext() *TestContext {
 }
 
 // testContextChanged is used to update the *testing.T reference used by library
-// level tests. Necessary because using the wrong *testing.T will cause go test library
+// level tests. Necessary because, using the wrong *testing.T will cause go test library
 // errors.
 func (ctx *TestContext) testContextChanged(t *testing.T) {
 	ctx.testing = t
 	ctx.Req = require.New(t)
 	ctx.Assertions = ctx.Req
+}
+
+// NextTest is an alias for testContextChanged and reflects the bbolt testing framework
+func (ctx *TestContext) NextTest(t *testing.T) {
+	ctx.testContextChanged(t)
 }
 
 func (ctx *TestContext) T() *testing.T {

--- a/tests/mfa_ziti_test.go
+++ b/tests/mfa_ziti_test.go
@@ -21,6 +21,7 @@ package tests
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/Jeffail/gabs"
 	"github.com/dgryski/dgoogauth"
@@ -1082,6 +1083,31 @@ func computeMFACode(secret string) string {
 
 	//pad leading 0s to 6 characters
 	return fmt.Sprintf("%06d", code)
+}
+
+func parseSecretFromProvisioningUrl(provisioningUrl string) (string, error) {
+	parsedUrl, err := url.Parse(provisioningUrl)
+
+	if err != nil {
+		return "", err
+	}
+
+	queryParams, err := url.ParseQuery(parsedUrl.RawQuery)
+	if err != nil {
+		return "", err
+	}
+
+	secrets, ok := queryParams["secret"]
+
+	if !ok {
+		return "", errors.New("no secret found in provisioning url")
+	}
+
+	if len(secrets) != 1 {
+		return "", fmt.Errorf("expected 1 secret, got %d", len(secrets))
+	}
+
+	return secrets[0], nil
 }
 
 type mfaCode struct {

--- a/zititest/go.mod
+++ b/zititest/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/michaelquigley/pfxlog v1.0.0
 	github.com/openziti/agent v1.0.30
 	github.com/openziti/channel/v4 v4.2.18
-	github.com/openziti/edge-api v0.26.46
+	github.com/openziti/edge-api v0.26.47
 	github.com/openziti/fablab v0.5.115
 	github.com/openziti/foundation/v2 v2.0.70
 	github.com/openziti/identity v1.0.109

--- a/zititest/go.sum
+++ b/zititest/go.sum
@@ -592,8 +592,8 @@ github.com/openziti/cobra-to-md v1.0.1 h1:WRinNoIRmwWUSJm+pSNXMjOrtU48oxXDZgeCYQ
 github.com/openziti/cobra-to-md v1.0.1/go.mod h1:FjCpk/yzHF7/r28oSTNr5P57yN5VolpdAtS/g7KNi2c=
 github.com/openziti/dilithium v0.3.5 h1:+envGNzxc3OyVPiuvtxivQmCsOjdZjtOMLpQBeMz7eM=
 github.com/openziti/dilithium v0.3.5/go.mod h1:XONq1iK6te/WwNzkgZHfIDHordMPqb0hMwJ8bs9EfSk=
-github.com/openziti/edge-api v0.26.46 h1:cFOGXTIMXmxTgcM/bGd50OqZES/yT37MriojGJxozzo=
-github.com/openziti/edge-api v0.26.46/go.mod h1:sYHVpm26Jr1u7VooNJzTb2b2nGSlmCHMnbGC8XfWSng=
+github.com/openziti/edge-api v0.26.47 h1:5QZeqhD4HFtox7FS5z816M1+MpJED1DdS6oOH128nI8=
+github.com/openziti/edge-api v0.26.47/go.mod h1:sYHVpm26Jr1u7VooNJzTb2b2nGSlmCHMnbGC8XfWSng=
 github.com/openziti/fablab v0.5.115 h1:npfOVGH6e3hcRnZ1OgzxVwC7w7Wg3+xGUsUiavYYPJw=
 github.com/openziti/fablab v0.5.115/go.mod h1:iesjVDWdXXdZAu8TTowI2yTepdItkFpQaPxL7dj6+RQ=
 github.com/openziti/foundation/v2 v2.0.70 h1:1g4jIl7nIdqW8oCgRcwlbNvK8dwk4mPyrwjjtjH1tp8=


### PR DESCRIPTION
- fixed controller store to no longer blank apis on all CUD actions
- controllers now report their current config state on leader change to avoid stale information
- fixes peer disconnect to only set online state