### PR TITLE
fix #3231 use root controller server certs for OIDC signing

### DIFF
--- a/controller/env/appenv.go
+++ b/controller/env/appenv.go
@@ -19,8 +19,6 @@ package env
 import (
 	"bytes"
 	"crypto"
-	"crypto/ecdsa"
-	"crypto/rsa"
 	"crypto/sha1"
 	"crypto/tls"
 	"crypto/x509"
@@ -113,13 +111,13 @@ type AppEnv struct {
 	InstanceId           string
 	AuthRateLimiter      rate.AdaptiveRateLimiter
 
-	serverSigner jwtsigner.Signer
-	ServerCert   *tls.Certificate
+	clientApiDefaultSigner *jwtsigner.TlsJwtSigner
 
 	TraceManager *TraceManager
 	timelineId   string
 }
 
+// GetPeerControllerAddresses returns the network addresses of peer controllers.
 func (ae *AppEnv) GetPeerControllerAddresses() []string {
 	return ae.HostController.GetPeerAddresses()
 }
@@ -145,6 +143,8 @@ func (ae *AppEnv) JwtSignerKeyFunc(token *jwt.Token) (interface{}, error) {
 	return pubKey, nil
 }
 
+// ValidateAccessToken verifies an access token and returns its claims if valid.
+// Checks token signature, audience, type, and revocation status.
 func (ae *AppEnv) ValidateAccessToken(token string) (*common.AccessClaims, error) {
 	accessClaims := &common.AccessClaims{}
 
@@ -182,13 +182,15 @@ func (ae *AppEnv) ValidateAccessToken(token string) (*common.AccessClaims, error
 		return nil, err
 	}
 
-	if revocation != nil && tokenRevocation.CreatedAt.After(accessClaims.IssuedAt.AsTime()) {
+	if revocation != nil && revocation.CreatedAt.After(accessClaims.IssuedAt.AsTime()) {
 		return nil, errors.New("access token has been revoked by identity")
 	}
 
 	return accessClaims, nil
 }
 
+// ValidateServiceAccessToken verifies a service access token and returns its claims.
+// Optionally validates against a specific API session ID.
 func (ae *AppEnv) ValidateServiceAccessToken(token string, apiSessionId *string) (*common.ServiceAccessClaims, error) {
 	serviceAccessClaims := &common.ServiceAccessClaims{}
 
@@ -243,34 +245,62 @@ func (ae *AppEnv) ValidateServiceAccessToken(token string, apiSessionId *string)
 	return serviceAccessClaims, nil
 }
 
-func (ae *AppEnv) GetServerCert() (serverCert *tls.Certificate, kid string, signingMethod jwt.SigningMethod) {
-	return ae.ServerCert, ae.serverSigner.KeyId(), ae.serverSigner.SigningMethod()
+// GetClientApiDefaultTlsJwtSigner returns the default JWT signer for client API operations.
+func (ae *AppEnv) GetClientApiDefaultTlsJwtSigner() *jwtsigner.TlsJwtSigner {
+	return ae.clientApiDefaultSigner
 }
 
+// GetRootTlsJwtSigner creates and returns a JWT signer using the root server certificate.
+func (ae *AppEnv) GetRootTlsJwtSigner() *jwtsigner.TlsJwtSigner {
+	rootCerts := ae.GetConfig().Id.ServerCert()
+	var rootCert *tls.Certificate
+
+	if len(rootCerts) != 0 {
+		rootCert = rootCerts[0]
+	} else {
+		rootCert = ae.GetConfig().Id.Cert()
+	}
+
+	if rootCert == nil {
+		panic(fmt.Errorf("root identity doesn't have a server cert or cert"))
+	}
+
+	rootSigner := &jwtsigner.TlsJwtSigner{}
+	rootSigner.Set(rootCerts[0])
+	return rootSigner
+}
+
+// GetApiServerCsrSigner returns the certificate signer for API server CSRs.
 func (ae *AppEnv) GetApiServerCsrSigner() cert.Signer {
 	return ae.ApiServerCsrSigner
 }
 
+// GetControlClientCsrSigner returns the certificate signer for control client CSRs.
 func (ae *AppEnv) GetControlClientCsrSigner() cert.Signer {
 	return ae.ControlClientCsrSigner
 }
 
+// GetApiClientCsrSigner returns the certificate signer for API client CSRs.
 func (ae *AppEnv) GetApiClientCsrSigner() cert.Signer {
 	return ae.ApiClientCsrSigner
 }
 
+// GetHostController returns the host controller instance.
 func (ae *AppEnv) GetHostController() HostController {
 	return ae.HostController
 }
 
+// GetManagers returns the business logic managers.
 func (ae *AppEnv) GetManagers() *model.Managers {
 	return ae.Managers
 }
 
+// GetEventDispatcher returns the event dispatcher for publishing system events.
 func (ae *AppEnv) GetEventDispatcher() event.Dispatcher {
 	return ae.HostController.GetEventDispatcher()
 }
 
+// GetConfig returns the controller configuration.
 func (ae *AppEnv) GetConfig() *config.Config {
 	return ae.HostController.GetConfig()
 }
@@ -285,11 +315,12 @@ func (ae *AppEnv) GetEnrollmentJwtSigner() (jwtsigner.Signer, error) {
 		return nil, fmt.Errorf("could not determine enrollment signer: %w", err)
 	}
 
-	signMethod := getJwtSigningMethod(enrollmentCert)
+	signMethod := jwtsigner.GetJwtSigningMethod(enrollmentCert)
 	kid := fmt.Sprintf("%x", sha1.Sum(enrollmentCert.Certificate[0]))
 	return jwtsigner.New(signMethod, enrollmentCert.PrivateKey, kid), nil
 }
 
+// getEnrollmentTlsCert finds the TLS certificate that matches the edge API address hostname.
 func (ae *AppEnv) getEnrollmentTlsCert() (*tls.Certificate, error) {
 	host, _, err := net.SplitHostPort(ae.GetConfig().Edge.Api.Address)
 
@@ -338,6 +369,7 @@ func (ae *AppEnv) getEnrollmentTlsCert() (*tls.Certificate, error) {
 	return nil, fmt.Errorf("could not find a configured server certificate that matches hostname [%s] in root controller identity nor in xweb identities", host)
 }
 
+// getCertForHostname searches for a certificate that can verify the given hostname.
 func (ae *AppEnv) getCertForHostname(tlsCerts []*tls.Certificate, hostname string) (*tls.Certificate, error) {
 	for i, tlsCert := range tlsCerts {
 		if tlsCert.Leaf == nil {
@@ -360,62 +392,72 @@ func (ae *AppEnv) getCertForHostname(tlsCerts []*tls.Certificate, hostname strin
 	return nil, fmt.Errorf("could not find a configured server certificate that matches hostname [%s]", hostname)
 }
 
-func (ae *AppEnv) GetServerJwtSigner() jwtsigner.Signer {
-	return ae.serverSigner
-}
-
+// GetDb returns the database instance.
 func (ae *AppEnv) GetDb() boltz.Db {
 	return ae.HostController.GetDb()
 }
 
+// GetStores returns the database stores.
 func (ae *AppEnv) GetStores() *db.Stores {
 	return ae.Stores
 }
 
+// GetAuthRegistry returns the authentication module registry.
 func (ae *AppEnv) GetAuthRegistry() model.AuthRegistry {
 	return ae.AuthRegistry
 }
 
+// GetEnrollRegistry returns the enrollment handler registry.
 func (ae *AppEnv) GetEnrollRegistry() model.EnrollmentRegistry {
 	return ae.EnrollRegistry
 }
 
+// IsEdgeRouterOnline checks if an edge router is currently connected.
 func (ae *AppEnv) IsEdgeRouterOnline(id string) bool {
 	return ae.Broker.IsEdgeRouterOnline(id)
 }
 
+// GetMetricsRegistry returns the metrics registry for collecting performance data.
 func (ae *AppEnv) GetMetricsRegistry() metrics.Registry {
 	return ae.HostController.GetMetricsRegistry()
 }
 
+// GetFingerprintGenerator returns the certificate fingerprint generator.
 func (ae *AppEnv) GetFingerprintGenerator() cert.FingerprintGenerator {
 	return ae.FingerprintGenerator
 }
 
+// GetRaftInfo returns Raft cluster information (node ID, leader, cluster state).
 func (ae *AppEnv) GetRaftInfo() (string, string, string) {
 	return ae.HostController.GetRaftInfo()
 }
 
+// GetApiAddresses returns the controller's API addresses and their fingerprint hash.
 func (ae *AppEnv) GetApiAddresses() (map[string][]event.ApiAddress, []byte) {
 	return ae.HostController.GetApiAddresses()
 }
 
+// GetCloseNotifyChannel returns a channel that signals when the controller is shutting down.
 func (ae *AppEnv) GetCloseNotifyChannel() <-chan struct{} {
 	return ae.HostController.GetCloseNotifyChannel()
 }
 
+// GetPeerSigners returns the certificates of peer controllers for signature verification.
 func (ae *AppEnv) GetPeerSigners() []*x509.Certificate {
 	return ae.HostController.GetPeerSigners()
 }
 
+// GetCommandDispatcher returns the command dispatcher for processing control plane commands.
 func (ae *AppEnv) GetCommandDispatcher() command.Dispatcher {
 	return ae.HostController.GetCommandDispatcher()
 }
 
+// AddRouterPresenceHandler registers a handler for router connect/disconnect events.
 func (ae *AppEnv) AddRouterPresenceHandler(h model.RouterPresenceHandler) {
 	ae.HostController.GetNetwork().AddRouterPresenceHandler(h)
 }
 
+// GetId returns the unique application identifier for this controller instance.
 func (ae *AppEnv) GetId() string {
 	return ae.HostController.GetNetwork().GetAppId()
 }
@@ -520,6 +562,7 @@ func (a authorizer) Authorize(request *http.Request, principal interface{}) erro
 	return nil
 }
 
+// ProcessZtSession validates a Ziti session token and populates the request context.
 func (ae *AppEnv) ProcessZtSession(rc *response.RequestContext, ztSession string) error {
 	logger := pfxlog.Logger()
 
@@ -603,6 +646,7 @@ func (ae *AppEnv) ProcessZtSession(rc *response.RequestContext, ztSession string
 	return nil
 }
 
+// ProcessJwt validates a JWT token and populates the request context with claims and identity.
 func (ae *AppEnv) ProcessJwt(rc *response.RequestContext, token *jwt.Token) error {
 	rc.SessionToken = token.Raw
 	rc.Jwt = token
@@ -682,6 +726,8 @@ func (ae *AppEnv) ProcessJwt(rc *response.RequestContext, token *jwt.Token) erro
 	return nil
 }
 
+// FillRequestContext extracts authentication information from the HTTP request
+// and populates the request context with session or JWT token data.
 func (ae *AppEnv) FillRequestContext(rc *response.RequestContext) error {
 	// do no process auth headers on authenticate request
 	if strings.HasSuffix(rc.Request.URL.Path, "/v1/authenticate") && !strings.HasSuffix(rc.Request.URL.Path, "/authenticate/mfa") {
@@ -902,11 +948,6 @@ func NewAppEnv(host HostController) (*AppEnv, error) {
 
 	ae.FingerprintGenerator = cert.NewFingerprintGenerator()
 
-	if err != nil {
-		log := pfxlog.Logger()
-		log.WithField("cause", err).Fatal("could not load schemas")
-	}
-
 	ae.Managers = model.NewManagers()
 	ae.Managers.Init(ae)
 
@@ -924,9 +965,9 @@ func (ae *AppEnv) InitPersistence() error {
 			return
 		}
 
-		if event, ok := i[0].(*db.EventualEventAdded); ok {
+		if addEvent, ok := i[0].(*db.EventualEventAdded); ok {
 			gauge := ae.GetHostController().GetMetricsRegistry().Gauge(EventualEventsGauge)
-			gauge.Update(event.Total)
+			gauge.Update(addEvent.Total)
 		} else {
 			pfxlog.Logger().Errorf("could not update metrics for %s gauge on add, event argument was %T expected *EventualEventAdded", EventualEventsGauge, i[0])
 		}
@@ -937,9 +978,9 @@ func (ae *AppEnv) InitPersistence() error {
 			return
 		}
 
-		if event, ok := i[0].(*db.EventualEventRemoved); ok {
+		if removeEvent, ok := i[0].(*db.EventualEventRemoved); ok {
 			gauge := ae.GetHostController().GetMetricsRegistry().Gauge(EventualEventsGauge)
-			gauge.Update(event.Total)
+			gauge.Update(removeEvent.Total)
 		} else {
 			pfxlog.Logger().Errorf("could not update metrics for %s gauge on remove, event argument was %T expected *EventualEventRemoved", EventualEventsGauge, i[0])
 		}
@@ -953,36 +994,12 @@ func (ae *AppEnv) InitPersistence() error {
 	return err
 }
 
-func getJwtSigningMethod(cert *tls.Certificate) jwt.SigningMethod {
-
-	var sm jwt.SigningMethod = jwt.SigningMethodNone
-
-	switch cert.Leaf.PublicKey.(type) {
-	case *ecdsa.PublicKey:
-		key := cert.Leaf.PublicKey.(*ecdsa.PublicKey)
-		switch key.Params().BitSize {
-		case jwt.SigningMethodES256.CurveBits:
-			sm = jwt.SigningMethodES256
-		case jwt.SigningMethodES384.CurveBits:
-			sm = jwt.SigningMethodES384
-		case jwt.SigningMethodES512.CurveBits:
-			sm = jwt.SigningMethodES512
-		default:
-			pfxlog.Logger().Panic("unsupported EC key size: ", key.Params().BitSize)
-		}
-	case *rsa.PublicKey:
-		sm = jwt.SigningMethodRS256
-	default:
-		pfxlog.Logger().Panic("unknown certificate type, unable to determine signing method")
-	}
-
-	return sm
-}
-
+// getZtSessionFromRequest extracts the Ziti session token from HTTP headers.
 func (ae *AppEnv) getZtSessionFromRequest(r *http.Request) string {
 	return r.Header.Get(ZitiSession)
 }
 
+// getJwtTokenFromRequest extracts and validates JWT tokens from Authorization headers.
 func (ae *AppEnv) getJwtTokenFromRequest(r *http.Request) *jwt.Token {
 	headers := r.Header.Values("authorization")
 
@@ -1006,6 +1023,7 @@ func (ae *AppEnv) getJwtTokenFromRequest(r *http.Request) *jwt.Token {
 	return nil
 }
 
+// ControllersKeyFunc provides public keys for JWT token verification from peer controllers.
 func (ae *AppEnv) ControllersKeyFunc(token *jwt.Token) (interface{}, error) {
 	kidVal, ok := token.Header["kid"]
 
@@ -1028,11 +1046,13 @@ func (ae *AppEnv) ControllersKeyFunc(token *jwt.Token) (interface{}, error) {
 	return key, nil
 }
 
+// GetControllerPublicKey retrieves a public key by key ID from peer controllers.
 func (ae *AppEnv) GetControllerPublicKey(kid string) crypto.PublicKey {
 	signers := ae.Broker.GetPublicKeys()
 	return signers[kid]
 }
 
+// CreateRequestContext creates a new request context for handling HTTP requests.
 func (ae *AppEnv) CreateRequestContext(rw http.ResponseWriter, r *http.Request) *response.RequestContext {
 	rid := eid.New()
 
@@ -1091,6 +1111,7 @@ func getMetricTimerName(r *http.Request) string {
 	return fmt.Sprintf("%s.%s", cleanUrl, r.Method)
 }
 
+// IsAllowed creates a middleware responder that checks permissions before executing the handler.
 func (ae *AppEnv) IsAllowed(responderFunc func(ae *AppEnv, rc *response.RequestContext), request *http.Request, entityId string, entitySubId string, permissions ...permissions.Resolver) openApiMiddleware.Responder {
 	return openApiMiddleware.ResponderFunc(func(writer http.ResponseWriter, producer runtime.Producer) {
 
@@ -1144,31 +1165,36 @@ func (ae *AppEnv) IsAllowed(responderFunc func(ae *AppEnv, rc *response.RequestC
 	})
 }
 
+// HandleServiceEvent processes service change events and triggers identity refreshes.
 func (ae *AppEnv) HandleServiceEvent(event *db.ServiceEvent) {
 	ae.HandleServiceUpdatedEventForIdentityId(event.IdentityId)
 }
 
+// HandleServiceUpdatedEventForIdentityId marks an identity for refresh due to service changes.
 func (ae *AppEnv) HandleServiceUpdatedEventForIdentityId(identityId string) {
 	ae.IdentityRefreshMap.Set(identityId, time.Now().UTC())
 	ae.identityRefreshMeter.Mark(1)
 }
 
-func (ae *AppEnv) SetServerCert(serverCert *tls.Certificate) {
-	ae.ServerCert = serverCert
+// SetClientApiDefaultCertificate configures the default JWT signer for client API operations.
+func (ae *AppEnv) SetClientApiDefaultCertificate(serverCert *tls.Certificate) {
+	newSigner := &jwtsigner.TlsJwtSigner{}
+	newSigner.Set(serverCert)
+	ae.clientApiDefaultSigner = newSigner
 
-	signMethod := getJwtSigningMethod(serverCert)
-	kid := fmt.Sprintf("%x", sha1.Sum(serverCert.Certificate[0]))
-	ae.serverSigner = jwtsigner.New(signMethod, serverCert.PrivateKey, kid)
 }
 
+// OidcIssuer returns the OIDC issuer URL for this controller.
 func (ae *AppEnv) OidcIssuer() string {
 	return ae.RootIssuer() + "/oidc"
 }
 
+// RootIssuer returns the base issuer URL for this controller.
 func (ae *AppEnv) RootIssuer() string {
 	return "https://" + ae.GetConfig().Edge.Api.Address
 }
 
+// InitTimelineId sets the timeline ID during startup, panics if already set.
 func (ae *AppEnv) InitTimelineId(timelineId string) {
 	if ae.timelineId == "" {
 		ae.timelineId = timelineId
@@ -1177,10 +1203,12 @@ func (ae *AppEnv) InitTimelineId(timelineId string) {
 	}
 }
 
+// OverrideTimelineId forcibly sets the timeline ID, bypassing startup checks.
 func (ae *AppEnv) OverrideTimelineId(timelineId string) {
 	ae.timelineId = timelineId
 }
 
+// TimelineId returns the current timeline identifier for event ordering.
 func (ae *AppEnv) TimelineId() string {
 	return ae.timelineId
 }

--- a/controller/internal/routes/ca_router.go
+++ b/controller/internal/routes/ca_router.go
@@ -273,7 +273,7 @@ func (r *CaRouter) generateJwt(ae *env.AppEnv, rc *response.RequestContext) {
 		},
 	}
 
-	jwtStr, genErr := ae.GetServerJwtSigner().Generate(claims)
+	jwtStr, genErr := ae.GetRootTlsJwtSigner().Generate(claims)
 
 	if genErr != nil {
 		rc.RespondWithError(errors.New("could not generate claims"))

--- a/controller/jwtsigner/jwt.go
+++ b/controller/jwtsigner/jwt.go
@@ -18,21 +18,34 @@ package jwtsigner
 
 import (
 	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/sha1"
+	"crypto/tls"
+	"fmt"
+
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/michaelquigley/pfxlog"
 )
 
+// Signer provides JWT signing capabilities with configurable signing methods and key identification.
+// It abstracts the process of creating signed JWT tokens from claims.
 type Signer interface {
 	Generate(jwt.Claims) (string, error)
 	SigningMethod() jwt.SigningMethod
 	KeyId() string
 }
 
+// SignerImpl is the concrete implementation of the Signer interface.
+// It holds the signing method, private key, and key identifier needed for JWT signing.
 type SignerImpl struct {
 	signingMethod jwt.SigningMethod
 	key           crypto.PrivateKey
 	keyId         string
 }
 
+// New creates a new SignerImpl with the specified signing method, private key, and key ID.
+// The key ID is used for JWT key identification in multi-key scenarios.
 func New(sm jwt.SigningMethod, key crypto.PrivateKey, keyId string) *SignerImpl {
 	return &SignerImpl{
 		signingMethod: sm,
@@ -41,14 +54,20 @@ func New(sm jwt.SigningMethod, key crypto.PrivateKey, keyId string) *SignerImpl 
 	}
 }
 
+// SigningMethod returns the JWT signing method configured for this signer.
 func (j *SignerImpl) SigningMethod() jwt.SigningMethod {
 	return j.signingMethod
 }
 
+// KeyId returns the key identifier associated with this signer.
+// This is used in the JWT header 'kid' field for key identification.
 func (j *SignerImpl) KeyId() string {
 	return j.keyId
 }
 
+// Generate creates a signed JWT token from the provided claims.
+// If a key ID is configured, it adds the 'kid' header to the token.
+// Returns the signed JWT string or an error if signing fails.
 func (j *SignerImpl) Generate(claims jwt.Claims) (string, error) {
 	token := jwt.NewWithClaims(j.signingMethod, claims)
 
@@ -57,4 +76,55 @@ func (j *SignerImpl) Generate(claims jwt.Claims) (string, error) {
 	}
 
 	return token.SignedString(j.key)
+}
+
+// TlsJwtSigner combines a JWT signer with its associated TLS certificate.
+// It wraps a jwtsigner.Signer and stores the certificate that was used to
+// create the signer, enabling JWT signing operations with certificate-based
+// key identification (kid).
+type TlsJwtSigner struct {
+	Signer
+	TlsCerts *tls.Certificate
+}
+
+// Set configures the TlsJwtSigner with a new TLS certificate.
+// It updates the stored certificate, determines the appropriate JWT signing method
+// based on the certificate's key type, generates a key ID (kid) from the certificate's
+// SHA1 hash, and creates a new JWT signer with these parameters.
+func (c *TlsJwtSigner) Set(cert *tls.Certificate) {
+	c.TlsCerts = cert
+	signingMethod := GetJwtSigningMethod(cert)
+	kid := fmt.Sprintf("%x", sha1.Sum(cert.Certificate[0]))
+	c.Signer = New(signingMethod, c.TlsCerts.PrivateKey, kid)
+}
+
+// GetJwtSigningMethod determines the appropriate JWT signing method based on the
+// certificate's public key type and parameters.
+// For ECDSA keys, it selects ES256, ES384, or ES512 based on the curve bit size.
+// For RSA keys, it defaults to RS256.
+// Panics if the certificate has an unsupported key type or ECDSA curve size.
+func GetJwtSigningMethod(cert *tls.Certificate) jwt.SigningMethod {
+
+	var sm jwt.SigningMethod = jwt.SigningMethodNone
+
+	switch cert.Leaf.PublicKey.(type) {
+	case *ecdsa.PublicKey:
+		key := cert.Leaf.PublicKey.(*ecdsa.PublicKey)
+		switch key.Params().BitSize {
+		case jwt.SigningMethodES256.CurveBits:
+			sm = jwt.SigningMethodES256
+		case jwt.SigningMethodES384.CurveBits:
+			sm = jwt.SigningMethodES384
+		case jwt.SigningMethodES512.CurveBits:
+			sm = jwt.SigningMethodES512
+		default:
+			pfxlog.Logger().Panic("unsupported EC key size: ", key.Params().BitSize)
+		}
+	case *rsa.PublicKey:
+		sm = jwt.SigningMethodRS256
+	default:
+		pfxlog.Logger().Panic("unknown certificate type, unable to determine signing method")
+	}
+
+	return sm
 }

--- a/controller/model/controller_manager.go
+++ b/controller/model/controller_manager.go
@@ -18,6 +18,8 @@ package model
 
 import (
 	"crypto/x509"
+	"time"
+
 	"github.com/michaelquigley/pfxlog"
 	nfpem "github.com/openziti/foundation/v2/pem"
 	"github.com/openziti/storage/boltz"
@@ -30,7 +32,6 @@ import (
 	"github.com/openziti/ziti/controller/models"
 	"go.etcd.io/bbolt"
 	"google.golang.org/protobuf/proto"
-	"time"
 )
 
 func NewControllerManager(env Env) *ControllerManager {
@@ -162,10 +163,10 @@ func (self *ControllerManager) Unmarshall(bytes []byte) (*Controller, error) {
 
 func (self *ControllerManager) getCurrentAsClusterPeer() *event.ClusterPeer {
 	addr, id, version := self.env.GetRaftInfo()
-	tlsConfig, _, _ := self.env.GetServerCert()
+	clientApiCert := self.env.GetRootTlsJwtSigner()
 	var leaderCerts []*x509.Certificate
 
-	for _, certBytes := range tlsConfig.Certificate {
+	for _, certBytes := range clientApiCert.TlsCerts.Certificate {
 		if cert, err := x509.ParseCertificate(certBytes); err == nil {
 			leaderCerts = append(leaderCerts, cert)
 		}

--- a/controller/model/env.go
+++ b/controller/model/env.go
@@ -17,8 +17,8 @@
 package model
 
 import (
-	"crypto/tls"
 	"crypto/x509"
+
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/openziti/metrics"
 	"github.com/openziti/storage/boltz"
@@ -31,41 +31,126 @@ import (
 	"github.com/openziti/ziti/controller/jwtsigner"
 )
 
+// Env defines the core environment interface for Ziti Edge controller operations.
+// It provides access to all essential services including data stores, authentication,
+// certificate management, JWT operations, network information, and controller coordination.
+// This interface abstracts the controller's runtime environment and is implemented by AppEnv.
 type Env interface {
+
+	// GetCommandDispatcher provides access to the command processing system for executing
+	// control plane operations like configuration changes and administrative tasks.
 	GetCommandDispatcher() command.Dispatcher
+
+	// GetManagers provides access to business logic managers that handle CRUD operations
+	// for entities like identities, services, policies, and certificates.
 	GetManagers() *Managers
+
+	// GetEventDispatcher enables publishing system events for auditing, monitoring,
+	// and integration with external systems.
 	GetEventDispatcher() event.Dispatcher
+
+	// GetConfig provides access to controller configuration for runtime behavior customization.
 	GetConfig() *config.Config
+
+	// GetDb provides direct access to the underlying database for low-level operations.
 	GetDb() boltz.Db
+
+	// GetStores provides access to the data access layer for entity persistence and querying.
 	GetStores() *db.Stores
+
+	// GetAuthRegistry provides access to pluggable authentication modules for different
+	// authentication methods like certificates, UPDB, and external JWT.
 	GetAuthRegistry() AuthRegistry
+
+	// GetEnrollRegistry provides access to enrollment handlers that process different
+	// types of enrollment requests (OTTCA, UPDB, etc.).
 	GetEnrollRegistry() EnrollmentRegistry
+
+	// GetApiClientCsrSigner provides certificate signing capability for API clients
+	// during enrollment and certificate renewal processes.
 	GetApiClientCsrSigner() cert.Signer
+
+	// GetApiServerCsrSigner provides certificate signing capability for API servers
+	// in multi-controller deployments.
 	GetApiServerCsrSigner() cert.Signer
+
+	// GetControlClientCsrSigner provides certificate signing capability for control
+	// plane clients like routers connecting to the controller.
 	GetControlClientCsrSigner() cert.Signer
+
+	// IsEdgeRouterOnline enables checking router connectivity status for service
+	// availability and load balancing decisions.
 	IsEdgeRouterOnline(id string) bool
+
+	// GetMetricsRegistry provides access to performance metrics collections for
+	// monitoring, alerting, and system health assessment.
 	GetMetricsRegistry() metrics.Registry
+
+	// GetFingerprintGenerator creates certificate fingerprints for identity verification
+	// and certificate matching during authentication.
 	GetFingerprintGenerator() cert.FingerprintGenerator
+
+	// HandleServiceUpdatedEventForIdentityId triggers identity refresh when services
+	// change, ensuring clients get updated service lists promptly.
 	HandleServiceUpdatedEventForIdentityId(identityId string)
 
+	// GetEnrollmentJwtSigner creates JWT tokens for enrollment processes, matching
+	// the hostname in edge.api.address for proper certificate validation.
 	GetEnrollmentJwtSigner() (jwtsigner.Signer, error)
 
-	GetServerJwtSigner() jwtsigner.Signer
-	GetServerCert() (*tls.Certificate, string, jwt.SigningMethod)
+	// GetRootTlsJwtSigner provides JWT signing using the controller's root certificate
+	// for administrative operations and inter-controller communication.
+	GetRootTlsJwtSigner() *jwtsigner.TlsJwtSigner
+
+	// GetClientApiDefaultTlsJwtSigner provides the standard JWT signer for client API
+	// operations like authentication.
+	GetClientApiDefaultTlsJwtSigner() *jwtsigner.TlsJwtSigner
+
+	// JwtSignerKeyFunc enables JWT token verification from multiple controllers in
+	// clustered deployments by providing appropriate public keys.
 	JwtSignerKeyFunc(token *jwt.Token) (interface{}, error)
+
+	// GetPeerControllerAddresses provides network addresses of other controllers
+	// for cluster coordination and failover scenarios.
 	GetPeerControllerAddresses() []string
 
+	// ValidateAccessToken verifies and extracts claims from access tokens, ensuring
+	// proper authentication and authorization for API requests.
 	ValidateAccessToken(token string) (*common.AccessClaims, error)
+
+	// ValidateServiceAccessToken validates tokens used for service-specific access,
+	// enabling fine-grained authorization for individual services.
 	ValidateServiceAccessToken(token string, apiSessionId *string) (*common.ServiceAccessClaims, error)
 
+	// OidcIssuer provides the OIDC-compliant issuer URL for integration with
+	// external identity providers and OAuth2/OIDC flows.
 	OidcIssuer() string
+
+	// RootIssuer provides the base issuer URL for JWT tokens and OIDC discovery,
+	// derived from the controller's API address.
 	RootIssuer() string
 
+	// GetRaftInfo exposes Raft consensus information for cluster health monitoring
+	// and debugging distributed consensus issues.
 	GetRaftInfo() (string, string, string)
+
+	// GetApiAddresses provides current API endpoints and their signatures for
+	// service discovery and client configuration updates.
 	GetApiAddresses() (map[string][]event.ApiAddress, []byte)
+
+	// GetCloseNotifyChannel enables graceful shutdown coordination by signaling
+	// when the controller is terminating.
 	GetCloseNotifyChannel() <-chan struct{}
+
+	// GetPeerSigners provides peer controller certificates for validating signed
+	// messages and ensuring secure inter-controller communication.
 	GetPeerSigners() []*x509.Certificate
+
+	// AddRouterPresenceHandler enables monitoring router connectivity changes
+	// for network topology updates and service availability tracking.
 	AddRouterPresenceHandler(h RouterPresenceHandler)
 
+	// GetId provides the unique controller instance identifier for cluster
+	// coordination and distributed system operations.
 	GetId() string
 }

--- a/controller/model/session_manager.go
+++ b/controller/model/session_manager.go
@@ -206,7 +206,7 @@ func (self *SessionManager) CreateJwt(entity *Session, ctx *change.Context) (str
 		TokenType:    common.TokenTypeServiceAccess,
 	}
 
-	return self.env.GetServerJwtSigner().Generate(claims)
+	return self.env.GetRootTlsJwtSigner().Generate(claims)
 }
 
 func (self *SessionManager) Create(entity *Session, ctx *change.Context) (string, error) {

--- a/controller/model/testing.go
+++ b/controller/model/testing.go
@@ -19,11 +19,12 @@ package model
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"testing"
+	"time"
+
 	"github.com/openziti/channel/v4"
 	"github.com/openziti/transport/v2"
 	"github.com/openziti/ziti/controller/models"
-	"testing"
-	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
@@ -50,6 +51,16 @@ type TestContext struct {
 	closeNotify     chan struct{}
 	dispatcher      command.Dispatcher
 	eventDispatcher event.Dispatcher
+}
+
+func (ctx *TestContext) GetRootTlsJwtSigner() *jwtsigner.TlsJwtSigner {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (ctx *TestContext) GetClientApiDefaultTlsJwtSigner() *jwtsigner.TlsJwtSigner {
+	//TODO implement me
+	panic("implement me")
 }
 
 func (ctx *TestContext) GetId() string {
@@ -97,11 +108,11 @@ func (ctx *TestContext) KeyId() string {
 }
 
 func (ctx *TestContext) JwtSignerKeyFunc(*jwt.Token) (interface{}, error) {
-	tlsCert, _, _ := ctx.GetServerCert()
+	tlsCert, _, _ := ctx.GetClientApiDefaultServerCert()
 	return tlsCert.Leaf.PublicKey, nil
 }
 
-func (ctx *TestContext) GetServerCert() (*tls.Certificate, string, jwt.SigningMethod) {
+func (ctx *TestContext) GetClientApiDefaultServerCert() (*tls.Certificate, string, jwt.SigningMethod) {
 	return nil, "", nil
 }
 

--- a/controller/oidc_auth/provider.go
+++ b/controller/oidc_auth/provider.go
@@ -70,8 +70,8 @@ func createIssuerSpecificOidcProvider(ctx context.Context, issuer string, config
 
 // NewNativeOnlyOP creates an OIDC Provider that allows native clients and only the AuthCode PKCE flow.
 func NewNativeOnlyOP(ctx context.Context, env model.Env, config Config) (http.Handler, error) {
-	cert, kid, method := env.GetServerCert()
-	config.Storage = NewStorage(kid, cert.Leaf.PublicKey, cert.PrivateKey, method, &config, env)
+	rootSigner := env.GetRootTlsJwtSigner()
+	config.Storage = NewStorage(rootSigner, &config, env)
 
 	openzitiClient := NativeClient(common.ClaimClientIdOpenZiti, config.RedirectURIs, config.PostLogoutURIs)
 	openzitiClient.idTokenDuration = config.IdTokenDuration

--- a/controller/webapis/client-api.go
+++ b/controller/webapis/client-api.go
@@ -18,6 +18,11 @@ package webapis
 
 import (
 	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
 	"github.com/openziti/edge-api/rest_client_api_client"
 	"github.com/openziti/edge-api/rest_client_api_server"
 	"github.com/openziti/edge-api/rest_management_api_server"
@@ -27,10 +32,6 @@ import (
 	"github.com/openziti/ziti/controller/env"
 	"github.com/openziti/ziti/controller/response"
 	"github.com/pkg/errors"
-	"net/http"
-	"os"
-	"strings"
-	"time"
 )
 
 const ZitiInstanceId = "ziti-instance-id"
@@ -61,7 +62,7 @@ func (factory ClientApiFactory) Validate(config *xweb.InstanceConfig) error {
 			if !clientApiFound && api.Binding() == ClientApiBinding {
 				for _, bindPoint := range webListener.BindPoints {
 					if bindPoint.Address == edgeConfig.Api.Address {
-						factory.appEnv.SetServerCert(webListener.Identity.ServerCert()[0])
+						factory.appEnv.SetClientApiDefaultCertificate(webListener.Identity.ServerCert()[0])
 						clientApiFound = true
 						break
 					}


### PR DESCRIPTION
- addresses HA vs non-HA signing
- fixes issue where APIs server w/ difference certs than the root identity
- adds documentation for env/appenv
- adds a new composite type for TLSCert JWT signers