### PR TITLE
add tests and safety for v1 linux migrations

### DIFF
--- a/dist/dist-packages/linux/dangerous.upgrade.linux.test.bash
+++ b/dist/dist-packages/linux/dangerous.upgrade.linux.test.bash
@@ -340,25 +340,41 @@ else
 fi
 
 # ============================================================
-# Phase 7: Verify breadcrumb (only present if migration actually ran)
+# Phase 7: Verify migration completeness
 # ============================================================
-log_section "Phase 7: Verify breadcrumbs"
+log_section "Phase 7: Verify migration completeness"
 
-# The breadcrumb is only created when the DynamicUser layout is detected.
-# On v1 packages that used DynamicUser, the symlink would exist.
+# The migration flag is only created when the DynamicUser layout is detected.
 # On CI with v1 packages that already use static users, migration may be
 # a no-op. Check conditionally.
 if [[ -d "/var/lib/private/ziti-controller" ]]; then
-    verify_readme_breadcrumb ziti-controller
+    verify_migration_flag ziti-controller
+    verify_private_dir_clean ziti-controller
+    verify_config_paths_migrated ziti-controller
 else
     log_info "no DynamicUser layout detected for ziti-controller (v1 may already use static users)"
 fi
 
 if [[ -d "/var/lib/private/ziti-router" ]]; then
-    verify_readme_breadcrumb ziti-router
+    verify_migration_flag ziti-router
+    verify_private_dir_clean ziti-router
+    verify_config_paths_migrated ziti-router
 else
     log_info "no DynamicUser layout detected for ziti-router (v1 may already use static users)"
 fi
+
+# Verify services are running after the upgrade (postinstall should have
+# restarted them if migration stopped them)
+verify_service_running ziti-controller
+verify_service_running ziti-router
+
+# ============================================================
+# Phase 8: Verify migration does not recur on subsequent upgrade
+# ============================================================
+log_section "Phase 8: Verify migration idempotency"
+
+verify_migration_does_not_recur openziti-controller ziti-controller
+verify_migration_does_not_recur openziti-router ziti-router
 
 log_section "All upgrade tests passed"
 # cleanup runs via EXIT trap

--- a/dist/dist-packages/linux/deployments-test-lib.bash
+++ b/dist/dist-packages/linux/deployments-test-lib.bash
@@ -309,16 +309,76 @@ verify_symlink_resolved() {
   log_pass "${_dir} is not a symlink"
 }
 
