### PR TITLE
fixes #3788 return proper OIDC error codes and HTTP status codes

### DIFF
--- a/controller/oidc_auth/client.go
+++ b/controller/oidc_auth/client.go
@@ -151,7 +151,7 @@ func NativeClient(id string, redirectURIs, postlogoutURIs []string) *Client {
 		applicationType:                op.ApplicationTypeNative,
 		authMethod:                     oidc.AuthMethodNone,
 		responseTypes:                  []oidc.ResponseType{oidc.ResponseTypeCode},
-		grantTypes:                     []oidc.GrantType{oidc.GrantTypeCode, oidc.GrantTypeRefreshToken},
+		grantTypes:                     []oidc.GrantType{oidc.GrantTypeCode, oidc.GrantTypeRefreshToken, oidc.GrantTypeTokenExchange},
 		accessTokenType:                op.AccessTokenTypeJWT,
 		devMode:                        false,
 		idTokenUserinfoClaimsAssertion: false,

--- a/controller/oidc_auth/login.go
+++ b/controller/oidc_auth/login.go
@@ -143,10 +143,10 @@ func (l *login) createRouter(issuerInterceptor *op.IssuerInterceptor) {
 	l.router.Path("/ext-jwt").Methods("GET").HandlerFunc(issuerInterceptor.HandlerFunc(l.genericHandler))
 	l.router.Path("/ext-jwt").Methods("POST").HandlerFunc(issuerInterceptor.HandlerFunc(l.authenticate))
 
-	l.router.Path("/totp").Methods("POST").HandlerFunc(l.checkTotp)
+	l.router.Path("/totp").Methods("POST").HandlerFunc(issuerInterceptor.HandlerFunc(l.checkTotp))
 	l.router.Path("/totp/enroll").Methods("POST").HandlerFunc(l.startEnrollTotp)
 	l.router.Path("/totp/enroll").Methods("DELETE").HandlerFunc(l.deleteEnrollTotp)
-	l.router.Path("/totp/enroll/verify").Methods("POST").HandlerFunc(l.verifyTotp)
+	l.router.Path("/totp/enroll/verify").Methods("POST").HandlerFunc(issuerInterceptor.HandlerFunc(l.verifyTotp))
 }
 
 func (l *login) genericHandler(w http.ResponseWriter, r *http.Request) {

--- a/controller/oidc_auth/provider.go
+++ b/controller/oidc_auth/provider.go
@@ -61,7 +61,6 @@ func createIssuerSpecificOidcProvider(ctx context.Context, issuer string, config
 	handler := http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		r := request.WithContext(context.WithValue(request.Context(), contextKeyHttpRequest, request))
 		r = request.WithContext(context.WithValue(r.Context(), contextKeyTokenState, &TokenState{}))
-		r = request.WithContext(op.ContextWithIssuer(r.Context(), issuerUrl))
 
 		oidcHandler.ServeHTTP(writer, r)
 	})
@@ -112,11 +111,17 @@ func NewNativeOnlyOP(ctx context.Context, env model.Env, config Config) (http.Ha
 
 }
 
-// newHttpRouter creates an OIDC HTTP router
+// newHttpRouter creates an OIDC HTTP router using the LegacyServer adapter. All OIDC
+// endpoint errors are routed through op.WriteError, which maps server_error to HTTP 500
+// and supports custom status codes via op.StatusError.
 func newHttpRouter(provider op.OpenIDProvider, config Config) (*mux.Router, error) {
 	if config.TokenSecret == "" {
 		return nil, errors.New("token secret must not be empty")
 	}
+
+	endpoints := *op.DefaultEndpoints
+	srv := newServer(provider, endpoints)
+	serverHandler := op.RegisterLegacyServer(srv, op.AuthorizeCallbackHandler(provider))
 
 	router := mux.NewRouter()
 
@@ -127,14 +132,14 @@ func newHttpRouter(provider op.OpenIDProvider, config Config) (*mux.Router, erro
 		}
 	})
 
-	loginRouter := newLogin(config.Storage, op.AuthCallbackURL(provider), op.NewIssuerInterceptor(provider.IssuerFromRequest))
+	loginRouter := newLogin(config.Storage, srv.AuthCallbackURL(), op.NewIssuerInterceptor(provider.IssuerFromRequest))
 
-	router.Handle("/oidc/"+WellKnownOidcConfiguration, http.StripPrefix("/oidc", provider))
-	router.Handle(WellKnownOidcConfiguration, provider)
+	router.Handle("/oidc/"+WellKnownOidcConfiguration, http.StripPrefix("/oidc", serverHandler))
+	router.Handle(WellKnownOidcConfiguration, serverHandler)
 
 	router.PathPrefix("/oidc/login").Handler(http.StripPrefix("/oidc/login", loginRouter.router))
 
