### PR TITLE
setup-cli GitHub action

### DIFF
--- a/setup-cli/action.yml
+++ b/setup-cli/action.yml
@@ -13,10 +13,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Setup GitHub CLI
-      if: runner.os == 'linux' 
-      uses: ksivamuthu/actions-setup-gh-cli@v3
-
     - name: process version
       shell: bash
       run: |


### PR DESCRIPTION
this action downloads ziti cli binary and adds to the PATH

primary use of this action is integration testing in SDK projects.

input parameters:
- `version`: can be the tag(v1.7.1), or 'stable' (latest release), 'latest' (latest tag, possibly pre-release)

usage:
```
   - uses: openziti/ziti/setup-cli@main
     with:
        version: v1.7.1 
```
       