### PR TITLE
fixes #3734 enforce client certificate proof-of-possession for OIDC sessions

### DIFF
--- a/common/oidc_tokens.go
+++ b/common/oidc_tokens.go
@@ -47,6 +47,7 @@ const (
 	CustomClaimServiceType      = "z_st"
 	CustomClaimRemoteAddress    = "z_ra"
 	CustomClaimIsCertExtendable = "z_ice"
+	CustomClaimCertAllowExpired = "z_cae"
 	CustomClaimImproperCert     = "z_iccc"
 	CustomClaimIsLegacy         = "z_leg"
 
@@ -76,6 +77,7 @@ type CustomClaims struct {
 	EnvInfo                 *rest_model.EnvInfo `json:"z_env"`
 	RemoteAddress           string              `json:"z_ra"`
 	IsCertExtendable        bool                `json:"z_ice"`
+	CertAllowExpired        bool                `json:"z_cae,omitempty"`
 	AuthenticatorId         string              `json:"z_authid,omitempty"`
 	IsCertExtendRequested   bool                `json:"z_cer"`
 	IsCertKeyRollRequested  bool                `json:"z_ckrr"`

--- a/common/spiffehlp/spiffe.go
+++ b/common/spiffehlp/spiffe.go
@@ -21,6 +21,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -88,4 +89,81 @@ func GetSpiffeIdFromCert(cert *x509.Certificate) (*url.URL, error) {
 	}
 
 	return spiffeId, nil
+}
+
+// SpiffeMatch describes what a SPIFFE URI matched against.
+type SpiffeMatch int
+
+const (
+	// SpiffeMatchNone indicates the SPIFFE URI did not match.
+	SpiffeMatchNone SpiffeMatch = iota
+
+	// SpiffeMatchIdentity indicates the SPIFFE URI matched the identity only
+	// (path: /identity/<id>). The caller must still verify the cert fingerprint
+	// against z_cfs.
+	SpiffeMatchIdentity
+
+	// SpiffeMatchApiSession indicates the SPIFFE URI matched both the identity and
+	// API session (path: /identity/<id>/apiSession/<id> or with /apiSessionCertificate/<id>).
+	// This is a full API session cert match.
+	SpiffeMatchApiSession
+)
+
+// VerifySpiffeId checks a SPIFFE URI against the expected identity and API session IDs.
+//
+// Three SPIFFE path formats are recognized:
+//
+//   - /identity/<id>/apiSession/<apiSessionId>/apiSessionCertificate/<certId>
+//     Canonical API session certificate format, produced by controllers since v1.1.9.
+//
+//   - /identity/<id>/apiSession/<apiSessionId>
+//     Defensive fallback for API session certs. No controller version is known to have
+//     produced this format, but SPIFFE ID validation was non-functional prior to v1.4.0
+//     due to a path-parsing bug, so certs from that era were never verified by routers.
+//
+//   - /identity/<id>
+//     Identity enrollment certificate. The cert belongs to the identity but is not bound
+//     to a specific API session. The caller must still verify the cert fingerprint against
+//     z_cfs.
+func VerifySpiffeId(spiffeId *url.URL, expectedIdentityId string, expectedApiSessionId string) SpiffeMatch {
+	if spiffeId.Scheme != "spiffe" {
+		return SpiffeMatchNone
+	}
+
+	path := strings.TrimPrefix(spiffeId.Path, "/")
+	parts := strings.Split(path, "/")
+
+	if len(parts) != 2 && len(parts) != 4 && len(parts) != 6 {
+		return SpiffeMatchNone
+	}
+
+	if parts[0] != "identity" {
+		return SpiffeMatchNone
+	}
+
+	if parts[1] != expectedIdentityId {
+		return SpiffeMatchNone
+	}
+
+	// 2-segment: /identity/<id>
+	if len(parts) == 2 {
+		return SpiffeMatchIdentity
+	}
+
+	// 4 or 6-segment: must have apiSession segment with matching ID
+	if parts[2] != "apiSession" {
+		return SpiffeMatchNone
+	}
+
+	if len(parts) == 6 {
+		if parts[4] != "apiSessionCertificate" {
+			return SpiffeMatchNone
+		}
+	}
+
+	if parts[3] != expectedApiSessionId {
+		return SpiffeMatchNone
+	}
+
+	return SpiffeMatchApiSession
 }

--- a/common/spiffehlp/spiffe_test.go
+++ b/common/spiffehlp/spiffe_test.go
@@ -1,0 +1,151 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package spiffehlp
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestVerifySpiffeId(t *testing.T) {
+	tests := []struct {
+		name       string
+		uri        string
+		identityId string
+		sessionId  string
+		want       SpiffeMatch
+	}{
+		{
+			name:       "6-segment api session cert",
+			uri:        "spiffe://trust-domain/identity/id1/apiSession/session1/apiSessionCertificate/cert1",
+			identityId: "id1",
+			sessionId:  "session1",
+			want:       SpiffeMatchApiSession,
+		},
+		{
+			name:       "4-segment api session (legacy fallback)",
+			uri:        "spiffe://trust-domain/identity/id1/apiSession/session1",
+			identityId: "id1",
+			sessionId:  "session1",
+			want:       SpiffeMatchApiSession,
+		},
+		{
+			name:       "2-segment identity only",
+			uri:        "spiffe://trust-domain/identity/id1",
+			identityId: "id1",
+			sessionId:  "session1",
+			want:       SpiffeMatchIdentity,
+		},
+		{
+			name:       "wrong identity id",
+			uri:        "spiffe://trust-domain/identity/wrong/apiSession/session1/apiSessionCertificate/cert1",
+			identityId: "id1",
+			sessionId:  "session1",
+			want:       SpiffeMatchNone,
+		},
+		{
+			name:       "wrong api session id",
+			uri:        "spiffe://trust-domain/identity/id1/apiSession/wrong/apiSessionCertificate/cert1",
+			identityId: "id1",
+			sessionId:  "session1",
+			want:       SpiffeMatchNone,
+		},
+		{
+			name:       "identity matches but session does not (4-segment)",
+			uri:        "spiffe://trust-domain/identity/id1/apiSession/wrong",
+			identityId: "id1",
+			sessionId:  "session1",
+			want:       SpiffeMatchNone,
+		},
+		{
+			name:       "wrong identity on 2-segment path",
+			uri:        "spiffe://trust-domain/identity/wrong",
+			identityId: "id1",
+			sessionId:  "session1",
+			want:       SpiffeMatchNone,
+		},
+		{
+			name:       "wrong scheme",
+			uri:        "https://trust-domain/identity/id1/apiSession/session1",
+			identityId: "id1",
+			sessionId:  "session1",
+			want:       SpiffeMatchNone,
+		},
+		{
+			name:       "wrong first segment",
+			uri:        "spiffe://trust-domain/notidentity/id1/apiSession/session1",
+			identityId: "id1",
+			sessionId:  "session1",
+			want:       SpiffeMatchNone,
+		},
+		{
+			name:       "wrong third segment",
+			uri:        "spiffe://trust-domain/identity/id1/notApiSession/session1",
+			identityId: "id1",
+			sessionId:  "session1",
+			want:       SpiffeMatchNone,
+		},
+		{
+			name:       "wrong fifth segment",
+			uri:        "spiffe://trust-domain/identity/id1/apiSession/session1/notApiSessionCertificate/cert1",
+			identityId: "id1",
+			sessionId:  "session1",
+			want:       SpiffeMatchNone,
+		},
+		{
+			name:       "too few segments",
+			uri:        "spiffe://trust-domain/identity",
+			identityId: "id1",
+			sessionId:  "session1",
+			want:       SpiffeMatchNone,
+		},
+		{
+			name:       "3 segments (invalid)",
+			uri:        "spiffe://trust-domain/identity/id1/apiSession",
+			identityId: "id1",
+			sessionId:  "session1",
+			want:       SpiffeMatchNone,
+		},
+		{
+			name:       "5 segments (invalid)",
+			uri:        "spiffe://trust-domain/identity/id1/apiSession/session1/extra",
+			identityId: "id1",
+			sessionId:  "session1",
+			want:       SpiffeMatchNone,
+		},
+		{
+			name:       "7 segments (too many)",
+			uri:        "spiffe://trust-domain/identity/id1/apiSession/session1/apiSessionCertificate/cert1/extra",
+			identityId: "id1",
+			sessionId:  "session1",
+			want:       SpiffeMatchNone,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := url.Parse(tt.uri)
+			if err != nil {
+				t.Fatalf("failed to parse URI: %v", err)
+			}
+			got := VerifySpiffeId(u, tt.identityId, tt.sessionId)
+			if got != tt.want {
+				t.Errorf("VerifySpiffeId(%q, %q, %q) = %v, want %v", tt.uri, tt.identityId, tt.sessionId, got, tt.want)
+			}
+		})
+	}
+}

--- a/controller/env/security_ctx.go
+++ b/controller/env/security_ctx.go
@@ -24,10 +24,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/edge-api/rest_model"
 	"github.com/openziti/foundation/v2/errorz"
 	"github.com/openziti/storage/boltz"
 	"github.com/openziti/ziti/v2/common"
+	"github.com/openziti/ziti/v2/common/spiffehlp"
 	"github.com/openziti/ziti/v2/controller/model"
 	"github.com/openziti/ziti/v2/controller/models"
 	"github.com/openziti/ziti/v2/controller/permissions"
@@ -428,6 +430,13 @@ func (ctx *SecurityCtx) resolveOidcSession(securityToken *common.SecurityToken) 
 		return
 	}
 
+	// Enforce certificate proof-of-possession when the token was issued with cert bindings.
+	if len(claims.CertFingerprints) > 0 {
+		if !ctx.verifyCertProofOfPossession(securityToken, claims) {
+			return
+		}
+	}
+
 	ctx.resolvedIdentity = identity
 	ctx.resolvedAuthPolicy = authPolicy
 
@@ -460,6 +469,80 @@ func (ctx *SecurityCtx) resolveOidcSession(securityToken *common.SecurityToken) 
 		IsCertKeyRollRequested:  claims.IsCertKeyRollRequested,
 		ImproperClientCertChain: claims.ImproperClientCertChain,
 	}