-	router.PathPrefix("/oidc").Handler(http.StripPrefix("/oidc", provider))
+	router.PathPrefix("/oidc").Handler(http.StripPrefix("/oidc", serverHandler))
 
 	return router, nil
 }

--- a/controller/oidc_auth/server.go
+++ b/controller/oidc_auth/server.go
@@ -1,0 +1,116 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package oidc_auth
+
+import (
+	"context"
+
+	"github.com/zitadel/oidc/v3/pkg/oidc"
+	"github.com/zitadel/oidc/v3/pkg/op"
+)
+
+// server embeds op.LegacyServer and overrides methods where the library's
+// helper functions re-wrap storage errors with empty descriptions, discarding
+// the error_description that storage set. The overrides call storage directly
+// and pass errors through so that WriteError serializes the original description.
+type server struct {
+	*op.LegacyServer
+}
+
+var _ op.ExtendedLegacyServer = (*server)(nil)
+
+func newServer(provider op.OpenIDProvider, endpoints op.Endpoints) *server {
+	return &server{
+		LegacyServer: op.NewLegacyServer(provider, endpoints),
+	}
+}
+
+// VerifyClient authenticates the client for a token request. It overrides
+// LegacyServer.VerifyClient to pass through storage errors from
+// GetClientByClientID without re-wrapping them in a new oidc.ErrInvalidClient
+// that has an empty description.
+func (s *server) VerifyClient(ctx context.Context, r *op.Request[op.ClientCredentials]) (op.Client, error) {
+	if oidc.GrantType(r.Form.Get("grant_type")) == oidc.GrantTypeClientCredentials {
+		storage, ok := s.Provider().Storage().(op.ClientCredentialsStorage)
+		if !ok {
+			return nil, oidc.ErrUnsupportedGrantType().WithDescription("client_credentials grant not supported")
+		}
+		return storage.ClientCredentials(ctx, r.Data.ClientID, r.Data.ClientSecret)
+	}
+
+	if r.Data.ClientAssertionType == oidc.ClientAssertionTypeJWTAssertion {
+		jwtExchanger, ok := s.Provider().(op.JWTAuthorizationGrantExchanger)
+		if !ok || !s.Provider().AuthMethodPrivateKeyJWTSupported() {
+			return nil, oidc.ErrInvalidClient().WithDescription("auth_method private_key_jwt not supported")
+		}
+		return op.AuthorizePrivateJWTKey(ctx, r.Data.ClientAssertion, jwtExchanger)
+	}
+
+	client, err := s.Provider().Storage().GetClientByClientID(ctx, r.Data.ClientID)
+	if err != nil {
+		return nil, err
+	}
+
+	switch client.AuthMethod() {
+	case oidc.AuthMethodNone:
+		return client, nil
+	case oidc.AuthMethodPrivateKeyJWT:
+		return nil, oidc.ErrInvalidClient().WithDescription("private_key_jwt not allowed for this client")
+	case oidc.AuthMethodPost:
+		if !s.Provider().AuthMethodPostSupported() {
+			return nil, oidc.ErrInvalidClient().WithDescription("auth_method post not supported")
+		}
+	}
+
+	err = op.AuthorizeClientIDSecret(ctx, r.Data.ClientID, r.Data.ClientSecret, s.Provider().Storage())
+	if err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}
+
+// RefreshToken handles refresh token requests. It overrides
+// LegacyServer.RefreshToken to call storage.TokenRequestByRefreshToken
+// directly instead of through the library's RefreshTokenRequestByRefreshToken
+// helper, which re-wraps errors in a new oidc.ErrInvalidGrant with an empty
+// description.
+func (s *server) RefreshToken(ctx context.Context, r *op.ClientRequest[oidc.RefreshTokenRequest]) (*op.Response, error) {
+	if !s.Provider().GrantTypeRefreshTokenSupported() {
+		return nil, oidc.ErrInvalidRequest().WithDescription("grant_type refresh_token not supported")
+	}
+
+	request, err := s.Provider().Storage().TokenRequestByRefreshToken(ctx, r.Data.RefreshToken)
+	if err != nil {
+		return nil, err
+	}
+
+	if r.Client.GetID() != request.GetClientID() {
+		return nil, oidc.ErrInvalidGrant().WithDescription("client_id does not match original grant")
+	}
+
+	if err = op.ValidateRefreshTokenScopes(r.Data.Scopes, request); err != nil {
+		return nil, err
+	}
+
+	resp, err := op.CreateTokenResponse(ctx, request, r.Client, s.Provider(), true, "", r.Data.RefreshToken)
+	if err != nil {
+		return nil, err
+	}
+
+	return op.NewResponse(resp), nil
+}

