### PR TITLE
Skip wildcard DNS SANs when building OIDC issuers. Fixes #3696

### DIFF
--- a/controller/webapis/oidc-api.go
+++ b/controller/webapis/oidc-api.go
@@ -230,6 +230,9 @@ func getPossibleIssuers(id identity.Identity, bindPoints []xweb.BindPoint) []oid
 		}
 		curServerCert := curServerCertChain[0]
 		for _, dnsName := range curServerCert.DNSNames {
+			if strings.HasPrefix(dnsName, "*.") {
+				continue // wildcard DNS names produce unusable OIDC issuer URLs
+			}
 			for _, port := range ports {
 				newIssuer := net.JoinHostPort(dnsName, port)
 				issuerMap[newIssuer] = struct{}{}

--- a/controller/webapis/oidc-api_test.go
+++ b/controller/webapis/oidc-api_test.go
@@ -145,7 +145,7 @@ func Test_getPossibleIssuers(t *testing.T) {
 
 		issuers := getPossibleIssuers(id, bindPoints)
 
-		req.Len(issuers, 21)
+		req.Len(issuers, 18) // wildcard DNS SANs (*.wildcard.io) are excluded
 
 		isValidIssuer := func(address string) error {
 			for _, issuer := range issuers {
@@ -169,9 +169,10 @@ func Test_getPossibleIssuers(t *testing.T) {
 		req.NoError(isValidIssuer("client3.netfoundry.io:443"))
 		req.NoError(isValidIssuer("client3.netfoundry.io"))
 
-		req.NoError(isValidIssuer("star.wildcard.io:1234"))
-		req.NoError(isValidIssuer("star.wildcard.io:443"))
-		req.NoError(isValidIssuer("star.wildcard.io"))
+		// wildcard DNS SANs are excluded from issuers since they produce unusable OIDC URLs
+		req.Error(isValidIssuer("star.wildcard.io:1234"))
+		req.Error(isValidIssuer("star.wildcard.io:443"))
+		req.Error(isValidIssuer("star.wildcard.io"))
 
 		req.NoError(isValidIssuer("127.0.0.1:1234"))
 		req.NoError(isValidIssuer("127.0.0.1:443"))


### PR DESCRIPTION
- skips certificate DNS names starting with "*." in getPossibleIssuers,
  since they produce unusable OIDC URLs (e.g. https://*.example.com/oidc/authorize)
- updates test to verify wildcard DNS SANs are excluded while IP SANs
  from the same cert remain valid issuers
