### PR TITLE
Support `ziti agent inspect` so ziti processes can be inspected via IPC. Fixes #3824. Fixes #2049

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1148,6 +1148,25 @@ non-NOERROR reply (NXDOMAIN > SERVFAIL > REFUSED) so authoritative negative answ
 transport failures. If every upstream fails to respond, the query is treated as unanswerable and handled
 per the configured `dnsUnanswerable` disposition.
 
+## Agent Inspect
+
+The `ziti agent` CLI now has a generic `inspect` subcommand that works against any ziti process
+(controller, router, or tunneler) over the local IPC agent channel. It sends the inspect request
+directly to the target process, so unlike `ziti fabric inspect` it doesn't fan out through the
+controller and doesn't require network connectivity to the target.
+
+```
+ziti agent inspect <value> [values...]
+```
+
+Values are matched against whatever the target process exposes. Common inspect keys:
+
+* Routers: `stackdump`, `links`, `config`, `metrics`, `sdk-terminators`, `ert-terminators`,
+  `router-circuits`, `router-data-model`, `router-controllers`
+* Controllers: `stackdump`, `config`, `metrics`, `connected-routers`, `connected-peers`,
+  `cluster-config`, `router-messaging`, `terminator-costs`, `data-model-index`
+* Tunnelers: `stackdump`, `sdk`
+
 ## Current Beta Features
 
 Beta features are still under development and are subject to change. They should
