### PR TITLE
fixes #3286 version API discovery for edge-oidc

### DIFF
--- a/controller/internal/routes/version_router.go
+++ b/controller/internal/routes/version_router.go
@@ -18,6 +18,9 @@
 package routes
 
 import (
+	"runtime"
+	"sync"
+
 	"github.com/go-openapi/runtime/middleware"
 	clientInformational "github.com/openziti/edge-api/rest_client_api_server/operations/informational"
 	managementInformational "github.com/openziti/edge-api/rest_management_api_server/operations/informational"
@@ -28,8 +31,6 @@ import (
 	"github.com/openziti/ziti/controller/internal/permissions"
 	"github.com/openziti/ziti/controller/response"
 	"github.com/openziti/ziti/controller/webapis"
-	"runtime"
-	"sync"
 )
 
 func init() {
@@ -172,6 +173,7 @@ func apiBindingToPath(binding string) string {
 		return webapis.ClientRestApiBaseUrlV1
 	case webapis.ManagementApiBinding:
 		return webapis.ManagementRestApiBaseUrlV1
+	case webapis.OidcApiBinding: return webapis.OidcRestApiBaseUrl
 	}
 	return ""
 }

--- a/tests/endpoint_test.go
+++ b/tests/endpoint_test.go
@@ -2,9 +2,10 @@ package tests
 
 import (
 	"encoding/json"
-	"github.com/openziti/edge-api/rest_model"
 	"net/http"
 	"testing"
+
+	"github.com/openziti/edge-api/rest_model"
 )
 
 // Test_Endpoints does HTTP testing against public entry URLs to ensure they continue to function.
@@ -116,14 +117,20 @@ func Test_Endpoints(t *testing.T) {
 				ctx.Req.Contains(data.APIVersions, "edge-client")
 				ctx.Req.Contains(data.APIVersions["edge-client"], "v1")
 				ctx.Req.Equal(*data.APIVersions["edge-client"]["v1"].Path, "/edge/client/v1")
+				ctx.Req.Len(data.APIVersions["edge-client"]["v1"].APIBaseUrls, 1)
+				ctx.Req.Equal(data.APIVersions["edge-client"]["v1"].APIBaseUrls[0], "https://"+ctx.ApiHost+"/edge/client/v1")
 
 				ctx.Req.Contains(data.APIVersions, "edge-management")
 				ctx.Req.Contains(data.APIVersions["edge-management"], "v1")
 				ctx.Req.Equal(*data.APIVersions["edge-management"]["v1"].Path, "/edge/management/v1")
+				ctx.Req.Len(data.APIVersions["edge-management"]["v1"].APIBaseUrls, 1)
+				ctx.Req.Equal(data.APIVersions["edge-management"]["v1"].APIBaseUrls[0], "https://"+ctx.ApiHost+"/edge/management/v1")
 
 				ctx.Req.Contains(data.APIVersions, "edge-oidc")
 				ctx.Req.Contains(data.APIVersions["edge-oidc"], "v1")
 				ctx.Req.Equal(*data.APIVersions["edge-oidc"]["v1"].Path, "/oidc")
+				ctx.Req.Len(data.APIVersions["edge-oidc"]["v1"].APIBaseUrls, 1)
+				ctx.Req.Equal(data.APIVersions["edge-oidc"]["v1"].APIBaseUrls[0], "https://"+ctx.ApiHost+"/oidc")
 
 				ctx.Req.Contains(data.APIVersions, "health-checks")
 				ctx.Req.Contains(data.APIVersions["health-checks"], "v1")


### PR DESCRIPTION
- fixes edge-oidc discovery API path
- adds test for all api bindings