### PR TITLE
Move router connection setup to bounded worker pool. Fixes #3766

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -977,6 +977,33 @@ ziti agent tunnel dump-sdk
 Returns JSON-formatted inspection data for all SDK contexts registered in the tunnel process,
 including service listeners, connections, and terminator state.
 
+## Router Connect Setup Pool
+
+Router connection setup (link building, presence notifications, terminator validation) now
+runs in a bounded worker pool instead of inline on the listener accept path. This prevents
+a thundering herd of reconnecting routers from saturating the controller's listener pool,
+which previously caused hello timeouts and connect/disconnect cycles lasting 10-15 minutes.
+
+If the pool is full when a router connects, the connection is rejected with an error and the
+router retries with its normal backoff. This gives the controller backpressure so it only
+processes what it can handle.
+
+New configuration under `network`:
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `routerConnectPool.queueSize` | `1` | Size of the work queue feeding the pool. Kept small so excess connections are rejected fast. |
+| `routerConnectPool.maxWorkers` | `200` | Maximum concurrent router connect setup workers. |
+
+New metrics (via the goroutine pool metrics):
+
+| Metric | Description |
+|--------|-------------|
+| `pool.router.connect.current_size` | Current number of active workers |
+| `pool.router.connect.busy_workers` | Workers currently executing setup work |
+| `pool.router.connect.work_timer` | Time spent per router connect setup |
+| `pool.router.connect.queue_size` | Current queue depth |
+
 ## Current Beta Features
 
 * Basic Permission System

