### PR TITLE
fix openziti/ziti#3575 OIDC token endpoint code bugs possibly resulting in panics/eof errors

### DIFF
--- a/controller/env/appenv.go
+++ b/controller/env/appenv.go
@@ -175,9 +175,9 @@ func (ae *AppEnv) JwtSignerKeyFunc(token *jwt.Token) (interface{}, error) {
 	kidToPubKey := ae.Broker.GetPublicKeys()
 
 	val := token.Header["kid"]
-	targetKid := val.(string)
+	targetKid, ok := val.(string)
 
-	if targetKid == "" {
+	if !ok || targetKid == "" {
 		return nil, errors.New("missing kid in token")
 	}
 
@@ -313,7 +313,7 @@ func (ae *AppEnv) GetRootTlsJwtSigner() *jwtsigner.TlsJwtSigner {
 	}
 
 	rootSigner := &jwtsigner.TlsJwtSigner{}
-	err := rootSigner.Set(rootCerts[0])
+	err := rootSigner.Set(rootCert)
 
 	if err != nil {
 		pfxlog.Logger().WithError(err).Panic("failed to set root controller identity signer")

--- a/controller/oidc_auth/storage.go
+++ b/controller/oidc_auth/storage.go
@@ -969,7 +969,10 @@ func (s *HybridStorage) createRefreshClaims(accessClaims *common.AccessClaims) (
 	claims.Expiration = oidc.Time(time.Now().Add(s.config.RefreshTokenDuration).Unix())
 	claims.Type = common.TokenTypeRefresh
 
-	token, _ := s.env.GetRootTlsJwtSigner().Generate(claims)
+	token, err := s.env.GetRootTlsJwtSigner().Generate(claims)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to generate refresh token: %w", err)
+	}
 
 	return token, claims, nil
 }
@@ -999,9 +1002,12 @@ func (s *HybridStorage) renewRefreshToken(currentRefreshToken string) (string, *
 	newRefreshClaims.NotBefore = oidc.Time(now.Unix())
 	newRefreshClaims.Expiration = oidc.Time(now.Add(s.config.RefreshTokenDuration).Unix())
 
-	token, _ := s.env.GetRootTlsJwtSigner().Generate(newRefreshClaims)
+	token, err := s.env.GetRootTlsJwtSigner().Generate(newRefreshClaims)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to generate refresh token: %w", err)
+	}
 
-	return token, newRefreshClaims, err
+	return token, newRefreshClaims, nil
 }
 
 func (s *HybridStorage) setInfo(userInfo *oidc.UserInfo, identityId string, scopes []string) (err error) {

--- a/controller/webapis/oidc-api.go
+++ b/controller/webapis/oidc-api.go
@@ -24,13 +24,16 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/openziti/identity"
 
 	"github.com/openziti/xweb/v3"
 	"github.com/openziti/ziti/v2/controller/api"
+	"github.com/openziti/ziti/v2/controller/apierror"
 	"github.com/openziti/ziti/v2/controller/env"
 	"github.com/openziti/ziti/v2/controller/oidc_auth"
+	"github.com/openziti/ziti/v2/controller/response"
 )
 
 var _ xweb.ApiHandlerFactory = &OidcApiFactory{}
@@ -181,7 +184,7 @@ func NewOidcApiHandler(serverConfig *xweb.ServerConfig, ae *env.AppEnv, options 
 	if err != nil {
 		return nil, err
 	}
-	oidcApi.handler = api.WrapCorsHandler(oidcApi.handler)
+	oidcApi.handler = api.TimeoutHandler(api.WrapCorsHandler(oidcApi.handler), 10*time.Second, apierror.NewTimeoutError(), response.EdgeResponseMapper{})
 
 	return oidcApi, nil
 }


### PR DESCRIPTION
OIDC token endpoint code bugs possibly resulting in panics/eof errors

- Wrap OIDC handler with TimeoutHandler to match all other API handlers
- Fix GetRootTlsJwtSigner using rootCerts[0] instead of resolved rootCert
- Propagate Generate() errors in createRefreshClaims and renewRefreshToken
- Use safe type assertion for kid header in JwtSignerKeyFunc