+}
+
+// verifyCertProofOfPossession validates that the TLS client certificate presented on this request
+// matches one of the certificate fingerprints bound to the OIDC token (z_cfs claim), and that
+// the certificate was issued by a trusted CA. SPIFFE ID matching is only allowed for certificates
+// issued by the internal (first-party) CA.
+func (ctx *SecurityCtx) verifyCertProofOfPossession(securityToken *common.SecurityToken, claims *common.AccessClaims) bool {
+	if securityToken.Request == nil || securityToken.Request.TLS == nil || len(securityToken.Request.TLS.PeerCertificates) == 0 {
+		pfxlog.Logger().Warn("OIDC cert PoP failed: no client certificate presented")
+		ctx.setApiSessionError(errorz.NewUnauthorizedOidcInvalid())
+		return false
+	}
+
+	peerCerts := securityToken.Request.TLS.PeerCertificates
+	leafCert := peerCerts[0]
+
+	fpg := ctx.env.GetFingerprintGenerator()
+	fingerprint := fpg.FromCert(leafCert)
+
+	// Chain verification bypasses time checks,  expiry is enforced below based on match type
+	// and the z_cae (cert allow expired) claim from the auth policy.
+	trustCache := ctx.env.GetManagers().Ca.GetTrustCache()
+	origin := trustCache.VerifyClientCertCached(fingerprint, peerCerts, true)
+
+	if origin == model.CertOriginUntrusted {
+		pfxlog.Logger().WithField("fingerprint", fingerprint).Warn("OIDC cert PoP failed: client certificate not issued by a trusted CA")
+		ctx.setApiSessionError(errorz.NewUnauthorizedOidcInvalid())
+		return false
+	}
+
+	now := time.Now()
+	certExpired := now.Before(leafCert.NotBefore) || now.After(leafCert.NotAfter)
+
+	// For first-party certs, check the SPIFFE ID to determine the match type.
+	if origin == model.CertOriginFirstParty {
+		spiffeId, err := spiffehlp.GetSpiffeIdFromCert(leafCert)
+		if err == nil && spiffeId != nil {
+			match := spiffehlp.VerifySpiffeId(spiffeId, claims.Subject, claims.ApiSessionId)
+
+			switch match {
+			case spiffehlp.SpiffeMatchApiSession:
+				// Full API session cert. Must not be expired.
+				if certExpired {
+					pfxlog.Logger().WithField("fingerprint", fingerprint).Warn("OIDC cert PoP failed: API session certificate is expired")
+					ctx.setApiSessionError(errorz.NewUnauthorizedOidcInvalid())
+					return false
+				}
+				return true
+
+			case spiffehlp.SpiffeMatchIdentity:
+				// Identity enrollment cert. The SPIFFE ID confirms the cert belongs to
+				// this identity, but we still need to verify the fingerprint is in z_cfs.
+				break
+			}
+		}
+	}
+
+	// Fingerprint matching against z_cfs (required for identity-only SPIFFE matches and
+	// for third-party certs). Expired certs are allowed only if the auth policy permits
+	// it (z_cae claim).
+	for _, boundFingerprint := range claims.CertFingerprints {
+		if fingerprint == boundFingerprint {
+			if certExpired && !claims.CertAllowExpired {
+				pfxlog.Logger().WithField("fingerprint", fingerprint).Warn("OIDC cert PoP failed: client certificate is expired and auth policy does not allow expired certs")
+				ctx.setApiSessionError(errorz.NewUnauthorizedOidcInvalid())
+				return false
+			}
+			return true
+		}
+	}
+
+	pfxlog.Logger().WithField("fingerprint", fingerprint).Warn("OIDC cert PoP failed: client certificate does not match any bound fingerprint or SPIFFE ID")
+	ctx.setApiSessionError(errorz.NewUnauthorizedOidcInvalid())
+	return false
 }
 
 func (ctx *SecurityCtx) resolvePermissions() {

--- a/controller/env/security_ctx.go
+++ b/controller/env/security_ctx.go
@@ -24,10 +24,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/edge-api/rest_model"
 	"github.com/openziti/foundation/v2/errorz"
 	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/openziti/ziti/v2/common"
+	"github.com/openziti/ziti/v2/common/spiffehlp"
 	"github.com/openziti/ziti/v2/controller/model"
 	"github.com/openziti/ziti/v2/controller/models"
 	"github.com/openziti/ziti/v2/controller/permissions"
@@ -428,6 +430,13 @@ func (ctx *SecurityCtx) resolveOidcSession(securityToken *common.SecurityToken) 
 		return
 	}
 
+	// Enforce certificate proof-of-possession when the token was issued with cert bindings.
+	if len(claims.CertFingerprints) > 0 {
+		if !ctx.verifyCertProofOfPossession(securityToken, claims) {
+			return
+		}
+	}
+
 	ctx.resolvedIdentity = identity
 	ctx.resolvedAuthPolicy = authPolicy
 
@@ -460,6 +469,80 @@ func (ctx *SecurityCtx) resolveOidcSession(securityToken *common.SecurityToken) 
 		IsCertKeyRollRequested:  claims.IsCertKeyRollRequested,
 		ImproperClientCertChain: claims.ImproperClientCertChain,
 	}
