### PR TITLE
Fix connect events handler goroutine leak. Fixes #3746

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ doc/ha/data
 simple-transfer-*/
 etc/endpoints
 etc/endpoints.yml
+.fablab-instance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,28 @@ when running HA. Legacy API and service session are now deprecated and will be r
   are not compatible with the new HA-only mode and will need to be recreated.
 * The `--clustered` flag on `ziti create config controller` has been removed; the generated config is always
   cluster-ready. If you have scripts passing `--clustered`, remove it.
+* [Connect events pool](#connect-events-pool) - fixes a goroutine leak when routers reconnect
+
+## Connect Events Pool
+
+The controller now uses a shared, bounded goroutine pool to process identity
+connect/disconnect events from routers. Previously each router connection spawned
+a dedicated goroutine that was never cleaned up on disconnect, leaking a goroutine
+per reconnect cycle. Under churn (e.g., chaos testing with hundreds of routers) this
+could accumulate tens of thousands of leaked goroutines and destabilize the controller.
+
+The pool is configurable in the controller config file:
+
+```yaml
+connectEvents:
+  queueSize:  16    # work queue depth (default: 16)
+  minWorkers: 0     # minimum pool goroutines (default: 0)
+  maxWorkers: 16    # maximum pool goroutines (default: 16)
+  idleTime:   30s   # worker idle timeout before exit (default: 30s)
+```
+
+The defaults are suitable for most deployments. Workers scale up on demand and
+exit after the idle timeout, so no goroutines are held when there is no work.
 
 ## Basic Permission System (BETA)
 

--- a/controller/config/config.go
+++ b/controller/config/config.go
@@ -98,6 +98,11 @@ const (
 	DefaultBackgroundQueueDropWhenFull = false
 	DefaultBackgroundQueueThreshold    = 50 * time.Millisecond
 
+	DefaultConnectEventsQueueSize  uint32 = 16
+	DefaultConnectEventsMinWorkers uint32 = 0
+	DefaultConnectEventsMaxWorkers uint32 = 16
+	DefaultConnectEventsIdleTime          = 30 * time.Second
+
 	// DefaultCtrlDialer* constants define the default values for the ctrl channel dialer configuration.
 	DefaultCtrlDialerEnabled            = false
 	DefaultCtrlDialerDialDelay          = 30 * time.Second
@@ -155,7 +160,23 @@ type Config struct {
 	}
 
 	TlsHandshakeRateLimiter command.AdaptiveRateLimitTrackerConfig
-	Src                     map[interface{}]interface{}
+
+	ConnectEventsConfig ConnectEventsConfig
+
+	Src map[interface{}]interface{}
+}
+
+// ConnectEventsConfig configures the goroutine pool used to process identity
+// connect/disconnect events from routers.
+type ConnectEventsConfig struct {
+	// QueueSize is the size of the work queue feeding the pool.
+	QueueSize uint32
+	// MinWorkers is the minimum number of pool goroutines.
+	MinWorkers uint32
+	// MaxWorkers is the maximum number of pool goroutines.
+	MaxWorkers uint32
+	// IdleTime is how long a worker can be idle before exiting.
+	IdleTime time.Duration
 }
 
 func (self *Config) ToJson() (string, error) {
@@ -875,6 +896,38 @@ func LoadConfig(path string) (*Config, error) {
 	if value, found := cfgmap["commandRateLimiter"]; found && !commandRateLimiterHandled {
 		if err = parseCommandRateLimiter(controllerConfig, value, "commandRateLimiter"); err != nil {
 			return nil, err
+		}
+	}
+
+	controllerConfig.ConnectEventsConfig = ConnectEventsConfig{
+		QueueSize:  DefaultConnectEventsQueueSize,
+		MinWorkers: DefaultConnectEventsMinWorkers,
+		MaxWorkers: DefaultConnectEventsMaxWorkers,
+		IdleTime:   DefaultConnectEventsIdleTime,
+	}
+
+	if value, found := cfgmap["connectEvents"]; found {
+		if submap, ok := value.(map[interface{}]interface{}); ok {
+			if value, found := submap["queueSize"]; found {
+				if intVal, ok := value.(int); ok && intVal > 0 {
+					controllerConfig.ConnectEventsConfig.QueueSize = uint32(intVal)
+				}
+			}
+			if value, found := submap["minWorkers"]; found {
+				if intVal, ok := value.(int); ok && intVal >= 0 {
+					controllerConfig.ConnectEventsConfig.MinWorkers = uint32(intVal)
+				}
+			}
+			if value, found := submap["maxWorkers"]; found {
+				if intVal, ok := value.(int); ok && intVal >= 1 {
+					controllerConfig.ConnectEventsConfig.MaxWorkers = uint32(intVal)
+				}
+			}
+			if value, found := submap["idleTime"]; found {
+				if val, err := time.ParseDuration(fmt.Sprintf("%v", value)); err == nil {
+					controllerConfig.ConnectEventsConfig.IdleTime = val
+				}
+			}
 		}
 	}
 

--- a/controller/env/appenv.go
+++ b/controller/env/appenv.go
@@ -45,6 +45,7 @@ import (
 	"github.com/openziti/edge-api/rest_model"
 	"github.com/openziti/foundation/v2/concurrenz"
 	"github.com/openziti/foundation/v2/errorz"
+	"github.com/openziti/foundation/v2/goroutines"
 	"github.com/openziti/foundation/v2/rate"
 	"github.com/openziti/foundation/v2/stringz"
 	"github.com/openziti/identity"
@@ -121,7 +122,8 @@ type AppEnv struct {
 	TraceManager *TraceManager
 	timelineId   concurrenz.AtomicValue[string]
 
-	TokenIssuerCache *model.TokenIssuerCache
+	TokenIssuerCache   *model.TokenIssuerCache
+	ConnectEventsPool  goroutines.Pool
 }
 
 // GetTokenIssuerCache returns the TokenIssuerCache instance for verifying external JWT tokens.
@@ -752,6 +754,21 @@ func NewAppEnv(host HostController) (*AppEnv, error) {
 	}
 
 	ae.timelineId.Store(timelineId)
+
+	connectEventsPool, err := goroutines.NewPool(goroutines.PoolConfig{
+		QueueSize:   cfg.ConnectEventsConfig.QueueSize,
+		MinWorkers:  cfg.ConnectEventsConfig.MinWorkers,
+		MaxWorkers:  cfg.ConnectEventsConfig.MaxWorkers,
+		IdleTime:    cfg.ConnectEventsConfig.IdleTime,
+		CloseNotify: host.GetCloseNotifyChannel(),
+		PanicHandler: func(err interface{}) {
+			pfxlog.Logger().Errorf("panic in connect events pool worker: %v", err)
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create connect events pool: %w", err)
+	}
+	ae.ConnectEventsPool = connectEventsPool
 
 	ae.identityRefreshMeter = host.GetMetricsRegistry().Meter("identity.refresh")
 

--- a/controller/handler_edge_ctrl/connect_events.go
+++ b/controller/handler_edge_ctrl/connect_events.go
@@ -31,19 +31,16 @@ import (
 
 type connectEventsHandler struct {
 	appEnv *env.AppEnv
-	eventC chan func()
 	ch     ctrlchan.CtrlChannel
 }
 
+// NewConnectEventsHandler creates a handler that processes identity connect/disconnect
+// events from routers using the shared ConnectEventsPool on AppEnv.
 func NewConnectEventsHandler(appEnv *env.AppEnv, ch ctrlchan.CtrlChannel) channel.TypedReceiveHandler {
-	result := &connectEventsHandler{
+	return &connectEventsHandler{
 		appEnv: appEnv,
-		eventC: make(chan func(), 1000),
 		ch:     ch,
 	}
-
-	go result.processEvents()
-	return result
 }
 
 func (self *connectEventsHandler) ContentType() int32 {
@@ -57,24 +54,10 @@ func (self *connectEventsHandler) HandleReceive(msg *channel.Message, ch channel
 		return
 	}
 
-	processF := func() {
+	if err := self.appEnv.ConnectEventsPool.Queue(func() {
 		self.HandleConnectEvents(req, ch)
-	}
-
-	select {
-	case self.eventC <- processF:
-	case <-self.appEnv.GetCloseNotifyChannel():
-	}
-}
-
-func (self *connectEventsHandler) processEvents() {
-	for {
-		select {
-		case eventF := <-self.eventC:
-			eventF()
-		case <-self.appEnv.GetCloseNotifyChannel():
-			return
-		}
+	}); err != nil {
+		pfxlog.Logger().WithError(err).Error("failed to queue connect events for processing")
 	}
 }
 


### PR DESCRIPTION
- replaces the per-handler goroutine in connectEventsHandler with a shared,
  bounded goroutine pool on AppEnv
- the old design spawned a processEvents goroutine per router connection that
  only exited on application shutdown, leaking a goroutine on every reconnect
- adds ConnectEventsConfig to the controller config with pool tuning options
  (queueSize, minWorkers, maxWorkers, idleTime)
- defaults: queue 16, 0-16 workers, 30s idle timeout