-# Check that the migration README breadcrumb exists
-verify_readme_breadcrumb() {
+# Check that the migration flag file exists in the old private state dir
+verify_migration_flag() {
   local _svc="$1"
-  local _readme="/var/lib/private/${_svc}/README.txt"
-  if [[ -s "${_readme}" ]]; then
-    log_pass "migration breadcrumb exists: ${_readme}"
+  local _flag="/var/lib/private/${_svc}/MIGRATED.txt"
+  if [[ -s "${_flag}" ]]; then
+    log_pass "migration flag exists: ${_flag}"
   else
-    log_fail "migration breadcrumb missing: ${_readme}"
+    log_fail "migration flag missing: ${_flag}"
     return 1
   fi
+}
+
+# Verify the old private dir contains only the migration flag (no leftover state)
+verify_private_dir_clean() {
+  local _svc="$1"
+  local _dir="/var/lib/private/${_svc}"
+  if [[ ! -d "${_dir}" ]]; then
+    log_pass "old private dir ${_dir} does not exist (clean)"
+    return 0
+  fi
+  local _extra
+  _extra=$(find "${_dir}" -mindepth 1 ! -name 'MIGRATED.txt' -print -quit 2>/dev/null || true)
+  if [[ -z "${_extra}" ]]; then
+    log_pass "old private dir ${_dir} contains only MIGRATED.txt"
+  else
+    log_fail "old private dir ${_dir} has leftover state: ${_extra}"
+    return 1
+  fi
+}
+
+# Verify config.yml has no references to the old /var/lib/private/ path
+verify_config_paths_migrated() {
+  local _svc="$1"
+  local _config="/var/lib/${_svc}/config.yml"
+  if [[ ! -f "${_config}" ]]; then
+    log_info "no config.yml found for ${_svc} (skipping path check)"
+    return 0
+  fi
+  if grep -q "/var/lib/private/${_svc}" "${_config}"; then
+    log_fail "${_config} still references /var/lib/private/${_svc}"
+    return 1
+  fi
+  log_pass "${_config} has no /var/lib/private/ references"
+}
+
+# Verify a systemd service is active after upgrade
+verify_service_running() {
+  local _svc="$1"
+  if systemctl is-active --quiet "${_svc}.service" 2>/dev/null; then
+    log_pass "${_svc}.service is active"
+  else
+    log_fail "${_svc}.service is not active"
+    journalctl -u "${_svc}.service" --no-pager -n 20 >&2 || true
+    return 1
+  fi
+}
+
+# Re-run the package upgrade and verify migration does NOT re-trigger.
+# Captures postinstall output and fails if the migration message appears.
+verify_migration_does_not_recur() {
+  local _pkg="$1" _svc="$2"
+  log_info "reinstalling ${_pkg} to verify migration does not recur"
+  local _output
+  _output=$(sudo apt-get install --reinstall -y "${_pkg}" 2>&1)
+  if echo "${_output}" | grep -q "detected DynamicUser state layout"; then
+    log_fail "migration re-triggered on reinstall of ${_pkg}"
+    echo "${_output}" >&2
+    return 1
+  fi
+  log_pass "migration did not recur for ${_pkg}"
 }
 
 # verify_traffic [--prefix <prefix>]

--- a/dist/dist-packages/linux/openziti-controller/postinstall.bash
+++ b/dist/dist-packages/linux/openziti-controller/postinstall.bash
@@ -42,7 +42,7 @@ commonActions() {
 # Detect whether the state directory uses the DynamicUser symlink layout from
 # v1 packages (DynamicUser=yes).  Returns 0 (true) when migration is needed.
 detectDynamicUserState() {
-  # The migration leaves a README breadcrumb in the old private dir.
+  # The migration leaves MIGRATED.txt in the old private dir as a flag.
   # Its presence means migration already completed — never re-migrate.
   if [[ -f "/var/lib/private/${SVC_USER}/MIGRATED.txt" ]]; then
     return 1
@@ -118,11 +118,12 @@ migrateDynamicUser() {
     echo "INFO: updated ${_config} paths from /var/lib/private/${SVC_USER} to ${STATE_DIR}"
   fi
 
-  # Leave a breadcrumb README in the old private location
+  # Leave a migration flag in the old private location so future upgrades
+  # skip re-detection. This directory is safe to remove manually.
   mkdir -p "${_private_dir}"
   chown root:root "${_private_dir}"
   chmod 0755 "${_private_dir}"
-  cat > "${_private_dir}/MIGRATED.txt" <<README
+  cat > "${_private_dir}/MIGRATED.txt" <<MIGRATED
 OpenZiti State Directory Migration
 ===================================
 Date: $(date --utc --iso-8601=seconds)
@@ -144,7 +145,7 @@ What happened:
   persistent ${SVC_USER} user.
 
 This directory is safe to remove.
-README
+MIGRATED
 
   logger -t "${SVC_USER}" "Migrated state from DynamicUser layout to static user ${SVC_USER}"
   echo "INFO: DynamicUser migration complete for ${SVC_USER}"

--- a/dist/dist-packages/linux/openziti-router/postinstall.bash
+++ b/dist/dist-packages/linux/openziti-router/postinstall.bash
@@ -42,7 +42,7 @@ commonActions() {
 # Detect whether the state directory uses the DynamicUser symlink layout from
 # v1 packages (DynamicUser=yes).  Returns 0 (true) when migration is needed.
 detectDynamicUserState() {
-  # The migration leaves a README breadcrumb in the old private dir.
+  # The migration leaves MIGRATED.txt in the old private dir as a flag.
   # Its presence means migration already completed — never re-migrate.
   if [[ -f "/var/lib/private/${SVC_USER}/MIGRATED.txt" ]]; then
     return 1
@@ -118,11 +118,12 @@ migrateDynamicUser() {
     echo "INFO: updated ${_config} paths from /var/lib/private/${SVC_USER} to ${STATE_DIR}"
   fi
 
-  # Leave a breadcrumb README in the old private location
+  # Leave a migration flag in the old private location so future upgrades
+  # skip re-detection. This directory is safe to remove manually.
   mkdir -p "${_private_dir}"
   chown root:root "${_private_dir}"
   chmod 0755 "${_private_dir}"
-  cat > "${_private_dir}/MIGRATED.txt" <<README
+  cat > "${_private_dir}/MIGRATED.txt" <<MIGRATED
 OpenZiti State Directory Migration
 ===================================
 Date: $(date --utc --iso-8601=seconds)
@@ -144,7 +145,7 @@ What happened:
   persistent ${SVC_USER} user.
 
 This directory is safe to remove.
-README
+MIGRATED
 
   logger -t "${SVC_USER}" "Migrated state from DynamicUser layout to static user ${SVC_USER}"
   echo "INFO: DynamicUser migration complete for ${SVC_USER}"


### PR DESCRIPTION
this covers an edge case where the user may unintentionally add files to the ziti v1 state directory thereby triggering another migration when the ziti v2 controller or router is upgraded again, potentially clobbering newer files in the ziti v2 state dir