### PR TITLE
[Backport-1.6] Fix revocation build-up in db and rdm. Fixes #3760

### DIFF
--- a/common/router_data_model.go
+++ b/common/router_data_model.go
@@ -875,6 +875,16 @@ func (rdm *RouterDataModel) getDataStateAlreadyLocked(index uint64) *edge_ctrl_p
 		events = append(events, newEvent)
 	})
 
+	rdm.Revocations.IterCb(func(key string, v *edge_ctrl_pb.DataState_Revocation) {
+		newEvent := &edge_ctrl_pb.DataState_Event{
+			Action: edge_ctrl_pb.DataState_Create,
+			Model: &edge_ctrl_pb.DataState_Event_Revocation{
+				Revocation: v,
+			},
+		}
+		events = append(events, newEvent)
+	})
+
 	var caches map[string]*edge_ctrl_pb.Cache
 
 	if !rdm.terminatorIdCache.IsEmpty() {

--- a/controller/env/appenv.go
+++ b/controller/env/appenv.go
@@ -182,7 +182,7 @@ func (ae *AppEnv) ValidateAccessToken(token string) (*common.AccessClaims, error
 		return nil, err
 	}
 
-	if revocation != nil && revocation.CreatedAt.After(accessClaims.IssuedAt.AsTime()) {
+	if revocation != nil && revocation.CreatedAt.Truncate(time.Second).After(accessClaims.IssuedAt.AsTime()) {
 		return nil, errors.New("access token has been revoked by identity")
 	}
 
@@ -726,6 +726,30 @@ func (ae *AppEnv) ProcessJwt(rc *response.RequestContext, token *jwt.Token) erro
 		} else {
 			return err
 		}
+	}
+
+	// Check if this specific token has been revoked by JWTID.
+	tokenRevocation, err := ae.GetManagers().Revocation.Read(rc.Claims.JWTID)
+	if err != nil && !boltz.IsErrNotFoundErr(err) {
+		return err
+	}
+	if tokenRevocation != nil {
+		apiErr := errorz.NewUnauthorized()
+		apiErr.Cause = errors.New("access token has been revoked by id")
+		apiErr.AppendCause = true
+		return apiErr
+	}
+
+	// Check if the issuing identity has been terminated via a high-water-mark revocation.
+	identityRevocation, err := ae.GetManagers().Revocation.Read(rc.Claims.Subject)
+	if err != nil && !boltz.IsErrNotFoundErr(err) {
+		return err
+	}
+	if identityRevocation != nil && identityRevocation.CreatedAt.Truncate(time.Second).After(rc.Claims.IssuedAt.AsTime()) {
+		apiErr := errorz.NewUnauthorized()
+		apiErr.Cause = errors.New("access token has been revoked by identity")
+		apiErr.AppendCause = true
+		return apiErr
 	}
 
 	rc.ActivePermissions = append(rc.ActivePermissions, permissions.AuthenticatedPermission)

--- a/controller/internal/policy/revocation_enforcer.go
+++ b/controller/internal/policy/revocation_enforcer.go
@@ -1,0 +1,71 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package policy
+
+import (
+	"time"
+
+	"github.com/michaelquigley/pfxlog"
+	"github.com/openziti/ziti/common/runner"
+	"github.com/openziti/ziti/controller/change"
+	"github.com/openziti/ziti/controller/env"
+)
+
+const (
+	RevocationEnforcerRun    = "revocation.enforcer.run"
+	RevocationEnforcerDelete = "revocation.enforcer.delete"
+	RevocationEnforcerSource = "revocation.enforcer"
+)
+
+// RevocationEnforcer periodically purges expired revocation records from the
+// controller database and router data models.
+type RevocationEnforcer struct {
+	appEnv *env.AppEnv
+	*runner.BaseOperation
+}
+
+// NewRevocationEnforcer creates a RevocationEnforcer that runs at the given frequency.
+func NewRevocationEnforcer(appEnv *env.AppEnv, frequency time.Duration) *RevocationEnforcer {
+	return &RevocationEnforcer{
+		appEnv:        appEnv,
+		BaseOperation: runner.NewBaseOperation("RevocationEnforcer", frequency),
+	}
+}
+
+// Run deletes all expired revocation entries.
+func (e *RevocationEnforcer) Run() error {
+	startTime := time.Now()
+
+	defer func() {
+		e.appEnv.GetMetricsRegistry().Timer(RevocationEnforcerRun).UpdateSince(startTime)
+	}()
+
+	ctx := change.New().SetSourceType(RevocationEnforcerSource).SetChangeAuthorType(change.AuthorTypeController)
+
+	total, err := e.appEnv.GetManagers().Revocation.DeleteExpired(ctx)
+	if err != nil {
+		pfxlog.Logger().WithError(err).Error("failed to delete expired revocations")
+		return nil
+	}
+
+	if total > 0 {
+		pfxlog.Logger().Debugf("removed %d expired revocations", total)
+		e.appEnv.GetMetricsRegistry().Meter(RevocationEnforcerDelete).Mark(int64(total))
+	}
+
+	return nil
+}

--- a/controller/model/revocation_manager.go
+++ b/controller/model/revocation_manager.go
@@ -17,6 +17,9 @@
 package model
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/openziti/storage/boltz"
 	"github.com/openziti/ziti/common/pb/edge_cmd_pb"
 	"github.com/openziti/ziti/controller/change"
