### PR TITLE
fixes #3806 expose OpenZiti endpoints in OIDC discovery document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,12 +99,52 @@ when running HA. Legacy API and service session are now deprecated and will be r
 * The dialing identity's ID and name are now forwarded to the hosting SDK
 * Controllers can now dial routers to establish control channels, enabling connectivity when routers are behind firewalls (Beta)
 * Refresh-token revocations are now batched and best-effort, removing the database/raft bottleneck on token refreshes
+* [OIDC discovery endpoint extensions](#oidc-discovery-endpoint-extensions) - OpenZiti-specific endpoint URLs in the OIDC discovery document
 * `ziti edge quickstart` now always runs in HA mode. The `ha` subcommand has been removed. Use
   `ziti edge quickstart join` to add additional members to the cluster. Note: existing quickstart instances
   are not compatible with the new HA-only mode and will need to be recreated.
 * The `--clustered` flag on `ziti create config controller` has been removed; the generated config is always
   cluster-ready. If you have scripts passing `--clustered`, remove it.
 * [Connect events pool](#connect-events-pool) - fixes a goroutine leak when routers reconnect
+
+## OIDC Discovery Endpoint Extensions
+
+The OIDC discovery document (`/.well-known/openid-configuration`) now includes a vendor-specific
+`openziti_endpoints` field. This lets SDKs discover OpenZiti's custom login and MFA endpoints at
+runtime instead of hardcoding paths.
+
+The field contains absolute URLs for each endpoint, derived from the issuer the client connected to:
+
+```json
+{
+  "issuer": "https://controller.example.com:1280/oidc",
+  "authorization_endpoint": "https://controller.example.com:1280/oidc/authorize",
+  "token_endpoint": "https://controller.example.com:1280/oidc/oauth/token",
+  "...other standard OIDC fields...",
+  "openziti_endpoints": {
+    "password":           "https://controller.example.com:1280/oidc/login/password",
+    "cert":               "https://controller.example.com:1280/oidc/login/cert",
+    "ext_jwt":            "https://controller.example.com:1280/oidc/login/ext-jwt",
+    "totp":               "https://controller.example.com:1280/oidc/login/totp",
+    "totp_enroll":        "https://controller.example.com:1280/oidc/login/totp/enroll",
+    "totp_enroll_verify": "https://controller.example.com:1280/oidc/login/totp/enroll/verify",
+    "auth_queries":       "https://controller.example.com:1280/oidc/login/auth-queries"
+  }
+}
+```
+
+| Key                | Method(s)   | Description                                       |
+|--------------------|-------------|---------------------------------------------------|
+| `password`         | POST        | Username/password authentication                  |
+| `cert`             | POST        | Client certificate authentication                 |
+| `ext_jwt`          | POST        | External JWT authentication                       |
+| `totp`             | POST        | TOTP code verification for MFA                    |
+| `totp_enroll`      | POST/DELETE | Start (POST) or delete (DELETE) TOTP enrollment   |
+| `totp_enroll_verify`| POST       | Verify a TOTP enrollment code                     |
+| `auth_queries`     | GET         | Retrieve pending authentication queries           |
+
+When the controller serves edge-oidc on multiple web servers, each discovery response reflects
+the issuer (and port) the client connected to.
 
 ## Connect Events Pool
 

--- a/controller/oidc_auth/server.go
+++ b/controller/oidc_auth/server.go
@@ -23,6 +23,39 @@ import (
 	"github.com/zitadel/oidc/v3/pkg/op"
 )
 
+// openZitiDiscoveryConfiguration extends the standard OIDC discovery response with
+// a vendor-specific "openziti_endpoints" field that advertises OpenZiti's custom
+// login and MFA endpoints. This allows SDKs to discover endpoint URLs at runtime
+// instead of hardcoding paths.
+type openZitiDiscoveryConfiguration struct {
+	*oidc.DiscoveryConfiguration
+	OpenZitiEndpoints openZitiEndpoints `json:"openziti_endpoints"`
+}
+
+// openZitiEndpoints contains the URLs for OpenZiti-specific OIDC endpoints.
+type openZitiEndpoints struct {
+	// Password is the URL for username/password authentication.
+	Password string `json:"password"`
+
+	// Cert is the URL for client certificate authentication.
+	Cert string `json:"cert"`
+
+	// ExtJwt is the URL for external JWT authentication.
+	ExtJwt string `json:"ext_jwt"`
+
+	// Totp is the URL where a TOTP code is submitted for MFA verification.
+	Totp string `json:"totp"`
+
+	// TotpEnroll is the URL for starting (POST) or deleting (DELETE) TOTP enrollment.
+	TotpEnroll string `json:"totp_enroll"`
+
+	// TotpEnrollVerify is the URL for verifying a TOTP enrollment code.
+	TotpEnrollVerify string `json:"totp_enroll_verify"`
+
+	// AuthQueries is the URL for retrieving pending authentication queries.
+	AuthQueries string `json:"auth_queries"`
+}
+
 // server embeds op.LegacyServer and overrides methods where the library's
 // helper functions re-wrap storage errors with empty descriptions, discarding
 // the error_description that storage set. The overrides call storage directly
@@ -37,6 +70,27 @@ func newServer(provider op.OpenIDProvider, endpoints op.Endpoints) *server {
 	return &server{
 		LegacyServer: op.NewLegacyServer(provider, endpoints),
 	}
+}
+
+// Discovery returns the OpenID Provider Configuration with OpenZiti-specific endpoint
+// extensions. It builds the standard OIDC discovery configuration, then wraps it with
+// vendor-specific fields under "openziti_endpoints".
+func (s *server) Discovery(ctx context.Context, r *op.Request[struct{}]) (*op.Response, error) {
+	config := op.CreateDiscoveryConfig(ctx, s.Provider(), s.Provider().Storage())
+	issuer := op.IssuerFromContext(ctx)
+
+	return op.NewResponse(&openZitiDiscoveryConfiguration{
+		DiscoveryConfiguration: config,
+		OpenZitiEndpoints: openZitiEndpoints{
+			Password:         issuer + "/login/password",
+			Cert:             issuer + "/login/cert",
+			ExtJwt:           issuer + "/login/ext-jwt",
+			Totp:             issuer + "/login/totp",
+			TotpEnroll:       issuer + "/login/totp/enroll",
+			TotpEnrollVerify: issuer + "/login/totp/enroll/verify",
+			AuthQueries:      issuer + "/login/auth-queries",
+		},
+	}), nil
 }
 
 // VerifyClient authenticates the client for a token request. It overrides

--- a/tests/configsets.go
+++ b/tests/configsets.go
@@ -43,3 +43,12 @@ var DisabledOidcAutoBinding = ConfigSet{
 	Name:       "disabled-oidc-auto-binding",
 	CtrlConfig: "testdata/configs/disabled-oidc-auto-binding/ctrl.yml",
 }
+
+// DualOidcServers is a controller-only config set with two web server entries, each
+// on a different port and each hosting the edge-oidc API. Used to verify that the OIDC
+// discovery document returns issuer-specific endpoint URLs that reflect the port the
+// client connected to.
+var DualOidcServers = ConfigSet{
+	Name:       "dual-oidc-servers",
+	CtrlConfig: "testdata/configs/dual-oidc-servers/ctrl.yml",
+}

--- a/tests/oidc_discovery_endpoint_test.go
+++ b/tests/oidc_discovery_endpoint_test.go
@@ -1,0 +1,112 @@
+package tests
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func Test_OidcDiscoveryEndpoints(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+
+	t.Run("discovery response contains openziti_endpoints", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		discoveryUrl := "https://" + ctx.ApiHost + "/oidc/.well-known/openid-configuration"
+		resp, err := ctx.newAnonymousClientApiRequest().Get(discoveryUrl)
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusOK, resp.StatusCode())
+
+		var discovery map[string]interface{}
+		err = json.Unmarshal(resp.Body(), &discovery)
+		ctx.Req.NoError(err)
+
+		t.Run("standard OIDC fields are still present", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			ctx.Req.Contains(discovery, "issuer")
+			ctx.Req.Contains(discovery, "token_endpoint")
+			ctx.Req.Contains(discovery, "authorization_endpoint")
+		})
+
+		t.Run("openziti_endpoints field exists and is an object", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			ctx.Req.Contains(discovery, "openziti_endpoints")
+
+			endpoints, ok := discovery["openziti_endpoints"].(map[string]interface{})
+			ctx.Req.True(ok, "openziti_endpoints should be a JSON object")
+
+			issuer, ok := discovery["issuer"].(string)
+			ctx.Req.True(ok, "issuer should be a string")
+
+			expectedEndpoints := map[string]string{
+				"password":           issuer + "/login/password",
+				"cert":               issuer + "/login/cert",
+				"ext_jwt":            issuer + "/login/ext-jwt",
+				"totp":               issuer + "/login/totp",
+				"totp_enroll":        issuer + "/login/totp/enroll",
+				"totp_enroll_verify": issuer + "/login/totp/enroll/verify",
+				"auth_queries":       issuer + "/login/auth-queries",
+			}
+
+			for key, expectedUrl := range expectedEndpoints {
+				t.Run(key+" endpoint is present", func(t *testing.T) {
+					ctx.testContextChanged(t)
+					ctx.Req.Contains(endpoints, key)
+					url, ok := endpoints[key].(string)
+					ctx.Req.True(ok, "%q should be a string", key)
+					ctx.Req.True(strings.HasPrefix(url, "https://"), "%q should be an absolute https URL", key)
+					ctx.Req.Equal(expectedUrl, url)
+				})
+			}
+		})
+	})
+}
+
+// Test_OidcDiscoveryEndpoints_DualServers verifies that when the controller exposes the
+// edge-oidc API on two web servers with different ports, the OIDC discovery document
+// returned by each server contains endpoint URLs that reflect the port the client
+// connected to.
+func Test_OidcDiscoveryEndpoints_DualServers(t *testing.T) {
+	ctx := NewTestContextWithConfigSet(t, DualOidcServers)
+	defer ctx.Teardown()
+	ctx.StartServer()
+
+	primaryHost := "127.0.0.1:1281"
+	secondaryHost := "127.0.0.1:1282"
+
+	for _, host := range []string{primaryHost, secondaryHost} {
+		t.Run("discovery on "+host, func(t *testing.T) {
+			ctx.testContextChanged(t)
+
+			client := ctx.NewRestClientWithDefaults()
+			discoveryUrl := "https://" + host + "/oidc/.well-known/openid-configuration"
+			resp, err := client.R().Get(discoveryUrl)
+			ctx.Req.NoError(err)
+			ctx.Req.Equal(http.StatusOK, resp.StatusCode())
+
+			var discovery map[string]interface{}
+			err = json.Unmarshal(resp.Body(), &discovery)
+			ctx.Req.NoError(err)
+
+			issuer, ok := discovery["issuer"].(string)
+			ctx.Req.True(ok, "issuer should be a string")
+			ctx.Req.Contains(issuer, host, "issuer should contain the host the client connected to")
+
+			endpoints, ok := discovery["openziti_endpoints"].(map[string]interface{})
+			ctx.Req.True(ok, "openziti_endpoints should be a JSON object")
+
+			for _, key := range []string{"password", "cert", "ext_jwt", "totp", "totp_enroll", "totp_enroll_verify", "auth_queries"} {
+				t.Run(key+" uses correct host", func(t *testing.T) {
+					ctx.testContextChanged(t)
+					url, ok := endpoints[key].(string)
+					ctx.Req.True(ok, "%q should be a string", key)
+					ctx.Req.True(strings.HasPrefix(url, issuer+"/login/"),
+						"%q URL %q should start with issuer %q", key, url, issuer)
+				})
+			}
+		})
+	}
+}