@@ -1230,6 +1249,7 @@ be removed.
 
 * github.com/openziti/go-term-markdown: v1.0.1 (new)
 * github.com/openziti/ziti/v2: [v1.6.8 -> v2.0.0](https://github.com/openziti/ziti/compare/v1.6.8...v2.0.0)
+    * [Issue #3784](https://github.com/openziti/ziti/issues/3784) - Fix link registry race condition on reporting links on reconnect
     * [Issue #3734](https://github.com/openziti/ziti/issues/3734) - Enforce client certificate proof-of-possession on controller REST API for OIDC sessions
     * [Issue #3806](https://github.com/openziti/ziti/issues/3806) - Expose OpenZiti-specific login and MFA endpoints in the OIDC discovery document
     * [Issue #3818](https://github.com/openziti/ziti/issues/3818) - Filtering policies by keywords `Dial` and `Bind` doesn't work

--- a/common/agentid/agentid.go
+++ b/common/agentid/agentid.go
@@ -1,0 +1,24 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+// Package agentid defines shared agent application identifier values used in
+// the IPC agent protocol to dispatch requests to the correct ziti application.
+package agentid
+
+// AppIdAny is the sentinel app id used in agent requests that are not specific
+// to any particular ziti application type. Servers accept it alongside their
+// own concrete app id.
+const AppIdAny byte = 0

--- a/controller/agent.go
+++ b/controller/agent.go
@@ -7,11 +7,13 @@ import (
 	"time"
 
 	"github.com/openziti/ziti/v2/common/pb/cmd_pb"
+	"github.com/openziti/ziti/v2/common/pb/ctrl_pb"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/channel/v4"
 	"github.com/openziti/channel/v4/protobufs"
+	"github.com/openziti/ziti/v2/common/agentid"
 	"github.com/openziti/ziti/v2/common/handler_common"
 	"github.com/openziti/ziti/v2/common/pb/mgmt_pb"
 	"github.com/pkg/errors"
@@ -32,6 +34,7 @@ func (self *Controller) RegisterAgentBindHandler(bindHandler channel.BindHandler
 }
 
 func (self *Controller) bindAgentChannel(binding channel.Binding) error {
+	binding.AddReceiveHandlerF(int32(ctrl_pb.ContentType_InspectRequestType), self.agentOpInspect)
 	binding.AddReceiveHandlerF(int32(mgmt_pb.ContentType_SnapshotDbRequestType), self.agentOpSnapshotDb)
 	binding.AddReceiveHandlerF(int32(mgmt_pb.ContentType_RaftListMembersRequestType), self.agentOpRaftList)
 	binding.AddReceiveHandlerF(int32(mgmt_pb.ContentType_RaftAddPeerRequestType), self.agentOpRaftAddPeer)
@@ -59,7 +62,7 @@ func (self *Controller) HandleCustomAgentAsyncOp(conn net.Conn) error {
 	}
 	appId := appIdBuf[0]
 
-	if appId != AgentAppId {
+	if appId != agentid.AppIdAny && appId != AgentAppId {
 		logrus.WithField("appId", appId).Debug("invalid app id on agent request")
 		return errors.New("invalid operation for controller")
 	}
@@ -69,6 +72,57 @@ func (self *Controller) HandleCustomAgentAsyncOp(conn net.Conn) error {
 	listener := channel.NewExistingConnListener(self.config.Id, conn, nil)
 	_, err = channel.NewChannel("agent", listener, channel.BindHandlerF(self.bindAgentChannel), options)
 	return err
+}
+
+func (self *Controller) agentOpInspect(m *channel.Message, ch channel.Channel) {
+	request := &ctrl_pb.InspectRequest{}
+	if err := proto.Unmarshal(m.Body, request); err != nil {
+		self.sendInspectError(m, ch, err.Error())
+		return
+	}
+
+	result := self.network.Inspections.InspectLocal(request.RequestedValues)
+
+	response := &ctrl_pb.InspectResponse{
+		Success: result.Success,
+		Errors:  result.Errors,
+	}
+
+	for _, val := range result.Results {
+		response.Values = append(response.Values, &ctrl_pb.InspectResponse_InspectValue{
+			Name:  val.Name,
+			Value: val.Value,
+		})
+	}
+
+	body, err := proto.Marshal(response)
+	if err != nil {
+		self.sendInspectError(m, ch, err.Error())
+		return
+	}
+
+	responseMsg := channel.NewMessage(int32(ctrl_pb.ContentType_InspectResponseType), body)
+	responseMsg.ReplyTo(m)
+	if err := ch.Send(responseMsg); err != nil {
+		pfxlog.Logger().WithError(err).Error("failed to send inspect response")
+	}
+}
+
+func (self *Controller) sendInspectError(m *channel.Message, ch channel.Channel, errMsg string) {
+	response := &ctrl_pb.InspectResponse{
+		Success: false,
+		Errors:  []string{errMsg},
+	}
+	body, err := proto.Marshal(response)
+	if err != nil {
+		pfxlog.Logger().WithError(err).Error("failed to marshal inspect error response")
+		return
+	}
+	responseMsg := channel.NewMessage(int32(ctrl_pb.ContentType_InspectResponseType), body)
+	responseMsg.ReplyTo(m)
+	if err := ch.Send(responseMsg); err != nil {
+		pfxlog.Logger().WithError(err).Error("failed to send inspect error response")
+	}
 }
 
 func (self *Controller) agentOpSnapshotDb(m *channel.Message, ch channel.Channel) {

--- a/controller/network/inspect.go
+++ b/controller/network/inspect.go
@@ -58,6 +58,23 @@ type InspectionsManager struct {
 	network *Network
 }
 
+// InspectLocal runs inspect processing only on the local controller, without fanning out to
+// routers or peer controllers.
+func (self *InspectionsManager) InspectLocal(values []string) *InspectResult {
+	ctx := &inspectRequestContext{
+		network:         self.network,
+		timeout:         time.Second * 10,
+		requestedValues: values,
+		response:        InspectResult{Success: true},
+	}
+
+	for _, requested := range values {
+		ctx.InspectLocal(requested)
+	}
+
+	return &ctx.response
+}
+
 func (self *InspectionsManager) Inspect(appRegex string, values []string) *InspectResult {
 	ctx := &inspectRequestContext{
 		network:         self.network,

--- a/router/agent.go
+++ b/router/agent.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/channel/v4"
+	"github.com/openziti/ziti/v2/common/agentid"
 	"github.com/openziti/ziti/v2/common/handler_common"
 	"github.com/openziti/ziti/v2/common/pb/ctrl_pb"
 	"github.com/openziti/ziti/v2/common/pb/mgmt_pb"
@@ -30,6 +31,7 @@ func (self *Router) RegisterAgentBindHandler(bindHandler channel.BindHandler) {
 
 func (self *Router) RegisterDefaultAgentOps(debugEnabled bool) {
 	self.agentBindHandlers = append(self.agentBindHandlers, channel.BindHandlerF(func(binding channel.Binding) error {
+		binding.AddTypedReceiveHandler(self.inspectHandler)
 		binding.AddReceiveHandlerF(int32(mgmt_pb.ContentType_RouterDebugDumpForwarderTablesRequestType), self.agentOpDumpForwarderTables)
 		binding.AddReceiveHandlerF(int32(mgmt_pb.ContentType_RouterDebugDumpLinksRequestType), self.agentOpsDumpLinks)
 		binding.AddReceiveHandlerF(int32(mgmt_pb.ContentType_RouterQuiesceRequestType), self.agentOpQuiesceRouter)
@@ -73,9 +75,9 @@ func (self *Router) HandleAgentAsyncOp(conn net.Conn) error {
 	}
 	appId := appIdBuf[0]
 
-	if appId != AgentAppId {
+	if appId != agentid.AppIdAny && appId != AgentAppId {
 		logrus.WithField("appId", appId).Debug("invalid app id on agent request")
-		return errors.New("invalid operation for controller")
+		return errors.New("invalid operation for router")
 	}
 
 	options := channel.DefaultOptions()

--- a/router/env/env.go
+++ b/router/env/env.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openziti/sdk-golang/xgress"
 	"github.com/openziti/ziti/v2/common"
 	"github.com/openziti/ziti/v2/common/pb/ctrl_pb"
+	"github.com/openziti/ziti/v2/router/xgress_router"
 	"github.com/openziti/ziti/v2/router/xlink"
 )
 
@@ -63,6 +64,8 @@ type RouterEnv interface {
 
 	UpdateCtrlEndpointDetails(controllers []*ctrl_pb.CtrlDetail)
 	UpdateLeader(leaderId string)
+	GetXgressListeners() []xgress_router.Listener
+	GetInspectHandler() channel.TypedReceiveHandler
 }
 
 type Alerter interface {

--- a/router/handler_ctrl/bind.go
+++ b/router/handler_ctrl/bind.go
@@ -30,17 +30,11 @@ import (
 	"github.com/openziti/ziti/v2/common/trace"
 	"github.com/openziti/ziti/v2/router/env"
 	"github.com/openziti/ziti/v2/router/forwarder"
-	"github.com/openziti/ziti/v2/router/xgress_router"
 	"github.com/sirupsen/logrus"
 )
 
-type InspectRouterEnv interface {
-	env.RouterEnv
-	GetXgressListeners() []xgress_router.Listener
-}
-
 type bindHandler struct {
-	env                        InspectRouterEnv
+	env                        env.RouterEnv
 	forwarder                  *forwarder.Forwarder
 	xgDialerPool               goroutines.Pool
 	terminatorValidationPool   goroutines.Pool
@@ -52,7 +46,7 @@ func XgressDialerWorker(_ uint32, f func()) {
 	f()
 }
 
-func NewBindHandler(routerEnv InspectRouterEnv, forwarder *forwarder.Forwarder) (channel.BindHandler, error) {
+func NewBindHandler(routerEnv env.RouterEnv, forwarder *forwarder.Forwarder) (channel.BindHandler, error) {
 	xgDialerPoolConfig := goroutines.PoolConfig{
 		QueueSize:   uint32(forwarder.Options.XgressDial.QueueLength),
 		MinWorkers:  0,
@@ -119,7 +113,7 @@ func (self *bindHandler) BindChannel(binding channel.Binding) error {
 	binding.AddTypedReceiveHandler(newValidateTerminatorsV2Handler(self.env, self.terminatorValidationPool))
 	binding.AddTypedReceiveHandler(newUnrouteHandler(self.forwarder))
 	binding.AddTypedReceiveHandler(newTraceHandler(self.env.GetRouterId(), self.forwarder.TraceController(), binding.GetChannel()))
-	binding.AddTypedReceiveHandler(newInspectHandler(self.env, self.forwarder))
+	binding.AddTypedReceiveHandler(self.env.GetInspectHandler())
 	binding.AddTypedReceiveHandler(newSettingsHandler(self.env))
 	binding.AddTypedReceiveHandler(newFaultHandler(self.env.GetXlinkRegistry()))
 	binding.AddTypedReceiveHandler(self.ctrlAddrChangeHandler)

--- a/router/inspect/inspect.go
+++ b/router/inspect/inspect.go
@@ -14,7 +14,7 @@
 	limitations under the License.
 */
 
-package handler_ctrl
+package inspect
 
 import (
 	"encoding/json"
@@ -27,29 +27,30 @@ import (
 	"github.com/openziti/foundation/v2/debugz"
 	"github.com/openziti/ziti/v2/common/inspect"
 	"github.com/openziti/ziti/v2/common/pb/ctrl_pb"
+	"github.com/openziti/ziti/v2/router/env"
 	"github.com/openziti/ziti/v2/router/forwarder"
 	"github.com/openziti/ziti/v2/router/xgress_router"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 )
 
-type inspectHandler struct {
-	env InspectRouterEnv
+type Handler struct {
+	env env.RouterEnv
 	fwd *forwarder.Forwarder
 }
 
-func newInspectHandler(env InspectRouterEnv, fwd *forwarder.Forwarder) *inspectHandler {
-	return &inspectHandler{
+func NewInspectHandler(env env.RouterEnv, fwd *forwarder.Forwarder) channel.TypedReceiveHandler {
+	return &Handler{
 		env: env,
 		fwd: fwd,
 	}
 }
 
-func (*inspectHandler) ContentType() int32 {
+func (*Handler) ContentType() int32 {
 	return int32(ctrl_pb.ContentType_InspectRequestType)
 }
 
-func (handler *inspectHandler) HandleReceive(msg *channel.Message, ch channel.Channel) {
+func (handler *Handler) HandleReceive(msg *channel.Message, ch channel.Channel) {
 	context := &inspectRequestContext{
 		handler:  handler,
 		msg:      msg,
@@ -73,7 +74,7 @@ func (handler *inspectHandler) HandleReceive(msg *channel.Message, ch channel.Ch
 }
 
 type inspectRequestContext struct {
-	handler  *inspectHandler
+	handler  *Handler
 	msg      *channel.Message
 	ch       channel.Channel
 	request  *ctrl_pb.InspectRequest

--- a/router/router.go
+++ b/router/router.go
@@ -66,6 +66,7 @@ import (
 	"github.com/openziti/ziti/v2/router/handler_ctrl"
 	"github.com/openziti/ziti/v2/router/handler_link"
 	"github.com/openziti/ziti/v2/router/handler_xgress"
+	"github.com/openziti/ziti/v2/router/inspect"
 	"github.com/openziti/ziti/v2/router/interfaces"
 	"github.com/openziti/ziti/v2/router/link"
 	routerMetrics "github.com/openziti/ziti/v2/router/metrics"
@@ -122,6 +123,7 @@ type Router struct {
 	xgMetrics           *routerMetrics.XgressMetrics
 	healthChecker       gosundheit.Health
 	alertReporter       *alert.Reporter
+	inspectHandler      channel.TypedReceiveHandler
 }
 
 func (self *Router) NotifyOfReconnect(ch ctrlchan.CtrlChannel) {
@@ -237,6 +239,10 @@ func (self *Router) GetXgressListeners() []xgress_router.Listener {
 	return self.xgressListeners
 }
 
+func (self *Router) GetInspectHandler() channel.TypedReceiveHandler {
+	return self.inspectHandler
+}
+
 func (self *Router) GetChannelHeaders() (channel.Headers, error) {
 	routerVersion, err := self.versionProvider.EncoderDecoder().Encode(self.versionProvider.AsVersionInfo())
 
@@ -342,6 +348,8 @@ func Create(cfg *env.Config, versionProvider versions.VersionProvider) *Router {
 	if err != nil {
 		panic(err)
 	}
+
+	router.inspectHandler = inspect.NewInspectHandler(router, router.forwarder)
 
 	router.xgBindHandler = handler_xgress.NewBindHandler(router, router.createDataPlaneAdapter(),
 		handler_xgress.NewCloseHandler(router.ctrls, router.forwarder),

--- a/ziti/cmd/agentcli/agent.go
+++ b/ziti/cmd/agentcli/agent.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openziti/agent"
 	"github.com/openziti/channel/v4"
 	"github.com/openziti/identity"
+	"github.com/openziti/ziti/v2/common/agentid"
 	"github.com/openziti/ziti/v2/common/pb/mgmt_pb"
 	"github.com/openziti/ziti/v2/controller"
 	"github.com/openziti/ziti/v2/router"
@@ -22,6 +23,10 @@ import (
 type AgentAppId byte
 
 const (
+	// AgentAppAny targets an agent request at any ziti application, regardless
+	// of type. Use for operations that are not app-specific.
+	AgentAppAny = AgentAppId(agentid.AppIdAny)
+
 	AgentAppController = AgentAppId(controller.AgentAppId)
 	AgentAppRouter     = AgentAppId(router.AgentAppId)
 	AgentAppSdk        = AgentAppId(tunnelpkg.AgentAppId)
@@ -54,6 +59,8 @@ func NewAgentCmd(p common.OptionsProvider) *cobra.Command {
 		Aliases: []string{"c"},
 		Short:   "Interact with a ziti controller process using the IPC agent",
 	}
+
+	agentCmd.AddCommand(NewAgentInspectCmd(p))
 
 	agentCmd.AddCommand(ctrlCmd)
 	ctrlCmd.AddCommand(NewAgentSnapshotDb(p))

--- a/ziti/cmd/agentcli/agent_inspect.go
+++ b/ziti/cmd/agentcli/agent_inspect.go
@@ -1,0 +1,132 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package agentcli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/openziti/channel/v4"
+	"github.com/openziti/ziti/v2/common/agentid"
+	"github.com/openziti/ziti/v2/common/pb/ctrl_pb"
+	"github.com/openziti/ziti/v2/ziti/cmd/common"
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
+)
+
+// NewAgentInspectCmd creates an inspect command that works against any ziti component
+// (controller, router, or tunnel) by sending agentid.AppIdAny.
+func NewAgentInspectCmd(p common.OptionsProvider) *cobra.Command {
+	action := &agentInspectAction{
+		AgentOptions: AgentOptions{
+			CommonOptions: p(),
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:   "inspect <value> [values...]",
+		Short: "Inspect local runtime state of the target process",
+		Long: `Sends an inspect request directly to the target process via the agent IPC channel.
+This inspects only the local process, unlike 'ziti fabric inspect' which fans out through the controller.
+
+Common inspect keys for routers:
+  stackdump, links, config, metrics, sdk-terminators, ert-terminators,
+  router-circuits, router-data-model, router-controllers
+
+Common inspect keys for controllers:
+  stackdump, config, metrics, connected-routers, connected-peers,
+  cluster-config, router-messaging, terminator-costs, data-model-index
+
+Common inspect keys for tunnelers:
+  stackdump, sdk`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			action.Cmd = cmd
+			action.Args = args
+			return action.Run()
+		},
+	}
+
+	action.AddAgentOptions(cmd)
+	return cmd
+}
+
+type agentInspectAction struct {
+	AgentOptions
+}
+
+func (self *agentInspectAction) Run() error {
+	return self.MakeChannelRequest(agentid.AppIdAny, self.makeRequest)
+}
+
+func (self *agentInspectAction) makeRequest(ch channel.Channel) error {
+	request := &ctrl_pb.InspectRequest{
+		RequestedValues: self.Args,
+	}
+
+	body, err := proto.Marshal(request)
+	if err != nil {
+		return fmt.Errorf("failed to marshal inspect request: %w", err)
+	}
+
+	msg := channel.NewMessage(int32(ctrl_pb.ContentType_InspectRequestType), body)
+	reply, err := msg.WithTimeout(self.timeout).SendForReply(ch)
+	if err != nil {
+		return fmt.Errorf("failed to send inspect request: %w", err)
+	}
+
+	response := &ctrl_pb.InspectResponse{}
+	if err := proto.Unmarshal(reply.Body, response); err != nil {
+		return fmt.Errorf("failed to unmarshal inspect response: %w", err)
+	}
+
+	if !response.Success {
+		fmt.Println("Errors:")
+		for _, e := range response.Errors {
+			fmt.Printf("  %s\n", e)
+		}
+		return nil
+	}
+
+	for i, val := range response.Values {
+		if i > 0 {
+			fmt.Println()
+		}
+		fmt.Print(color.New(color.FgGreen, color.Bold).Sprintf("%s\n", val.Name))
+		prettyPrintValue(val.Value)
+	}
+
+	return nil
+}
+
+func prettyPrintValue(val string) {
+	// If it looks like JSON, pretty-print it
+	val = strings.TrimSpace(val)
+	if strings.HasPrefix(val, "{") || strings.HasPrefix(val, "[") {
+		var parsed interface{}
+		if err := json.Unmarshal([]byte(val), &parsed); err == nil {
+			if pretty, err := json.MarshalIndent(parsed, "", "  "); err == nil {
+				fmt.Println(string(pretty))
+				return
+			}
+		}
+	}
+	// Otherwise print as-is
+	fmt.Println(val)
+}

--- a/ziti/tunnel/agent.go
+++ b/ziti/tunnel/agent.go
@@ -19,12 +19,22 @@ package tunnel
 import (
 	"bufio"
 	"encoding/json"
+	"io"
 	"net"
+	"strings"
+	"time"
 
 	"github.com/michaelquigley/pfxlog"
-	"github.com/openziti/sdk-golang/inspect"
+	"github.com/openziti/channel/v4"
+	"github.com/openziti/foundation/v2/debugz"
+	"github.com/openziti/identity"
+	sdkInspect "github.com/openziti/sdk-golang/inspect"
 	"github.com/openziti/sdk-golang/ziti"
+	"github.com/openziti/ziti/v2/common/agentid"
+	"github.com/openziti/ziti/v2/common/pb/ctrl_pb"
 	cmap "github.com/orcaman/concurrent-map/v2"
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -41,7 +51,7 @@ func RegisterContext(name string, ctx ziti.Context) {
 func handleAgentDump(conn net.Conn) error {
 	c := bufio.NewReadWriter(bufio.NewReader(conn), bufio.NewWriter(conn))
 
-	var results []*inspect.ContextInspectResult
+	var results []*sdkInspect.ContextInspectResult
 	tunnelContexts.IterCb(func(key string, ctx ziti.Context) {
 		results = append(results, ctx.Inspect())
 	})
@@ -56,4 +66,79 @@ func handleAgentDump(conn net.Conn) error {
 	_, _ = c.Write(data)
 	_, _ = c.WriteString("\n")
 	return c.Flush()
+}
+
+// HandleAgentAsyncOp handles channel-based agent operations for the tunnel, enabling commands
+// like inspect that use typed protobuf messages.
+func HandleAgentAsyncOp(conn net.Conn) error {
+	appIdBuf := []byte{0}
+	if _, err := io.ReadFull(conn, appIdBuf); err != nil {
+		return err
+	}
+	appId := appIdBuf[0]
+
+	if appId != agentid.AppIdAny && appId != AgentAppId {
+		return errors.New("invalid operation for tunnel")
+	}
+
+	options := channel.DefaultOptions()
+	options.ConnectTimeout = time.Second
+	listener := channel.NewExistingConnListener(&identity.TokenId{Token: "tunnel"}, conn, nil)
+	_, err := channel.NewChannel("agent", listener, channel.BindHandlerF(bindAgentChannel), options)
+	return err
+}
+
+func bindAgentChannel(binding channel.Binding) error {
+	binding.AddReceiveHandlerF(int32(ctrl_pb.ContentType_InspectRequestType), handleAgentInspect)
+	return nil
+}
+
+func handleAgentInspect(m *channel.Message, ch channel.Channel) {
+	log := pfxlog.Logger()
+
+	request := &ctrl_pb.InspectRequest{}
+	if err := proto.Unmarshal(m.Body, request); err != nil {
+		log.WithError(err).Error("failed to unmarshal inspect request")
+		return
+	}
+
+	response := &ctrl_pb.InspectResponse{Success: true}
+
+	for _, requested := range request.RequestedValues {
+		lc := strings.ToLower(requested)
+		if lc == "stackdump" {
+			val := debugz.GenerateStack()
+			response.Values = append(response.Values, &ctrl_pb.InspectResponse_InspectValue{
+				Name:  requested,
+				Value: val,
+			})
+		} else if lc == "sdk" {
+			var results []*sdkInspect.ContextInspectResult
+			tunnelContexts.IterCb(func(key string, ctx ziti.Context) {
+				results = append(results, ctx.Inspect())
+			})
+			data, err := json.Marshal(results)
+			if err != nil {
+				response.Success = false
+				response.Errors = append(response.Errors, err.Error())
+			} else {
+				response.Values = append(response.Values, &ctrl_pb.InspectResponse_InspectValue{
+					Name:  requested,
+					Value: string(data),
+				})
+			}
+		}
+	}
+
+	body, err := proto.Marshal(response)
+	if err != nil {
+		log.WithError(err).Error("failed to marshal inspect response")
+		return
+	}
+
+	responseMsg := channel.NewMessage(int32(ctrl_pb.ContentType_InspectResponseType), body)
+	responseMsg.ReplyTo(m)
+	if err := ch.Send(responseMsg); err != nil {
+		log.WithError(err).Error("failed to send inspect response")
+	}
 }

--- a/ziti/tunnel/root.go
+++ b/ziti/tunnel/root.go
@@ -133,7 +133,8 @@ func rootPostRun(cmd *cobra.Command, _ []string) {
 			AppAlias:        cliAgentAlias,
 			AppType:         "tunnel",
 			CustomOps: map[byte]func(c net.Conn) error{
-				AgentDump: handleAgentDump,
+				AgentDump:           handleAgentDump,
+				agent.CustomOpAsync: HandleAgentAsyncOp,
 			},
 		})
 


### PR DESCRIPTION
- adds `ziti agent inspect <value>...` CLI that sends an InspectRequest directly to a ziti process over its agent IPC channel and pretty-prints JSON values in the response
- accepts app id 0 on controller and router agent channels so a single inspect command works against any process type
- adds Controller.agentOpInspect, backed by a new InspectionsManager.InspectLocal that runs inspect processing on the local controller only, without fanning out to routers or peer controllers
- extracts the router inspect handler into a new router/inspect package and stores a single shared instance on Router, reused by both the control channel and the agent IPC channel
- adds RouterEnv.GetInspectHandler and RouterEnv.GetXgressListeners so the control channel bind pulls the shared handler from env
- removes the now-redundant InspectRouterEnv interface from handler_ctrl/bind.go
- adds tunnel HandleAgentAsyncOp with support for stackdump and sdk inspect keys
