### PR TITLE
Filter service policies by type="Dial"/type="Bind" in queries. Fixes #3818

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,10 @@ Since we already have a breaking change, we're removing some other backwards com
     * This is the first implementation of the tunneler in edge-router code (ER/T) which used legacy api sessions and services
     * The v2 version uses the router data model and was introduced in v0.30.x
     * Github tracking issue: https://github.com/openziti/ziti/issues/3516
+* Service policy filter `type = 1` / `type = 2`
+    * Service policy list queries now expect the string form (`type = "Dial"`, `type = "Bind"`) matching the REST API
+    * The integer form was an undocumented side effect of the internal storage format and never worked with the documented filter names
+    * Github tracking issue: https://github.com/openziti/ziti/issues/3818
 
 ### Legacy Session Deprecation
 
@@ -1191,6 +1195,7 @@ be removed.
 
 * github.com/openziti/go-term-markdown: v1.0.1 (new)
 * github.com/openziti/ziti/v2: [v1.6.8 -> v2.0.0](https://github.com/openziti/ziti/compare/v1.6.8...v2.0.0)
+    * [Issue #3818](https://github.com/openziti/ziti/issues/3818) - Filtering service policies by `type = "Dial"` / `type = "Bind"` (breaking: `type = 1`/`type = 2` no longer works)
     * [Issue #3816](https://github.com/openziti/ziti/issues/3816) - Support multiple upstream DNS providers in ziti tunnel and ER/T
     * [Issue #3699](https://github.com/openziti/ziti/issues/3699) - Consolidate CLI edge and fabric commands in top level create/update/delete/list/login commands
     * [Issue #3788](https://github.com/openziti/ziti/issues/3788) - OIDC Endpoints return 400 Bad Request instead of underlying error

--- a/controller/db/service_policy_store.go
+++ b/controller/db/service_policy_store.go
@@ -45,6 +45,20 @@ func GetPolicyTypeForId(policyTypeId int32) PolicyType {
 	return policyType
 }
 
+// policyTypeSymbolMapper maps the stored int32 policy type to its "Dial"/"Bind"
+// string form so that queries can filter by the same names used in the REST API.
+type policyTypeSymbolMapper struct{}
+
+func (policyTypeSymbolMapper) Map(_ boltz.EntitySymbol, fieldType boltz.FieldType, value []byte) (boltz.FieldType, []byte) {
+	if fieldType != boltz.TypeInt32 {
+		return fieldType, value
+	}
+	if intVal := boltz.BytesToInt32(value); intVal != nil {
+		return boltz.TypeString, []byte(GetPolicyTypeForId(*intVal).String())
+	}
+	return fieldType, value
+}
+
 const (
 	FieldServicePolicyType = "type"
 
@@ -127,7 +141,8 @@ func (store *servicePolicyStoreImpl) initializeLocal() {
 	store.AddExtEntitySymbols()
 
 	store.indexName = store.addUniqueNameField()
-	store.symbolPolicyType = store.AddSymbol(FieldServicePolicyType, ast.NodeTypeInt64)
+	store.symbolPolicyType = store.AddSymbol(FieldServicePolicyType, ast.NodeTypeString)
+	store.MapSymbol(FieldServicePolicyType, policyTypeSymbolMapper{})
 	store.symbolSemantic = store.AddSymbol(FieldSemantic, ast.NodeTypeString)
 
 	store.symbolIdentityRoles = store.AddPublicSetSymbol(FieldIdentityRoles, ast.NodeTypeString)

--- a/controller/db/service_policy_store_test.go
+++ b/controller/db/service_policy_store_test.go
@@ -23,6 +23,7 @@ func Test_ServicePolicyStore(t *testing.T) {
 	t.Run("test create/update service policies with invalid entity refs", ctx.testServicePolicyInvalidValues)
 	t.Run("test service policy evaluation", ctx.testServicePolicyRoleEvaluation)
 	t.Run("test update/delete referenced entities", ctx.testServicePolicyUpdateDeleteRefs)
+	t.Run("test filter service policies by type name", ctx.testServicePolicyFilterByTypeName)
 }
 
 func newServicePolicy(name string) *ServicePolicy {
@@ -37,6 +38,41 @@ func newServicePolicy(name string) *ServicePolicy {
 		PolicyType:    policyType,
 		Semantic:      SemanticAllOf,
 	}
+}
+
+func (ctx *TestContext) testServicePolicyFilterByTypeName(_ *testing.T) {
+	ctx.CleanupAll()
+
+	dialPolicy := &ServicePolicy{
+		BaseExtEntity: boltz.BaseExtEntity{Id: eid.New()},
+		Name:          eid.New(),
+		PolicyType:    PolicyTypeDial,
+		Semantic:      SemanticAllOf,
+	}
+	boltztest.RequireCreate(ctx, dialPolicy)
+
+	bindPolicy := &ServicePolicy{
+		BaseExtEntity: boltz.BaseExtEntity{Id: eid.New()},
+		Name:          eid.New(),
+		PolicyType:    PolicyTypeBind,
+		Semantic:      SemanticAllOf,
+	}
+	boltztest.RequireCreate(ctx, bindPolicy)
+
+	err := ctx.GetDb().View(func(tx *bbolt.Tx) error {
+		dialIds, _, err := ctx.stores.ServicePolicy.QueryIds(tx, `type = "Dial"`)
+		ctx.NoError(err)
+		ctx.Contains(dialIds, dialPolicy.Id)
+		ctx.NotContains(dialIds, bindPolicy.Id)
+
+		bindIds, _, err := ctx.stores.ServicePolicy.QueryIds(tx, `type = "Bind"`)
+		ctx.NoError(err)
+		ctx.Contains(bindIds, bindPolicy.Id)
+		ctx.NotContains(bindIds, dialPolicy.Id)
+
+		return nil
+	})
+	ctx.NoError(err)
 }
 
 func (ctx *TestContext) testCreateServicePolicy(_ *testing.T) {

--- a/controller/model/edge_service_manager.go
+++ b/controller/model/edge_service_manager.go
@@ -356,8 +356,8 @@ func (self *EdgeServiceManager) GetPolicyPostureChecks(identityId, serviceId str
 
 			policyName := boltz.FieldToString(policyNameSymbol.Eval(tx, policyIdBytes))
 			policyType := db.PolicyTypeDial
-			if fieldType, policyTypeValue := policyTypeSymbol.Eval(tx, policyIdBytes); fieldType == boltz.TypeInt32 {
-				policyType = db.GetPolicyTypeForId(*boltz.BytesToInt32(policyTypeValue))
+			if fieldType, policyTypeValue := policyTypeSymbol.Eval(tx, policyIdBytes); fieldType == boltz.TypeString {
+				policyType = db.PolicyType(policyTypeValue)
 			}
 
 			//required to provide an entry for policies w/ no checks


### PR DESCRIPTION
- registers the service policy type symbol as a string, so queries match the
  API's "Dial" and "Bind" names rather than the internal int32 ids
- adds a symbol mapper that converts the stored int32 to its PolicyType name
  at query eval time
- updates the posture-checks lookup in EdgeServiceManager, the only direct
  caller that went through GetSymbol, to read the mapped string form
- adds a store test covering type = "Dial" and type = "Bind" filtering
- notes the breaking removal of the undocumented type = 1/type = 2 form in
  the 2.0 deprecation cleanup list