--- a/tests/testdata/configs/dual-oidc-servers/ctrl.yml
+++ b/tests/testdata/configs/dual-oidc-servers/ctrl.yml
@@ -1,0 +1,65 @@
+v: 3
+
+db: ${ZITI_TEST_DB}
+
+identity:
+  cert: testdata/ca/intermediate/certs/ctrl-client.cert.pem
+  server_cert: testdata/ca/intermediate/certs/ctrl-server.cert.pem
+  key: testdata/ca/intermediate/private/ctrl.key.pem
+  ca: testdata/ca/intermediate/certs/ca-chain.cert.pem
+
+trustDomain: at-test
+
+ctrl:
+  listener: tls:127.0.0.1:6262
+
+mgmt:
+  listener: tls:127.0.0.1:10000
+
+terminator:
+  validators:
+    edge: edge
+
+edge:
+  api:
+    sessionTimeout: 30m
+    address: 127.0.0.1:1281
+  enrollment:
+    signingCert:
+      cert: testdata/ca/intermediate/certs/intermediate.cert.pem
+      key: testdata/ca/intermediate/private/intermediate.key.decrypted.pem
+      ca: testdata/ca/intermediate/certs/ca-chain.cert.pem
+    edgeIdentity:
+      duration: 20m
+    edgeRouter:
+      duration: 60m
+
+
+web:
+  - name: primary-server
+    bindPoints:
+      - interface: 127.0.0.1:1281
+        address: 127.0.0.1:1281
+    options: {}
+    apis:
+      - binding: health-checks
+      - binding: fabric
+      - binding: edge-management
+      - binding: edge-client
+      - binding: edge-oidc
+        options:
+          redirectURIs:
+            - "http://localhost:*/auth/callback"
+            - "http://127.0.0.1:*/auth/callback"
+
+  - name: secondary-server
+    bindPoints:
+      - interface: 127.0.0.1:1282
+        address: 127.0.0.1:1282
+    options: {}
+    apis:
+      - binding: edge-oidc
+        options:
+          redirectURIs:
+            - "http://localhost:*/auth/callback"
+            - "http://127.0.0.1:*/auth/callback"


### PR DESCRIPTION
- adds vendor-specific "openziti_endpoints" field to the /.well-known/openid-configuration response
- overrides Discovery() on the OIDC server to wrap the standard config with OpenZiti login and MFA endpoint URLs
- advertises password, cert, ext-jwt, totp, totp enrollment, and auth query endpoints as absolute URLs derived from the issuer
- adds integration test verifying all openziti_endpoints fields
- adds dual-server integration test confirming endpoint URLs reflect the correct issuer when edge-oidc is hosted on multiple bind points