--- a/controller/oidc_auth/storage.go
+++ b/controller/oidc_auth/storage.go
@@ -709,7 +709,7 @@ func (s *HybridStorage) createAccessToken(ctx context.Context, request op.TokenR
 			}
 
 			if subjectClaims.CustomClaims.Type != common.TokenTypeAccess && subjectClaims.CustomClaims.Type != common.TokenTypeRefresh {
-				return "", nil, fmt.Errorf("invalid token type: %s", claims.CustomClaims.Type)
+				return "", nil, oidc.ErrInvalidGrant().WithDescription("invalid token type for exchange")
 			}
 
 			claims.Audience = subjectClaims.Audience
@@ -799,15 +799,18 @@ func (s *HybridStorage) parseRefreshToken(tokenStr string) (*jwt.Token, *common.
 	parsedToken, err := jwt.ParseWithClaims(tokenStr, refreshClaims, s.env.JwtSignerKeyFunc)
 
 	if err != nil || parsedToken == nil {
-		return nil, nil, fmt.Errorf("failed to parse token")
+		if errors.Is(err, jwt.ErrTokenExpired) {
+			return nil, nil, oidc.ErrInvalidGrant().WithDescription("refresh token expired").WithParent(err)
+		}
+		return nil, nil, oidc.ErrInvalidGrant().WithDescription("failed to parse refresh token").WithParent(err)
 	}
 
 	if !parsedToken.Valid {
-		return nil, nil, fmt.Errorf("invalid refresh_token")
+		return nil, nil, oidc.ErrInvalidGrant().WithDescription("invalid refresh token")
 	}
 
 	if refreshClaims.Type != common.TokenTypeRefresh {
-		return nil, nil, errors.New("invalid token type")
+		return nil, nil, oidc.ErrInvalidGrant().WithDescription("invalid token type, expected refresh")
 	}
 
 	return parsedToken, refreshClaims, nil
@@ -819,11 +822,14 @@ func (s *HybridStorage) parseAccessToken(tokenStr string) (*jwt.Token, *common.A
 	parsedToken, err := jwt.ParseWithClaims(tokenStr, accessClaims, s.env.JwtSignerKeyFunc)
 
 	if err != nil || parsedToken == nil {
-		return nil, nil, fmt.Errorf("failed to parse token")
+		if errors.Is(err, jwt.ErrTokenExpired) {
+			return nil, nil, oidc.ErrInvalidGrant().WithDescription("access token expired").WithParent(err)
+		}
+		return nil, nil, oidc.ErrInvalidGrant().WithDescription("failed to parse access token").WithParent(err)
 	}
 
 	if !parsedToken.Valid {
-		return nil, nil, fmt.Errorf("invalid refresh_token")
+		return nil, nil, oidc.ErrInvalidGrant().WithDescription("invalid access token")
 	}
 
 	return parsedToken, accessClaims, nil
@@ -835,7 +841,10 @@ func (s *HybridStorage) TokenRequestByRefreshToken(_ context.Context, refreshTok
 	if err != nil {
 		return nil, err
 	}
-	return &RefreshTokenRequest{*token}, err
+	if s.IsTokenRevoked(token.JWTID) {
+		return nil, oidc.ErrInvalidGrant().WithDescription("refresh token revoked")
+	}
+	return &RefreshTokenRequest{*token}, nil
 }
 
 // TerminateSession implements the op.Storage interface
@@ -932,7 +941,7 @@ func (s *HybridStorage) KeySet(_ context.Context) ([]op.Key, error) {
 func (s *HybridStorage) GetClientByClientID(_ context.Context, clientID string) (op.Client, error) {
 	client, ok := s.clients.Get(clientID)
 	if !ok {
-		return nil, fmt.Errorf("client not found")
+		return nil, oidc.ErrInvalidClient().WithDescription("client not found")
 	}
 	return client, nil
 }
@@ -941,12 +950,12 @@ func (s *HybridStorage) GetClientByClientID(_ context.Context, clientID string) 
 func (s *HybridStorage) AuthorizeClientIDSecret(_ context.Context, clientID, clientSecret string) error {
 	client, ok := s.clients.Get(clientID)
 	if !ok {
-		return fmt.Errorf("client not found")
+		return oidc.ErrInvalidClient().WithDescription("client not found")
 	}
 
 	//this isn't used and is plain text comparison
 	if client.secret != clientSecret {
-		return fmt.Errorf("invalid secret")
+		return oidc.ErrInvalidClient().WithDescription("invalid client secret")
 	}
 	return nil
 }
@@ -966,7 +975,7 @@ func (s *HybridStorage) SetUserinfoFromToken(ctx context.Context, userinfo *oidc
 	httpRequest, err := HttpRequestFromContext(ctx)
 
 	if s.IsTokenRevoked(tokenID) {
-		return errors.New("token is revoked")
+		return oidc.ErrAccessDenied().WithDescription("access token revoked")
 	}
 
 	if err != nil {
@@ -1084,7 +1093,7 @@ func (s *HybridStorage) renewRefreshToken(currentRefreshToken string) (string, *
 	_, refreshClaims, err := s.parseRefreshToken(currentRefreshToken)
 
 	if err != nil {
-		return "", nil, fmt.Errorf("invalid refresh token")
+		return "", nil, oidc.ErrInvalidGrant().WithDescription("invalid refresh token").WithParent(err)
 	}
 
 	// Best-effort revocation of the old refresh token. Skip if the token is

--- a/tests/context.go
+++ b/tests/context.go
@@ -1005,7 +1005,9 @@ func (ctx *TestContext) shutdownRouters() {
 }
 
 func (ctx *TestContext) NewAdminCredentials() *edgeApis.UpdbCredentials {
-	return edgeApis.NewUpdbCredentials(ctx.AdminAuthenticator.Username, ctx.AdminAuthenticator.Password)
+	creds := edgeApis.NewUpdbCredentials(ctx.AdminAuthenticator.Username, ctx.AdminAuthenticator.Password)
+	creds.CaPool = ctx.ControllerCaPool()
+	return creds
 }
 
 func (ctx *TestContext) EnrollFabricRouter(id string, name string, certFile string) {

--- a/tests/oidc_error_codes_test.go
+++ b/tests/oidc_error_codes_test.go
@@ -1,0 +1,518 @@
+//go:build apitests
+
+package tests
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+	edge_apis "github.com/openziti/sdk-golang/edge-apis"
+	"github.com/openziti/ziti/v2/common"
+	"github.com/openziti/ziti/v2/controller/change"
+	"github.com/openziti/ziti/v2/controller/model"
+	"github.com/openziti/ziti/v2/controller/models"
+	"github.com/openziti/ziti/v2/controller/oidc_auth"
+	"github.com/zitadel/oidc/v3/pkg/oidc"
+)
+
+// oidcErrorResponse matches the JSON structure returned by the zitadel/oidc library's
+// WriteError handler for OAuth/OIDC error responses.
+type oidcErrorResponse struct {
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+func Test_OIDC_ErrorCodes(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+
+	clientHelper := ctx.NewEdgeClientApi(nil)
+	adminCreds := ctx.NewAdminCredentials()
+	tokenUrl := "https://" + ctx.ApiHost + "/oidc/oauth/token"
+
+	// Authenticate once to get valid tokens for reuse in sub-tests.
+	tokens, _, err := clientHelper.RawOidcAuthRequest(adminCreds)
+	ctx.Req.NoError(err)
+	ctx.Req.NotNil(tokens)
+
+	t.Run("token endpoint returns invalid_client for unknown client_id", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		resp, err := ctx.newAnonymousClientApiRequest().
+			SetHeader("content-type", oidc_auth.FormContentType).
+			SetFormData(map[string]string{
+				"grant_type":    string(oidc.GrantTypeRefreshToken),
+				"refresh_token": tokens.RefreshToken,
+				"client_id":     "nonexistent-client",
+			}).
+			Post(tokenUrl)
+
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusBadRequest, resp.StatusCode(),
+			"expected 400 for unknown client, got %d: %s", resp.StatusCode(), resp.String())
+
+		errResp := parseOidcError(t, resp.Body())
+		ctx.Req.Equal("invalid_client", errResp.Error)
+		ctx.Req.NotEmpty(errResp.ErrorDescription, "expected non-empty error_description")
+	})
+
+	t.Run("token endpoint returns invalid_grant for garbage refresh_token", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		resp, err := ctx.newAnonymousClientApiRequest().
+			SetHeader("content-type", oidc_auth.FormContentType).
+			SetFormData(map[string]string{
+				"grant_type":    string(oidc.GrantTypeRefreshToken),
+				"refresh_token": "not-a-valid-jwt",
+				"client_id":     tokens.IDTokenClaims.ClientID,
+			}).
+			Post(tokenUrl)
+
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusBadRequest, resp.StatusCode(),
+			"expected 400 for bad refresh token, got %d: %s", resp.StatusCode(), resp.String())
+
+		errResp := parseOidcError(t, resp.Body())
+		ctx.Req.Equal("invalid_grant", errResp.Error)
+		ctx.Req.NotEmpty(errResp.ErrorDescription, "expected non-empty error_description")
+	})
+
+	t.Run("token endpoint returns invalid_grant for expired or revoked refresh_token", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		// Use an access token (wrong token type) as the refresh_token value.
+		// parseRefreshToken will reject this because the token type claim is not "refresh".
+		resp, err := ctx.newAnonymousClientApiRequest().
+			SetHeader("content-type", oidc_auth.FormContentType).
+			SetFormData(map[string]string{
+				"grant_type":    string(oidc.GrantTypeRefreshToken),
+				"refresh_token": tokens.AccessToken,
+				"client_id":     tokens.IDTokenClaims.ClientID,
+			}).
+			Post(tokenUrl)
+
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusBadRequest, resp.StatusCode(),
+			"expected 400 for wrong token type, got %d: %s", resp.StatusCode(), resp.String())
+
+		errResp := parseOidcError(t, resp.Body())
+		ctx.Req.Equal("invalid_grant", errResp.Error)
+	})
+
+	t.Run("token endpoint returns invalid_grant for missing grant_type", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		resp, err := ctx.newAnonymousClientApiRequest().
+			SetHeader("content-type", oidc_auth.FormContentType).
+			SetFormData(map[string]string{
+				"refresh_token": tokens.RefreshToken,
+				"client_id":     tokens.IDTokenClaims.ClientID,
+			}).
+			Post(tokenUrl)
+
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusBadRequest, resp.StatusCode(),
+			"expected 400 for missing grant_type, got %d: %s", resp.StatusCode(), resp.String())
+
+		errResp := parseOidcError(t, resp.Body())
+		ctx.Req.Equal("invalid_request", errResp.Error)
+	})
+
+	t.Run("token endpoint returns error for unsupported grant_type", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		resp, err := ctx.newAnonymousClientApiRequest().
+			SetHeader("content-type", oidc_auth.FormContentType).
+			SetFormData(map[string]string{
+				"grant_type": "urn:fake:unsupported",
+				"client_id":  tokens.IDTokenClaims.ClientID,
+			}).
+			Post(tokenUrl)
+
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusBadRequest, resp.StatusCode(),
+			"expected 400 for unsupported grant_type, got %d: %s", resp.StatusCode(), resp.String())
+
+		errResp := parseOidcError(t, resp.Body())
+		ctx.Req.Equal("unsupported_grant_type", errResp.Error)
+	})
+
+	t.Run("token endpoint returns invalid_grant for code exchange with invalid code", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		resp, err := ctx.newAnonymousClientApiRequest().
+			SetHeader("content-type", oidc_auth.FormContentType).
+			SetFormData(map[string]string{
+				"grant_type":    string(oidc.GrantTypeCode),
+				"code":          "bogus-auth-code",
+				"redirect_uri":  "http://localhost:18643/auth/callback",
+				"client_id":     tokens.IDTokenClaims.ClientID,
+				"code_verifier": "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+			}).
+			Post(tokenUrl)
+
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusBadRequest, resp.StatusCode(),
+			"expected 400 for invalid code, got %d: %s", resp.StatusCode(), resp.String())
+
+		errResp := parseOidcError(t, resp.Body())
+		ctx.Req.Equal("invalid_grant", errResp.Error)
+	})
+
+	t.Run("login endpoint returns 401 for invalid credentials", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		result, err := clientHelper.OidcAuthorize(adminCreds)
+		ctx.Req.NoError(err)
+
+		loginUrl := "https://" + ctx.ApiHost + "/oidc/login/username?id=" + result.AuthRequestId
+
+		resp, err := result.Client.R().
+			SetHeader("Accept", "application/json").
+			SetFormData(map[string]string{
+				"username": ctx.AdminAuthenticator.Username,
+				"password": "wrong-password",
+			}).
+			Post(loginUrl)
+
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusUnauthorized, resp.StatusCode(),
+			"expected 401 for bad password, got %d: %s", resp.StatusCode(), resp.String())
+	})
+
+	t.Run("login endpoint returns 401 for unknown username", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		result, err := clientHelper.OidcAuthorize(adminCreds)
+		ctx.Req.NoError(err)
+
+		loginUrl := "https://" + ctx.ApiHost + "/oidc/login/username?id=" + result.AuthRequestId
+
+		resp, err := result.Client.R().
+			SetHeader("Accept", "application/json").
+			SetFormData(map[string]string{
+				"username": "nonexistent-user",
+				"password": "irrelevant",
+			}).
+			Post(loginUrl)
+
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusUnauthorized, resp.StatusCode(),
+			"expected 401 for unknown user, got %d: %s", resp.StatusCode(), resp.String())
+	})
+
+	t.Run("userinfo endpoint returns 401 for invalid access token", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		userinfoUrl := "https://" + ctx.ApiHost + "/oidc/userinfo"
+
+		resp, err := ctx.newAnonymousClientApiRequest().
+			SetHeader("Authorization", "Bearer not-a-valid-jwt").
+			Get(userinfoUrl)
+
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusUnauthorized, resp.StatusCode(),
+			"expected 401 for bad access token, got %d: %s", resp.StatusCode(), resp.String())
+	})
+
+	t.Run("userinfo endpoint returns 401 for missing access token", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		userinfoUrl := "https://" + ctx.ApiHost + "/oidc/userinfo"
+
+		resp, err := ctx.newAnonymousClientApiRequest().
+			Get(userinfoUrl)
+
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusUnauthorized, resp.StatusCode(),
+			"expected 401 for missing token, got %d: %s", resp.StatusCode(), resp.String())
+	})
+
+	t.Run("token refresh preserves correct error types after successful auth", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		// Authenticate fresh to get a known-good refresh token
+		freshTokens, _, err := clientHelper.RawOidcAuthRequest(adminCreds)
+		ctx.Req.NoError(err)
+
+		// Refresh with invalid scopes should return invalid_scope
+		enc := oidc.NewEncoder()
+		dst := map[string][]string{}
+		req := &oidc.RefreshTokenRequest{
+			RefreshToken: freshTokens.RefreshToken,
+			ClientID:     freshTokens.IDTokenClaims.ClientID,
+			Scopes:       []string{"bogus-scope-not-in-original"},
+		}
+		err = enc.Encode(req, dst)
+		ctx.Req.NoError(err)
+		dst["grant_type"] = []string{string(req.GrantType())}
+
+		resp, err := ctx.newAnonymousClientApiRequest().
+			SetHeader("content-type", oidc_auth.FormContentType).
+			SetMultiValueFormData(dst).
+			Post(tokenUrl)
+
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusBadRequest, resp.StatusCode(),
+			"expected 400 for invalid scope, got %d: %s", resp.StatusCode(), resp.String())
+
+		errResp := parseOidcError(t, resp.Body())
+		ctx.Req.Equal("invalid_scope", errResp.Error)
+	})
+
+	t.Run("token endpoint returns invalid_grant with expired description for expired refresh_token", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		// Manufacture a refresh token that is already expired by signing it
+		// with the controller's own key.
+		signer := ctx.EdgeController.AppEnv.GetRootTlsJwtSigner()
+		now := time.Now()
+		expiredClaims := &common.RefreshClaims{
+			IDTokenClaims: oidc.IDTokenClaims{
+				TokenClaims: oidc.TokenClaims{
+					JWTID:      uuid.NewString(),
+					Issuer:     "https://" + ctx.ApiHost + "/oidc",
+					Subject:    "fake-identity",
+					Expiration: oidc.Time(now.Add(-1 * time.Hour).Unix()),
+					IssuedAt:   oidc.Time(now.Add(-2 * time.Hour).Unix()),
+					NotBefore:  oidc.Time(now.Add(-2 * time.Hour).Unix()),
+				},
+			},
+			CustomClaims: common.CustomClaims{
+				Type: common.TokenTypeRefresh,
+			},
+		}
+
+		expiredToken, err := signer.Generate(expiredClaims)
+		ctx.Req.NoError(err)
+
+		resp, err := ctx.newAnonymousClientApiRequest().
+			SetHeader("content-type", oidc_auth.FormContentType).
+			SetFormData(map[string]string{
+				"grant_type":    string(oidc.GrantTypeRefreshToken),
+				"refresh_token": expiredToken,
+				"client_id":     tokens.IDTokenClaims.ClientID,
+			}).
+			Post(tokenUrl)
+
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusBadRequest, resp.StatusCode(),
+			"expected 400 for expired refresh token, got %d: %s", resp.StatusCode(), resp.String())
+
+		errResp := parseOidcError(t, resp.Body())
+		ctx.Req.Equal("invalid_grant", errResp.Error)
+		ctx.Req.Contains(errResp.ErrorDescription, "expired")
+	})
+
+	t.Run("token endpoint returns invalid_grant for revoked refresh_token", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		// Authenticate to get a valid refresh token, then revoke it via the DB
+		freshTokens, _, err := clientHelper.RawOidcAuthRequest(adminCreds)
+		ctx.Req.NoError(err)
+
+		// Parse the refresh token to get its JWTID
+		refreshClaims := &common.RefreshClaims{}
+		parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+		_, _, err = parser.ParseUnverified(freshTokens.RefreshToken, refreshClaims)
+		ctx.Req.NoError(err)
+		ctx.Req.NotEmpty(refreshClaims.JWTID)
+
+		// Plant a revocation record for this token's JWTID
+		changeCtx := change.New().SetSourceType("test").SetChangeAuthorType(change.AuthorTypeController)
+		err = ctx.EdgeController.AppEnv.Managers.Revocation.Create(&model.Revocation{
+			BaseEntity: models.BaseEntity{Id: refreshClaims.JWTID},
+			ExpiresAt:  time.Now().Add(1 * time.Hour),
+		}, changeCtx)
+		ctx.Req.NoError(err)
+
+		// Try to refresh with the revoked token
+		resp, err := ctx.newAnonymousClientApiRequest().
+			SetHeader("content-type", oidc_auth.FormContentType).
+			SetFormData(map[string]string{
+				"grant_type":    string(oidc.GrantTypeRefreshToken),
+				"refresh_token": freshTokens.RefreshToken,
+				"client_id":     freshTokens.IDTokenClaims.ClientID,
+			}).
+			Post(tokenUrl)
+
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusBadRequest, resp.StatusCode(),
+			"expected 400 for revoked refresh token, got %d: %s", resp.StatusCode(), resp.String())
+
+		errResp := parseOidcError(t, resp.Body())
+		ctx.Req.Equal("invalid_grant", errResp.Error)
+		ctx.Req.Contains(errResp.ErrorDescription, "revoked")
+	})
+
+	t.Run("userinfo endpoint returns error for revoked access token", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		// Authenticate to get a valid access token, then revoke it
+		freshTokens, _, err := clientHelper.RawOidcAuthRequest(adminCreds)
+		ctx.Req.NoError(err)
+
+		// Parse the access token to get its JWTID
+		accessClaims := &common.AccessClaims{}
+		parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+		_, _, err = parser.ParseUnverified(freshTokens.AccessToken, accessClaims)
+		ctx.Req.NoError(err)
+		ctx.Req.NotEmpty(accessClaims.JWTID)
+
+		// Plant a revocation record for this token's JWTID
+		changeCtx := change.New().SetSourceType("test").SetChangeAuthorType(change.AuthorTypeController)
+		err = ctx.EdgeController.AppEnv.Managers.Revocation.Create(&model.Revocation{
+			BaseEntity: models.BaseEntity{Id: accessClaims.JWTID},
+			ExpiresAt:  time.Now().Add(1 * time.Hour),
+		}, changeCtx)
+		ctx.Req.NoError(err)
+
+		// Try to use the revoked access token on userinfo
+		userinfoUrl := "https://" + ctx.ApiHost + "/oidc/userinfo"
+		resp, err := ctx.newAnonymousClientApiRequest().
+			SetHeader("Authorization", "Bearer "+freshTokens.AccessToken).
+			Get(userinfoUrl)
+
+		ctx.Req.NoError(err)
+		ctx.Req.NotEqual(http.StatusOK, resp.StatusCode(),
+			"expected error for revoked access token, got %d: %s", resp.StatusCode(), resp.String())
+	})
+
+	t.Run("end_session endpoint is reachable", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		endSessionUrl := "https://" + ctx.ApiHost + "/oidc/end_session"
+
+		// POST with no id_token_hint. The endpoint redirects to /oidc/logged-out
+		// on success (even with no hint), so disable redirects and check the
+		// status directly.
+		resp, err := ctx.DefaultClientApiClient().
+			SetRedirectPolicy().R().
+			SetHeader("content-type", oidc_auth.FormContentType).
+			Post(endSessionUrl)
+
+		ctx.Req.NoError(err)
+		ctx.Req.Less(resp.StatusCode(), 500,
+			"expected non-server-error, got %d: %s", resp.StatusCode(), resp.String())
+	})
+
+	t.Run("well-known openid-configuration is accessible", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		discoveryUrl := "https://" + ctx.ApiHost + "/oidc/.well-known/openid-configuration"
+
+		resp, err := ctx.newAnonymousClientApiRequest().Get(discoveryUrl)
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusOK, resp.StatusCode(),
+			"expected 200 for discovery, got %d: %s", resp.StatusCode(), resp.String())
+
+		// Verify it's valid JSON with expected fields
+		var discovery map[string]interface{}
+		err = json.Unmarshal(resp.Body(), &discovery)
+		ctx.Req.NoError(err)
+		ctx.Req.Contains(discovery, "issuer")
+		ctx.Req.Contains(discovery, "token_endpoint")
+		ctx.Req.Contains(discovery, "authorization_endpoint")
+	})
+
+	t.Run("successful OIDC auth still works end to end", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		// Full auth flow should still succeed after all the error handling changes
+		freshTokens, _, err := clientHelper.RawOidcAuthRequest(adminCreds)
+		ctx.Req.NoError(err)
+		ctx.Req.NotEmpty(freshTokens.AccessToken)
+		ctx.Req.NotEmpty(freshTokens.RefreshToken)
+		ctx.Req.NotEmpty(freshTokens.IDToken)
+
+		// Use the access token to hit the userinfo endpoint
+		userinfoUrl := "https://" + ctx.ApiHost + "/oidc/userinfo"
+		resp, err := ctx.newAnonymousClientApiRequest().
+			SetHeader("Authorization", "Bearer "+freshTokens.AccessToken).
+			Get(userinfoUrl)
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusOK, resp.StatusCode(),
+			"expected 200 for valid userinfo request, got %d: %s", resp.StatusCode(), resp.String())
+
+		// Refresh should work
+		enc := oidc.NewEncoder()
+		dst := map[string][]string{}
+		req := &oidc.RefreshTokenRequest{
+			RefreshToken: freshTokens.RefreshToken,
+			ClientID:     freshTokens.IDTokenClaims.ClientID,
+			Scopes:       []string{oidc.ScopeOpenID, oidc.ScopeOfflineAccess},
+		}
+		err = enc.Encode(req, dst)
+		ctx.Req.NoError(err)
+		dst["grant_type"] = []string{string(req.GrantType())}
+
+		resp, err = ctx.newAnonymousClientApiRequest().
+			SetHeader("content-type", oidc_auth.FormContentType).
+			SetMultiValueFormData(dst).
+			Post(tokenUrl)
+
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusOK, resp.StatusCode(),
+			"expected 200 for valid refresh, got %d: %s", resp.StatusCode(), resp.String())
+	})
+}
+
+func Test_OIDC_ErrorCodes_CertAuth(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+	ctx.RequireAdminManagementApiLogin()
+
+	clientHelper := ctx.NewEdgeClientApi(nil)
+	adminCreds := ctx.NewAdminCredentials()
+
+	_, certAuth := ctx.AdminManagementSession.requireCreateIdentityOttEnrollment("oidc-err-cert-test", false)
+	certCreds := edge_apis.NewCertCredentials(certAuth.certs, certAuth.key)
+	certCreds.CaPool = ctx.ControllerCaPool()
+
+	t.Run("cert auth OIDC flow succeeds", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		tokens, _, err := clientHelper.RawOidcAuthRequest(certCreds)
+		ctx.Req.NoError(err)
+		ctx.Req.NotEmpty(tokens.AccessToken)
+	})
+
+	t.Run("login endpoint returns error for invalid auth request id", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		result, err := clientHelper.OidcAuthorize(adminCreds)
+		ctx.Req.NoError(err)
+
+		loginUrl := "https://" + ctx.ApiHost + "/oidc/login/username?id=bogus-request-id"
+
+		resp, err := result.Client.R().
+			SetHeader("Accept", "application/json").
+			SetFormData(map[string]string{
+				"username": ctx.AdminAuthenticator.Username,
+				"password": ctx.AdminAuthenticator.Password,
+			}).
+			Post(loginUrl)
+
+		ctx.Req.NoError(err)
+		ctx.Req.GreaterOrEqual(resp.StatusCode(), 400,
+			"expected error for bogus request id, got %d: %s", resp.StatusCode(), resp.String())
+		ctx.Req.Less(resp.StatusCode(), 500,
+			"expected client error not server error, got %d: %s", resp.StatusCode(), resp.String())
+	})
+}
+
+// parseOidcError unmarshals an OIDC/OAuth error response body.
+func parseOidcError(t *testing.T, body []byte) oidcErrorResponse {
+	t.Helper()
+	var errResp oidcErrorResponse
+	if err := json.Unmarshal(body, &errResp); err != nil {
+		t.Fatalf("failed to parse OIDC error response: %v\nbody: %s", err, string(body))
+	}
+	return errResp
+}


### PR DESCRIPTION
- migrates from op.NewProvider() to LegacyServer/RegisterLegacyServer, routing all OIDC endpoint errors through op.WriteError which maps server_error to HTTP 500 and supports custom status codes via op.StatusError
- returns oidc.ErrInvalidClient() from AuthorizeClientIDSecret for unknown clients and bad secrets (HTTP 400 with invalid_client)
- returns oidc.ErrInvalidGrant() from parseRefreshToken, parseAccessToken, createAccessToken, and renewRefreshToken for client-supplied token errors (HTTP 400 with invalid_grant)
- fixes copy-paste bug in parseAccessToken that reported "invalid refresh_token" for access token errors
- plain Go errors from server-side failures (identity read, JSON marshal, token signing, Raft dispatch) now correctly surface as HTTP 500 via WriteError's DefaultToServerError handling
- adds integration tests covering error codes for token endpoint, login endpoint, userinfo endpoint, and end_session endpoint