--- a/controller/config/config_network.go
+++ b/controller/config/config_network.go
@@ -17,6 +17,7 @@
 package config
 
 import (
+	"fmt"
 	"math"
 	"time"
 
@@ -33,9 +34,11 @@ const (
 	DefaultOptionsMetricsReportInterval     = time.Minute
 	DefaultOptionsMinRouterCost             = 10
 	DefaultOptionsRouterConnectChurnLimit   = time.Minute
-	DefaultOptionsRouterMessagingMaxWorkers = 100
-	DefaultOptionsRouterMessagingQueueSize  = 100
-	DefaultOptionsRouteTimeout              = 10 * time.Second
+	DefaultOptionsRouterMessagingMaxWorkers  = 100
+	DefaultOptionsRouterMessagingQueueSize   = 100
+	DefaultOptionsRouterConnectPoolMaxWorkers = 200
+	DefaultOptionsRouterConnectPoolQueueSize  = 1
+	DefaultOptionsRouteTimeout               = 10 * time.Second
 
 	DefaultOptionsSmartRerouteCap          = 4
 	DefaultOptionsSmartRerouteFraction     = 0.02
@@ -55,7 +58,11 @@ type NetworkConfig struct {
 	PendingLinkTimeout      time.Duration
 	RouteTimeout            time.Duration
 	RouterConnectChurnLimit time.Duration
-	RouterComm              struct {
+	RouterComm struct {
+		QueueSize  uint32
+		MaxWorkers uint32
+	}
+	RouterConnectPool struct {
 		QueueSize  uint32
 		MaxWorkers uint32
 	}
@@ -80,6 +87,13 @@ func DefaultNetworkConfig() *NetworkConfig {
 		}{
 			QueueSize:  DefaultOptionsRouterMessagingQueueSize,
 			MaxWorkers: DefaultOptionsRouterMessagingMaxWorkers,
+		},
+		RouterConnectPool: struct {
+			QueueSize  uint32
+			MaxWorkers uint32
+		}{
+			QueueSize:  DefaultOptionsRouterConnectPoolQueueSize,
+			MaxWorkers: DefaultOptionsRouterConnectPoolMaxWorkers,
 		},
 		RouterConnectChurnLimit: DefaultOptionsRouterConnectChurnLimit,
 		RouteTimeout:            DefaultOptionsRouteTimeout,
@@ -188,6 +202,40 @@ func LoadNetworkConfig(src map[interface{}]interface{}) (*NetworkConfig, error) 
 			}
 		} else {
 			logrus.Errorf("invalid 'routerMessaging' stanza")
+		}
+	}
+
+	if value, found := src["routerConnectPool"]; found {
+		if submap, ok := value.(map[interface{}]interface{}); ok {
+			if value, found := submap["queueSize"]; found {
+				if queueSize, ok := value.(int); ok {
+					if queueSize < 0 {
+						return nil, fmt.Errorf("invalid value for 'routerConnectPool.queueSize', must be greater than or equal to 0")
+					}
+					if queueSize > OptionsRouterCommMaxQueueSize {
+						return nil, fmt.Errorf("invalid value for 'routerConnectPool.queueSize', must be less than or equal to %v", OptionsRouterCommMaxQueueSize)
+					}
+					options.RouterConnectPool.QueueSize = uint32(queueSize)
+				} else {
+					return nil, fmt.Errorf("invalid value for 'routerConnectPool.queueSize'")
+				}
+			}
+
+			if value, found := submap["maxWorkers"]; found {
+				if maxWorkers, ok := value.(int); ok {
+					if maxWorkers < 1 {
+						return nil, fmt.Errorf("invalid value for 'routerConnectPool.maxWorkers', must be greater than 0")
+					}
+					if maxWorkers > OptionsRouterCommMaxWorkers {
+						return nil, fmt.Errorf("invalid value for 'routerConnectPool.maxWorkers', must be less than or equal to %v", OptionsRouterCommMaxWorkers)
+					}
+					options.RouterConnectPool.MaxWorkers = uint32(maxWorkers)
+				} else {
+					return nil, fmt.Errorf("invalid value for 'routerConnectPool.maxWorkers'")
+				}
+			}
+		} else {
+			logrus.Errorf("invalid 'routerConnectPool' stanza")
 		}
 	}
 

--- a/controller/handler_ctrl/accept.go
+++ b/controller/handler_ctrl/accept.go
@@ -17,6 +17,7 @@
 package handler_ctrl
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -202,7 +203,9 @@ func (self *CtrlAccepter) Bind(binding channel.Binding) error {
 
 	log.Info("accepted new router connection")
 
-	self.network.ConnectRouter(r)
+	if err := self.network.QueueRouterConnect(r); err != nil {
+		return fmt.Errorf("router connect pool full, rejecting connection: %w", err)
+	}
 
 	return nil
 }

--- a/controller/network/network.go
+++ b/controller/network/network.go
@@ -115,6 +115,7 @@ type Network struct {
 
 	Inspections         *InspectionsManager
 	RouterMessaging     *RouterMessaging
+	routerConnectPool   goroutines.Pool
 	inspectionTargets   concurrenz.CopyOnWriteSlice[InspectTarget]
 	ctrlDialerValidator CtrlDialerValidator
 }
@@ -158,6 +159,12 @@ func NewNetwork(config Config, env model.Env) (*Network, error) {
 
 	env.GetManagers().Command.Decoders.RegisterF(int32(cmd_pb.CommandType_SyncSnapshot), network.decodeSyncSnapshotCommand)
 
+	routerConnectPool, err := network.createRouterConnectPool(config)
+	if err != nil {
+		return nil, err
+	}
+	network.routerConnectPool = routerConnectPool
+
 	routerCommPool, err := network.createRouterCommPool(config)
 	if err != nil {
 		return nil, err
@@ -198,6 +205,27 @@ func (self *Network) decodeSyncSnapshotCommand(_ int32, data []byte) (command.Co
 
 func routerCommunicationsWorker(_ uint32, f func()) {
 	f()
+}
+
+func (network *Network) createRouterConnectPool(config Config) (goroutines.Pool, error) {
+	poolConfig := goroutines.PoolConfig{
+		QueueSize:   config.GetOptions().RouterConnectPool.QueueSize,
+		MinWorkers:  0,
+		MaxWorkers:  config.GetOptions().RouterConnectPool.MaxWorkers,
+		IdleTime:    30 * time.Second,
+		CloseNotify: config.GetCloseNotify(),
+		PanicHandler: func(err interface{}) {
+			pfxlog.Logger().WithField(logrus.ErrorKey, err).WithField("backtrace", string(debug.Stack())).Error("panic during router connect setup")
+		},
+	}
+
+	fabricMetrics.ConfigureGoroutinesPoolMetrics(&poolConfig, config.GetMetricsRegistry(), "pool.router.connect")
+
+	pool, err := goroutines.NewPool(poolConfig)
+	if err != nil {
+		return nil, fmt.Errorf("error creating router connect pool: %w", err)
+	}
+	return pool, nil
 }
 
 func (network *Network) createRouterCommPool(config Config) (goroutines.Pool, error) {
@@ -347,18 +375,39 @@ func (network *Network) ConnectedRouter(id string) bool {
 	return network.Router.IsConnected(id)
 }
 
-func (network *Network) ConnectRouter(r *model.Router) {
-	network.Link.BuildRouterLinks(r)
+// QueueRouterConnect marks the router as connected and notifies synchronous
+// presence handlers immediately, then queues the remaining connection setup
+// work (link building, async handlers, terminator validation) to the bounded
+// router connect pool. Returns an error if the pool is full, which causes
+// the connection to be rejected so the router can retry later.
+func (network *Network) QueueRouterConnect(r *model.Router) error {
 	network.Router.MarkConnected(r)
 
 	for _, h := range network.routerPresenceHandlers.Value() {
 		if syncCapableHandler, ok := h.(model.SyncRouterPresenceHandler); ok && syncCapableHandler.InvokeRouterConnectedSynchronously() {
 			h.RouterConnected(r)
-		} else {
-			go h.RouterConnected(r)
 		}
 	}
-	go network.ValidateTerminators(r)
+
+	return network.routerConnectPool.QueueOrError(func() {
+		network.ConnectRouter(r)
+	})
+}
+
+func (network *Network) ConnectRouter(r *model.Router) {
+	if r.Control.IsClosed() {
+		return
+	}
+
+	network.Link.BuildRouterLinks(r)
+
+	for _, h := range network.routerPresenceHandlers.Value() {
+		if syncHandler, ok := h.(model.SyncRouterPresenceHandler); ok && syncHandler.InvokeRouterConnectedSynchronously() {
+			continue // already called synchronously in QueueRouterConnect
+		}
+		h.RouterConnected(r)
+	}
+	network.ValidateTerminators(r)
 }
 
 func (network *Network) ValidateTerminators(r *model.Router) {

--- a/etc/ctrl.with.edge.yml
+++ b/etc/ctrl.with.edge.yml
@@ -8,6 +8,13 @@ network:
   # Defaults to 1 minute
   routerConnectChurnLimit: 1m
 
+  # Controls the bounded pool used for router connection setup (link building, presence
+  # notifications, terminator validation). If the pool is full when a router connects, the
+  # connection is rejected and the router retries with its normal backoff.
+  #routerConnectPool:
+    #queueSize:  1    # keep small so excess connections are rejected fast
+    #maxWorkers: 200  # max concurrent router connect setup workers
+
 # `trustDomain` is used to name and uniquely identify a network. Its main use is as a trust domain in SPIFFE ids.
 # Defining it here is only for single controller environments that are not configured for high
 # availability. Deployments with high availability MUST be configured via x509 certificate URI SANs.

--- a/etc/ctrl.yml
+++ b/etc/ctrl.yml
@@ -72,6 +72,13 @@ cluster:
   # Defaults to 1 minute
   routerConnectChurnLimit: 1m
 
+  # Controls the bounded pool used for router connection setup (link building, presence
+  # notifications, terminator validation). If the pool is full when a router connects, the
+  # connection is rejected and the router retries with its normal backoff.
+  #routerConnectPool:
+    #queueSize:  1    # keep small so excess connections are rejected fast
+    #maxWorkers: 200  # max concurrent router connect setup workers
+
   #smart:
     #
     # Defines the fractional upper limit of underperforming circuits that are candidates to be re-routed. If 

--- a/etc/ctrl2.yml
+++ b/etc/ctrl2.yml
@@ -50,6 +50,13 @@ cluster:
   # running on the network.
   #
   cycleSeconds:         15
+
+  # Controls the bounded pool used for router connection setup (link building, presence
+  # notifications, terminator validation). If the pool is full when a router connects, the
+  # connection is rejected and the router retries with its normal backoff.
+  #routerConnectPool:
+    #queueSize:  1    # keep small so excess connections are rejected fast
+    #maxWorkers: 200  # max concurrent router connect setup workers
   #
   #smart:
     #

--- a/etc/ctrl3.yml
+++ b/etc/ctrl3.yml
@@ -50,6 +50,13 @@ cluster:
   # running on the network.
   #
   cycleSeconds:         15
+
+  # Controls the bounded pool used for router connection setup (link building, presence
+  # notifications, terminator validation). If the pool is full when a router connects, the
+  # connection is rejected and the router retries with its normal backoff.
+  #routerConnectPool:
+    #queueSize:  1    # keep small so excess connections are rejected fast
+    #maxWorkers: 200  # max concurrent router connect setup workers
   #
   #smart:
     #


### PR DESCRIPTION
  - adds a routerConnectPool to the controller network config with
    configurable queueSize (default 1) and maxWorkers (default 200)
  - moves ConnectRouter (BuildRouterLinks, presence handlers,
    ValidateTerminators) out of the channel bind path and into the pool
  - rejects the connection if the pool is full, letting the router retry
    with its normal backoff
  - removes goroutine spawning inside ConnectRouter since the pool
    already provides concurrency control
  - guards ConnectRouter against channel close races
  - adds pool.router.connect.* metrics via goroutine pool metrics
  - updates example controller configs and changelog
