### PR TITLE
fix cli login with file; resolves #3378

### DIFF
--- a/tests/cli_tests/login_test.go
+++ b/tests/cli_tests/login_test.go
@@ -521,7 +521,7 @@ func (s *loginTestState) testControllerUnavailable(t *testing.T) {
 
 func (s *loginTestState) reconfigureTargetForZiti(pkiRoot string) error {
 	v2 := cmd.NewRootCommand(os.Stdin, os.Stdout, os.Stderr)
-	v2.SetArgs(strings.Split("pki create server --key-file server --pki-root "+pkiRoot+" --ip 127.0.0.1,::1 --dns localhost,mgmt,mgmt.ziti.internal --ca-name intermediate-ca-quickstart --server-file mgmt.ziti.internal", " "))
+	v2.SetArgs(strings.Split("pki create server --key-file server --pki-root "+pkiRoot+" --ip 127.0.0.1,::1 --dns localhost,mgmt,mgmt.ziti --ca-name intermediate-ca-quickstart --server-file mgmt.ziti", " "))
 	if zitiCmdErr := v2.Execute(); zitiCmdErr != nil {
 		return zitiCmdErr
 	}
@@ -545,7 +545,7 @@ func (s *loginTestState) loginTestsOverZiti(t *testing.T, now, zitiPath string) 
 		defer controllerUnderTestCancel()
 		s.controllerUnderTest.Ctx = controllerUnderTestCtx2
 		s.controllerUnderTest.ConfigFile = gopath.Join(s.controllerUnderTest.Home, "ctrl.yaml")
-		newServerCertPath := gopath.Join(s.controllerUnderTest.Home, "pki/intermediate-ca-quickstart/certs/mgmt.ziti.internal.chain.pem")
+		newServerCertPath := gopath.Join(s.controllerUnderTest.Home, "pki/intermediate-ca-quickstart/certs/mgmt.ziti.chain.pem")
 		if re := s.controllerUnderTest.ReplaceConfig(newServerCertPath); re != nil {
 			t.Fatalf("failed to replace config: %v", re)
 		}
@@ -557,9 +557,9 @@ func (s *loginTestState) loginTestsOverZiti(t *testing.T, now, zitiPath string) 
 			log.Fatalf("controllerUnderTest start failed: %v", cutStartErr)
 		}
 
-		s.updateAdminIdFileForZiti(t, "https://mgmt.ziti.internal:443")
+		s.updateAdminIdFileForZiti(t, "https://mgmt.ziti:443")
 
-		s.controllerUnderTest.ControllerAddress = "mgmt.ziti.internal"
+		s.controllerUnderTest.ControllerAddress = "mgmt.ziti"
 		s.controllerUnderTest.ControllerPort = 443
 
 		s.runLoginTests(t)
@@ -571,7 +571,7 @@ func (s *loginTestState) loginTestsOverZiti(t *testing.T, now, zitiPath string) 
 }
 
 func (s *loginTestState) updateAdminIdFileForZiti(t *testing.T, newAddr string) {
-	t.Logf("Updating %s with new url: %s from %s", s.controllerUnderTest.AdminIdFile, "https://mgmt.ziti.internal:443", s.controllerUnderTest.ControllerHostPort())
+	t.Logf("Updating %s with new url: %s from %s", s.controllerUnderTest.AdminIdFile, "https://mgmt.ziti:443", s.controllerUnderTest.ControllerHostPort())
 	data, _ := os.ReadFile(s.controllerUnderTest.AdminIdFile)
 	out := strings.ReplaceAll(string(data), s.controllerUnderTest.ControllerHostPort(), newAddr)
 	_ = os.WriteFile(s.controllerUnderTest.AdminIdFile, []byte(out), 0644)

--- a/tests/cli_tests/login_test_import.yml
+++ b/tests/cli_tests/login_test_import.yml
@@ -7,7 +7,7 @@
       "configType": "@intercept.v1",
       "data": {
         "addresses": [
-          "mgmt.ziti.internal"
+          "mgmt.ziti"
         ],
         "portRanges": [
           {


### PR DESCRIPTION
## Summary

Fixed `ziti edge login --file` to use the URL from the identity file instead of failing with "invalid controller URL supplied".

### Root Cause

[addHttpsIfNeeded("")](cci:1://file:///home/kbingham/Sites/netfoundry/github/ziti/ziti/cmd/edge/login.go:822:0-827:1) was converting empty strings to `"https://"`, which happened in two places early in the login flow ([terminatorId()](cci:1://file:///home/kbingham/Sites/netfoundry/github/ziti/ziti/cmd/edge/login.go:510:0-520:1) and [PopulateFromCache()](cci:1://file:///home/kbingham/Sites/netfoundry/github/ziti/ziti/cmd/edge/login.go:554:0-588:1)). This caused the code to skip extracting the URL from the identity file.

### Fix

Added guards to prevent calling [addHttpsIfNeeded()](cci:1://file:///home/kbingham/Sites/netfoundry/github/ziti/ziti/cmd/edge/login.go:822:0-827:1) on empty strings in three locations:
1. **[terminatorId()](cci:1://file:///home/kbingham/Sites/netfoundry/github/ziti/ziti/cmd/edge/login.go:510:0-520:1)** - Only call if `o.ControllerUrl != ""`
2. **[PopulateFromCache()](cci:1://file:///home/kbingham/Sites/netfoundry/github/ziti/ziti/cmd/edge/login.go:554:0-588:1)** - Only call if `o.ControllerUrl != ""`
3. **[addHttpsIfNeeded()](cci:1://file:///home/kbingham/Sites/netfoundry/github/ziti/ziti/cmd/edge/login.go:822:0-827:1)** - Return empty string unchanged

This ensures `o.ControllerUrl` stays empty when no URL is provided, allowing the identity file URL to be correctly extracted.