### PR TITLE
fixes openziti/ziti#3673 purge expired revocations, fix revocation bugs

### DIFF
--- a/controller/env/appenv.go
+++ b/controller/env/appenv.go
@@ -229,7 +229,7 @@ func (ae *AppEnv) ValidateAccessToken(token string) (*common.AccessClaims, error
 		return nil, err
 	}
 
-	if revocation != nil && revocation.CreatedAt.After(accessClaims.IssuedAt.AsTime()) {
+	if revocation != nil && revocation.CreatedAt.Truncate(time.Second).After(accessClaims.IssuedAt.AsTime()) {
 		return nil, errors.New("access token has been revoked by identity")
 	}
 

--- a/controller/env/security_ctx.go
+++ b/controller/env/security_ctx.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/openziti/edge-api/rest_model"
 	"github.com/openziti/foundation/v2/errorz"
+	"github.com/openziti/storage/boltz"
 	"github.com/openziti/ziti/v2/common"
 	"github.com/openziti/ziti/v2/controller/model"
 	"github.com/openziti/ziti/v2/controller/models"
@@ -393,6 +394,28 @@ func (ctx *SecurityCtx) resolveOidcSession(securityToken *common.SecurityToken) 
 	}
 	if authPolicy == nil {
 		ctx.setApiSessionError(errorz.NewUnauthorizedOidcInvalid())
+		return
+	}
+
+	// Check if this specific token has been revoked by JWTID.
+	tokenRevocation, err := ctx.env.GetManagers().Revocation.Read(claims.JWTID)
+	if err != nil && !boltz.IsErrNotFoundErr(err) {
+		ctx.setApiSessionError(errorz.NewUnauthorizedOidcInvalid())
+		return
+	}
+	if tokenRevocation != nil {
+		ctx.setApiSessionError(errorz.NewUnauthorizedOidcInvalid())
+		return
+	}
+
+	// Check if the issuing identity has been terminated via a high-water-mark revocation.
+	identityRevocation, err := ctx.env.GetManagers().Revocation.Read(claims.Subject)
+	if err != nil && !boltz.IsErrNotFoundErr(err) {
+		ctx.setApiSessionError(errorz.NewUnauthorizedOidcInvalid())
+		return
+	}
+	if identityRevocation != nil && identityRevocation.CreatedAt.Truncate(time.Second).After(claims.IssuedAt.AsTime()) {
+		ctx.setApiSessionError(errorz.NewUnauthorizedOidcExpired())
 		return
 	}
 

--- a/controller/internal/policy/revocation_enforcer.go
+++ b/controller/internal/policy/revocation_enforcer.go
@@ -1,0 +1,71 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package policy
+
+import (
+	"time"
+
+	"github.com/michaelquigley/pfxlog"
+	"github.com/openziti/ziti/v2/common/runner"
+	"github.com/openziti/ziti/v2/controller/change"
+	"github.com/openziti/ziti/v2/controller/env"
+)
+
+const (
+	RevocationEnforcerRun    = "revocation.enforcer.run"
+	RevocationEnforcerDelete = "revocation.enforcer.delete"
+	RevocationEnforcerSource = "revocation.enforcer"
+)
+
+// RevocationEnforcer periodically purges expired revocation records from the
+// controller database and router data models.
+type RevocationEnforcer struct {
+	appEnv *env.AppEnv
+	*runner.BaseOperation
+}
+
+// NewRevocationEnforcer creates a RevocationEnforcer that runs at the given frequency.
+func NewRevocationEnforcer(appEnv *env.AppEnv, frequency time.Duration) *RevocationEnforcer {
+	return &RevocationEnforcer{
+		appEnv:        appEnv,
+		BaseOperation: runner.NewBaseOperation("RevocationEnforcer", frequency),
+	}
+}
+
+// Run deletes all expired revocation entries.
+func (e *RevocationEnforcer) Run() error {
+	startTime := time.Now()
+
+	defer func() {
+		e.appEnv.GetMetricsRegistry().Timer(RevocationEnforcerRun).UpdateSince(startTime)
+	}()
+
+	ctx := change.New().SetSourceType(RevocationEnforcerSource).SetChangeAuthorType(change.AuthorTypeController)
+
+	total, err := e.appEnv.GetManagers().Revocation.DeleteExpired(ctx)
+	if err != nil {
+		pfxlog.Logger().WithError(err).Error("failed to delete expired revocations")
+		return nil
+	}
+
+	if total > 0 {
+		pfxlog.Logger().Debugf("removed %d expired revocations", total)
+		e.appEnv.GetMetricsRegistry().Meter(RevocationEnforcerDelete).Mark(int64(total))
+	}
+
+	return nil
+}

