### PR TITLE
Azure Service Bus logger for controller event streaming

### DIFF
--- a/controller/events/dispatcher.go
+++ b/controller/events/dispatcher.go
@@ -18,11 +18,12 @@ package events
 
 import (
 	"fmt"
+	"io"
+	"strings"
+
 	"github.com/openziti/storage/boltz"
 	"github.com/openziti/ziti/controller/db"
 	"github.com/openziti/ziti/controller/event"
-	"io"
-	"strings"
 
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/foundation/v2/concurrenz"
@@ -88,6 +89,7 @@ func NewDispatcher(closeNotify <-chan struct{}) *Dispatcher {
 	result.RegisterEventHandlerFactory("file", FileEventLoggerFactory{})
 	result.RegisterEventHandlerFactory("stdout", StdOutLoggerFactory{})
 	result.RegisterEventHandlerFactory("amqp", AMQPEventLoggerFactory{})
+	result.RegisterEventHandlerFactory("servicebus", ServiceBusEventLoggerFactory{})
 
 	return result
 }

--- a/controller/events/servicebus_logger.go
+++ b/controller/events/servicebus_logger.go
@@ -1,0 +1,313 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package events
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
+	"github.com/cenkalti/backoff/v4"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+var contentType = "application/json"
+
+type ServiceBusEventLoggerFactory struct{}
+
+func (ServiceBusEventLoggerFactory) NewEventHandler(config map[interface{}]interface{}) (interface{}, error) {
+	return NewServiceBusEventLogger(fabricFormatterFactory{}, config)
+}
+
+type serviceBusWriteCloser struct {
+	client    *azservicebus.Client
+	sender    *azservicebus.Sender
+	config    *serviceBusConfig
+	ctx       context.Context
+	cancel    context.CancelFunc
+	messages  chan []byte
+}
+
+func newServiceBusWriteCloser(config *serviceBusConfig) serviceBusWriteCloser {
+	ctx, cancel := context.WithCancel(context.Background())
+	ret := serviceBusWriteCloser{
+		config:   config,
+		ctx:      ctx,
+		cancel:   cancel,
+		messages: make(chan []byte, config.bufferSize),
+	}
+	go func() {
+		ret.connect()
+		for {
+			select {
+			case m := <-ret.messages:
+				{
+					ret.sendMessage(m)
+				}
+			case <-ret.ctx.Done():
+				{
+					var retErr error
+					if ret.sender != nil {
+						if err := ret.sender.Close(context.Background()); err != nil {
+							retErr = err
+						}
+					}
+					if ret.client != nil {
+						if err := ret.client.Close(context.Background()); err != nil {
+							if retErr != nil {
+								retErr = fmt.Errorf("%v; %w", retErr, err)
+							} else {
+								retErr = err
+							}
+						}
+					}
+					if retErr != nil {
+						logrus.Errorf("error closing service bus connections: %v", retErr)
+						return
+					}
+					logrus.Info("closed connection to service bus")
+				}
+			}
+		}
+	}()
+
+	return ret
+}
+
+func (wc *serviceBusWriteCloser) sendMessage(message []byte) {
+	for {
+		select {
+		case <-wc.ctx.Done():
+			return
+		default:
+		}
+		
+		sbMessage := &azservicebus.Message{
+			ContentType: &contentType,
+			Body: message,
+		}
+		
+		err := wc.sender.SendMessage(context.Background(), sbMessage, nil)
+		if err == nil {
+			return
+		}
+		
+		// Check if it's a connection error that requires reconnection
+		if isConnectionError(err) {
+			logrus.Info("Need to attempt reconnect to service bus")
+			wc.connect()
+			continue
+		}
+		
+		// Enhanced error logging with more details
+		logEntry := logrus.WithFields(logrus.Fields{
+			"body":        string(message),
+			"error":       err.Error(),
+			"error_type":  fmt.Sprintf("%T", err),
+		})
+		
+		// Add destination information if available
+		if wc.config.topicName != "" {
+			logEntry = logEntry.WithField("destination", "topic:"+wc.config.topicName)
+		} else if wc.config.queueName != "" {
+			logEntry = logEntry.WithField("destination", "queue:"+wc.config.queueName)
+		}
+		
+		// Add response error details if available
+		var respErr *azcore.ResponseError
+		if errors.As(err, &respErr) {
+			logEntry = logEntry.WithFields(logrus.Fields{
+				"status_code": respErr.StatusCode,
+				"raw_response": respErr.RawResponse,
+			})
+		}
+		
+		logEntry.Error("error sending message to service bus")
+	}
+}
+
+func isConnectionError(err error) bool {
+	// Check for common connection-related errors
+	var respErr *azcore.ResponseError
+	if errors.As(err, &respErr) {
+		// Check for connection-related status codes
+		switch respErr.StatusCode {
+		case 401, 403, 404, 408, 500, 502, 503, 504:
+			return true
+		}
+	}
+	
+	// Check for context errors
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return true
+	}
+	
+	// Check for network-related errors
+	// Note: azservicebus doesn't export ErrConnectionClosed, so we check for specific error types
+	if err != nil {
+		// Check if it's a connection-related error by examining the error message
+		errMsg := err.Error()
+		if strings.Contains(errMsg, "connection") || strings.Contains(errMsg, "network") || strings.Contains(errMsg, "timeout") {
+			return true
+		}
+	}
+	
+	return false
+}
+
+func (wc *serviceBusWriteCloser) connect() {
+	expBackoff := backoff.NewExponentialBackOff()
+	expBackoff.InitialInterval = 1 * time.Second
+	expBackoff.MaxInterval = 5 * time.Minute
+	expBackoff.MaxElapsedTime = 0
+
+	operation := func() error {
+		select {
+		case <-wc.ctx.Done():
+			return backoff.Permanent(nil)
+		default:
+		}
+		
+		// Create client options
+		clientOptions := &azservicebus.ClientOptions{}
+		
+		// Create the client
+		client, err := azservicebus.NewClientFromConnectionString(wc.config.connectionString, clientOptions)
+		if err != nil {
+			logrus.Errorf("unable to create service bus client: %v", err)
+			return err
+		}
+		wc.client = client
+		
+		// Create sender - support both topic and queue
+		var sender *azservicebus.Sender
+		if wc.config.topicName != "" {
+			sender, err = client.NewSender(wc.config.topicName, nil)
+		} else if wc.config.queueName != "" {
+			sender, err = client.NewSender(wc.config.queueName, nil)
+		} else {
+			return fmt.Errorf("either topic or queue must be specified")
+		}
+		if err != nil {
+			logrus.Errorf("error creating service bus sender: %v", err)
+			return err
+		}
+		wc.sender = sender
+		
+		return nil
+	}
+	
+	if err := backoff.Retry(operation, expBackoff); err != nil {
+		logrus.Errorf("service bus connection failed after exponential backoff: %v", err)
+		return
+	}
+	
+	// Log the connection success with appropriate destination
+	if wc.config.topicName != "" {
+		logrus.Infof("connected to service bus topic: %s", wc.config.topicName)
+	} else {
+		logrus.Infof("connected to service bus queue: %s", wc.config.queueName)
+	}
+}
+
+func (wc serviceBusWriteCloser) Write(data []byte) (int, error) {
+	select {
+	case wc.messages <- data:
+		return len(data), nil
+	default:
+		return 0, fmt.Errorf("service bus queue full. Message: %s", string(data))
+	}
+}
+
+func (wc serviceBusWriteCloser) Close() error {
+	wc.cancel()
+	return nil
+}
+
+type serviceBusConfig struct {
+	connectionString string
+	topicName        string
+	queueName        string
+	bufferSize       int
+}
+
+func parseServiceBusConfig(config map[interface{}]interface{}) (*serviceBusConfig, error) {
+	ret := &serviceBusConfig{
+		bufferSize: 50,
+	}
+	
+	if value, found := config["connectionString"]; !found {
+		return nil, fmt.Errorf("missing service bus connection string")
+	} else {
+		if u, ok := value.(string); ok {
+			ret.connectionString = u
+		} else {
+			return nil, fmt.Errorf("invalid service bus connection string")
+		}
+	}
+
+	// Check for topic or queue configuration
+	if value, found := config["topic"]; found {
+		if u, ok := value.(string); ok {
+			ret.topicName = u
+		} else {
+			return nil, fmt.Errorf("invalid service bus topic name")
+		}
+	} else if value, found := config["queue"]; found {
+		if u, ok := value.(string); ok {
+			ret.queueName = u
+		} else {
+			return nil, fmt.Errorf("invalid service bus queue name")
+		}
+	} else {
+		return nil, fmt.Errorf("either topic or queue must be specified for service bus")
+	}
+
+	if value, found := config["bufferSize"]; found {
+		if u, ok := value.(int); ok {
+			ret.bufferSize = u
+		}
+	}
+
+	return ret, nil
+}
+
+func NewServiceBusEventLogger(formatterFactory LoggingHandlerFactory, config map[interface{}]interface{}) (interface{}, error) {
+	bufferSize := 10
+	if value, found := config["bufferSize"]; found {
+		if size, ok := value.(int); ok {
+			bufferSize = size
+		}
+	}
+
+	conf, err := parseServiceBusConfig(config)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to parse service bus config")
+	}
+
+	if value, found := config["format"]; found {
+		if format, ok := value.(string); ok {
+			return formatterFactory.NewLoggingHandler(format, bufferSize, newServiceBusWriteCloser(conf))
+		}
+		return nil, errors.New("invalid 'format' for event service bus log")
+	}
+	return nil, errors.New("'format' must be specified for event handler")
+}