@@ -57,6 +60,41 @@ func (self *RevocationManager) ApplyCreate(cmd *command.CreateEntityCommand[*Rev
 
 func (self *RevocationManager) newModelEntity() *Revocation {
 	return &Revocation{}
+}
+
+const revocationDeleteBatchSize = 500
+
+// DeleteExpired deletes all revocations whose ExpiresAt is in the past, working
+// in batches of revocationDeleteBatchSize until no expired entries remain.
+// Returns the total number of entries deleted.
+func (self *RevocationManager) DeleteExpired(ctx *change.Context) (int, error) {
+	query := fmt.Sprintf(`expiresAt < datetime(%s) limit %d`, time.Now().UTC().Format(time.RFC3339), revocationDeleteBatchSize)
+	total := 0
+	for {
+		result, err := self.BaseList(query)
+		if err != nil {
+			return total, err
+		}
+
+		ids := make([]string, 0, len(result.GetEntities()))
+		for _, entity := range result.GetEntities() {
+			ids = append(ids, entity.GetId())
+		}
+
+		if len(ids) == 0 {
+			break
+		}
+
+		if err = self.deleteEntityBatch(ids, ctx); err != nil {
+			return total, err
+		}
+		total += len(ids)
+
+		if len(ids) < revocationDeleteBatchSize {
+			break
+		}
+	}
+	return total, nil
 }
 
 func (self *RevocationManager) Read(id string) (*Revocation, error) {

--- a/controller/oidc_auth/storage.go
+++ b/controller/oidc_auth/storage.go
@@ -755,7 +755,7 @@ func (s *HybridStorage) TokenRequestByRefreshToken(_ context.Context, refreshTok
 // TerminateSession implements the op.Storage interface
 func (s *HybridStorage) TerminateSession(_ context.Context, identityId string, clientID string) error {
 	now := time.Now()
-	return s.saveRevocation(NewRevocation(identityId+","+clientID, now.Add(s.config.MaxTokenDuration())))
+	return s.saveRevocation(NewRevocation(identityId, now.Add(s.config.MaxTokenDuration())))
 }
 
 // GetRefreshTokenInfo implements the op.Storage interface
@@ -781,6 +781,7 @@ func (s *HybridStorage) RevokeToken(_ context.Context, tokenIDOrToken string, _ 
 			return oidc.ErrServerError()
 		}
 
+		return nil
 	}
 
 	revocation := NewRevocation(tokenIDOrToken, time.Now().Add(s.config.MaxTokenDuration()))

--- a/controller/server/controller.go
+++ b/controller/server/controller.go
@@ -46,10 +46,11 @@ type Controller struct {
 }
 
 const (
-	policyMinFreq     = 1 * time.Second
-	policyMaxFreq     = 1 * time.Hour
-	policyAppWanFreq  = 1 * time.Second
-	policySessionFreq = 5 * time.Second
+	policyMinFreq          = 1 * time.Second
+	policyMaxFreq          = 1 * time.Hour
+	policyAppWanFreq       = 1 * time.Second
+	policySessionFreq      = 5 * time.Second
+	policyRevocationFreq   = 1 * time.Minute
 )
 
 func NewController(host env.HostController) (*Controller, error) {
@@ -193,6 +194,14 @@ func (c *Controller) Initialize() {
 			WithField("enforcerId", sessionEnforcer.GetId()).
 			Errorf("could not add session enforcer")
 
+	}
+
+	revocationEnforcer := policy.NewRevocationEnforcer(c.AppEnv, policyRevocationFreq)
+	if err := c.policyEngine.AddOperation(revocationEnforcer); err != nil {
+		log.WithField("cause", err).
+			WithField("enforcerName", revocationEnforcer.GetName()).
+			WithField("enforcerId", revocationEnforcer.GetId()).
+			Errorf("could not add revocation enforcer")
 	}
 
 	if err := c.AppEnv.GetStores().EventualEventer.Start(c.AppEnv.GetHostController().GetCloseNotifyChannel()); err != nil {

--- a/controller/sync_strats/sync_instant.go
+++ b/controller/sync_strats/sync_instant.go
@@ -1806,7 +1806,7 @@ func (strategy *InstantStrategy) RevocationUpdate(index uint64, revocation *db.R
 }
 
 func (strategy *InstantStrategy) RevocationDelete(index uint64, revocation *db.Revocation) {
-	strategy.handleRevocation(index, edge_ctrl_pb.DataState_Create, revocation)
+	strategy.handleRevocation(index, edge_ctrl_pb.DataState_Delete, revocation)
 }
 
 func (strategy *InstantStrategy) handlePublicKey(index uint64, action edge_ctrl_pb.DataState_Action, publicKey *edge_ctrl_pb.DataState_PublicKey) {

--- a/tests/configsets.go
+++ b/tests/configsets.go
@@ -1,0 +1,22 @@
+package tests
+
+// ConfigSet describes a named collection of config files for a single test scenario.
+// All file paths are relative to the tests/ working directory.
+type ConfigSet struct {
+	Name           string // display name matching the testdata/configs subdirectory
+	CtrlConfig     string // controller config file; empty if the set does not define one
+	EdgeRouter     string // edge router config; empty if the set does not define one
+	TunnelerRouter string // tunneler-enabled edge router config; empty if not defined
+	TransitRouter  string // transit router config; empty if not defined
+}
+
+// DefaultATS is the standard full-stack config set used by the majority of the
+// integration test suite. It covers the controller, edge router, tunneler router,
+// and transit router.
+var DefaultATS = ConfigSet{
+	Name:           "default-ats",
+	CtrlConfig:     "ats-ctrl.yml",
+	EdgeRouter:     "ats-edge.router.yml",
+	TunnelerRouter: "ats-edge-tunneler.router.yml",
+	TransitRouter:  "ats-transit.router.yml",
+}

--- a/tests/context.go
+++ b/tests/context.go
@@ -39,11 +39,12 @@ import (
 	"testing"
 	"time"
 
-	edge_apis "github.com/openziti/sdk-golang/edge-apis"
+	edgeApis "github.com/openziti/sdk-golang/edge-apis"
 	"github.com/openziti/ziti/controller/config"
-	env2 "github.com/openziti/ziti/router/env"
-	"github.com/openziti/ziti/router/xgress_router"
+	routerEnv "github.com/openziti/ziti/router/env"
 	"github.com/openziti/ziti/zitirest"
+	oidcPkg "github.com/zitadel/oidc/v3/pkg/oidc"
+	oauth2Pkg "golang.org/x/oauth2"
 
 	"github.com/Jeffail/gabs"
 	"github.com/go-openapi/strfmt"
@@ -63,7 +64,6 @@ import (
 	"github.com/openziti/transport/v2"
 	"github.com/openziti/transport/v2/tcp"
 	"github.com/openziti/transport/v2/tls"
-	"github.com/openziti/ziti/common"
 	"github.com/openziti/ziti/common/eid"
 	"github.com/openziti/ziti/controller"
 	"github.com/openziti/ziti/controller/env"
@@ -71,23 +71,18 @@ import (
 	"github.com/openziti/ziti/controller/xt_smartrouting"
 	"github.com/openziti/ziti/router"
 	"github.com/openziti/ziti/router/enroll"
-	"github.com/openziti/ziti/router/xgress_edge"
-	"github.com/openziti/ziti/router/xgress_edge_tunnel"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/require"
 	"gopkg.in/resty.v1"
 )
 
-const (
-	ControllerConfFile         = "ats-ctrl.yml"
-	EdgeRouterConfFile         = "ats-edge.router.yml"
-	TunnelerEdgeRouterConfFile = "ats-edge-tunneler.router.yml"
-	TransitRouterConfFile      = "ats-transit.router.yml"
-)
-
 func init() {
-	pfxlog.GlobalInit(logrus.DebugLevel, pfxlog.DefaultOptions().SetTrimPrefix("github.com/openziti/").StartingToday())
+	logOptions := pfxlog.DefaultOptions().
+		SetTrimPrefix("github.com/openziti/").
+		StartingToday()
+
+	pfxlog.GlobalInit(logrus.InfoLevel, logOptions)
+	pfxlog.SetFormatter(pfxlog.NewFormatter(logOptions))
 
 	_ = os.Setenv("ZITI_TRACE_ENABLED", "false")
 
@@ -111,10 +106,6 @@ func I(i int64) *int64 {
 	return &i
 }
 
-func T(t time.Time) *time.Time {
-	return &t
-}
-
 // ST returns a pointer to a strfmt.Date time. A helper function
 // for creating rest_model types
 func ST(t time.Time) *strfmt.DateTime {
@@ -123,15 +114,16 @@ func ST(t time.Time) *strfmt.DateTime {
 }
 
 type TestContext struct {
-	*require.Assertions
+	*CustomAssertions
 	ApiHost                string
 	AdminAuthenticator     *updbAuthenticator
+	Managers               *ManagerHelpers
 	AdminManagementSession *session
 	AdminClientSession     *session
 	RestClients            *zitirest.Clients
 	fabricController       *controller.Controller
 	EdgeController         *server.Controller
-	Req                    *require.Assertions
+	Req                    *CustomAssertions
 	clientApiClient        *resty.Client
 	managementApiClient    *resty.Client
 	enabledJsonLogging     bool
@@ -142,13 +134,20 @@ type TestContext struct {
 	testing             *testing.T
 	LogLevel            string
 	ControllerConfig    *config.Config
+	configSet           ConfigSet
 }
 
-var defaultTestContext = &TestContext{
-	AdminAuthenticator: &updbAuthenticator{
-		Username: eid.New(),
-		Password: eid.New(),
-	},
+var defaultTestContext = newDefaultTestContext()
+
+func newDefaultTestContext() *TestContext {
+	ctx := &TestContext{
+		AdminAuthenticator: &updbAuthenticator{
+			Username: eid.New(),
+			Password: eid.New(),
+		},
+	}
+	ctx.Managers = &ManagerHelpers{ctx: ctx}
+	return ctx
 }
 
 func NewTestContext(t *testing.T) *TestContext {
@@ -158,13 +157,25 @@ func NewTestContext(t *testing.T) *TestContext {
 			Username: eid.New(),
 			Password: eid.New(),
 		},
-		LogLevel: os.Getenv("ZITI_TEST_LOG_LEVEL"),
-		Req:      require.New(t),
+		LogLevel:  os.Getenv("ZITI_TEST_LOG_LEVEL"),
+		configSet: DefaultATS,
 	}
-	ret.Assertions = ret.Req
+	ret.Managers = &ManagerHelpers{ctx: ret}
 	ret.testContextChanged(t)
 
 	return ret
+}
+
+// NewTestContextWithConfigSet creates a TestContext that uses the supplied ConfigSet
+// instead of DefaultATS. All other behavior, including DB path and API host, is unchanged.
+func NewTestContextWithConfigSet(t *testing.T, cs ConfigSet) *TestContext {
+	ret := NewTestContext(t)
+	ret.configSet = cs
+	return ret
+}
+
+func (ctx *TestContext) controllerConfFile() string {
+	return ctx.configSet.CtrlConfig
 }
 
 func GetTestContext() *TestContext {
@@ -176,8 +187,9 @@ func GetTestContext() *TestContext {
 // errors.
 func (ctx *TestContext) testContextChanged(t *testing.T) {
 	ctx.testing = t
-	ctx.Req = require.New(t)
-	ctx.Assertions = ctx.Req
+	newReq := NewCustomAssertions(t)
+	ctx.Req = newReq
+	ctx.CustomAssertions = newReq
 }
 
 // NextTest is an alias for testContextChanged and reflects the bbolt testing framework
@@ -219,7 +231,7 @@ func (ctx *TestContext) NewEdgeClientApi(totpProvider func(chan string)) *Client
 	if totpProvider == nil {
 		totpProvider = func(chan string) {}
 	}
-	client := edge_apis.NewClientApiClient([]*url.URL{ctx.ClientApiUrl()}, ctx.ControllerCaPool(), totpProvider)
+	client := edgeApis.NewClientApiClient([]*url.URL{ctx.ClientApiUrl()}, ctx.ControllerCaPool(), totpProvider)
 
 	return &ClientHelperClient{
 		ClientApiClient: client,
@@ -231,7 +243,7 @@ func (ctx *TestContext) NewEdgeManagementApi(totpProvider func(chan string)) *Ma
 	if totpProvider == nil {
 		totpProvider = func(chan string) {}
 	}
-	client := edge_apis.NewManagementApiClient([]*url.URL{ctx.ManagementApiUrl()}, ctx.ControllerCaPool(), totpProvider)
+	client := edgeApis.NewManagementApiClient([]*url.URL{ctx.ManagementApiUrl()}, ctx.ControllerCaPool(), totpProvider)
 
 	return &ManagementHelperClient{
 		ManagementApiClient: client,
@@ -395,11 +407,23 @@ func (ctx *TestContext) NewClientComponentsWithClientCert(certs []*x509.Certific
 
 }
 
-func (ctx *TestContext) StartServer() {
-	ctx.StartServerFor("testdata/default.db", true)
+func (ctx *TestContext) StartServer() *ControllerHelper {
+	return ctx.StartServerFor("testdata/default.db", true)
 }
 
-func (ctx *TestContext) StartServerFor(testDb string, clean bool) {
+// StartServerWithConfigModifier starts the controller and edge layer, applying
+// modifier to the loaded config before the controller is created. This lets a
+// single test override settings (e.g., OIDC token durations) without affecting
+// other tests that call StartServer with the shared default config.
+func (ctx *TestContext) StartServerWithConfigModifier(modifier func(*config.Config)) *ControllerHelper {
+	return ctx.startServerWith("testdata/default.db", true, modifier)
+}
+
+func (ctx *TestContext) StartServerFor(testDb string, clean bool) *ControllerHelper {
+	return ctx.startServerWith(testDb, clean, nil)
+}
+
+func (ctx *TestContext) startServerWith(testDb string, clean bool, modifier func(*config.Config)) *ControllerHelper {
 	if ctx.LogLevel != "" {
 		if level, err := logrus.ParseLevel(ctx.LogLevel); err == nil {
 			logrus.StandardLogger().SetLevel(level)
@@ -426,8 +450,12 @@ func (ctx *TestContext) StartServerFor(testDb string, clean bool) {
 	ctx.Req.NoError(err)
 
 	log.Info("loading config")
-	ctrlConfig, err := config.LoadConfig(ControllerConfFile)
+	ctrlConfig, err := config.LoadConfig(ctx.controllerConfFile())
 	ctx.Req.NoError(err)
+
+	if modifier != nil {
+		modifier(ctrlConfig)
+	}
 
 	ctx.ControllerConfig = ctrlConfig
 
@@ -446,16 +474,18 @@ func (ctx *TestContext) StartServerFor(testDb string, clean bool) {
 		log.WithError(err).Warn("error during initialize admin")
 	}
 
-	logrus.Infof("username: %v", ctx.AdminAuthenticator.Username)
-	logrus.Infof("password: %v", ctx.AdminAuthenticator.Password)
+	logrus.Infof("default admin - username: %v", ctx.AdminAuthenticator.Username)
+	logrus.Infof("default admin - password: %v", ctx.AdminAuthenticator.Password)
 
 	ctx.EdgeController.Run()
 	go func() {
 		err = ctx.fabricController.Run()
 		ctx.Req.NoError(err)
 	}()
-	err = ctx.waitForCtrlPort(time.Minute * 5)
+	err = ctx.waitForRestAPIPort(time.Minute * 5)
 	ctx.Req.NoError(err)
+
+	return &ControllerHelper{Controller: ctx.EdgeController}
 }
 
 func (ctx *TestContext) createAndEnrollEdgeRouter(tunneler bool, roleAttributes ...string) *edgeRouter {
@@ -485,11 +515,11 @@ func (ctx *TestContext) requireCreateEdgeRouter(tunneler bool, roleAttributes ..
 func (ctx *TestContext) requireEnrollEdgeRouter(tunneler bool, routerId string) {
 	jwt := ctx.AdminManagementSession.getEdgeRouterJwt(routerId)
 
-	configFile := EdgeRouterConfFile
+	configFile := ctx.configSet.EdgeRouter
 	if tunneler {
-		configFile = TunnelerEdgeRouterConfFile
+		configFile = ctx.configSet.TunnelerRouter
 	}
-	routerConfig, err := env2.LoadConfigWithOptions(configFile, false)
+	routerConfig, err := routerEnv.LoadConfigWithOptions(configFile, false)
 	ctx.Req.NoError(err)
 
 	enroller := enroll.NewRestEnroller(routerConfig)
@@ -510,7 +540,7 @@ func (ctx *TestContext) createAndEnrollTransitRouter() *transitRouter {
 	ctx.transitRouterEntity = ctx.AdminManagementSession.requireNewTransitRouter()
 	jwt := ctx.AdminManagementSession.getTransitRouterJwt(ctx.transitRouterEntity.id)
 
-	routerConfig, err := env2.LoadConfigWithOptions(TransitRouterConfFile, false)
+	routerConfig, err := routerEnv.LoadConfigWithOptions(ctx.configSet.TransitRouter, false)
 	ctx.Req.NoError(err)
 
 	enroller := enroll.NewRestEnroller(routerConfig)
@@ -527,7 +557,7 @@ func (ctx *TestContext) createEnrollAndStartTransitRouter() {
 }
 
 func (ctx *TestContext) startTransitRouter() {
-	routerConfig, err := env2.LoadConfig(TransitRouterConfFile)
+	routerConfig, err := routerEnv.LoadConfig(ctx.configSet.TransitRouter)
 	ctx.Req.NoError(err)
 	newRouter := router.Create(routerConfig, NewVersionProviderTest())
 	ctx.routers = append(ctx.routers, newRouter)
@@ -541,48 +571,38 @@ func (ctx *TestContext) CreateEnrollAndStartTunnelerEdgeRouter(roleAttributes ..
 	ctx.startEdgeRouter(nil)
 }
 
-func (ctx *TestContext) CreateEnrollAndStartEdgeRouter(roleAttributes ...string) *router.Router {
+func (ctx *TestContext) CreateEnrollAndStartEdgeRouter(roleAttributes ...string) *EdgeRouterHelper {
 	ctx.shutdownRouters()
 	ctx.createAndEnrollEdgeRouter(false, roleAttributes...)
 	return ctx.startEdgeRouter(nil)
 }
 
-func (ctx *TestContext) CreateEnrollAndStartEdgeRouterWithCfgTweaks(cfgTweaks func(*env2.Config), roleAttributes ...string) *router.Router {
+func (ctx *TestContext) CreateEnrollAndStartEdgeRouterWithCfgTweaks(cfgTweaks func(*routerEnv.Config), roleAttributes ...string) *EdgeRouterHelper {
 	ctx.shutdownRouters()
 	ctx.createAndEnrollEdgeRouter(false, roleAttributes...)
 	return ctx.startEdgeRouter(cfgTweaks)
 }
 
-func (ctx *TestContext) CreateEnrollAndStartHAEdgeRouter(roleAttributes ...string) *router.Router {
+func (ctx *TestContext) CreateEnrollAndStartHAEdgeRouter(roleAttributes ...string) *EdgeRouterHelper {
 	ctx.shutdownRouters()
 	ctx.createAndEnrollEdgeRouter(false, roleAttributes...)
 	return ctx.startEdgeRouter(nil)
 }
 
-func (ctx *TestContext) startEdgeRouter(cfgTweaks func(*env2.Config)) *router.Router {
-	configFile := EdgeRouterConfFile
+func (ctx *TestContext) startEdgeRouter(cfgTweaks func(*routerEnv.Config)) *EdgeRouterHelper {
+	configFile := ctx.configSet.EdgeRouter
 	if ctx.edgeRouterEntity.isTunnelerEnabled {
-		configFile = TunnelerEdgeRouterConfFile
+		configFile = ctx.configSet.TunnelerRouter
 	}
-	config, err := env2.LoadConfig(configFile)
+	routerCfg, err := routerEnv.LoadConfig(configFile)
 	ctx.Req.NoError(err)
 	if cfgTweaks != nil {
-		cfgTweaks(config)
+		cfgTweaks(routerCfg)
 	}
-	newRouter := router.Create(config, NewVersionProviderTest())
+	newRouter := router.Create(routerCfg, NewVersionProviderTest())
 	ctx.routers = append(ctx.routers, newRouter)
-
-	xgressEdgeFactory := xgress_edge.NewFactory(config, newRouter, newRouter.GetStateManager())
-	xgress_router.GlobalRegistry().Register(common.EdgeBinding, xgressEdgeFactory)
-
-	xgressEdgeTunnelFactory := xgress_edge_tunnel.NewFactory(newRouter, newRouter.GetStateManager())
-	xgress_router.GlobalRegistry().Register(common.TunnelBinding, xgressEdgeTunnelFactory)
-
-	ctx.Req.NoError(newRouter.RegisterXrctrl(xgressEdgeFactory))
-	ctx.Req.NoError(newRouter.RegisterXrctrl(xgressEdgeTunnelFactory))
-	ctx.Req.NoError(newRouter.RegisterXrctrl(newRouter.GetStateManager()))
 	ctx.Req.NoError(newRouter.Start())
-	return newRouter
+	return &EdgeRouterHelper{Router: newRouter}
 }
 
 func (ctx *TestContext) EnrollIdentity(identityId string) *ziti.Config {
@@ -604,7 +624,7 @@ func (ctx *TestContext) EnrollIdentity(identityId string) *ziti.Config {
 	return conf
 }
 
-func (ctx *TestContext) waitForCtrlPort(duration time.Duration) error {
+func (ctx *TestContext) waitForRestAPIPort(duration time.Duration) error {
 	return ctx.waitForPort(ctx.ApiHost, duration)
 }
 
@@ -960,6 +980,41 @@ func (ctx *TestContext) shutdownRouters() {
 		ctx.Req.NoError(r.Shutdown())
 	}
 	ctx.routers = nil
+}
+
+// NewAdminCredentials returns OIDC-compatible UPDB credentials for the default admin user.
+func (ctx *TestContext) NewAdminCredentials() *edgeApis.UpdbCredentials {
+	return edgeApis.NewUpdbCredentials(ctx.AdminAuthenticator.Username, ctx.AdminAuthenticator.Password)
+}
+
+// NewEdgeManagementApiWithToken returns a ManagementHelperClient pre-loaded with
+// the given raw OIDC access token. No authentication step is required.
+func (ctx *TestContext) NewEdgeManagementApiWithToken(accessToken string) *ManagementHelperClient {
+	client := ctx.NewEdgeManagementApi(nil)
+	var session edgeApis.ApiSession = &edgeApis.ApiSessionOidc{
+		OidcTokens: &oidcPkg.Tokens[*oidcPkg.IDTokenClaims]{
+			Token: &oauth2Pkg.Token{
+				AccessToken: accessToken,
+			},
+		},
+	}
+	client.ApiSession.Store(&session)
+	return client
+}
+
+// NewEdgeClientApiWithToken returns a ClientHelperClient pre-loaded with the
+// given raw OIDC access token. No authentication step is required.
+func (ctx *TestContext) NewEdgeClientApiWithToken(accessToken string) *ClientHelperClient {
+	client := ctx.NewEdgeClientApi(nil)
+	var session edgeApis.ApiSession = &edgeApis.ApiSessionOidc{
+		OidcTokens: &oidcPkg.Tokens[*oidcPkg.IDTokenClaims]{
+			Token: &oauth2Pkg.Token{
+				AccessToken: accessToken,
+			},
+		},
+	}
+	client.ApiSession.Store(&session)
+	return client
 }
 
 type TestConn struct {

--- a/tests/context_manager_helpers.go
+++ b/tests/context_manager_helpers.go
@@ -1,0 +1,81 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package tests
+
+import (
+	"github.com/openziti/ziti/common/eid"
+	"github.com/openziti/ziti/controller/db"
+	"github.com/openziti/ziti/controller/model"
+	"github.com/openziti/ziti/controller/models"
+)
+
+// ManagerHelpers provides direct access to controller manager operations, bypassing the REST API.
+// Accessible via TestContext.Managers after StartServer() has been called.
+type ManagerHelpers struct {
+	ctx *TestContext
+}
+
+// CreateAuthPolicy creates an auth policy via the manager. The policy's Id field is populated on success.
+func (m *ManagerHelpers) CreateAuthPolicy(policy *model.AuthPolicy) error {
+	return m.ctx.EdgeController.AppEnv.Managers.AuthPolicy.Create(policy, nil)
+}
+
+// CreateIdentity creates an identity via the manager. The identity's Id field is populated on success.
+func (m *ManagerHelpers) CreateIdentity(identity *model.Identity) error {
+	return m.ctx.EdgeController.AppEnv.Managers.Identity.Create(identity, nil)
+}
+
+// CreateUpdbAuthenticator creates a username/password authenticator for the given identity.
+func (m *ManagerHelpers) CreateUpdbAuthenticator(identityId, username, password string) error {
+	authenticator := &model.Authenticator{
+		BaseEntity: models.BaseEntity{},
+		Method:     db.MethodAuthenticatorUpdb,
+		IdentityId: identityId,
+		SubType: &model.AuthenticatorUpdb{
+			Username: username,
+			Password: password,
+		},
+	}
+	return m.ctx.EdgeController.AppEnv.Managers.Authenticator.Create(authenticator, nil)
+}
+
+// NewIdentityWithUpdb creates a non-admin identity with random credentials attached to the given
+// auth policy, and registers a UPDB authenticator for it. Returns the identity, credentials, and
+// any error.
+func (m *ManagerHelpers) NewIdentityWithUpdb(authPolicyId string) (*model.Identity, *updbAuthenticator, error) {
+	creds := &updbAuthenticator{
+		Username: eid.New(),
+		Password: eid.New(),
+	}
+
+	identity := &model.Identity{
+		Name:           creds.Username,
+		IdentityTypeId: db.DefaultIdentityType,
+		IsAdmin:        false,
+		AuthPolicyId:   authPolicyId,
+	}
+
+	if err := m.CreateIdentity(identity); err != nil {
+		return nil, nil, err
+	}
+
+	if err := m.CreateUpdbAuthenticator(identity.Id, creds.Username, creds.Password); err != nil {
+		return nil, nil, err
+	}
+
+	return identity, creds, nil
+}

--- a/tests/controller_helper.go
+++ b/tests/controller_helper.go
@@ -1,0 +1,61 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package tests
+
+import (
+	"time"
+
+	"github.com/openziti/storage/boltz"
+	"github.com/openziti/ziti/controller/change"
+	"github.com/openziti/ziti/controller/model"
+	"github.com/openziti/ziti/controller/models"
+	"github.com/openziti/ziti/controller/server"
+)
+
+// ControllerHelper wraps a server.Controller with test-oriented helper methods.
+// All methods return values and errors; none accept *testing.T.
+// Because it embeds *server.Controller, all controller methods are available directly.
+type ControllerHelper struct {
+	*server.Controller
+}
+
+// ReadRevocation returns the revocation with the given id from the controller DB,
+// or (nil, nil) if not found.
+func (h *ControllerHelper) ReadRevocation(id string) (*model.Revocation, error) {
+	rev, err := h.AppEnv.GetManagers().Revocation.Read(id)
+	if boltz.IsErrNotFoundErr(err) {
+		return nil, nil
+	}
+	return rev, err
+}
+
+// CreateRevocation writes a revocation entry with the given id and ExpiresAt directly
+// to the controller DB. Useful for planting entries (e.g. with a past ExpiresAt) in tests.
+func (h *ControllerHelper) CreateRevocation(id string, expiresAt time.Time) error {
+	ctx := change.New().SetSourceType("test").SetChangeAuthorType(change.AuthorTypeController)
+	return h.AppEnv.GetManagers().Revocation.Create(&model.Revocation{
+		BaseEntity: models.BaseEntity{Id: id},
+		ExpiresAt:  expiresAt,
+	}, ctx)
+}
+
+// DeleteExpiredRevocations calls DeleteExpired on the revocation manager and returns
+// the total number of entries removed.
+func (h *ControllerHelper) DeleteExpiredRevocations() (int, error) {
+	ctx := change.New().SetSourceType("test").SetChangeAuthorType(change.AuthorTypeController)
+	return h.AppEnv.GetManagers().Revocation.DeleteExpired(ctx)
+}

--- a/tests/custom_assertions.go
+++ b/tests/custom_assertions.go
@@ -1,0 +1,73 @@
+package tests
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/openziti/edge-api/rest_util"
+	"github.com/openziti/ziti/ziti/util"
+	"github.com/stretchr/testify/require"
+)
+
+// CustomAssertions wraps require.Assertions with additional assertion helpers
+// for REST API error inspection.
+type CustomAssertions struct {
+	*require.Assertions
+}
+
+// NewCustomAssertions creates a CustomAssertions backed by the given testing handle.
+func NewCustomAssertions(t require.TestingT) *CustomAssertions {
+	return &CustomAssertions{require.New(t)}
+}
+
+// ApiError asserts that err is a RestApiError.
+func (c *CustomAssertions) ApiError(err error) {
+	restApiError := &util.RestApiError{}
+	if errors.As(err, restApiError) {
+		return
+	}
+	c.Fail(fmt.Sprintf("expected error to be an api error, got %T", err))
+}
+
+// ApiErrorWithCode asserts that err is a REST API error carrying the given code.
+func (c *CustomAssertions) ApiErrorWithCode(err error, code string) {
+	// if not wrapped
+	if apiErrorPayload, ok := err.(rest_util.ApiErrorPayload); ok {
+		if apiErrorPayload == nil {
+			c.Fail("expected ApiErrorPayload to not be nil")
+		}
+
+		payload := apiErrorPayload.GetPayload()
+		if payload == nil {
+			c.Fail("expected RestAPIError to have payload, got nil")
+			return
+		}
+
+		if payload.Error == nil {
+			c.Fail("expected RestApiError payload to have an error, got nil")
+			return
+		}
+
+		if payload.Error.Code != code {
+			c.Fail(fmt.Sprintf("expected RestApiError payload to have code %s, got %s", code, payload.Error.Code))
+			return
+		}
+
+		//success
+		return
+	}
+
+	//if wrapped
+	restApiFormattedError := &rest_util.APIFormattedError{}
+	if errors.As(err, &restApiFormattedError) {
+		if restApiFormattedError.Code != code {
+			c.Fail(fmt.Sprintf("expected RestApiError payload to have code %s, got %s", code, restApiFormattedError.Code))
+			return
+		}
+
+		//success
+		return
+	}
+
+	c.Fail(fmt.Sprintf("expected error to be an RestApiError, got %T", err))
+}

--- a/tests/edge_router_helper.go
+++ b/tests/edge_router_helper.go
@@ -1,0 +1,80 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package tests
+
+import (
+	"time"
+
+	"github.com/openziti/ziti/router"
+)
+
+// EdgeRouterHelper wraps a router.Router with test-oriented helper methods.
+// All methods return values; none accept *testing.T.
+// Because it embeds *router.Router, all router methods are available directly.
+type EdgeRouterHelper struct {
+	*router.Router
+}
+
+// WaitForRouterSync polls until the router has received its initial data state
+// from the controller (indicated by a non-zero RDM index). Returns true if
+// sync completes within the timeout.
+func (h *EdgeRouterHelper) WaitForRouterSync(timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		rdm := h.GetRouterDataModel()
+		if rdm != nil {
+			if idx, ok := rdm.CurrentIndex(); ok && idx > 0 {
+				return true
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return false
+}
+
+// HasRevocation reports whether the given id is currently present in the
+// router's RDM revocations map.
+func (h *EdgeRouterHelper) HasRevocation(id string) bool {
+	_, ok := h.GetRouterDataModel().Revocations.Get(id)
+	return ok
+}
+
+// WaitForRevocation polls the router's RDM until id appears in the revocations
+// map or timeout elapses. Returns true if the entry is found within the timeout.
+func (h *EdgeRouterHelper) WaitForRevocation(id string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if h.HasRevocation(id) {
+			return true
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return false
+}
+
+// WaitForRevocationGone polls the router's RDM until id is absent from the
+// revocations map or timeout elapses. Returns true if gone within the timeout.
+func (h *EdgeRouterHelper) WaitForRevocationGone(id string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !h.HasRevocation(id) {
+			return true
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return false
+}

--- a/tests/generated_client_helpers.go
+++ b/tests/generated_client_helpers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openziti/edge-api/rest_client_api_client/current_api_session"
 	clientEnroll "github.com/openziti/edge-api/rest_client_api_client/enroll"
 	"github.com/openziti/edge-api/rest_management_api_client/certificate_authority"
+	managementCurrentApiSession "github.com/openziti/edge-api/rest_management_api_client/current_api_session"
 	managementEnrollment "github.com/openziti/edge-api/rest_management_api_client/enrollment"
 	managementIdentity "github.com/openziti/edge-api/rest_management_api_client/identity"
 	"github.com/openziti/edge-api/rest_model"
@@ -622,4 +623,40 @@ func IsJwt(token string) bool {
 	}
 
 	return false
+}
+
+// AuthenticateOidc sets the client to use OIDC, authenticates with the given
+// credentials, and returns the OIDC API session. Returns an error if
+// authentication fails or the session is not an OIDC session.
+func (helper *ManagementHelperClient) AuthenticateOidc(creds edge_apis.Credentials) (*edge_apis.ApiSessionOidc, error) {
+	helper.SetUseOidc(true)
+	apiSession, err := helper.Authenticate(creds, nil)
+	if err != nil {
+		return nil, err
+	}
+	oidcSession, ok := apiSession.(*edge_apis.ApiSessionOidc)
+	if !ok {
+		return nil, fmt.Errorf("expected *edge_apis.ApiSessionOidc, got %T", apiSession)
+	}
+	return oidcSession, nil
+}
+
+// GetCurrentApiSessionDetail returns the current API session detail for a management client.
+func (helper *ManagementHelperClient) GetCurrentApiSessionDetail() (*rest_model.CurrentAPISessionDetail, error) {
+	resp, err := helper.GetCurrentApiSessionDetailResponse()
+	if err != nil {
+		return nil, err
+	}
+	return resp.Payload.Data, nil
+}
+
+// GetCurrentApiSessionDetailResponse returns the full response for the current API session,
+// including typed errors for status-code assertions.
+func (helper *ManagementHelperClient) GetCurrentApiSessionDetailResponse() (*managementCurrentApiSession.GetCurrentAPISessionOK, error) {
+	params := &managementCurrentApiSession.GetCurrentAPISessionParams{}
+	resp, err := helper.API.CurrentAPISession.GetCurrentAPISession(params, nil)
+	if err != nil {
+		return nil, fmt.Errorf("could not get current api session detail: %w", rest_util.WrapErr(err))
+	}
+	return resp, nil
 }

--- a/tests/revocation_test.go
+++ b/tests/revocation_test.go
@@ -1,0 +1,277 @@
+//go:build apitests
+
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package tests
+
+import (
+	"errors"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	managementCurrentApiSession "github.com/openziti/edge-api/rest_management_api_client/current_api_session"
+	"github.com/openziti/ziti/common"
+	"github.com/openziti/ziti/controller/config"
+	"github.com/openziti/ziti/controller/oidc_auth"
+	"github.com/zitadel/oidc/v3/pkg/oidc"
+)
+
+// Test_Revocation verifies the OIDC token revocation lifecycle: refresh-token
+// rotation, explicit revocation via /oidc/revoke, session termination via
+// /oidc/end_session, and periodic purge of expired revocation entries.
+func Test_Revocation(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+
+	ctrl := ctx.StartServerWithConfigModifier(func(cfg *config.Config) {
+		cfg.Edge.Oidc.AccessTokenDuration = 10 * time.Second
+		cfg.Edge.Oidc.RefreshTokenDuration = 15 * time.Second
+		cfg.Edge.Oidc.IdTokenDuration = 10 * time.Second
+	})
+	ctx.RequireAdminManagementApiLogin()
+	router := ctx.CreateEnrollAndStartEdgeRouter()
+
+	// Wait for the router to complete its initial data state sync with the
+	// controller. Without this, the first revocation may be created before
+	// the router is ready to receive change set events.
+	ctx.Req.True(router.WaitForRouterSync(30*time.Second), "timed out waiting for router initial sync")
+
+	jwtParser := jwt.NewParser()
+
+	t.Run("refresh revokes old refresh token JWTID", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		client := ctx.NewEdgeManagementApi(nil)
+		oidcSession, err := client.AuthenticateOidc(ctx.NewAdminCredentials())
+		ctx.Req.NoError(err)
+
+		// Extract the JWTID from the old refresh token before exchanging it.
+		oldRefreshClaims := &common.RefreshClaims{}
+		_, _, err = jwtParser.ParseUnverified(oidcSession.OidcTokens.RefreshToken, oldRefreshClaims)
+		ctx.Req.NoError(err)
+		oldRefreshJTI := oldRefreshClaims.JWTID
+		ctx.Req.NotEmpty(oldRefreshJTI)
+
+		// Exchange the refresh token for a new token pair.
+		req := &oidc.RefreshTokenRequest{
+			RefreshToken: oidcSession.OidcTokens.RefreshToken,
+			ClientID:     oidcSession.OidcTokens.IDTokenClaims.ClientID,
+			Scopes:       []string{oidc.ScopeOpenID, oidc.ScopeOfflineAccess},
+		}
+		enc := oidc.NewEncoder()
+		dst := map[string][]string{}
+		ctx.Req.NoError(enc.Encode(req, dst))
+		dst["grant_type"] = []string{string(req.GrantType())}
+
+		newTokens := &oidc.TokenExchangeResponse{}
+		resp, err := ctx.newAnonymousClientApiRequest().
+			SetHeader("content-type", oidc_auth.FormContentType).
+			SetMultiValueFormData(dst).
+			SetResult(newTokens).
+			Post("https://" + ctx.ApiHost + "/oidc/oauth/token")
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(200, resp.StatusCode())
+
+		t.Run("old refresh token JWTID is in the controller revocation DB", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			rev, err := ctrl.ReadRevocation(oldRefreshJTI)
+			ctx.Req.NoError(err)
+			ctx.Req.NotNil(rev, "expected revocation entry for old refresh JWTID %s", oldRefreshJTI)
+		})
+
+		t.Run("revocation propagates to the router RDM within 10s", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			ctx.Req.True(router.WaitForRevocation(oldRefreshJTI, 10*time.Second),
+				"timed out waiting for revocation %s to appear in router RDM", oldRefreshJTI)
+		})
+	})
+
+	t.Run("explicit revocation revokes refresh token by JWTID", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		client := ctx.NewEdgeManagementApi(nil)
+		oidcSession, err := client.AuthenticateOidc(ctx.NewAdminCredentials())
+		ctx.Req.NoError(err)
+
+		// Extract the JWTID from the refresh token before revoking it.
+		refreshClaims := &common.RefreshClaims{}
+		_, _, err = jwtParser.ParseUnverified(oidcSession.OidcTokens.RefreshToken, refreshClaims)
+		ctx.Req.NoError(err)
+		refreshJTI := refreshClaims.JWTID
+		ctx.Req.NotEmpty(refreshJTI)
+
+		clientID := oidcSession.OidcTokens.IDTokenClaims.ClientID
+		refreshToken := oidcSession.OidcTokens.RefreshToken
+
+		// POST to the OIDC revocation endpoint with the refresh token.
+		resp, err := ctx.newAnonymousClientApiRequest().
+			SetHeader("content-type", oidc_auth.FormContentType).
+			SetMultiValueFormData(map[string][]string{
+				"token":           {refreshToken},
+				"token_type_hint": {"refresh_token"},
+				"client_id":       {clientID},
+			}).
+			Post("https://" + ctx.ApiHost + "/oidc/revoke")
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(200, resp.StatusCode())
+
+		t.Run("refresh token JWTID is in the controller revocation DB", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			rev, err := ctrl.ReadRevocation(refreshJTI)
+			ctx.Req.NoError(err)
+			ctx.Req.NotNil(rev, "expected revocation entry for refresh JWTID %s", refreshJTI)
+		})
+
+		t.Run("raw refresh token string is NOT stored as a separate revocation key", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			// Verifies bug 1 fix: no double-write with the raw JWT string as key.
+			rev, err := ctrl.ReadRevocation(refreshToken)
+			ctx.Req.NoError(err)
+			ctx.Req.Nil(rev, "expected no revocation keyed on raw token string")
+		})
+
+		t.Run("revocation propagates to the router RDM within 10s", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			ctx.Req.True(router.WaitForRevocation(refreshJTI, 10*time.Second),
+				"timed out waiting for revocation %s to appear in router RDM", refreshJTI)
+		})
+	})
+
+	t.Run("session termination revokes all identity tokens by subject", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		client := ctx.NewEdgeManagementApi(nil)
+		oidcSession, err := client.AuthenticateOidc(ctx.NewAdminCredentials())
+		ctx.Req.NoError(err)
+
+		// Extract identityId (Subject) and IssuedAt from the access token.
+		accessClaims := &common.AccessClaims{}
+		_, _, err = jwtParser.ParseUnverified(oidcSession.OidcTokens.AccessToken, accessClaims)
+		ctx.Req.NoError(err)
+		identityId := accessClaims.Subject
+		ctx.Req.NotEmpty(identityId)
+
+		clientID := oidcSession.OidcTokens.IDTokenClaims.ClientID
+		idToken := oidcSession.OidcTokens.IDToken
+		oldAccessToken := oidcSession.OidcTokens.AccessToken
+
+		// Wait one full second so that the revocation's CreatedAt lands in a
+		// strictly later second than the old token's IssuedAt. JWT timestamps
+		// have second-level precision and the revocation check uses truncated
+		// comparison, so this sleep is required for a deterministic result.
+		time.Sleep(time.Second)
+
+		// Hit the OIDC end_session endpoint. The redirect destination uses a
+		// custom scheme so the HTTP client will not be able to follow it; we
+		// discard that error and rely on the server having processed the request.
+		endSessionURL := "https://" + ctx.ApiHost + "/oidc/end_session?" + url.Values{
+			"id_token_hint":            {idToken},
+			"client_id":                {clientID},
+			"post_logout_redirect_uri": {"openziti://auth/logout"},
+		}.Encode()
+		_, _ = ctx.newAnonymousClientApiRequest().Get(endSessionURL)
+
+		t.Run("identityId is in the controller revocation DB", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			rev, err := ctrl.ReadRevocation(identityId)
+			ctx.Req.NoError(err)
+			ctx.Req.NotNil(rev, "expected high-water-mark revocation entry for identity %s", identityId)
+		})
+
+		t.Run("revocation CreatedAt is after the token IssuedAt", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			rev, err := ctrl.ReadRevocation(identityId)
+			ctx.Req.NoError(err)
+			ctx.Req.NotNil(rev)
+			ctx.Req.True(rev.CreatedAt.After(accessClaims.IssuedAt.AsTime()),
+				"expected revocation CreatedAt %v to be after token IssuedAt %v",
+				rev.CreatedAt, accessClaims.IssuedAt.AsTime())
+		})
+
+		t.Run("revocation propagates to the router RDM within 10s", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			// Verifies bug 2 fix: key is identityId alone, which is what both
+			// TerminateSession now stores and the RDM lookup uses.
+			ctx.Req.True(router.WaitForRevocation(identityId, 10*time.Second),
+				"timed out waiting for revocation %s to appear in router RDM", identityId)
+		})
+
+		t.Run("old access token is rejected by the controller", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			_, err := ctx.NewEdgeManagementApiWithToken(oldAccessToken).GetCurrentApiSessionDetailResponse()
+			ctx.Req.Error(err)
+			var unauthorizedErr *managementCurrentApiSession.GetCurrentAPISessionUnauthorized
+			ctx.Req.True(errors.As(err, &unauthorizedErr), "expected 401 Unauthorized, got: %v", err)
+		})
+
+		t.Run("new token issued after termination is accepted", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			// Re-authenticate as the same identity; the new token's IssuedAt is
+			// after the revocation's CreatedAt so the high-water mark does not block it.
+			newClient := ctx.NewEdgeManagementApi(nil)
+			_, err := newClient.AuthenticateOidc(ctx.NewAdminCredentials())
+			ctx.Req.NoError(err)
+			_, err = newClient.GetCurrentApiSessionDetailResponse()
+			ctx.Req.NoError(err)
+		})
+	})
+
+	t.Run("DeleteExpired purges revocations from DB and router RDM", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		const testRevocationId = "test-expired-revocation-id"
+
+		// Plant an already-expired revocation directly.
+		err := ctrl.CreateRevocation(testRevocationId, time.Now().Add(-1*time.Second))
+		ctx.Req.NoError(err)
+
+		t.Run("entry is visible in the controller DB before purge", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			rev, err := ctrl.ReadRevocation(testRevocationId)
+			ctx.Req.NoError(err)
+			ctx.Req.NotNil(rev)
+		})
+
+		t.Run("entry propagates to the router RDM before purge", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			ctx.Req.True(router.WaitForRevocation(testRevocationId, 10*time.Second),
+				"timed out waiting for planted revocation to appear in router RDM")
+		})
+
+		// Purge expired entries.
+		n, err := ctrl.DeleteExpiredRevocations()
+		ctx.Req.NoError(err)
+		ctx.Req.GreaterOrEqual(n, 1, "expected at least 1 expired revocation to be deleted")
+
+		t.Run("entry is gone from the controller DB after purge", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			rev, err := ctrl.ReadRevocation(testRevocationId)
+			ctx.Req.NoError(err)
+			ctx.Req.Nil(rev, "expected revocation to be purged from DB")
+		})
+
+		t.Run("entry is evicted from the router RDM after purge within 10s", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			// Verifies bug 3 fix: RevocationDelete now sends DataState_Delete so
+			// the router removes the entry from its in-memory map.
+			ctx.Req.True(router.WaitForRevocationGone(testRevocationId, 10*time.Second),
+				"timed out waiting for purged revocation to be evicted from router RDM")
+		})
+	})
+}


### PR DESCRIPTION
- fixes RevokeToken double-write: adds return after JWTID-keyed revocation save, preventing fallthrough write with raw JWT string as unreachable key 
- fixes TerminateSession key mismatch: stores revocation by identityId alone, matching the Subject-based lookup in ValidateAccessToken 
- fixes RevocationDelete sync action: passes DataState_Delete instead of DataState_Create so routers evict the entry from their data model 
- adds RevocationManager.DeleteExpired: batch-deletes expired revocations in batches of 500 until none remain 
- adds RevocationEnforcer: periodic policy runner (every 1 minute) that calls DeleteExpired and records metrics