### PR TITLE
add metrics to router config template

### DIFF
--- a/ziti/cmd/create/config_templates/router.yml
+++ b/ziti/cmd/create/config_templates/router.yml
@@ -104,3 +104,7 @@ forwarder:
   xgressDialWorkerCount: {{ .Router.Forwarder.XgressDialWorkerCount }}
   linkDialQueueLength: {{ .Router.Forwarder.LinkDialQueueLength }}
   linkDialWorkerCount: {{ .Router.Forwarder.LinkDialWorkerCount }}
+
+metrics:
+  reportInterval: 1m
+  messageQueueSize: 10


### PR DESCRIPTION
The router installers for Docker, Kubernetes, and Linux use this template.