### PR TITLE
fix openziti/ziti#3648 tunnel: log circuitId instead of routerId in myCopy

### DIFF
--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -97,7 +97,7 @@ func Run(zitiConn edge.Conn, clientConn net.Conn, halfClose bool) {
 
 	go myCopy(clientConn, zitiConn, doneSend, halfClose, zitiConn.GetCircuitId())
 
-	go myCopy(zitiConn, clientConn, doneRecv, halfClose, zitiConn.GetRouterId())
+	go myCopy(zitiConn, clientConn, doneRecv, halfClose, zitiConn.GetCircuitId())
 
 	defer func() {
 		_ = clientConn.Close()


### PR DESCRIPTION
## Description

fix openziti/ziti#3648

The `Run()` function in `tunnel/tunnel.go` starts two `myCopy` goroutines for bidirectional data copy. The send direction (client → ziti) correctly passes `zitiConn.GetCircuitId()`, but the receive direction (ziti → client) passes `zitiConn.GetRouterId()`:

```go
go myCopy(clientConn, zitiConn, doneSend, halfClose, zitiConn.GetCircuitId())
go myCopy(zitiConn, clientConn, doneRecv, halfClose, zitiConn.GetRouterId())  // ← bug
```

Inside `myCopy()`, this value is logged under the field `"circuitId"`. This means every "stopping pipe", "copy failed", and "half-close" log entry from the receive direction shows the **router identity** (e.g., `AZD.aVO2ob`) instead of the actual circuit ID.

## Impact

The router identity appears as a constant "circuitId" across **all** connections through that router, making it appear to be a single persistent zombie circuit that never dies. This led us on a multi-hour debugging session chasing a phantom zombie circuit that turned out to be normal router identity logging. Operators investigating connection issues will waste significant time on this red herring.

With the fix, both directions log the actual circuit ID, enabling proper log correlation and faster root cause analysis.

## Changes

One-line change in `tunnel/tunnel.go`: replace `zitiConn.GetRouterId()` with `zitiConn.GetCircuitId()` in the receive-direction `myCopy` call.

## Testing

- Verified the change compiles (single method call swap, same return type)
- `GetRouterId()` is not used anywhere else in the `tunnel/` package
- `GetCircuitId()` is already used by the send-direction `myCopy` and the initial "tunnel started" log entry