### PR TITLE
Fix ops verify ext-jwt-signer oidc

### DIFF
--- a/ziti/cmd/edge/login.go
+++ b/ziti/cmd/edge/login.go
@@ -782,6 +782,8 @@ func (o *LoginOptions) Login() (edge_apis.ApiSession, error) {
 			return nil, err
 		}
 		authCreds = edge_apis.NewIdentityCredentialsFromConfig(cfg.ID)
+	} else if o.ExtJwtToken != "" {
+		authCreds = edge_apis.NewJwtCredentials(o.ExtJwtToken)
 	} else if o.extJwtFile != "" {
 		jwt, jwtErr := os.ReadFile(o.extJwtFile)
 		if jwtErr != nil {


### PR DESCRIPTION
* forgot to merge the unset from the local cache file resulting in empty url
* forgot an ext-jwt-token branch causing a panic when using --authenticate to test/verify
