### PR TITLE
fixes #3770 close channel on invalid token update requests

### DIFF
--- a/router/xgress_edge/listener.go
+++ b/router/xgress_edge/listener.go
@@ -1354,11 +1354,11 @@ func (self *edgeClientConn) processTokenUpdate(req *channel.Message, ch channel.
 		reply := sdkedge.NewUpdateTokenFailedMsg(retErr)
 
 		retErr.ApplyToMsg(reply)
-		reply.ReplyTo(req)
 
-		if err := ch.Send(reply); err != nil {
+		if err := reply.ReplyTo(req).WithTimeout(5 * time.Second).SendAndWaitForWire(ch); err != nil {
 			logrus.WithError(err).WithField("reqSeq", reply.Sequence()).Error("failed to send error: " + err.Error())
 		}
+		_ = ch.Close()
 		return
 	}
 
@@ -1369,9 +1369,8 @@ func (self *edgeClientConn) processTokenUpdate(req *channel.Message, ch channel.
 		reply := sdkedge.NewUpdateTokenFailedMsg(retErr)
 
 		retErr.ApplyToMsg(reply)
-		reply.ReplyTo(req)
 
-		if err := ch.Send(reply); err != nil {
+		if err := reply.ReplyTo(req).WithTimeout(5 * time.Second).SendAndWaitForWire(ch); err != nil {
 			logrus.WithError(err).WithField("reqSeq", reply.Sequence()).Error("failed to send error: " + err.Error())
 		}
 		_ = ch.Close()
@@ -1385,9 +1384,8 @@ func (self *edgeClientConn) processTokenUpdate(req *channel.Message, ch channel.
 		reply := sdkedge.NewUpdateTokenFailedMsg(retErr)
 
 		retErr.ApplyToMsg(reply)
-		reply.ReplyTo(req)
 
-		if err := ch.Send(reply); err != nil {
+		if err := reply.ReplyTo(req).WithTimeout(5 * time.Second).SendAndWaitForWire(ch); err != nil {
 			logrus.WithError(err).WithField("reqSeq", reply.Sequence()).Error("failed to send error: " + err.Error())
 		}
 		_ = ch.Close()
@@ -1399,9 +1397,8 @@ func (self *edgeClientConn) processTokenUpdate(req *channel.Message, ch channel.
 		reply := sdkedge.NewUpdateTokenFailedMsg(retErr)
 
 		retErr.ApplyToMsg(reply)
-		reply.ReplyTo(req)
 
-		if err := ch.Send(reply); err != nil {
+		if err := reply.ReplyTo(req).WithTimeout(5 * time.Second).SendAndWaitForWire(ch); err != nil {
 			logrus.WithError(err).WithField("reqSeq", reply.Sequence()).Error("failed to send error: " + err.Error())
 		}
 		_ = ch.Close()
@@ -1413,11 +1410,12 @@ func (self *edgeClientConn) processTokenUpdate(req *channel.Message, ch channel.
 		reply := sdkedge.NewUpdateTokenFailedMsg(errors.Wrap(err, ""))
 
 		retErr.ApplyToMsg(reply)
-		reply.ReplyTo(req)
 
-		if err := ch.Send(reply); err != nil {
+		if err := reply.ReplyTo(req).WithTimeout(5 * time.Second).SendAndWaitForWire(ch); err != nil {
 			logrus.WithError(err).WithField("reqSeq", reply.Sequence()).Error("failed to send error: " + err.Error())
 		}
+
+		_ = ch.Close()
 		return
 	}
 


### PR DESCRIPTION
  - closes channel when token update contains an unparseable bearer token
  - closes channel when token update fails JWT signature validation
  - closes channel when token update API session ID does not match
  - fixes missing return after API session ID mismatch check, which allowed mismatched tokens to fall through to processing