+}
+
+// verifyCertProofOfPossession validates that the TLS client certificate presented on this request
+// matches one of the certificate fingerprints bound to the OIDC token (z_cfs claim), and that
+// the certificate was issued by a trusted CA. SPIFFE ID matching is only allowed for certificates
+// issued by the internal (first-party) CA.
+func (ctx *SecurityCtx) verifyCertProofOfPossession(securityToken *common.SecurityToken, claims *common.AccessClaims) bool {
+	if securityToken.Request == nil || securityToken.Request.TLS == nil || len(securityToken.Request.TLS.PeerCertificates) == 0 {
+		pfxlog.Logger().Warn("OIDC cert PoP failed: no client certificate presented")
+		ctx.setApiSessionError(errorz.NewUnauthorizedOidcInvalid())
+		return false
+	}
+
+	peerCerts := securityToken.Request.TLS.PeerCertificates
+	leafCert := peerCerts[0]
+
+	fpg := ctx.env.GetFingerprintGenerator()
+	fingerprint := fpg.FromCert(leafCert)
+
+	// Chain verification bypasses time checks,  expiry is enforced below based on match type
+	// and the z_cae (cert allow expired) claim from the auth policy.
+	trustCache := ctx.env.GetManagers().Ca.GetTrustCache()
+	origin := trustCache.VerifyClientCertCached(fingerprint, peerCerts, true)
+
+	if origin == model.CertOriginUntrusted {
+		pfxlog.Logger().WithField("fingerprint", fingerprint).Warn("OIDC cert PoP failed: client certificate not issued by a trusted CA")
+		ctx.setApiSessionError(errorz.NewUnauthorizedOidcInvalid())
+		return false
+	}
+
+	now := time.Now()
+	certExpired := now.Before(leafCert.NotBefore) || now.After(leafCert.NotAfter)
+
+	// For first-party certs, check the SPIFFE ID to determine the match type.
+	if origin == model.CertOriginFirstParty {
+		spiffeId, err := spiffehlp.GetSpiffeIdFromCert(leafCert)
+		if err == nil && spiffeId != nil {
+			match := spiffehlp.VerifySpiffeId(spiffeId, claims.Subject, claims.ApiSessionId)
+
+			switch match {
+			case spiffehlp.SpiffeMatchApiSession:
+				// Full API session cert. Must not be expired.
+				if certExpired {
+					pfxlog.Logger().WithField("fingerprint", fingerprint).Warn("OIDC cert PoP failed: API session certificate is expired")
+					ctx.setApiSessionError(errorz.NewUnauthorizedOidcInvalid())
+					return false
+				}
+				return true
+
+			case spiffehlp.SpiffeMatchIdentity:
+				// Identity enrollment cert. The SPIFFE ID confirms the cert belongs to
+				// this identity, but we still need to verify the fingerprint is in z_cfs.
+				break
+			}
+		}
+	}
+
+	// Fingerprint matching against z_cfs (required for identity-only SPIFFE matches and
+	// for third-party certs). Expired certs are allowed only if the auth policy permits
+	// it (z_cae claim).
+	for _, boundFingerprint := range claims.CertFingerprints {
+		if fingerprint == boundFingerprint {
+			if certExpired && !claims.CertAllowExpired {
+				pfxlog.Logger().WithField("fingerprint", fingerprint).Warn("OIDC cert PoP failed: client certificate is expired and auth policy does not allow expired certs")
+				ctx.setApiSessionError(errorz.NewUnauthorizedOidcInvalid())
+				return false
+			}
+			return true
+		}
+	}
+
+	pfxlog.Logger().WithField("fingerprint", fingerprint).Warn("OIDC cert PoP failed: client certificate does not match any bound fingerprint or SPIFFE ID")
+	ctx.setApiSessionError(errorz.NewUnauthorizedOidcInvalid())
+	return false
 }
 
 func (ctx *SecurityCtx) resolvePermissions() {

--- a/controller/env/security_ctx.go
+++ b/controller/env/security_ctx.go
@@ -488,7 +488,7 @@ func (ctx *SecurityCtx) verifyCertProofOfPossession(securityToken *common.Securi
 	fpg := ctx.env.GetFingerprintGenerator()
 	fingerprint := fpg.FromCert(leafCert)
 
-	// Chain verification bypasses time checks,  expiry is enforced below based on match type
+	// Chain verification bypasses time checks, expiry is enforced below based on match type
 	// and the z_cae (cert allow expired) claim from the auth policy.
 	trustCache := ctx.env.GetManagers().Ca.GetTrustCache()
 	origin := trustCache.VerifyClientCertCached(fingerprint, peerCerts, true)

--- a/controller/model/authenticator_manager.go
+++ b/controller/model/authenticator_manager.go
@@ -457,10 +457,13 @@ func (self *AuthenticatorManager) ExtendCertForIdentity(identityId string, authe
 		intermediatePool.AddCert(c)
 	}
 
-	peer.NotBefore = time.Now().Add(-1 * time.Hour)
-	peer.NotAfter = time.Now().Add(+1 * time.Hour)
+	// Shallow-copy the peer cert so we can override time fields without mutating the original
+	// (which may be shared across concurrent HTTP/2 requests on the same TLS connection).
+	peerCopy := *peer
+	peerCopy.NotBefore = time.Now().Add(-1 * time.Hour)
+	peerCopy.NotAfter = time.Now().Add(+1 * time.Hour)
 
-	validChain, err := peer.Verify(x509.VerifyOptions{
+	validChain, err := peerCopy.Verify(x509.VerifyOptions{
 		Roots:         rootPool,
 		Intermediates: intermediatePool,
 		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},

--- a/controller/model/authenticator_mod_cert.go
+++ b/controller/model/authenticator_mod_cert.go
@@ -73,13 +73,11 @@ func (module *AuthModuleCert) CanHandle(method string) bool {
 // certificates are allowed by authentication policy. Due to the way certificate authentication works, we may
 // not know the authentication policy until after the signing root CA is determined.
 func (module *AuthModuleCert) verifyClientCerts(clientCerts []*x509.Certificate, roots *x509.CertPool) ([][]*x509.Certificate, error) {
-	clientCert := clientCerts[0]
-
-	//time checks are done manually based on authentication policy
-	origNotBefore := clientCert.NotBefore
-	origNotAfter := clientCert.NotAfter
-	clientCert.NotBefore = time.Now().Add(-1 * time.Hour)
-	clientCert.NotAfter = time.Now().Add(1 * time.Hour)
+	// Shallow-copy the leaf cert so we can override time fields without mutating the original
+	// (which may be shared across concurrent HTTP/2 requests on the same TLS connection).
+	leafCopy := *clientCerts[0]
+	leafCopy.NotBefore = time.Now().Add(-1 * time.Hour)
+	leafCopy.NotAfter = time.Now().Add(1 * time.Hour)
 
 	intermediates := x509.NewCertPool()
 	for _, curCert := range clientCerts[1:] {
@@ -92,12 +90,7 @@ func (module *AuthModuleCert) verifyClientCerts(clientCerts []*x509.Certificate,
 		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
 	}
 
-	chains, err := clientCert.Verify(opts)
-
-	clientCert.NotBefore = origNotBefore
-	clientCert.NotAfter = origNotAfter
-
-	return chains, err
+	return leafCopy.Verify(opts)
 }
 
 // isCertExpirationValid returns true if the provided certificates validations period is currently valid.

--- a/controller/model/ca_manager.go
+++ b/controller/model/ca_manager.go
@@ -115,9 +115,6 @@ func (self *TrustCache) GetAllPool() *x509.CertPool {
 // VerifyClientCert verifies a client certificate chain against the tiered trust pools and returns
 // which pool matched. First-party pools (roots, then roots+intermediates) are tried first, then
 // third-party. Returns CertOriginUntrusted if no pool validates the cert.
-// VerifyClientCert verifies a client certificate chain against the tiered trust pools and returns
-// which pool matched. First-party pools (roots, then roots+intermediates) are tried first, then
-// third-party. Returns CertOriginUntrusted if no pool validates the cert.
 //
 // When skipTimeCheck is true, certificate time validity (NotBefore/NotAfter) is bypassed during
 // chain verification. This supports auth policies that allow expired certificates. The caller

--- a/controller/model/ca_manager.go
+++ b/controller/model/ca_manager.go
@@ -21,7 +21,9 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
+	"github.com/jellydator/ttlcache/v3"
 	"github.com/michaelquigley/pfxlog"
 	nfpem "github.com/openziti/foundation/v2/pem"
 	"github.com/openziti/identity"
@@ -52,6 +54,8 @@ func NewCaManager(env Env) *CaManager {
 	return manager
 }
 
+const certVerifyCacheTTL = 10 * time.Minute
+
 type TrustCache struct {
 	// static root certificates from the controller's root identity CA bundle (roots and intermediates)
 	staticFirstPartyTrustAnchors []*x509.Certificate
@@ -77,9 +81,25 @@ type TrustCache struct {
 	// a pool of all roots, intermediates and 3rd parties
 	allPool *x509.CertPool
 
+	// certOriginCache caches cert chain verification results by fingerprint, avoiding repeated
+	// x509.Verify calls for the same certificate. TLS handshake guarantees private key possession
+	// per-connection, so caching the chain verification result is safe.
+	certOriginCache *ttlcache.Cache[string, CertOrigin]
+
 	sync.RWMutex
 	initOnce sync.Once
 }
+
+// CertOrigin indicates whether a client certificate was issued by a first-party (internal) CA
+// or a third-party CA. This distinction is used to gate SPIFFE ID matching, which is only
+// valid for first-party certificates.
+type CertOrigin int
+
+const (
+	CertOriginUntrusted CertOrigin = iota
+	CertOriginFirstParty
+	CertOriginThirdParty
+)
 
 func (self *TrustCache) GetAllPool() *x509.CertPool {
 	self.RLock()
@@ -92,12 +112,103 @@ func (self *TrustCache) GetAllPool() *x509.CertPool {
 	return self.allPool
 }
 
+// VerifyClientCert verifies a client certificate chain against the tiered trust pools and returns
+// which pool matched. First-party pools (roots, then roots+intermediates) are tried first, then
+// third-party. Returns CertOriginUntrusted if no pool validates the cert.
+// VerifyClientCert verifies a client certificate chain against the tiered trust pools and returns
+// which pool matched. First-party pools (roots, then roots+intermediates) are tried first, then
+// third-party. Returns CertOriginUntrusted if no pool validates the cert.
+//
+// When skipTimeCheck is true, certificate time validity (NotBefore/NotAfter) is bypassed during
+// chain verification. This supports auth policies that allow expired certificates. The caller
+// is responsible for enforcing expiry when appropriate.
+func (self *TrustCache) VerifyClientCert(clientCerts []*x509.Certificate, skipTimeCheck bool) CertOrigin {
+	if len(clientCerts) == 0 {
+		return CertOriginUntrusted
+	}
+
+	self.RLock()
+	defer self.RUnlock()
+
+	intermediates := x509.NewCertPool()
+	for _, cert := range clientCerts[1:] {
+		intermediates.AddCert(cert)
+	}
+
+	// Shallow-copy the leaf cert so we can override time fields without mutating the original
+	// (which may be shared across concurrent HTTP/2 requests on the same TLS connection).
+	leafCopy := *clientCerts[0]
+	leaf := &leafCopy
+	if skipTimeCheck {
+		leaf.NotBefore = time.Now().Add(-1 * time.Hour)
+		leaf.NotAfter = time.Now().Add(1 * time.Hour)
+	}
+
+	if self.staticFirstPartyRootPool != nil {
+		opts := x509.VerifyOptions{
+			Roots:         self.staticFirstPartyRootPool,
+			Intermediates: intermediates,
+			KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+		}
+		if _, err := leaf.Verify(opts); err == nil {
+			return CertOriginFirstParty
+		}
+	}
+
+	if self.staticFirstPartyTrustAnchorPool != nil {
+		opts := x509.VerifyOptions{
+			Roots:         self.staticFirstPartyTrustAnchorPool,
+			Intermediates: intermediates,
+			KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+		}
+		if _, err := leaf.Verify(opts); err == nil {
+			return CertOriginFirstParty
+		}
+	}
+
+	if self.thirdPartyTrustAnchorPool != nil {
+		opts := x509.VerifyOptions{
+			Roots:         self.thirdPartyTrustAnchorPool,
+			Intermediates: intermediates,
+			KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+		}
+		if _, err := leaf.Verify(opts); err == nil {
+			return CertOriginThirdParty
+		}
+	}
+
+	return CertOriginUntrusted
+}
+
+// VerifyClientCertCached is like VerifyClientCert but caches results by fingerprint for the
+// configured TTL. Safe because TLS handshake proves private key possession per-connection.
+func (self *TrustCache) VerifyClientCertCached(fingerprint string, clientCerts []*x509.Certificate, skipTimeCheck bool) CertOrigin {
+	if self.certOriginCache != nil {
+		if item := self.certOriginCache.Get(fingerprint); item != nil {
+			return item.Value()
+		}
+	}
+
+	origin := self.VerifyClientCert(clientCerts, skipTimeCheck)
+
+	if self.certOriginCache != nil && origin != CertOriginUntrusted {
+		self.certOriginCache.Set(fingerprint, origin, ttlcache.DefaultTTL)
+	}
+
+	return origin
+}
+
 type CaManager struct {
 	baseEntityManager[*Ca, *db.Ca]
 	cache TrustCache
 }
 
 func (self *CaManager) initCache() {
+	self.cache.certOriginCache = ttlcache.New[string, CertOrigin](
+		ttlcache.WithTTL[string, CertOrigin](certVerifyCacheTTL),
+	)
+	go self.cache.certOriginCache.Start()
+
 	err := self.RefreshActiveAuthCaCertCache()
 	if err != nil {
 		pfxlog.Logger().WithError(err).Info("failed to refresh active auth ca cert cache")
@@ -112,6 +223,11 @@ func (self *CaManager) GetTrustCache() *TrustCache {
 func (self *CaManager) RefreshActiveAuthCaCertCache() error {
 	self.cache.Lock()
 	defer self.cache.Unlock()
+
+	// invalidate cached cert verification results since trust pools are changing
+	if self.cache.certOriginCache != nil {
+		self.cache.certOriginCache.DeleteAll()
+	}
 
 	// for TLS config
 	allPool := x509.NewCertPool()

--- a/controller/model/ca_manager_cert_pop_test.go
+++ b/controller/model/ca_manager_cert_pop_test.go
@@ -1,0 +1,217 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package model
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/jellydator/ttlcache/v3"
+)
+
+// newTestCA creates a self-signed CA certificate and key for testing.
+func newTestCA(t *testing.T, cn string) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+
+	certDer, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cert, err := x509.ParseCertificate(certDer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return cert, key
+}
+
+// newTestLeaf creates a leaf certificate signed by the given CA.
+func newTestLeaf(t *testing.T, ca *x509.Certificate, caKey *ecdsa.PrivateKey, cn string) *x509.Certificate {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	certDer, err := x509.CreateCertificate(rand.Reader, tmpl, ca, &key.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cert, err := x509.ParseCertificate(certDer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return cert
+}
+
+func newTestTrustCache(t *testing.T, firstPartyCa *x509.Certificate, thirdPartyCa *x509.Certificate) *TrustCache {
+	t.Helper()
+
+	tc := &TrustCache{}
+
+	if firstPartyCa != nil {
+		tc.staticFirstPartyRootPool = x509.NewCertPool()
+		tc.staticFirstPartyRootPool.AddCert(firstPartyCa)
+		tc.staticFirstPartyTrustAnchorPool = x509.NewCertPool()
+		tc.staticFirstPartyTrustAnchorPool.AddCert(firstPartyCa)
+	}
+
+	if thirdPartyCa != nil {
+		tc.thirdPartyTrustAnchorPool = x509.NewCertPool()
+		tc.thirdPartyTrustAnchorPool.AddCert(thirdPartyCa)
+	}
+
+	tc.certOriginCache = ttlcache.New[string, CertOrigin](
+		ttlcache.WithTTL[string, CertOrigin](certVerifyCacheTTL),
+	)
+
+	return tc
+}
+
+func TestTrustCache_VerifyClientCert_FirstParty(t *testing.T) {
+	ca, caKey := newTestCA(t, "first-party-ca")
+	leaf := newTestLeaf(t, ca, caKey, "client")
+	tc := newTestTrustCache(t, ca, nil)
+
+	result := tc.VerifyClientCert([]*x509.Certificate{leaf}, false)
+	if result != CertOriginFirstParty {
+		t.Errorf("expected CertOriginFirstParty, got %v", result)
+	}
+}
+
+func TestTrustCache_VerifyClientCert_ThirdParty(t *testing.T) {
+	firstPartyCa, _ := newTestCA(t, "first-party-ca")
+	thirdPartyCa, thirdPartyKey := newTestCA(t, "third-party-ca")
+	leaf := newTestLeaf(t, thirdPartyCa, thirdPartyKey, "client")
+	tc := newTestTrustCache(t, firstPartyCa, thirdPartyCa)
+
+	result := tc.VerifyClientCert([]*x509.Certificate{leaf}, false)
+	if result != CertOriginThirdParty {
+		t.Errorf("expected CertOriginThirdParty, got %v", result)
+	}
+}
+
+func TestTrustCache_VerifyClientCert_Untrusted(t *testing.T) {
+	firstPartyCa, _ := newTestCA(t, "first-party-ca")
+	untrustedCa, untrustedKey := newTestCA(t, "untrusted-ca")
+	leaf := newTestLeaf(t, untrustedCa, untrustedKey, "client")
+	tc := newTestTrustCache(t, firstPartyCa, nil)
+
+	result := tc.VerifyClientCert([]*x509.Certificate{leaf}, false)
+	if result != CertOriginUntrusted {
+		t.Errorf("expected CertOriginUntrusted, got %v", result)
+	}
+}
+
+func TestTrustCache_VerifyClientCert_NoCerts(t *testing.T) {
+	tc := newTestTrustCache(t, nil, nil)
+
+	result := tc.VerifyClientCert(nil, false)
+	if result != CertOriginUntrusted {
+		t.Errorf("expected CertOriginUntrusted for nil certs, got %v", result)
+	}
+
+	result = tc.VerifyClientCert([]*x509.Certificate{}, false)
+	if result != CertOriginUntrusted {
+		t.Errorf("expected CertOriginUntrusted for empty certs, got %v", result)
+	}
+}
+
+func TestTrustCache_VerifyClientCertCached(t *testing.T) {
+	ca, caKey := newTestCA(t, "first-party-ca")
+	leaf := newTestLeaf(t, ca, caKey, "client")
+	tc := newTestTrustCache(t, ca, nil)
+
+	fingerprint := "test-fingerprint"
+
+	// First call: cache miss, should verify
+	result := tc.VerifyClientCertCached(fingerprint, []*x509.Certificate{leaf}, false)
+	if result != CertOriginFirstParty {
+		t.Errorf("expected CertOriginFirstParty, got %v", result)
+	}
+
+	// Verify it's cached
+	item := tc.certOriginCache.Get(fingerprint)
+	if item == nil {
+		t.Fatal("expected cache entry to exist")
+	}
+	if item.Value() != CertOriginFirstParty {
+		t.Errorf("expected cached CertOriginFirstParty, got %v", item.Value())
+	}
+
+	// Second call: should use cache. We verify by removing pools and checking it still works.
+	tc.staticFirstPartyRootPool = nil
+	tc.staticFirstPartyTrustAnchorPool = nil
+	result = tc.VerifyClientCertCached(fingerprint, []*x509.Certificate{leaf}, false)
+	if result != CertOriginFirstParty {
+		t.Errorf("expected CertOriginFirstParty from cache, got %v", result)
+	}
+}
+
+func TestTrustCache_VerifyClientCertCached_UntrustedNotCached(t *testing.T) {
+	firstPartyCa, _ := newTestCA(t, "first-party-ca")
+	untrustedCa, untrustedKey := newTestCA(t, "untrusted-ca")
+	leaf := newTestLeaf(t, untrustedCa, untrustedKey, "client")
+	tc := newTestTrustCache(t, firstPartyCa, nil)
+
+	fingerprint := "untrusted-fingerprint"
+
+	result := tc.VerifyClientCertCached(fingerprint, []*x509.Certificate{leaf}, false)
+	if result != CertOriginUntrusted {
+		t.Errorf("expected CertOriginUntrusted, got %v", result)
+	}
+
+	// Untrusted results should NOT be cached
+	item := tc.certOriginCache.Get(fingerprint)
+	if item != nil {
+		t.Error("untrusted results should not be cached")
+	}
+}

--- a/controller/model/enrollment_mod_ott.go
+++ b/controller/model/enrollment_mod_ott.go
@@ -17,6 +17,8 @@
 package model
 
 import (
+	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/openziti/edge-api/rest_model"
@@ -86,7 +88,16 @@ func (module *EnrollModuleOtt) Process(ctx EnrollmentContext) (*EnrollmentResult
 		return nil, apiErr
 	}
 
-	certRaw, err := module.env.GetApiClientCsrSigner().SignCsr(csr, &cert.SigningOpts{})
+	trustDomain := module.env.GetConfig().SpiffeIdTrustDomain.Hostname()
+	spiffeId := &url.URL{
+		Scheme: "spiffe",
+		Host:   trustDomain,
+		Path:   fmt.Sprintf("identity/%s", identity.Id),
+	}
+
+	certRaw, err := module.env.GetApiClientCsrSigner().SignCsr(csr, &cert.SigningOpts{
+		URIs: []*url.URL{spiffeId},
+	})
 
 	if err != nil {
 		apiErr := apierror.NewCouldNotProcessCsr()

--- a/controller/model/enrollment_mod_token.go
+++ b/controller/model/enrollment_mod_token.go
@@ -18,6 +18,8 @@ package model
 
 import (
 	"errors"
+	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/michaelquigley/pfxlog"
@@ -178,7 +180,16 @@ func (module *EnrollModuleToken) Process(ctx EnrollmentContext) (*EnrollmentResu
 			return nil, apiErr
 		}
 
-		certRaw, err := module.env.GetApiClientCsrSigner().SignCsr(csr, &cert.SigningOpts{})
+		trustDomain := module.env.GetConfig().SpiffeIdTrustDomain.Hostname()
+		spiffeId := &url.URL{
+			Scheme: "spiffe",
+			Host:   trustDomain,
+			Path:   fmt.Sprintf("identity/%s", newIdentity.Id),
+		}
+
+		certRaw, err := module.env.GetApiClientCsrSigner().SignCsr(csr, &cert.SigningOpts{
+			URIs: []*url.URL{spiffeId},
+		})
 
 		if err != nil {
 			apiErr := apierror.NewCouldNotProcessCsr()

--- a/controller/oidc_auth/requests.go
+++ b/controller/oidc_auth/requests.go
@@ -51,6 +51,7 @@ type AuthRequest struct {
 	EnvInfo                 *rest_model.EnvInfo
 	RemoteAddress           string
 	IsCertExtendable        bool
+	CertAllowExpired        bool
 	IsCertExtendRequested   bool
 	IsCertKeyRollRequested  bool
 	AuthenticatorId         string

--- a/controller/oidc_auth/storage.go
+++ b/controller/oidc_auth/storage.go
@@ -460,6 +460,7 @@ func (s *HybridStorage) Authenticate(authCtx model.AuthContext, id string, confi
 			authRequest.ImproperClientCertChain = result.ImproperClientCertChain()
 		}
 
+		authRequest.CertAllowExpired = result.AuthPolicy().Primary.Cert.AllowExpiredCerts
 	}
 
 	authRequest.AuthenticatorId = result.AuthenticatorId()
@@ -671,6 +672,7 @@ func (s *HybridStorage) createAccessToken(ctx context.Context, request op.TokenR
 		claims.CustomClaims.SdkInfo = req.SdkInfo
 		claims.CustomClaims.RemoteAddress = req.RemoteAddress
 		claims.CustomClaims.IsCertExtendable = req.IsCertExtendable
+		claims.CustomClaims.CertAllowExpired = req.CertAllowExpired
 		claims.CustomClaims.IsCertExtendRequested = req.IsCertExtendRequested
 		claims.CustomClaims.IsCertKeyRollRequested = req.IsCertKeyRollRequested
 		claims.CustomClaims.ImproperClientCertChain = req.ImproperClientCertChain

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/hashicorp/raft v1.7.3
 	github.com/hashicorp/raft-boltdb/v2 v2.3.1
 	github.com/jedib0t/go-pretty/v6 v6.7.9
+	github.com/jellydator/ttlcache/v3 v3.4.0
 	github.com/jessevdk/go-flags v1.6.1
 	github.com/jinzhu/copier v0.4.0
 	github.com/judedaryl/go-arrayutils v0.0.1
@@ -154,7 +155,6 @@ require (
 	github.com/hashicorp/go-msgpack/v2 v2.1.5 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/jellydator/ttlcache/v3 v3.4.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/kr/pty v1.1.8 // indirect
 	github.com/kyokomi/emoji/v2 v2.2.13 // indirect

--- a/go.mod
+++ b/go.mod
@@ -155,6 +155,7 @@ require (
 	github.com/hashicorp/go-msgpack/v2 v2.1.5 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/jellydator/ttlcache/v3 v3.4.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/kr/pty v1.1.8 // indirect
 	github.com/kyokomi/emoji/v2 v2.2.13 // indirect

--- a/go.mod
+++ b/go.mod
@@ -154,6 +154,7 @@ require (
 	github.com/hashicorp/go-msgpack/v2 v2.1.5 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/jellydator/ttlcache/v3 v3.4.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/kr/pty v1.1.8 // indirect
 	github.com/kyokomi/emoji/v2 v2.2.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -400,6 +400,7 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jedib0t/go-pretty/v6 v6.7.9 h1:frarzQWmkZd97syT81+TH8INKPpzoxQnk+Mk5EIHSrM=
 github.com/jedib0t/go-pretty/v6 v6.7.9/go.mod h1:YwC5CE4fJ1HFUDeivSV1r//AmANFHyqczZk+U6BDALU=
+github.com/jellydator/ttlcache/v3 v3.4.0 h1:YS4P125qQS0tNhtL6aeYkheEaB/m8HCqdMMP4mnWdTY=
 github.com/jellydator/ttlcache/v3 v3.4.0/go.mod h1:Hw9EgjymziQD3yGsQdf1FqFdpp7YjFMd4Srg5EJlgD4=
 github.com/jeremija/gosubmit v0.2.8 h1:mmSITBz9JxVtu8eqbN+zmmwX7Ij2RidQxhcwRVI4wqA=
 github.com/jeremija/gosubmit v0.2.8/go.mod h1:Ui+HS073lCFREXBbdfrJzMB57OI/bdxTiLtrDHHhFPI=

--- a/go.sum
+++ b/go.sum
@@ -400,6 +400,7 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jedib0t/go-pretty/v6 v6.7.9 h1:frarzQWmkZd97syT81+TH8INKPpzoxQnk+Mk5EIHSrM=
 github.com/jedib0t/go-pretty/v6 v6.7.9/go.mod h1:YwC5CE4fJ1HFUDeivSV1r//AmANFHyqczZk+U6BDALU=
+github.com/jellydator/ttlcache/v3 v3.4.0/go.mod h1:Hw9EgjymziQD3yGsQdf1FqFdpp7YjFMd4Srg5EJlgD4=
 github.com/jeremija/gosubmit v0.2.8 h1:mmSITBz9JxVtu8eqbN+zmmwX7Ij2RidQxhcwRVI4wqA=
 github.com/jeremija/gosubmit v0.2.8/go.mod h1:Ui+HS073lCFREXBbdfrJzMB57OI/bdxTiLtrDHHhFPI=
 github.com/jessevdk/go-flags v1.6.1 h1:Cvu5U8UGrLay1rZfv/zP7iLpSHGUZ/Ou68T0iX1bBK4=

--- a/go.sum
+++ b/go.sum
@@ -400,6 +400,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jedib0t/go-pretty/v6 v6.7.8 h1:BVYrDy5DPBA3Qn9ICT+PokP9cvCv1KaHv2i+Hc8sr5o=
 github.com/jedib0t/go-pretty/v6 v6.7.8/go.mod h1:YwC5CE4fJ1HFUDeivSV1r//AmANFHyqczZk+U6BDALU=
+github.com/jellydator/ttlcache/v3 v3.4.0 h1:YS4P125qQS0tNhtL6aeYkheEaB/m8HCqdMMP4mnWdTY=
+github.com/jellydator/ttlcache/v3 v3.4.0/go.mod h1:Hw9EgjymziQD3yGsQdf1FqFdpp7YjFMd4Srg5EJlgD4=
 github.com/jeremija/gosubmit v0.2.8 h1:mmSITBz9JxVtu8eqbN+zmmwX7Ij2RidQxhcwRVI4wqA=
 github.com/jeremija/gosubmit v0.2.8/go.mod h1:Ui+HS073lCFREXBbdfrJzMB57OI/bdxTiLtrDHHhFPI=
 github.com/jessevdk/go-flags v1.6.1 h1:Cvu5U8UGrLay1rZfv/zP7iLpSHGUZ/Ou68T0iX1bBK4=

--- a/router/state/cert_origin.go
+++ b/router/state/cert_origin.go
@@ -19,6 +19,7 @@ package state
 import (
 	"crypto/x509"
 	"sync"
+	"time"
 
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/identity"
@@ -50,12 +51,18 @@ func (self *ManagerImpl) IsFirstPartyCert(clientCert *x509.Certificate) bool {
 		return false
 	}
 
+	// Shallow-copy the cert so we can bypass time checks without mutating the original.
+	// This determines CA origin only; expiry is enforced by the caller.
+	certCopy := *clientCert
+	certCopy.NotBefore = time.Now().Add(-1 * time.Hour)
+	certCopy.NotAfter = time.Now().Add(1 * time.Hour)
+
 	opts := x509.VerifyOptions{
 		Roots:     pool,
 		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
 	}
 
-	if _, err := clientCert.Verify(opts); err == nil {
+	if _, err := certCopy.Verify(opts); err == nil {
 		return true
 	}
 

--- a/router/state/cert_origin.go
+++ b/router/state/cert_origin.go
@@ -1,0 +1,124 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package state
+
+import (
+	"crypto/x509"
+	"sync"
+
+	"github.com/michaelquigley/pfxlog"
+	"github.com/openziti/identity"
+)
+
+// CertOrigin indicates whether a client certificate was issued by the internal (first-party) CA
+// or a third-party CA. This distinction gates SPIFFE ID matching, which is only valid for
+// first-party certificates.
+type CertOrigin int
+
+const (
+	CertOriginFirstParty CertOrigin = iota
+	CertOriginThirdParty
+)
+
+// controllerRootCache caches the root CA extracted from a controller's cert chain.
+type controllerRootCache struct {
+	mu       sync.RWMutex
+	rootPool *x509.CertPool
+	inited   bool
+}
+
+// IsFirstPartyCert determines if a client certificate was issued by the internal (first-party) CA
+// by checking whether it chains to the same root CA as the controller connection. The controller
+// root CA is extracted from any ctrl channel and cached for subsequent calls.
+func (self *ManagerImpl) IsFirstPartyCert(clientCert *x509.Certificate) bool {
+	pool := self.getControllerRootPool()
+	if pool == nil {
+		return false
+	}
+
+	opts := x509.VerifyOptions{
+		Roots:     pool,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+	}
+
+	if _, err := clientCert.Verify(opts); err == nil {
+		return true
+	}
+
+	return false
+}
+
+func (self *ManagerImpl) getControllerRootPool() *x509.CertPool {
+	self.ctrlRootCache.mu.RLock()
+	if self.ctrlRootCache.inited {
+		pool := self.ctrlRootCache.rootPool
+		self.ctrlRootCache.mu.RUnlock()
+		return pool
+	}
+	self.ctrlRootCache.mu.RUnlock()
+
+	self.ctrlRootCache.mu.Lock()
+	defer self.ctrlRootCache.mu.Unlock()
+
+	// double-check after acquiring write lock
+	if self.ctrlRootCache.inited {
+		return self.ctrlRootCache.rootPool
+	}
+
+	ctrls := self.env.GetNetworkControllers()
+	ctrlCh := ctrls.AnyCtrlChannel()
+	if ctrlCh == nil {
+		pfxlog.Logger().Warn("no ctrl channel available to determine controller root CA")
+		return nil
+	}
+
+	certs := ctrlCh.GetChannel().Certificates()
+	if len(certs) == 0 {
+		pfxlog.Logger().Warn("ctrl channel has no certificates")
+		return nil
+	}
+
+	// Walk the cert chain to find the root (self-signed) CA.
+	rootPool := x509.NewCertPool()
+	for _, cert := range certs {
+		if identity.IsRootCa(cert) {
+			rootPool.AddCert(cert)
+		}
+	}
+
+	// If no explicit root in the chain, use the identity's CA bundle to find the root
+	// that signed the controller's leaf cert.
+	if len(certs) > 0 {
+		idCA := self.env.GetRouterId().CA()
+		if idCA != nil {
+			opts := x509.VerifyOptions{
+				Roots:     idCA,
+				KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+			}
+			if chains, err := certs[0].Verify(opts); err == nil {
+				for _, chain := range chains {
+					root := chain[len(chain)-1]
+					rootPool.AddCert(root)
+				}
+			}
+		}
+	}
+
+	self.ctrlRootCache.inited = true
+	self.ctrlRootCache.rootPool = rootPool
+	return rootPool
+}

--- a/router/state/cert_validating_identity.go
+++ b/router/state/cert_validating_identity.go
@@ -1,0 +1,122 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package state
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"time"
+
+	"github.com/michaelquigley/pfxlog"
+	"github.com/openziti/identity"
+	"github.com/openziti/ziti/v2/common/pb/edge_ctrl_pb"
+)
+
+// certValidatingIdentity wraps an identity.Identity to add client certificate chain verification
+// at the TLS level via a VerifyConnection callback. It dynamically builds a CA pool from the
+// router data model's PublicKeys with ClientX509CertValidation usage, ensuring the latest
+// trust anchors are always used.
+type certValidatingIdentity struct {
+	identity.Identity
+	stateManager Manager
+}
+
+// WrapIdentityWithCertValidation returns a new identity.TokenId with the same Token and Data
+// but an Identity that adds TLS-level client certificate verification using the router's
+// data model CA pool.
+func WrapIdentityWithCertValidation(id *identity.TokenId, stateManager Manager) *identity.TokenId {
+	return &identity.TokenId{
+		Identity: &certValidatingIdentity{
+			Identity:     id.Identity,
+			stateManager: stateManager,
+		},
+		Token: id.Token,
+		Data:  id.Data,
+	}
+}
+
+func (self *certValidatingIdentity) ServerTLSConfig() *tls.Config {
+	cfg := self.Identity.ServerTLSConfig()
+	cfg.VerifyConnection = self.verifyConnection
+	return cfg
+}
+
+// verifyConnection is a TLS VerifyConnection callback that verifies client certificates against
+// the CA pool built from RDM PublicKeys.
+func (self *certValidatingIdentity) verifyConnection(state tls.ConnectionState) error {
+	if len(state.PeerCertificates) == 0 {
+		// No client cert presented. The edge listener requires a cert (RequireAnyClientCert),
+		// so this should not happen. Reject to be safe.
+		return fmt.Errorf("no client certificate presented")
+	}
+
+	rdm := self.stateManager.RouterDataModel()
+	if rdm == nil {
+		return fmt.Errorf("router data model not yet available, cannot verify client certificate")
+	}
+
+	rootPool := x509.NewCertPool()
+	intermediatePool := x509.NewCertPool()
+	certCount := 0
+	for keysTuple := range rdm.PublicKeys.IterBuffered() {
+		if contains(keysTuple.Val.Usages, edge_ctrl_pb.DataState_PublicKey_ClientX509CertValidation) {
+			parsed, err := x509.ParseCertificate(keysTuple.Val.GetData())
+			if err != nil {
+				pfxlog.Logger().WithField("kid", keysTuple.Val.Kid).WithError(err).Error("could not parse x509 certificate data for TLS client verification")
+				continue
+			}
+			rootPool.AddCert(parsed)
+			certCount++
+		}
+	}
+
+	if certCount == 0 {
+		return fmt.Errorf("no trusted CA certificates available in router data model")
+	}
+
+	// Add the router identity's CA bundle as intermediates. The RDM PublicKeys typically
+	// contain only root CAs, but client certs may be signed by an intermediate CA that
+	// is part of the router's trust bundle.
+	if idCa := self.Identity.CA(); idCa != nil {
+		intermediatePool = idCa
+	}
+
+	// Also add any additional certs from the TLS peer chain as intermediates.
+	for _, cert := range state.PeerCertificates[1:] {
+		intermediatePool.AddCert(cert)
+	}
+
+	// Shallow-copy the leaf cert so we can override time fields without mutating the original.
+	// Expiry enforcement is deferred to application code which has access to the API session
+	// token and auth policy (z_cae claim).
+	leafCopy := *state.PeerCertificates[0]
+	leafCopy.NotBefore = time.Now().Add(-1 * time.Hour)
+	leafCopy.NotAfter = time.Now().Add(1 * time.Hour)
+
+	opts := x509.VerifyOptions{
+		Roots:         rootPool,
+		Intermediates: intermediatePool,
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+	}
+
+	if _, err := leafCopy.Verify(opts); err != nil {
+		return fmt.Errorf("client certificate not issued by a trusted CA: %w", err)
+	}
+
+	return nil
+}

--- a/router/state/cert_validating_identity.go
+++ b/router/state/cert_validating_identity.go
@@ -19,6 +19,7 @@ package state
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"time"
 
@@ -62,12 +63,12 @@ func (self *certValidatingIdentity) verifyConnection(state tls.ConnectionState) 
 	if len(state.PeerCertificates) == 0 {
 		// No client cert presented. The edge listener requires a cert (RequireAnyClientCert),
 		// so this should not happen. Reject to be safe.
-		return fmt.Errorf("no client certificate presented")
+		return errors.New("no client certificate presented")
 	}
 
 	rdm := self.stateManager.RouterDataModel()
 	if rdm == nil {
-		return fmt.Errorf("router data model not yet available, cannot verify client certificate")
+		return errors.New("router data model not yet available, cannot verify client certificate")
 	}
 
 	rootPool := x509.NewCertPool()
@@ -86,7 +87,7 @@ func (self *certValidatingIdentity) verifyConnection(state tls.ConnectionState) 
 	}
 
 	if certCount == 0 {
-		return fmt.Errorf("no trusted CA certificates available in router data model")
+		return errors.New("no trusted CA certificates available in router data model")
 	}
 
 	// Add the router identity's CA bundle as intermediates. The RDM PublicKeys typically

--- a/router/state/cert_validating_identity.go
+++ b/router/state/cert_validating_identity.go
@@ -94,7 +94,7 @@ func (self *certValidatingIdentity) verifyConnection(state tls.ConnectionState) 
 	// contain only root CAs, but client certs may be signed by an intermediate CA that
 	// is part of the router's trust bundle.
 	if idCa := self.Identity.CA(); idCa != nil {
-		intermediatePool = idCa
+		intermediatePool = idCa.Clone()
 	}
 
 	// Also add any additional certs from the TLS peer chain as intermediates.

--- a/router/state/manager.go
+++ b/router/state/manager.go
@@ -93,9 +93,9 @@ type ApiSessionTokenProvider interface {
 //
 // 1. subscribe to controller 1
 // 2. controller starts sending events
-// 3. before receiving any events, controller change event is triggered and we re-subscribe to controller 1
+// 3. before receiving any events, a controller change event is triggered and we re-subscribe to controller 1
 // 4. controller restarts event stream
-// 5. the resubscribe temporarily reset the current controller to ""
+// 5. the `resubscribe` temporarily resets the current controller to ""
 // 6. in that state we received event 1 from the first stream of events from the controller and discarded it
 // 7. we then were resubscribed and got event 2 from the first stream and processed it
 // 8. At some point we get event 1 again from the second stream, but because it's no longer in order, we discard it
@@ -216,7 +216,7 @@ type Manager interface {
 	StartHeartbeat(env env.RouterEnv, seconds int, closeNotify <-chan struct{})
 
 	// ValidateSessions performs batch validation of active service sessions against
-	// controller state, enabling detection of sessions that have been revoked or expired.
+	// the controller state, enabling detection of sessions that have been revoked or expired.
 	ValidateSessions(ch channel.Channel, chunkSize uint32, minInterval, maxInterval time.Duration)
 
 	// DumpApiSessions provides diagnostic output of all tracked API sessions
@@ -235,6 +235,10 @@ type Manager interface {
 	// VerifyClientCert validates client certificates against the router's trusted
 	// certificate authorities.
 	VerifyClientCert(cert *x509.Certificate) error
+
+	// IsFirstPartyCert determines if a client certificate was issued by the internal
+	// (first-party) CA by checking whether it chains to the controller's root CA.
+	IsFirstPartyCert(cert *x509.Certificate) bool
 
 	// StartRouterModelSave begins periodic saving of the router data model to disk.
 	StartRouterModelSave(path string, duration time.Duration)
@@ -286,7 +290,7 @@ var _ Manager = (*ManagerImpl)(nil)
 // NewManager creates a new state manager instance with all necessary components
 // for session tracking, posture monitoring, and router data model management.
 // This is the primary factory function that initializes the complete state
-// management infrastructure including goroutine pools, caches, and event handlers.
+// management infrastructure, including goroutine pools, caches, and event handlers.
 func NewManager(stateEnv env.RouterEnv) Manager {
 	routerDataModelPoolConfig := goroutines.PoolConfig{
 		QueueSize:   uint32(1000),
@@ -352,7 +356,7 @@ func NewManager(stateEnv env.RouterEnv) Manager {
 // meet policy requirements are automatically terminated with appropriate error messages.
 //
 // Parameters:
-//   - data: The updated posture instance data containing current device state
+//   - data: The updated posture instance data containing the current device state
 func (self *ManagerImpl) onPostureDataUpdate(data *posture.InstanceData) {
 	rdm := self.routerDataModel.Load()
 	channels := self.connectionTracker.GetChannelsByIdentityId(data.IdentityId)
@@ -442,6 +446,7 @@ type ManagerImpl struct {
 	rmdReplaceInProgress atomic.Bool
 
 	certCache           cmap.ConcurrentMap[string, *x509.Certificate]
+	ctrlRootCache       controllerRootCache
 	routerDataModel     atomic.Pointer[common.RouterDataModel]
 	routerDataModelPool goroutines.Pool
 
@@ -644,6 +649,11 @@ func (self *ManagerImpl) GetRouterDataModelPool() goroutines.Pool {
 //   - response: The posture response containing device state information
 func (self *ManagerImpl) ProcessPostureResponses(ch channel.Channel, responses *edge_client_pb.PostureResponses) {
 	apiSessionToken := GetApiSessionTokenFromCh(ch)
+
+	if apiSessionToken == nil {
+		return
+	}
+
 	self.postureCache.AddResponses(apiSessionToken.IdentityId, apiSessionToken.Id, responses)
 }
 
@@ -918,9 +928,9 @@ func (self *ManagerImpl) pubKeyLookup(token *jwt.Token) (any, error) {
 // RouterDataModel returns the current router data model containing
 // network topology and policy information.
 func (self *ManagerImpl) RouterDataModel() *common.RouterDataModel {
-	// If a router data model replace is in progress, we need to wait for it to be fully
-	// initialized before we get it, otherwise there's the possibility of race conditions
-	// Should happen rarely, so a sleep is the simplest solution
+	// If a router data model `replace` is in progress, we need to wait for it to be fully
+	// initialized before we return it. Otherwise, there's the possibility of race conditions.
+	// This should happen rarely, so a sleep is the simplest solution
 	for self.rmdReplaceInProgress.Load() {
 		time.Sleep(100 * time.Millisecond)
 	}
@@ -972,7 +982,7 @@ func (self *ManagerImpl) SetRouterDataModel(model *common.RouterDataModel, reset
 	model.SyncAllSubscribers()
 
 	if resetSubscription {
-		// notify subscription manager code to resubscribe with updated model and index
+		// notify subscription manager code to resubscribe with the updated model and index
 		select {
 		case self.modelChanged <- struct{}{}:
 		default:
@@ -986,7 +996,7 @@ func (self *ManagerImpl) ResyncRouterDataModel() {
 	self.resyncRouterDataModel.Store(true)
 	self.dataModelSubscription.Store(DataModelSubscription{})
 
-	// notify subscription manager code to resubscribe with updated model and index
+	// notify subscription manager code to resubscribe with the updated model and index
 	select {
 	case self.modelChanged <- struct{}{}:
 	default:
@@ -996,7 +1006,7 @@ func (self *ManagerImpl) ResyncRouterDataModel() {
 func (self *ManagerImpl) ResubscribeRouterDataModel() {
 	self.dataModelSubscription.Store(DataModelSubscription{})
 
-	// notify subscription manager code to resubscribe with current index
+	// notify subscription manager code to resubscribe with the current index
 	select {
 	case self.modelChanged <- struct{}{}:
 	default:
@@ -1043,7 +1053,7 @@ func (self *ManagerImpl) AddLegacyApiSession(apiSessionToken *ApiSessionToken) {
 
 	if apiSessionToken.Type == ApiSessionTokenLegacyProtobuf {
 		logger.Debug("adding legacy api session")
-		//for legacy api sessions, token is a UUID
+		//for legacy api sessions, the token is a UUID
 		self.legacyApiSessionsByToken.Set(apiSessionToken.Token(), apiSessionToken)
 		self.Emit(EventAddedApiSession, apiSessionToken)
 	} else {
@@ -1088,7 +1098,7 @@ func (self *ManagerImpl) RemoveLegacyApiSession(apiSessionToken *ApiSessionToken
 }
 
 // RemoveMissingApiSessions removes API Sessions not present in the knownApiSessions argument. If the beforeSessionId
-// value is not empty string, it will be used as a monotonic comparison between it and API session ids. API session ids
+// value is not an empty string, it will be used as a monotonic comparison between it and API session ids. API session ids
 // later than the sync will be ignored.
 // RemoveMissingApiSessions reconciles router session state with controller state
 // by removing sessions not present in the authoritative controller list. The
@@ -1151,7 +1161,7 @@ func (self *ManagerImpl) RemoveLegacyServiceSession(serviceSessionToken *Service
 // during the window between session creation notification and local cache population.
 // This addresses race conditions where clients attempt to use newly created sessions
 // before synchronization completes, using exponential backoff to balance responsiveness
-// with system load during high session creation rates.
+// with the system load during high session creation rates.
 func (self *ManagerImpl) GetApiSessionTokenWithTimeout(token string, timeout time.Duration) *ApiSessionToken {
 	deadline := time.Now().Add(timeout)
 	session := self.GetApiSessionToken(token)
@@ -1203,7 +1213,7 @@ func (self *ManagerImpl) WasLegacyServiceSessionRecentlyRemoved(token string) bo
 
 // MarkLegacyServiceSessionRecentlyRemoved adds session invalidation timestamps
 // to enable fast-path rejection of connection attempts using recently removed
-// sessions. This optimization reduces controller query load and improves client
+// sessions. This optimization reduces the controller query load and improves client
 // error response times during session cleanup scenarios.
 func (self *ManagerImpl) MarkLegacyServiceSessionRecentlyRemoved(token string) {
 	self.recentlyRemovedSessions.Set(token, time.Now())
@@ -1411,7 +1421,7 @@ func (self *ManagerImpl) DumpApiSessions(c *bufio.ReadWriter) error {
 }
 
 // ValidateSessions performs batch validation of active service sessions against
-// controller state, enabling detection of sessions that have been revoked or expired.
+// the controller state, enabling detection of sessions that have been revoked or expired.
 // The chunked approach with randomized intervals prevents thundering herd effects
 // while maintaining reasonable validation latency for large session volumes.
 func (self *ManagerImpl) ValidateSessions(ch channel.Channel, chunkSize uint32, minInterval, maxInterval time.Duration) {

--- a/router/xgress_edge/connections.go
+++ b/router/xgress_edge/connections.go
@@ -20,10 +20,8 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"net/url"
 	"reflect"
 	"slices"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -605,13 +603,38 @@ func (handler *sessionConnectionHandler) validateApiSession(binding channel.Bind
 
 	edgeConn.apiSessionToken = apiSession
 
-	isValid := handler.validateBySpiffeId(apiSession, certificates[0])
+	now := time.Now()
+	certExpired := now.Before(certificates[0].NotBefore) || now.After(certificates[0].NotAfter)
 
-	if !isValid {
-		isValid = handler.validateByFingerprint(apiSession, fingerprint)
+	// For first-party certs, check SPIFFE ID to determine match type.
+	if handler.stateManager.IsFirstPartyCert(certificates[0]) {
+		match := handler.validateBySpiffeId(apiSession, certificates[0])
+
+		switch match {
+		case spiffehlp.SpiffeMatchApiSession:
+			// Full API session cert. Must not be expired.
+			if certExpired {
+				_ = ch.Close()
+				return errors.New("API session certificate is expired")
+			}
+			return nil
+
+		case spiffehlp.SpiffeMatchIdentity:
+			// Identity enrollment cert. SPIFFE confirms the cert belongs to this identity,
+			// but we still need to verify the fingerprint is in CertFingerprints below.
+			break
+		}
 	}
 
-	if isValid {
+	// Fingerprint matching against CertFingerprints. Required for identity-only SPIFFE
+	// matches, third-party certs, and certs without SPIFFE IDs.
+	// For OIDC sessions, expired certs are allowed only if the auth policy permits it
+	// (z_cae claim). Legacy sessions skip expiry checks entirely.
+	if handler.validateByFingerprint(apiSession, fingerprint) {
+		if certExpired && apiSession.Claims != nil && !apiSession.Claims.CertAllowExpired {
+			_ = ch.Close()
+			return errors.New("client certificate is expired and auth policy does not allow expired certs")
+		}
 		return nil
 	}
 
@@ -654,46 +677,12 @@ func (handler *sessionConnectionHandler) HandleClose(channel.Channel) {
 	//no work, interface fulfillment
 }
 
-func (handler *sessionConnectionHandler) validateBySpiffeId(apiSession *state.ApiSessionToken, clientCert *x509.Certificate) bool {
+func (handler *sessionConnectionHandler) validateBySpiffeId(apiSession *state.ApiSessionToken, clientCert *x509.Certificate) spiffehlp.SpiffeMatch {
 	spiffeId, err := spiffehlp.GetSpiffeIdFromCert(clientCert)
 
-	if err != nil {
-		return false
+	if err != nil || spiffeId == nil {
+		return spiffehlp.SpiffeMatchNone
 	}
 
-	if spiffeId == nil {
-		return false
-	}
-
-	return verifySpiffId(spiffeId, apiSession.Id)
-}
-
-func verifySpiffId(spiffeId *url.URL, expectedApiSessionId string) bool {
-	if spiffeId.Scheme != "spiffe" {
-		return false
-	}
-
-	path := strings.TrimPrefix(spiffeId.Path, "/")
-	parts := strings.Split(path, "/")
-
-	// /identity/<id>/apiSession/<id> or /identity/<id>/apiSession/<id>/apiSessionCertificate/<id>
-	if len(parts) != 4 && len(parts) != 6 {
-		return false
-	}
-
-	if parts[0] != "identity" {
-		return false
-	}
-
-	if parts[2] != "apiSession" {
-		return false
-	}
-
-	if len(parts) == 6 {
-		if parts[4] != "apiSessionCertificate" {
-			return false
-		}
-	}
-
-	return parts[3] == expectedApiSessionId
+	return spiffehlp.VerifySpiffeId(spiffeId, apiSession.IdentityId, apiSession.Id)
 }

--- a/router/xgress_edge/connections_test.go
+++ b/router/xgress_edge/connections_test.go
@@ -19,13 +19,12 @@ package xgress_edge
 import (
 	"crypto/x509"
 	"encoding/pem"
-	"fmt"
-	"net/url"
 	"testing"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/openziti/ziti/v2/common"
 	"github.com/openziti/ziti/v2/common/pb/edge_ctrl_pb"
+	"github.com/openziti/ziti/v2/common/spiffehlp"
 	"github.com/openziti/ziti/v2/router/state"
 	"github.com/stretchr/testify/require"
 )
@@ -101,7 +100,7 @@ OA==
 
 		result := handler.validateBySpiffeId(apiSession, clientCert)
 
-		req.True(result)
+		req.Equal(spiffehlp.SpiffeMatchApiSession, result)
 	})
 
 	t.Run("does not validate if SPIFFE IDs do not match", func(t *testing.T) {
@@ -173,174 +172,7 @@ OA==
 
 		result := handler.validateBySpiffeId(apiSession, clientCert)
 
-		req.False(result)
+		req.Equal(spiffehlp.SpiffeMatchNone, result)
 	})
 
-}
-
-func Test_verifySpiffId(t *testing.T) {
-
-	t.Run("a valid format and expected value returns true", func(t *testing.T) {
-		req := require.New(t)
-
-		const expectedApiSessionId = "4567"
-		spiffeId, err := url.Parse(fmt.Sprintf("spiffe://example.com/identity/1234/apiSession/%s", expectedApiSessionId))
-		req.NoError(err)
-
-		result := verifySpiffId(spiffeId, expectedApiSessionId)
-		req.True(result)
-	})
-
-	t.Run("extra mid-path slashes returns false", func(t *testing.T) {
-		req := require.New(t)
-
-		const expectedApiSessionId = "4567"
-		spiffeId, err := url.Parse(fmt.Sprintf("spiffe://example.com//identity/1234/apiSession/%s", expectedApiSessionId))
-		req.NoError(err)
-
-		result := verifySpiffId(spiffeId, expectedApiSessionId)
-		req.False(result)
-	})
-
-	t.Run("extra mid-path encoded slashes returns false", func(t *testing.T) {
-		req := require.New(t)
-
-		const expectedApiSessionId = "4567"
-		spiffeId, err := url.Parse(fmt.Sprintf("spiffe://example.com/%sidentity/1234/apiSession/%s", "%2F", expectedApiSessionId))
-		req.NoError(err)
-
-		result := verifySpiffId(spiffeId, expectedApiSessionId)
-		req.False(result)
-	})
-
-	t.Run("a trailing slash returns false", func(t *testing.T) {
-		req := require.New(t)
-
-		const expectedApiSessionId = "4567"
-		spiffeId, err := url.Parse(fmt.Sprintf("spiffe://example.com/identity/1234/apiSession/%s/", expectedApiSessionId))
-		req.NoError(err)
-
-		result := verifySpiffId(spiffeId, expectedApiSessionId)
-		req.False(result)
-	})
-
-	t.Run("a valid path, invalid scheme, and expected value returns false", func(t *testing.T) {
-		req := require.New(t)
-
-		const expectedApiSessionId = "4567"
-		spiffeId, err := url.Parse(fmt.Sprintf("https://example.com/identity/1234/apiSession/%s", expectedApiSessionId))
-		req.NoError(err)
-
-		result := verifySpiffId(spiffeId, expectedApiSessionId)
-		req.False(result)
-	})
-
-	t.Run("a valid format and invalid value returns false", func(t *testing.T) {
-		req := require.New(t)
-
-		const expectedApiSessionId = "4567"
-		spiffeId, err := url.Parse(fmt.Sprintf("spiffe://example.com/identity/1234/apiSession/%s", "invalidValue"))
-		req.NoError(err)
-
-		result := verifySpiffId(spiffeId, expectedApiSessionId)
-		req.False(result)
-	})
-
-	t.Run("a identity path and valid value returns false", func(t *testing.T) {
-		req := require.New(t)
-
-		const expectedApiSessionId = "4567"
-		spiffeId, err := url.Parse(fmt.Sprintf("spiffe://example.com/identityInvalid/1234/apiSession/%s", expectedApiSessionId))
-		req.NoError(err)
-
-		result := verifySpiffId(spiffeId, expectedApiSessionId)
-		req.False(result)
-	})
-
-	t.Run("an apiSession path and valid value returns false", func(t *testing.T) {
-		req := require.New(t)
-
-		const expectedApiSessionId = "4567"
-		spiffeId, err := url.Parse(fmt.Sprintf("spiffe://example.com/identity/1234/apiSessionInvalid/%s", expectedApiSessionId))
-		req.NoError(err)
-
-		result := verifySpiffId(spiffeId, expectedApiSessionId)
-		req.False(result)
-	})
-
-	t.Run("a missing path returns false", func(t *testing.T) {
-		req := require.New(t)
-
-		const expectedApiSessionId = "4567"
-		spiffeId, err := url.Parse("spiffe://example.com")
-		req.NoError(err)
-
-		result := verifySpiffId(spiffeId, expectedApiSessionId)
-		req.False(result)
-	})
-
-	t.Run("a root path returns false", func(t *testing.T) {
-		req := require.New(t)
-
-		const expectedApiSessionId = "4567"
-		spiffeId, err := url.Parse("spiffe://example.com/")
-		req.NoError(err)
-
-		result := verifySpiffId(spiffeId, expectedApiSessionId)
-		req.False(result)
-	})
-
-	t.Run("an identity only path returns false", func(t *testing.T) {
-		req := require.New(t)
-
-		const expectedApiSessionId = "4567"
-		spiffeId, err := url.Parse("spiffe://example.com/identity")
-		req.NoError(err)
-
-		result := verifySpiffId(spiffeId, expectedApiSessionId)
-		req.False(result)
-	})
-
-	t.Run("an identity and value only path returns false", func(t *testing.T) {
-		req := require.New(t)
-
-		const expectedApiSessionId = "4567"
-		spiffeId, err := url.Parse("spiffe://example.com/identity/1234")
-		req.NoError(err)
-
-		result := verifySpiffId(spiffeId, expectedApiSessionId)
-		req.False(result)
-	})
-
-	t.Run("an identity, value, apiSession only path returns false", func(t *testing.T) {
-		req := require.New(t)
-
-		const expectedApiSessionId = "4567"
-		spiffeId, err := url.Parse("spiffe://example.com/identity/1234/apiSession")
-		req.NoError(err)
-
-		result := verifySpiffId(spiffeId, expectedApiSessionId)
-		req.False(result)
-	})
-
-	t.Run("an identity, value, apiSession only path returns false", func(t *testing.T) {
-		req := require.New(t)
-
-		const expectedApiSessionId = "4567"
-		spiffeId, err := url.Parse("spiffe://example.com/identity/1234/apiSession")
-		req.NoError(err)
-
-		result := verifySpiffId(spiffeId, expectedApiSessionId)
-		req.False(result)
-	})
-	t.Run("a too long spiffe id returns false", func(t *testing.T) {
-		req := require.New(t)
-
-		const expectedApiSessionId = "4567"
-		spiffeId, err := url.Parse(fmt.Sprintf("spiffe://example.com/identity/1234/apiSession/%s/iamtoolong", expectedApiSessionId))
-		req.NoError(err)
-
-		result := verifySpiffId(spiffeId, expectedApiSessionId)
-		req.False(result)
-	})
 }

--- a/router/xgress_edge/factory.go
+++ b/router/xgress_edge/factory.go
@@ -101,7 +101,7 @@ func (factory *Factory) Run(env env.RouterEnv) error {
 	return nil
 }
 
-func (factory *Factory) LoadConfig(configMap map[interface{}]interface{}) error {
+func (factory *Factory) LoadConfig(_ map[interface{}]interface{}) error {
 	factory.enabled = factory.routerConfig.Edge.Enabled
 
 	if !factory.enabled {
@@ -173,7 +173,8 @@ func (factory *Factory) CreateListener(optionsData xgress.OptionsData) (xgress_r
 		edge.SupportsPostureChecksHeader: {1},
 	}
 
-	return newListener(factory.env.GetRouterId(), factory, options, headers), nil
+	wrappedId := state.WrapIdentityWithCertValidation(factory.env.GetRouterId(), factory.stateManager)
+	return newListener(wrappedId, factory, options, headers), nil
 }
 
 // CreateDialer creates a new Edge Xgress dialer
@@ -187,7 +188,7 @@ func (factory *Factory) CreateDialer(optionsData xgress.OptionsData) (xgress_rou
 		return nil, err
 	}
 
-	// CreateDialer is called for every egress route and for inspect and validations
+	// CreateDialer is called for every egress route and for `inspect` and validations
 	// can't Log this every time.
 	// pfxlog.Logger().Infof("xgress edge dialer options: %v", options.ToLoggableString())
 
@@ -203,35 +204,35 @@ type Options struct {
 
 func (options *Options) ToLoggableString() string {
 	buf := strings.Builder{}
-	fmt.Fprintf(&buf, "mtu=%v\n", options.Mtu)
-	fmt.Fprintf(&buf, "randomDrops=%v\n", options.RandomDrops)
-	fmt.Fprintf(&buf, "drop1InN=%v\n", options.Drop1InN)
-	fmt.Fprintf(&buf, "txQueueSize=%v\n", options.TxQueueSize)
-	fmt.Fprintf(&buf, "txPortalStartSize=%v\n", options.TxPortalStartSize)
-	fmt.Fprintf(&buf, "txPortalMaxSize=%v\n", options.TxPortalMaxSize)
-	fmt.Fprintf(&buf, "txPortalMinSize=%v\n", options.TxPortalMinSize)
-	fmt.Fprintf(&buf, "txPortalIncreaseThresh=%v\n", options.TxPortalIncreaseThresh)
-	fmt.Fprintf(&buf, "txPortalIncreaseScale=%v\n", options.TxPortalIncreaseScale)
-	fmt.Fprintf(&buf, "txPortalRetxThresh=%v\n", options.TxPortalRetxThresh)
-	fmt.Fprintf(&buf, "txPortalRetxScale=%v\n", options.TxPortalRetxScale)
-	fmt.Fprintf(&buf, "txPortalDupAckThresh=%v\n", options.TxPortalDupAckThresh)
-	fmt.Fprintf(&buf, "txPortalDupAckScale=%v\n", options.TxPortalDupAckScale)
-	fmt.Fprintf(&buf, "rxBufferSize=%v\n", options.RxBufferSize)
-	fmt.Fprintf(&buf, "retxStartMs=%v\n", options.RetxStartMs)
-	fmt.Fprintf(&buf, "retxScale=%v\n", options.RetxScale)
-	fmt.Fprintf(&buf, "retxAddMs=%v\n", options.RetxAddMs)
-	fmt.Fprintf(&buf, "retxMaxMs=%v\n", options.RetxMaxMs)
-	fmt.Fprintf(&buf, "maxRttScale=%v\n", options.MaxRttScale)
-	fmt.Fprintf(&buf, "maxCloseWait=%v\n", options.MaxCloseWait)
-	fmt.Fprintf(&buf, "getCircuitTimeout=%v\n", options.GetCircuitTimeout)
+	_, _ = fmt.Fprintf(&buf, "mtu=%v\n", options.Mtu)
+	_, _ = fmt.Fprintf(&buf, "randomDrops=%v\n", options.RandomDrops)
+	_, _ = fmt.Fprintf(&buf, "drop1InN=%v\n", options.Drop1InN)
+	_, _ = fmt.Fprintf(&buf, "txQueueSize=%v\n", options.TxQueueSize)
+	_, _ = fmt.Fprintf(&buf, "txPortalStartSize=%v\n", options.TxPortalStartSize)
+	_, _ = fmt.Fprintf(&buf, "txPortalMaxSize=%v\n", options.TxPortalMaxSize)
+	_, _ = fmt.Fprintf(&buf, "txPortalMinSize=%v\n", options.TxPortalMinSize)
+	_, _ = fmt.Fprintf(&buf, "txPortalIncreaseThresh=%v\n", options.TxPortalIncreaseThresh)
+	_, _ = fmt.Fprintf(&buf, "txPortalIncreaseScale=%v\n", options.TxPortalIncreaseScale)
+	_, _ = fmt.Fprintf(&buf, "txPortalRetxThresh=%v\n", options.TxPortalRetxThresh)
+	_, _ = fmt.Fprintf(&buf, "txPortalRetxScale=%v\n", options.TxPortalRetxScale)
+	_, _ = fmt.Fprintf(&buf, "txPortalDupAckThresh=%v\n", options.TxPortalDupAckThresh)
+	_, _ = fmt.Fprintf(&buf, "txPortalDupAckScale=%v\n", options.TxPortalDupAckScale)
+	_, _ = fmt.Fprintf(&buf, "rxBufferSize=%v\n", options.RxBufferSize)
+	_, _ = fmt.Fprintf(&buf, "retxStartMs=%v\n", options.RetxStartMs)
+	_, _ = fmt.Fprintf(&buf, "retxScale=%v\n", options.RetxScale)
+	_, _ = fmt.Fprintf(&buf, "retxAddMs=%v\n", options.RetxAddMs)
+	_, _ = fmt.Fprintf(&buf, "retxMaxMs=%v\n", options.RetxMaxMs)
+	_, _ = fmt.Fprintf(&buf, "maxRttScale=%v\n", options.MaxRttScale)
+	_, _ = fmt.Fprintf(&buf, "maxCloseWait=%v\n", options.MaxCloseWait)
+	_, _ = fmt.Fprintf(&buf, "getCircuitTimeout=%v\n", options.GetCircuitTimeout)
 
-	fmt.Fprintf(&buf, "lookupApiSessionTimeout=%v\n", options.lookupApiSessionTimeout)
-	fmt.Fprintf(&buf, "lookupSessionTimeout=%v\n", options.lookupSessionTimeout)
+	_, _ = fmt.Fprintf(&buf, "lookupApiSessionTimeout=%v\n", options.lookupApiSessionTimeout)
+	_, _ = fmt.Fprintf(&buf, "lookupSessionTimeout=%v\n", options.lookupSessionTimeout)
 
-	fmt.Fprintf(&buf, "channel.outQueueSize=%v\n", options.channelOptions.OutQueueSize)
-	fmt.Fprintf(&buf, "channel.connectTimeout=%v\n", options.channelOptions.ConnectTimeout)
-	fmt.Fprintf(&buf, "channel.maxOutstandingConnects=%v\n", options.channelOptions.MaxOutstandingConnects)
-	fmt.Fprintf(&buf, "channel.maxQueuedConnects=%v\n", options.channelOptions.MaxQueuedConnects)
+	_, _ = fmt.Fprintf(&buf, "channel.outQueueSize=%v\n", options.channelOptions.OutQueueSize)
+	_, _ = fmt.Fprintf(&buf, "channel.connectTimeout=%v\n", options.channelOptions.ConnectTimeout)
+	_, _ = fmt.Fprintf(&buf, "channel.maxOutstandingConnects=%v\n", options.channelOptions.MaxOutstandingConnects)
+	_, _ = fmt.Fprintf(&buf, "channel.maxQueuedConnects=%v\n", options.channelOptions.MaxQueuedConnects)
 
 	return buf.String()
 }

--- a/tests/auth_oidc_cert_totp_test.go
+++ b/tests/auth_oidc_cert_totp_test.go
@@ -53,6 +53,13 @@ func Test_Authenticate_OIDC_Cert_Totp_Refresh(t *testing.T) {
 		initialTokens, _, err := clientHelper.RawOidcAuthRequest(certCreds)
 		ctx.Req.NoError(err)
 
+		// Configure the client transport with the cert credentials so that subsequent
+		// API calls present the client certificate (required for cert PoP enforcement).
+		tlsCfg := clientHelper.Components.TlsAwareTransport.GetTlsClientConfig()
+		tlsCfg.Certificates = certCreds.TlsCerts()
+		clientHelper.Components.TlsAwareTransport.SetTlsClientConfig(tlsCfg)
+		clientHelper.Components.HttpClient.CloseIdleConnections()
+
 		var apiSession edge_apis.ApiSession = &edge_apis.ApiSessionOidc{OidcTokens: initialTokens}
 		clientHelper.ApiSession.Store(&apiSession)
 
@@ -126,7 +133,7 @@ func Test_Authenticate_OIDC_Cert_Totp_Refresh(t *testing.T) {
 		t.Run("authenticated token works on /services", func(t *testing.T) {
 			ctx.NextTest(t)
 
-			resp, err := ctx.newAnonymousClientApiRequest().
+			resp, err := ctx.newRequestWithTlsCerts(certCreds.TlsCerts()).
 				SetHeader("Authorization", "Bearer "+tokens.AccessToken).
 				Get("https://" + ctx.ApiHost + EdgeClientApiPath + "/services")
 			ctx.Req.NoError(err)
@@ -154,7 +161,7 @@ func Test_Authenticate_OIDC_Cert_Totp_Refresh(t *testing.T) {
 		dst["grant_type"] = []string{string(req.GrantType())}
 
 		newTokens := &oidc.TokenExchangeResponse{}
-		resp, err := ctx.newAnonymousClientApiRequest().
+		resp, err := ctx.newRequestWithTlsCerts(certCreds.TlsCerts()).
 			SetHeader("content-type", oidc_auth.FormContentType).
 			SetMultiValueFormData(dst).
 			SetResult(newTokens).
@@ -179,7 +186,7 @@ func Test_Authenticate_OIDC_Cert_Totp_Refresh(t *testing.T) {
 		t.Run("refreshed token works on /services", func(t *testing.T) {
 			ctx.NextTest(t)
 
-			resp, err := ctx.newAnonymousClientApiRequest().
+			resp, err := ctx.newRequestWithTlsCerts(certCreds.TlsCerts()).
 				SetHeader("Authorization", "Bearer "+newTokens.AccessToken).
 				Get("https://" + ctx.ApiHost + EdgeClientApiPath + "/services")
 			ctx.Req.NoError(err)
@@ -230,6 +237,13 @@ func Test_Authenticate_OIDC_Cert_With_Required_Totp(t *testing.T) {
 		ctx.Req.NotNil(tokens)
 		ctx.Req.NotEmpty(tokens.AccessToken)
 		initialTokens = tokens
+
+		// Configure the client transport with the cert credentials so that subsequent
+		// API calls present the client certificate (required for cert PoP enforcement).
+		tlsCfg := clientHelper.Components.TlsAwareTransport.GetTlsClientConfig()
+		tlsCfg.Certificates = certCreds.TlsCerts()
+		clientHelper.Components.TlsAwareTransport.SetTlsClientConfig(tlsCfg)
+		clientHelper.Components.HttpClient.CloseIdleConnections()
 
 		parser := jwt.NewParser()
 		claims := &common.AccessClaims{}

--- a/tests/context.go
+++ b/tests/context.go
@@ -722,6 +722,20 @@ func (ctx *TestContext) newRequestWithClientCert(certs []*x509.Certificate, priv
 		SetHeader("content-type", "application/json")
 }
 
+// newRequestWithTlsCerts creates an anonymous resty request that presents the given TLS
+// certificates for client authentication. Useful for testing cert proof-of-possession
+// with OIDC bearer tokens.
+func (ctx *TestContext) newRequestWithTlsCerts(tlsCerts []cryptoTls.Certificate) *resty.Request {
+	transport := ctx.NewTransport()
+	transport.TLSClientConfig.Certificates = tlsCerts
+
+	client := resty.NewWithClient(ctx.NewHttpClient(transport))
+	client.SetHostURL("https://" + ctx.ApiHost + EdgeClientApiPath)
+
+	return client.R().
+		SetHeader("content-type", "application/json")
+}
+
 func (ctx *TestContext) completeUpdbEnrollment(identityId string, password string) {
 	result := ctx.AdminManagementSession.requireQuery(fmt.Sprintf("identities/%v", identityId))
 	path := result.Search(path("data.enrollment.updb.token")...)

--- a/tests/context.go
+++ b/tests/context.go
@@ -714,6 +714,20 @@ func (ctx *TestContext) newRequestWithClientCert(certs []*x509.Certificate, priv
 		SetHeader("content-type", "application/json")
 }
 
+// newRequestWithTlsCerts creates an anonymous resty request that presents the given TLS
+// certificates for client authentication. Useful for testing cert proof-of-possession
+// with OIDC bearer tokens.
+func (ctx *TestContext) newRequestWithTlsCerts(tlsCerts []cryptoTls.Certificate) *resty.Request {
+	transport := ctx.NewTransport()
+	transport.TLSClientConfig.Certificates = tlsCerts
+
+	client := resty.NewWithClient(ctx.NewHttpClient(transport))
+	client.SetHostURL("https://" + ctx.ApiHost + EdgeClientApiPath)
+
+	return client.R().
+		SetHeader("content-type", "application/json")
+}
+
 func (ctx *TestContext) completeUpdbEnrollment(identityId string, password string) {
 	result := ctx.AdminManagementSession.requireQuery(fmt.Sprintf("identities/%v", identityId))
 	path := result.Search(path("data.enrollment.updb.token")...)

--- a/tests/revocation_test.go
+++ b/tests/revocation_test.go
@@ -227,6 +227,12 @@ func Test_Revocation(t *testing.T) {
 			// Use a static-token client so the token cannot be silently refreshed.
 			c := ctx.NewEdgeManagementApiWithStaticToken(accessToken)
 
+			// Attach the client cert so cert PoP enforcement on the z_cfs-bearing token passes.
+			tlsCfg := c.Components.TlsAwareTransport.GetTlsClientConfig()
+			tlsCfg.Certificates = freshCreds.TlsCerts()
+			c.Components.TlsAwareTransport.SetTlsClientConfig(tlsCfg)
+			c.Components.HttpClient.CloseIdleConnections()
+
 			// Token should be valid before revocation.
 			_, err = c.GetCurrentApiSessionDetail()
 			ctx.Req.NoError(err)

--- a/zititest/go.mod
+++ b/zititest/go.mod
@@ -149,6 +149,7 @@ require (
 	github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d // indirect
 	github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 // indirect
 	github.com/jedib0t/go-pretty/v6 v6.7.9 // indirect
+	github.com/jellydator/ttlcache/v3 v3.4.0 // indirect
 	github.com/jessevdk/go-flags v1.6.1 // indirect
 	github.com/jinzhu/copier v0.4.0 // indirect
 	github.com/judedaryl/go-arrayutils v0.0.1 // indirect

--- a/zititest/go.sum
+++ b/zititest/go.sum
@@ -452,6 +452,8 @@ github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
 github.com/jedib0t/go-pretty/v6 v6.7.9 h1:frarzQWmkZd97syT81+TH8INKPpzoxQnk+Mk5EIHSrM=
 github.com/jedib0t/go-pretty/v6 v6.7.9/go.mod h1:YwC5CE4fJ1HFUDeivSV1r//AmANFHyqczZk+U6BDALU=
+github.com/jellydator/ttlcache/v3 v3.4.0 h1:YS4P125qQS0tNhtL6aeYkheEaB/m8HCqdMMP4mnWdTY=
+github.com/jellydator/ttlcache/v3 v3.4.0/go.mod h1:Hw9EgjymziQD3yGsQdf1FqFdpp7YjFMd4Srg5EJlgD4=
 github.com/jeremija/gosubmit v0.2.8 h1:mmSITBz9JxVtu8eqbN+zmmwX7Ij2RidQxhcwRVI4wqA=
 github.com/jeremija/gosubmit v0.2.8/go.mod h1:Ui+HS073lCFREXBbdfrJzMB57OI/bdxTiLtrDHHhFPI=
 github.com/jessevdk/go-flags v1.6.1 h1:Cvu5U8UGrLay1rZfv/zP7iLpSHGUZ/Ou68T0iX1bBK4=


### PR DESCRIPTION
- adds verifyCertProofOfPossession() in resolveOidcSession() to require TLS client cert matching a z_cfs fingerprint or SPIFFE ID when the OIDC token was issued with cert bindings
- adds z_cae (CertAllowExpired) claim from auth policy, propagated through token issuance and refresh
- adds TrustCache.VerifyClientCert() with tiered pool matching (first-party roots, trust anchors, third-party) and TTL cache
- adds WrapIdentityWithCertValidation() on the router to verify client certs at the TLS level against RDM PublicKeys
- adds IsFirstPartyCert() on the router to gate SPIFFE ID matching by checking whether the cert chains to the controller root CA
- adds VerifySpiffeId() in common/spiffehlp with SpiffeMatchApiSession, SpiffeMatchIdentity, and SpiffeMatchNone return types
- adds SPIFFE IDs to OTT and token enrollment certs (/identity/<id>)
- enforces cert expiry by match type: API session certs must be valid, fingerprint-matched certs respect z_cae, legacy sessions skip checks
- shallow-copies leaf certs before overriding time fields in all cert verification paths to avoid races on shared x509.Certificate pointers
- fixes controllerRootCache setting inited=true before the ctrl channel is available, which permanently cached the failure