--- a/controller/model/revocation_manager.go
+++ b/controller/model/revocation_manager.go
@@ -17,6 +17,9 @@
 package model
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/openziti/storage/boltz"
 	"github.com/openziti/ziti/v2/common/pb/edge_cmd_pb"
 	"github.com/openziti/ziti/v2/controller/change"
@@ -57,6 +60,41 @@ func (self *RevocationManager) ApplyCreate(cmd *command.CreateEntityCommand[*Rev
 
 func (self *RevocationManager) NewModelEntity() *Revocation {
 	return &Revocation{}
+}
+
+const revocationDeleteBatchSize = 500
+
+// DeleteExpired deletes all revocations whose ExpiresAt is in the past, working
+// in batches of revocationDeleteBatchSize until no expired entries remain.
+// Returns the total number of entries deleted.
+func (self *RevocationManager) DeleteExpired(ctx *change.Context) (int, error) {
+	query := fmt.Sprintf(`expiresAt < datetime(%s) limit %d`, time.Now().UTC().Format(time.RFC3339), revocationDeleteBatchSize)
+	total := 0
+	for {
+		result, err := self.BaseList(query)
+		if err != nil {
+			return total, err
+		}
+
+		ids := make([]string, 0, len(result.GetEntities()))
+		for _, entity := range result.GetEntities() {
+			ids = append(ids, entity.GetId())
+		}
+
+		if len(ids) == 0 {
+			break
+		}
+
+		if err = self.deleteEntityBatch(ids, ctx); err != nil {
+			return total, err
+		}
+		total += len(ids)
+
+		if len(ids) < revocationDeleteBatchSize {
+			break
+		}
+	}
+	return total, nil
 }
 
 func (self *RevocationManager) Read(id string) (*Revocation, error) {

--- a/controller/oidc_auth/storage.go
+++ b/controller/oidc_auth/storage.go
@@ -822,7 +822,7 @@ func (s *HybridStorage) TokenRequestByRefreshToken(_ context.Context, refreshTok
 // TerminateSession implements the op.Storage interface
 func (s *HybridStorage) TerminateSession(_ context.Context, identityId string, clientID string) error {
 	now := time.Now()
-	return s.saveRevocation(NewRevocation(identityId+","+clientID, now.Add(s.config.MaxTokenDuration())))
+	return s.saveRevocation(NewRevocation(identityId, now.Add(s.config.MaxTokenDuration())))
 }
 
 // GetRefreshTokenInfo implements the op.Storage interface
@@ -848,6 +848,7 @@ func (s *HybridStorage) RevokeToken(_ context.Context, tokenIDOrToken string, _ 
 			return oidc.ErrServerError()
 		}
 
+		return nil
 	}
 
 	revocation := NewRevocation(tokenIDOrToken, time.Now().Add(s.config.MaxTokenDuration()))

--- a/controller/server/controller.go
+++ b/controller/server/controller.go
@@ -47,10 +47,11 @@ type Controller struct {
 }
 
 const (
-	policyMinFreq     = 1 * time.Second
-	policyMaxFreq     = 1 * time.Hour
-	policyAppWanFreq  = 1 * time.Second
-	policySessionFreq = 5 * time.Second
+	policyMinFreq          = 1 * time.Second
+	policyMaxFreq          = 1 * time.Hour
+	policyAppWanFreq       = 1 * time.Second
+	policySessionFreq      = 5 * time.Second
+	policyRevocationFreq   = 1 * time.Minute
 )
 
 func NewController(host env.HostController) (*Controller, error) {
@@ -200,6 +201,14 @@ func (c *Controller) Initialize() {
 			WithField("enforcerId", sessionEnforcer.GetId()).
 			Errorf("could not add session enforcer")
 
+	}
+
+	revocationEnforcer := policy.NewRevocationEnforcer(c.AppEnv, policyRevocationFreq)
+	if err := c.policyEngine.AddOperation(revocationEnforcer); err != nil {
+		log.WithField("cause", err).
+			WithField("enforcerName", revocationEnforcer.GetName()).
+			WithField("enforcerId", revocationEnforcer.GetId()).
+			Errorf("could not add revocation enforcer")
 	}
 
 	if err := c.AppEnv.GetStores().EventualEventer.Start(c.AppEnv.GetHostController().GetCloseNotifyChannel()); err != nil {

--- a/controller/sync_strats/sync_instant.go
+++ b/controller/sync_strats/sync_instant.go
@@ -1826,7 +1826,7 @@ func (strategy *InstantStrategy) RevocationUpdate(index uint64, revocation *db.R
 }
 
 func (strategy *InstantStrategy) RevocationDelete(index uint64, revocation *db.Revocation) {
-	strategy.handleRevocation(index, edge_ctrl_pb.DataState_Create, revocation)
+	strategy.handleRevocation(index, edge_ctrl_pb.DataState_Delete, revocation)
 }
 
 func (strategy *InstantStrategy) handlePublicKey(index uint64, action edge_ctrl_pb.DataState_Action, publicKey *edge_ctrl_pb.DataState_PublicKey) {

--- a/tests/api_client_management.go
+++ b/tests/api_client_management.go
@@ -596,6 +596,22 @@ func (helper *ManagementHelperClient) PatchIdentity(id string, patch *rest_model
 	return helper.GetIdentity(id)
 }
 
+// AuthenticateOidc sets the client to use OIDC, authenticates with the given
+// credentials, and returns the OIDC API session. Returns an error if
+// authentication fails or the session is not an OIDC session.
+func (helper *ManagementHelperClient) AuthenticateOidc(creds edgeApis.Credentials) (*edgeApis.ApiSessionOidc, error) {
+	helper.SetUseOidc(true)
+	apiSession, err := helper.Authenticate(creds, nil)
+	if err != nil {
+		return nil, err
+	}
+	oidcSession, ok := apiSession.(*edgeApis.ApiSessionOidc)
+	if !ok {
+		return nil, fmt.Errorf("expected *edge_apis.ApiSessionOidc, got %T", apiSession)
+	}
+	return oidcSession, nil
+}
+
 func (helper *ManagementHelperClient) GetCurrentApiSessionDetail() (*rest_model.CurrentAPISessionDetail, error) {
 	resp, err := helper.GetCurrentApiSessionDetailResponse()
 

--- a/tests/context.go
+++ b/tests/context.go
@@ -75,6 +75,8 @@ import (
 	"github.com/openziti/ziti/v2/zitirest"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	oidcPkg "github.com/zitadel/oidc/v3/pkg/oidc"
+	oauth2Pkg "golang.org/x/oauth2"
 	"gopkg.in/resty.v1"
 )
 
@@ -157,7 +159,7 @@ func NewTestContext(t *testing.T) *TestContext {
 }
 
 // NewTestContextWithConfigSet creates a TestContext that uses the supplied ConfigSet
-// instead of DefaultATS. All other behaviour, including DB path and API host, is unchanged.
+// instead of DefaultATS. All other behavior, including DB path and API host, is unchanged.
 func NewTestContextWithConfigSet(t *testing.T, cs ConfigSet) *TestContext {
 	ret := NewTestContext(t)
 	ret.configSet = cs
@@ -239,6 +241,36 @@ func (ctx *TestContext) NewEdgeManagementApi(totpProvider func(chan string)) *Ma
 		ManagementApiClient: client,
 		testCtx:             ctx,
 	}
+}
+
+// NewEdgeManagementApiWithToken returns a ManagementHelperClient pre-loaded with
+// the given raw OIDC access token. No authentication step is required.
+func (ctx *TestContext) NewEdgeManagementApiWithToken(accessToken string) *ManagementHelperClient {
+	client := ctx.NewEdgeManagementApi(nil)
+	var session edgeApis.ApiSession = &edgeApis.ApiSessionOidc{
+		OidcTokens: &oidcPkg.Tokens[*oidcPkg.IDTokenClaims]{
+			Token: &oauth2Pkg.Token{
+				AccessToken: accessToken,
+			},
+		},
+	}
+	client.ApiSession.Store(&session)
+	return client
+}
+
+// NewEdgeClientApiWithToken returns a ClientHelperClient pre-loaded with the
+// given raw OIDC access token. No authentication step is required.
+func (ctx *TestContext) NewEdgeClientApiWithToken(accessToken string) *ClientHelperClient {
+	client := ctx.NewEdgeClientApi(nil)
+	var session edgeApis.ApiSession = &edgeApis.ApiSessionOidc{
+		OidcTokens: &oidcPkg.Tokens[*oidcPkg.IDTokenClaims]{
+			Token: &oauth2Pkg.Token{
+				AccessToken: accessToken,
+			},
+		},
+	}
+	client.ApiSession.Store(&session)
+	return client
 }
 
 func (ctx *TestContext) NewTransportWithIdentity(i idlib.Identity) *http.Transport {
@@ -397,11 +429,23 @@ func (ctx *TestContext) NewClientComponentsWithClientCert(certs []*x509.Certific
 
 }
 
-func (ctx *TestContext) StartServer() {
-	ctx.StartServerFor("testdata/default.db", true)
+func (ctx *TestContext) StartServer() *ControllerHelper {
+	return ctx.StartServerFor("testdata/default.db", true)
 }
 
-func (ctx *TestContext) StartServerFor(testDb string, clean bool) {
+// StartServerWithConfigModifier starts the controller and edge layer, applying
+// modifier to the loaded config before the controller is created. This lets a
+// single test override settings (e.g., OIDC token durations) without affecting
+// other tests that call StartServer with the shared default config.
+func (ctx *TestContext) StartServerWithConfigModifier(modifier func(*config.Config)) *ControllerHelper {
+	return ctx.startServerWith("testdata/default.db", true, modifier)
+}
+
+func (ctx *TestContext) StartServerFor(testDb string, clean bool) *ControllerHelper {
+	return ctx.startServerWith(testDb, clean, nil)
+}
+
+func (ctx *TestContext) startServerWith(testDb string, clean bool, modifier func(*config.Config)) *ControllerHelper {
 	if ctx.LogLevel != "" {
 		if level, err := logrus.ParseLevel(ctx.LogLevel); err == nil {
 			logrus.StandardLogger().SetLevel(level)
@@ -431,6 +475,10 @@ func (ctx *TestContext) StartServerFor(testDb string, clean bool) {
 	ctrlConfig, err := config.LoadConfig(ctx.controllerConfFile())
 	ctx.Req.NoError(err)
 
+	if modifier != nil {
+		modifier(ctrlConfig)
+	}
+
 	ctx.ControllerConfig = ctrlConfig
 
 	log.Info("creating fabric controller")
@@ -458,6 +506,8 @@ func (ctx *TestContext) StartServerFor(testDb string, clean bool) {
 	}()
 	err = ctx.waitForRestAPIPort(time.Minute * 5)
 	ctx.Req.NoError(err)
+
+	return &ControllerHelper{Controller: ctx.EdgeController}
 }
 
 func (ctx *TestContext) createAndEnrollEdgeRouter(tunneler bool, roleAttributes ...string) *edgeRouter {
@@ -543,25 +593,25 @@ func (ctx *TestContext) CreateEnrollAndStartTunnelerEdgeRouter(roleAttributes ..
 	ctx.startEdgeRouter(nil)
 }
 
-func (ctx *TestContext) CreateEnrollAndStartEdgeRouter(roleAttributes ...string) *router.Router {
+func (ctx *TestContext) CreateEnrollAndStartEdgeRouter(roleAttributes ...string) *EdgeRouterHelper {
 	ctx.shutdownRouters()
 	ctx.createAndEnrollEdgeRouter(false, roleAttributes...)
 	return ctx.startEdgeRouter(nil)
 }
 
-func (ctx *TestContext) CreateEnrollAndStartEdgeRouterWithCfgTweaks(cfgTweaks func(*routerEnv.Config), roleAttributes ...string) *router.Router {
+func (ctx *TestContext) CreateEnrollAndStartEdgeRouterWithCfgTweaks(cfgTweaks func(*routerEnv.Config), roleAttributes ...string) *EdgeRouterHelper {
 	ctx.shutdownRouters()
 	ctx.createAndEnrollEdgeRouter(false, roleAttributes...)
 	return ctx.startEdgeRouter(cfgTweaks)
 }
 
-func (ctx *TestContext) CreateEnrollAndStartHAEdgeRouter(roleAttributes ...string) *router.Router {
+func (ctx *TestContext) CreateEnrollAndStartHAEdgeRouter(roleAttributes ...string) *EdgeRouterHelper {
 	ctx.shutdownRouters()
 	ctx.createAndEnrollEdgeRouter(false, roleAttributes...)
 	return ctx.startEdgeRouter(nil)
 }
 
-func (ctx *TestContext) startEdgeRouter(cfgTweaks func(*routerEnv.Config)) *router.Router {
+func (ctx *TestContext) startEdgeRouter(cfgTweaks func(*routerEnv.Config)) *EdgeRouterHelper {
 	configFile := ctx.configSet.EdgeRouter
 	if ctx.edgeRouterEntity.isTunnelerEnabled {
 		configFile = ctx.configSet.TunnelerRouter
@@ -574,7 +624,7 @@ func (ctx *TestContext) startEdgeRouter(cfgTweaks func(*routerEnv.Config)) *rout
 	newRouter := router.Create(routerCfg, NewVersionProviderTest())
 	ctx.routers = append(ctx.routers, newRouter)
 	ctx.Req.NoError(newRouter.Start())
-	return newRouter
+	return &EdgeRouterHelper{Router: newRouter}
 }
 
 func (ctx *TestContext) EnrollIdentity(identityId string) *ziti.Config {
@@ -958,9 +1008,9 @@ func (ctx *TestContext) NewAdminCredentials() *edgeApis.UpdbCredentials {
 	return edgeApis.NewUpdbCredentials(ctx.AdminAuthenticator.Username, ctx.AdminAuthenticator.Password)
 }
 
-func (self *TestContext) EnrollFabricRouter(id string, name string, certFile string) {
+func (ctx *TestContext) EnrollFabricRouter(id string, name string, certFile string) {
 	cert, err := certtools.LoadCertFromFile(certFile)
-	self.Req.NoError(err)
+	ctx.Req.NoError(err)
 
 	fingerprint := fmt.Sprintf("%x", sha1.Sum(cert[0].Raw))
 
@@ -977,12 +1027,12 @@ func (self *TestContext) EnrollFabricRouter(id string, name string, certFile str
 		},
 		Context: timeoutContext,
 	}
-	_, err = self.RestClients.Fabric.Router.CreateRouter(createRouterParams, nil)
+	_, err = ctx.RestClients.Fabric.Router.CreateRouter(createRouterParams, nil)
 	if err != nil {
 		js, _ := json.MarshalIndent(err, "", "    ")
 		fmt.Println(string(js))
 	}
-	self.Req.NoError(err)
+	ctx.Req.NoError(err)
 }
 
 func (ctx *TestContext) startFabricRouter(index uint8) *router.Router {
@@ -1105,7 +1155,7 @@ func (server *testServer) acceptLoop() {
 		}
 	}
 
-	// If listener is closed, assume this error is just letting us know the listener was closed
+	// if the listener is closed, assume this error is just letting us know the listener was closed
 	if !server.listener.IsClosed() {
 		if err != nil {
 			server.errorC <- err
@@ -1152,7 +1202,7 @@ func (server *testServer) dispatch(conn *testServerConn) {
 		conn.RequireClose()
 	}()
 
-	log.Debugf("beginnging dispatch to conn %v-%v", conn.server.idx, conn.id)
+	log.Debugf("beginning dispatch to conn %v-%v", conn.server.idx, conn.id)
 	err := server.dispatcher(conn)
 	log.Debugf("finished dispatch to conn %v-%v", conn.server.idx, conn.id)
 	if err != nil {

--- a/tests/controller_helper.go
+++ b/tests/controller_helper.go
@@ -1,0 +1,61 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package tests
+
+import (
+	"time"
+
+	"github.com/openziti/storage/boltz"
+	"github.com/openziti/ziti/v2/controller/change"
+	"github.com/openziti/ziti/v2/controller/model"
+	"github.com/openziti/ziti/v2/controller/models"
+	"github.com/openziti/ziti/v2/controller/server"
+)
+
+// ControllerHelper wraps a server.Controller with test-oriented helper methods.
+// All methods return values and errors; none accept *testing.T.
+// Because it embeds *server.Controller, all controller methods are available directly.
+type ControllerHelper struct {
+	*server.Controller
+}
+
+// ReadRevocation returns the revocation with the given id from the controller DB,
+// or (nil, nil) if not found.
+func (h *ControllerHelper) ReadRevocation(id string) (*model.Revocation, error) {
+	rev, err := h.AppEnv.GetManagers().Revocation.Read(id)
+	if boltz.IsErrNotFoundErr(err) {
+		return nil, nil
+	}
+	return rev, err
+}
+
+// CreateRevocation writes a revocation entry with the given id and ExpiresAt directly
+// to the controller DB. Useful for planting entries (e.g. with a past ExpiresAt) in tests.
+func (h *ControllerHelper) CreateRevocation(id string, expiresAt time.Time) error {
+	ctx := change.New().SetSourceType("test").SetChangeAuthorType(change.AuthorTypeController)
+	return h.AppEnv.GetManagers().Revocation.Create(&model.Revocation{
+		BaseEntity: models.BaseEntity{Id: id},
+		ExpiresAt:  expiresAt,
+	}, ctx)
+}
+
+// DeleteExpiredRevocations calls DeleteExpired on the revocation manager and returns
+// the total number of entries removed.
+func (h *ControllerHelper) DeleteExpiredRevocations() (int, error) {
+	ctx := change.New().SetSourceType("test").SetChangeAuthorType(change.AuthorTypeController)
+	return h.AppEnv.GetManagers().Revocation.DeleteExpired(ctx)
+}

--- a/tests/edge_router_helper.go
+++ b/tests/edge_router_helper.go
@@ -1,0 +1,63 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package tests
+
+import (
+	"time"
+
+	"github.com/openziti/ziti/v2/router"
+)
+
+// EdgeRouterHelper wraps a router.Router with test-oriented helper methods.
+// All methods return values; none accept *testing.T.
+// Because it embeds *router.Router, all router methods are available directly.
+type EdgeRouterHelper struct {
+	*router.Router
+}
+
+// HasRevocation reports whether the given id is currently present in the
+// router's RDM revocations map.
+func (h *EdgeRouterHelper) HasRevocation(id string) bool {
+	_, ok := h.GetRouterDataModel().Revocations.Get(id)
+	return ok
+}
+
+// WaitForRevocation polls the router's RDM until id appears in the revocations
+// map or timeout elapses. Returns true if the entry is found within the timeout.
+func (h *EdgeRouterHelper) WaitForRevocation(id string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if h.HasRevocation(id) {
+			return true
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return false
+}
+
+// WaitForRevocationGone polls the router's RDM until id is absent from the
+// revocations map or timeout elapses. Returns true if gone within the timeout.
+func (h *EdgeRouterHelper) WaitForRevocationGone(id string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !h.HasRevocation(id) {
+			return true
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return false
+}

--- a/tests/revocation_test.go
+++ b/tests/revocation_test.go
@@ -1,0 +1,272 @@
+//go:build apitests
+
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package tests
+
+import (
+	"errors"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	managementCurrentApiSession "github.com/openziti/edge-api/rest_management_api_client/current_api_session"
+	"github.com/openziti/ziti/v2/common"
+	"github.com/openziti/ziti/v2/controller/config"
+	"github.com/openziti/ziti/v2/controller/oidc_auth"
+	"github.com/zitadel/oidc/v3/pkg/oidc"
+)
+
+// Test_Revocation verifies the OIDC token revocation lifecycle: refresh-token
+// rotation, explicit revocation via /oidc/revoke, session termination via
+// /oidc/end_session, and periodic purge of expired revocation entries.
+func Test_Revocation(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+
+	ctrl := ctx.StartServerWithConfigModifier(func(cfg *config.Config) {
+		cfg.Edge.Oidc.AccessTokenDuration = 10 * time.Second
+		cfg.Edge.Oidc.RefreshTokenDuration = 15 * time.Second
+		cfg.Edge.Oidc.IdTokenDuration = 10 * time.Second
+	})
+	ctx.RequireAdminManagementApiLogin()
+	router := ctx.CreateEnrollAndStartEdgeRouter()
+
+	jwtParser := jwt.NewParser()
+
+	t.Run("refresh revokes old refresh token JWTID", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		client := ctx.NewEdgeManagementApi(nil)
+		oidcSession, err := client.AuthenticateOidc(ctx.NewAdminCredentials())
+		ctx.Req.NoError(err)
+
+		// Extract the JWTID from the old refresh token before exchanging it.
+		oldRefreshClaims := &common.RefreshClaims{}
+		_, _, err = jwtParser.ParseUnverified(oidcSession.OidcTokens.RefreshToken, oldRefreshClaims)
+		ctx.Req.NoError(err)
+		oldRefreshJTI := oldRefreshClaims.JWTID
+		ctx.Req.NotEmpty(oldRefreshJTI)
+
+		// Exchange the refresh token for a new token pair.
+		req := &oidc.RefreshTokenRequest{
+			RefreshToken: oidcSession.OidcTokens.RefreshToken,
+			ClientID:     oidcSession.OidcTokens.IDTokenClaims.ClientID,
+			Scopes:       []string{oidc.ScopeOpenID, oidc.ScopeOfflineAccess},
+		}
+		enc := oidc.NewEncoder()
+		dst := map[string][]string{}
+		ctx.Req.NoError(enc.Encode(req, dst))
+		dst["grant_type"] = []string{string(req.GrantType())}
+
+		newTokens := &oidc.TokenExchangeResponse{}
+		resp, err := ctx.newAnonymousClientApiRequest().
+			SetHeader("content-type", oidc_auth.FormContentType).
+			SetMultiValueFormData(dst).
+			SetResult(newTokens).
+			Post("https://" + ctx.ApiHost + "/oidc/oauth/token")
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(200, resp.StatusCode())
+
+		t.Run("old refresh token JWTID is in the controller revocation DB", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			rev, err := ctrl.ReadRevocation(oldRefreshJTI)
+			ctx.Req.NoError(err)
+			ctx.Req.NotNil(rev, "expected revocation entry for old refresh JWTID %s", oldRefreshJTI)
+		})
+
+		t.Run("revocation propagates to the router RDM within 10s", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			ctx.Req.True(router.WaitForRevocation(oldRefreshJTI, 10*time.Second),
+				"timed out waiting for revocation %s to appear in router RDM", oldRefreshJTI)
+		})
+	})
+
+	t.Run("explicit revocation revokes refresh token by JWTID", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		client := ctx.NewEdgeManagementApi(nil)
+		oidcSession, err := client.AuthenticateOidc(ctx.NewAdminCredentials())
+		ctx.Req.NoError(err)
+
+		// Extract the JWTID from the refresh token before revoking it.
+		refreshClaims := &common.RefreshClaims{}
+		_, _, err = jwtParser.ParseUnverified(oidcSession.OidcTokens.RefreshToken, refreshClaims)
+		ctx.Req.NoError(err)
+		refreshJTI := refreshClaims.JWTID
+		ctx.Req.NotEmpty(refreshJTI)
+
+		clientID := oidcSession.OidcTokens.IDTokenClaims.ClientID
+		refreshToken := oidcSession.OidcTokens.RefreshToken
+
+		// POST to the OIDC revocation endpoint with the refresh token.
+		resp, err := ctx.newAnonymousClientApiRequest().
+			SetHeader("content-type", oidc_auth.FormContentType).
+			SetMultiValueFormData(map[string][]string{
+				"token":           {refreshToken},
+				"token_type_hint": {"refresh_token"},
+				"client_id":       {clientID},
+			}).
+			Post("https://" + ctx.ApiHost + "/oidc/revoke")
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(200, resp.StatusCode())
+
+		t.Run("refresh token JWTID is in the controller revocation DB", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			rev, err := ctrl.ReadRevocation(refreshJTI)
+			ctx.Req.NoError(err)
+			ctx.Req.NotNil(rev, "expected revocation entry for refresh JWTID %s", refreshJTI)
+		})
+
+		t.Run("raw refresh token string is NOT stored as a separate revocation key", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			// Verifies bug 1 fix: no double-write with the raw JWT string as key.
+			rev, err := ctrl.ReadRevocation(refreshToken)
+			ctx.Req.NoError(err)
+			ctx.Req.Nil(rev, "expected no revocation keyed on raw token string")
+		})
+
+		t.Run("revocation propagates to the router RDM within 10s", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			ctx.Req.True(router.WaitForRevocation(refreshJTI, 10*time.Second),
+				"timed out waiting for revocation %s to appear in router RDM", refreshJTI)
+		})
+	})
+
+	t.Run("session termination revokes all identity tokens by subject", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		client := ctx.NewEdgeManagementApi(nil)
+		oidcSession, err := client.AuthenticateOidc(ctx.NewAdminCredentials())
+		ctx.Req.NoError(err)
+
+		// Extract identityId (Subject) and IssuedAt from the access token.
+		accessClaims := &common.AccessClaims{}
+		_, _, err = jwtParser.ParseUnverified(oidcSession.OidcTokens.AccessToken, accessClaims)
+		ctx.Req.NoError(err)
+		identityId := accessClaims.Subject
+		ctx.Req.NotEmpty(identityId)
+
+		clientID := oidcSession.OidcTokens.IDTokenClaims.ClientID
+		idToken := oidcSession.OidcTokens.IDToken
+		oldAccessToken := oidcSession.OidcTokens.AccessToken
+
+		// Wait one full second so that the revocation's CreatedAt lands in a
+		// strictly later second than the old token's IssuedAt. JWT timestamps
+		// have second-level precision and the revocation check uses truncated
+		// comparison, so this sleep is required for a deterministic result.
+		time.Sleep(time.Second)
+
+		// Hit the OIDC end_session endpoint. The redirect destination uses a
+		// custom scheme so the HTTP client will not be able to follow it; we
+		// discard that error and rely on the server having processed the request.
+		endSessionURL := "https://" + ctx.ApiHost + "/oidc/end_session?" + url.Values{
+			"id_token_hint":            {idToken},
+			"client_id":                {clientID},
+			"post_logout_redirect_uri": {"openziti://auth/logout"},
+		}.Encode()
+		_, _ = ctx.newAnonymousClientApiRequest().Get(endSessionURL)
+
+		t.Run("identityId is in the controller revocation DB", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			rev, err := ctrl.ReadRevocation(identityId)
+			ctx.Req.NoError(err)
+			ctx.Req.NotNil(rev, "expected high-water-mark revocation entry for identity %s", identityId)
+		})
+
+		t.Run("revocation CreatedAt is after the token IssuedAt", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			rev, err := ctrl.ReadRevocation(identityId)
+			ctx.Req.NoError(err)
+			ctx.Req.NotNil(rev)
+			ctx.Req.True(rev.CreatedAt.After(accessClaims.IssuedAt.AsTime()),
+				"expected revocation CreatedAt %v to be after token IssuedAt %v",
+				rev.CreatedAt, accessClaims.IssuedAt.AsTime())
+		})
+
+		t.Run("revocation propagates to the router RDM within 10s", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			// Verifies bug 2 fix: key is identityId alone, which is what both
+			// TerminateSession now stores and the RDM lookup uses.
+			ctx.Req.True(router.WaitForRevocation(identityId, 10*time.Second),
+				"timed out waiting for revocation %s to appear in router RDM", identityId)
+		})
+
+		t.Run("old access token is rejected by the controller", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			_, err := ctx.NewEdgeManagementApiWithToken(oldAccessToken).GetCurrentApiSessionDetailResponse()
+			ctx.Req.Error(err)
+			var unauthorizedErr *managementCurrentApiSession.GetCurrentAPISessionUnauthorized
+			ctx.Req.True(errors.As(err, &unauthorizedErr), "expected 401 Unauthorized, got: %v", err)
+		})
+
+		t.Run("new token issued after termination is accepted", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			// Re-authenticate as the same identity; the new token's IssuedAt is
+			// after the revocation's CreatedAt so the high-water mark does not block it.
+			newClient := ctx.NewEdgeManagementApi(nil)
+			_, err := newClient.AuthenticateOidc(ctx.NewAdminCredentials())
+			ctx.Req.NoError(err)
+			_, err = newClient.GetCurrentApiSessionDetailResponse()
+			ctx.Req.NoError(err)
+		})
+	})
+
+	t.Run("DeleteExpired purges revocations from DB and router RDM", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		const testRevocationId = "test-expired-revocation-id"
+
+		// Plant an already-expired revocation directly.
+		err := ctrl.CreateRevocation(testRevocationId, time.Now().Add(-1*time.Second))
+		ctx.Req.NoError(err)
+
+		t.Run("entry is visible in the controller DB before purge", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			rev, err := ctrl.ReadRevocation(testRevocationId)
+			ctx.Req.NoError(err)
+			ctx.Req.NotNil(rev)
+		})
+
+		t.Run("entry propagates to the router RDM before purge", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			ctx.Req.True(router.WaitForRevocation(testRevocationId, 10*time.Second),
+				"timed out waiting for planted revocation to appear in router RDM")
+		})
+
+		// Purge expired entries.
+		n, err := ctrl.DeleteExpiredRevocations()
+		ctx.Req.NoError(err)
+		ctx.Req.GreaterOrEqual(n, 1, "expected at least 1 expired revocation to be deleted")
+
+		t.Run("entry is gone from the controller DB after purge", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			rev, err := ctrl.ReadRevocation(testRevocationId)
+			ctx.Req.NoError(err)
+			ctx.Req.Nil(rev, "expected revocation to be purged from DB")
+		})
+
+		t.Run("entry is evicted from the router RDM after purge within 10s", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			// Verifies bug 3 fix: RevocationDelete now sends DataState_Delete so
+			// the router removes the entry from its in-memory map.
+			ctx.Req.True(router.WaitForRevocationGone(testRevocationId, 10*time.Second),
+				"timed out waiting for purged revocation to be evicted from router RDM")
+		})
+	})
+}


### PR DESCRIPTION
  - fixes RevokeToken double-write: adds return after JWTID-keyed revocation save, preventing fallthrough write with raw JWT string as unreachable key
  - fixes TerminateSession key mismatch: stores revocation by identityId alone, matching the Subject-based lookup in ValidateAccessToken
  - fixes RevocationDelete sync action: passes DataState_Delete instead of DataState_Create so routers evict the entry from their data model
  - adds RevocationManager.DeleteExpired: batch-deletes expired revocations in batches of 500 until none remain
  - adds RevocationEnforcer: periodic policy runner (every 1 minute) that calls DeleteExpired and records metrics

before test fixes