### PR TITLE
harden a workflow

### DIFF
--- a/.github/workflows/check-needs-reviews.yml
+++ b/.github/workflows/check-needs-reviews.yml
@@ -6,6 +6,8 @@ on:
   pull_request_target:
     types: [ opened ]
 
+permissions: {}
+
 jobs:
   add-to-project:
     runs-on: ubuntu-latest
@@ -14,7 +16,7 @@ jobs:
         if: >-
           github.actor != 'dependabot[bot]' &&
           !contains(fromJson('["andrewpmartinez", "dovholuknf","ekoby","michaelquigley", "mikegorman-nf", "plorenz", "qrkourier","scarey","smilindave26"]'), github.actor)
-        uses: actions/add-to-project@v1.0.2
+        uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e  # v1.0.2
         with:
           project-url: https://github.com/orgs/openziti/projects/38
           github-token: ${{ secrets.GH_CI_KEY }}


### PR DESCRIPTION
strip unnecessary perms and pin the action commit because the action handles a high-value secret