--- a/doc/003-local-deploy.md
+++ b/doc/003-local-deploy.md
@@ -32,7 +32,7 @@ mkdir -p ./db
 Before you can run the controller will initialize its configuration and database. We'll use the demo CA that's checked in to this repo in `./etc/ca`.
 
 ```bash
-ZITI_HOME=. \                              
+ZITI_HOME=. \
 ZITI_CTRL_ADVERTISED_ADDRESS=127.0.0.1 \
 ZITI_CTRL_EDGE_ADVERTISED_HOST_PORT=127.0.0.1:1280 \
 ZITI_EDGE_CTRL_ADVERTISED_HOST_PORT=127.0.0.1:1280 \

--- a/etc/ctrl.with.edge.yml
+++ b/etc/ctrl.with.edge.yml
@@ -129,6 +129,54 @@ events:
 #      noWait: false      //default:false
 #      bufferSize: 50     //default:50
 
+  # serviceBusLogger:
+  #   subscriptions:
+  #     - type: apiSession
+  #     - type: authentication
+  #     - type: circuit
+  #     - type: connect
+  #     - type: sdk
+  #     - type: entityChange
+  #       include:
+  #         - services
+  #         - identities
+  #     - type: entityCount
+  #     - type: link
+  #     - type: metrics
+  #       sourceFilter: .*
+  #       metricFilter: .*
+  #     - type: router
+  #     - type: session
+  #     - type: services
+  #     - type: terminator
+  #     - type: usage
+  #       version: 3
+  #     - type: usage
+  #       version: 2
+  #       include:
+  #         - ingress.rx
+  #         - egress.rx
+  #       interval: 5s
+  #   handler:
+  #     type: servicebus
+  #     format: json
+  #     connectionString: "Endpoint=sb://your-namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=your-key"
+  #     topic: "ziti-events"
+  #     bufferSize: 100
+
+# Alternative configuration with queue instead of topic
+# events:
+#   serviceBusQueueLogger:
+#     subscriptions:
+#       - type: fabric.circuits
+#       - type: edge.sessions
+#     handler:
+#       type: servicebus
+#       format: json
+#       connectionString: "Endpoint=sb://your-namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=your-key"
+#       queue: "ziti-events-queue"
+#       bufferSize: 50
+
 # xctrl_example
 #
 #example:

--- a/go.mod
+++ b/go.mod
@@ -106,6 +106,10 @@ require (
 )
 
 require (
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.2 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus v1.10.0 // indirect
+	github.com/Azure/go-amqp v1.4.0 // indirect
 	github.com/MichaelMure/go-term-markdown v0.1.4 // indirect
 	github.com/MichaelMure/go-term-text v0.3.1 // indirect
 	github.com/alecthomas/chroma v0.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,15 @@ git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGy
 github.com/AlecAivazis/survey/v2 v2.0.5/go.mod h1:WYBhg6f0y/fNYUuesWQc0PKbJcEliGcYHB9sNT3Bg74=
 github.com/AppsFlyer/go-sundheit v0.6.0 h1:d2hBvCjBSb2lUsEWGfPigr4MCOt04sxB+Rppl0yUMSk=
 github.com/AppsFlyer/go-sundheit v0.6.0/go.mod h1:LDdBHD6tQBtmHsdW+i1GwdTt6Wqc0qazf5ZEJVTbTME=
+github.com/Azure/azure-sdk-for-go v68.0.0+incompatible h1:fcYLmCpyNYRnvJbPerq7U0hS+6+I79yEDJBqVNcqUzU=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.2 h1:Hr5FTipp7SL07o2FvoVOX9HRiRH3CR3Mj8pxqCcdD5A=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.2/go.mod h1:QyVsSSN64v5TGltphKLQ2sQxe4OBQg0J1eKRcVBnfgE=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 h1:9iefClla7iYpfYWdzPCRDozdmndjTm8DXdpCzPajMgA=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2/go.mod h1:XtLgD3ZD34DAaVIIAyG3objl5DynM3CQ/vMcbBNJZGI=
+github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus v1.10.0 h1:kE5kpeiSqu4jcCQ/sWuyggMXJ/pT6oQ99+8hwPmyeJ0=
+github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus v1.10.0/go.mod h1:IAN3Z0DMtehoxoQQnfqg1891z1P7GNoDryKtFcAyMBI=
+github.com/Azure/go-amqp v1.4.0 h1:Xj3caqi4comOF/L1Uc5iuBxR/pB6KumejC01YQOqOR4=
+github.com/Azure/go-amqp v1.4.0/go.mod h1:vZAogwdrkbyK3Mla8m/CxSc/aKdnTZ4IbPxl51Y5WZE=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=

--- a/tests/events_test.go
+++ b/tests/events_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openziti/foundation/v2/stringz"
 	"github.com/openziti/sdk-golang/ziti"
 	"github.com/openziti/ziti/controller/event"
+	"github.com/openziti/ziti/controller/events"
 	"github.com/openziti/ziti/controller/xt_smartrouting"
 )
 
@@ -164,4 +165,73 @@ func Test_EventsTest(t *testing.T) {
 			ctx.Req.Fail("unexpected event type: %v", reflect.TypeOf(evt))
 		}
 	}
+}
+
+func Test_ServiceBusEventLogger(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+
+	ctx.StartServer()
+
+	t.Run("servicebus event handler factory", func(t *testing.T) {
+		factory := events.ServiceBusEventLoggerFactory{}
+
+		// Test valid topic configuration
+		topicConfig := map[interface{}]interface{}{
+			"connectionString": "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=test-key",
+			"topic":            "test-topic",
+			"format":           "json",
+			"bufferSize":       100,
+		}
+
+		handler, err := factory.NewEventHandler(topicConfig)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(handler)
+
+		// Test valid queue configuration
+		queueConfig := map[interface{}]interface{}{
+			"connectionString": "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=test-key",
+			"queue":            "test-queue",
+			"format":           "json",
+		}
+
+		handler, err = factory.NewEventHandler(queueConfig)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(handler)
+
+		// Test missing connection string
+		invalidConfig := map[interface{}]interface{}{
+			"topic":  "test-topic",
+			"format": "json",
+		}
+
+		_, err = factory.NewEventHandler(invalidConfig)
+		ctx.Req.Error(err)
+		ctx.Req.Contains(err.Error(), "unable to parse service bus config")
+	})
+
+	t.Run("servicebus configuration validation", func(t *testing.T) {
+		factory := events.ServiceBusEventLoggerFactory{}
+
+		// Test missing topic and queue
+		invalidConfig := map[interface{}]interface{}{
+			"connectionString": "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=test-key",
+			"format":           "json",
+		}
+
+		_, err := factory.NewEventHandler(invalidConfig)
+		ctx.Req.Error(err)
+		ctx.Req.Contains(err.Error(), "unable to parse service bus config")
+
+		// Test invalid format
+		invalidFormatConfig := map[interface{}]interface{}{
+			"connectionString": "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=test-key",
+			"topic":            "test-topic",
+			"format":           "invalid",
+		}
+
+		_, err = factory.NewEventHandler(invalidFormatConfig)
+		ctx.Req.Error(err)
+		ctx.Req.Contains(err.Error(), "invalid 'format' for event log output file")
+	})
 }


### PR DESCRIPTION
# Add Azure Service Bus Event Logger

## Summary

This PR adds support for logging OpenZiti controller events to Azure Service Bus topics and queues. This enables integration with Azure-based event processing pipelines, monitoring systems, and other Azure services.

## Features

- **Topic and Queue Support**: Send events to either Service Bus topics or queues
- **Automatic Reconnection**: Handles connection failures with exponential backoff
- **Buffered Messaging**: Configurable buffer size for high-throughput scenarios
- **JSON Format**: Events are formatted as JSON messages
- **Error Handling**: Comprehensive error handling and logging
- **Configuration Flexibility**: Support for both topic and queue destinations


