### PR TITLE
fixes #3239 router enrollment used identity expiration duration

### DIFF
--- a/controller/model/edge_router_manager.go
+++ b/controller/model/edge_router_manager.go
@@ -19,6 +19,7 @@ package model
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/storage/boltz"
 	"github.com/openziti/ziti/common/cert"
@@ -131,7 +132,7 @@ func (self *EdgeRouterManager) ApplyCreate(cmd *CreateEdgeRouterCmd, ctx boltz.M
 			return err
 		}
 
-		if err = enrollment.FillJwtInfo(self.env, edgeRouter.Id); err != nil {
+		if err = enrollment.FillJwtInfoForRouter(self.env, edgeRouter.Id); err != nil {
 			return err
 		}
 

--- a/controller/model/enrollment_manager.go
+++ b/controller/model/enrollment_manager.go
@@ -19,6 +19,8 @@ package model
 import (
 	"crypto/x509"
 	"fmt"
+	"time"
+
 	"github.com/google/uuid"
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/foundation/v2/errorz"
@@ -37,7 +39,6 @@ import (
 	"github.com/pkg/errors"
 	"go.etcd.io/bbolt"
 	"google.golang.org/protobuf/proto"
-	"time"
 )
 
 type EnrollmentManager struct {
@@ -454,7 +455,7 @@ func (self *EnrollmentManager) ApplyReEnrollEdgeRouter(cmd *ReEnrollEdgeRouterCm
 			EdgeRouterId: &cmd.edgeRouterId,
 		}
 
-		if err := enrollment.FillJwtInfo(self.env, cmd.edgeRouterId); err != nil {
+		if err := enrollment.FillJwtInfoForRouter(self.env, cmd.edgeRouterId); err != nil {
 			return fmt.Errorf("unable to fill jwt info for re-enrolling edge router: %v", err)
 		}
 

--- a/controller/model/identity_manager.go
+++ b/controller/model/identity_manager.go
@@ -20,6 +20,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync"
+	"time"
+
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/channel/v4"
 	"github.com/openziti/foundation/v2/errorz"
@@ -41,8 +44,6 @@ import (
 	cmap "github.com/orcaman/concurrent-map/v2"
 	"go.etcd.io/bbolt"
 	"google.golang.org/protobuf/proto"
-	"sync"
-	"time"
 )
 
 const (
@@ -134,7 +135,7 @@ func (self *IdentityManager) ApplyCreateWithEnrollments(cmd *CreateIdentityWithE
 		for _, enrollment := range enrollmentsModels {
 			enrollment.IdentityId = &identityModel.Id
 
-			if err = enrollment.FillJwtInfo(self.env, identityModel.Id); err != nil {
+			if err = enrollment.FillJwtInfoForIdentity(self.env, identityModel.Id); err != nil {
 				return err
 			}
 

--- a/controller/model/transit_router_manager.go
+++ b/controller/model/transit_router_manager.go
@@ -18,6 +18,7 @@ package model
 
 import (
 	"fmt"
+
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/storage/boltz"
 	"github.com/openziti/ziti/common/eid"
@@ -99,7 +100,7 @@ func (self *TransitRouterManager) ApplyCreate(cmd *CreateTransitRouterCmd, ctx b
 			return err
 		}
 
-		if err = enrollment.FillJwtInfo(self.env, txRouter.Id); err != nil {
+		if err = enrollment.FillJwtInfoForRouter(self.env, txRouter.Id); err != nil {
 			return err
 		}
 

--- a/tests/ats-ctrl.yml
+++ b/tests/ats-ctrl.yml
@@ -42,9 +42,9 @@ edge:
       key: testdata/ca/intermediate/private/intermediate.key.decrypted.pem
       ca: testdata/ca/intermediate/certs/ca-chain.cert.pem
     edgeIdentity:
-      duration: 5m
+      duration: 20m
     edgeRouter:
-      duration: 5m
+      duration: 60m
 
 
 web:


### PR DESCRIPTION
- clearer naming for JWT filling functions, doc
- fixed router logic references
- tests