### PR TITLE
Fix memory leak caused by api session removed listeners never getting cleaned up. Fixes #3830

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1255,6 +1255,7 @@ be removed.
 
 * github.com/openziti/go-term-markdown: v1.0.1 (new)
 * github.com/openziti/ziti/v2: [v1.6.8 -> v2.0.0](https://github.com/openziti/ziti/compare/v1.6.8...v2.0.0)
+    * [Issue #3830](https://github.com/openziti/ziti/issues/3830) - statemanager is holding on to edge connections and they're never getting cleared
     * [Issue #3824](https://github.com/openziti/ziti/issues/3824) - Allow calling inspect using the IPC agent on the controller, router and go tunnel
     * [Issue #2049](https://github.com/openziti/ziti/issues/2049) - The ziti agent command should have a controller connection status
     * [Issue #3784](https://github.com/openziti/ziti/issues/3784) - Fix link registry race condition on reporting links on reconnect

--- a/router/xgress_edge/connections.go
+++ b/router/xgress_edge/connections.go
@@ -642,19 +642,27 @@ func (handler *sessionConnectionHandler) validateApiSession(binding channel.Bind
 	return errors.New("invalid client certificate for api session")
 }
 
-// completeBinding finalizes the connection setup after successful validation by registering
-// the connection for lifecycle management. This includes setting up cleanup handlers for
-// API session removal, adding the connection to active tracking systems, and ensuring
-// proper cleanup coordination to prevent resource leaks.
+// completeBinding finalizes the connection setup after successful validation. For legacy
+// (controller-synchronized) API sessions, it registers a listener that closes the channel
+// when the controller notifies the router of session removal. The RemoveListener is stored
+// on edgeConn so that HandleClose can unregister it; without that, the listener closure
+// pins the channel (and transitively the whole edgeClientConn graph) in the state manager's
+// event emitter for the lifetime of the router process.
+//
+// For OIDC sessions no listener is registered: the EventRemovedApiSession event is only
+// emitted from RemoveLegacyApiSession, so the callback would never fire for a JWT token.
 //
 // Parameters:
 //   - binding: The validated channel binding to complete setup for
 //   - edgeConn: The validated edgeClientConn to register for operation
 func (handler *sessionConnectionHandler) completeBinding(binding channel.Binding, edgeConn *edgeClientConn) {
-	ch := binding.GetChannel()
 	apiSession := edgeConn.apiSessionToken
+	if apiSession.IsOidc() {
+		return
+	}
 
-	_ = handler.stateManager.AddApiSessionRemovedListener(apiSession, func(_ *state.ApiSessionToken) {
+	ch := binding.GetChannel()
+	edgeConn.removeApiSessionListener = handler.stateManager.AddApiSessionRemovedListener(apiSession, func(_ *state.ApiSessionToken) {
 		if !ch.IsClosed() {
 			if err := ch.Close(); err != nil {
 				pfxlog.Logger().WithError(err).Error("could not close channel during api session removal")

--- a/router/xgress_edge/listener.go
+++ b/router/xgress_edge/listener.go
@@ -393,6 +393,11 @@ type edgeClientConn struct {
 	forwarder       env.Forwarder
 	xgCircuits      cmap.ConcurrentMap[string, *xgEdgeForwarder]
 
+	// removeApiSessionListener removes the legacy api-session-removed listener registered in completeBinding.
+	// Nil for OIDC sessions (no listener is registered for them). Must be called from HandleClose to avoid
+	// pinning the channel via the listener closure on the state manager's event emitter.
+	removeApiSessionListener state.RemoveListener
+
 	stateListener struct {
 		sync.Mutex
 		enabled      atomic.Bool
@@ -580,6 +585,9 @@ func (self *edgeClientConn) HandleClose(ch channel.Channel) {
 	self.msgMux.Close()
 	self.cleanupXgressCircuits()
 	self.listener.factory.stateManager.RouterDataModel().UnsubscribeFromIdentityChanges(self.getIdentityId(), self)
+	if self.removeApiSessionListener != nil {
+		self.removeApiSessionListener()
+	}
 }
 
 func (self *edgeClientConn) cleanupXgressCircuits() {


### PR DESCRIPTION
- Also don't add api session removed listener for oidc sessions
