### PR TITLE
Allow defining spa on any path and support multiple spa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,37 @@ Since we already have a breaking change, we're removing some other backwards com
     * The integer form was an undocumented side effect of the internal storage format and never worked with the documented filter names
     * Github tracking issue: https://github.com/openziti/ziti/issues/3818
 
+### Generic SPA Hosting
+
+The controller's web layer now supports hosting arbitrary single-page applications via a generic
+`binding: spa` API. Each `binding: spa` entry takes a `path` (which becomes the URL context root) and
+a `location` (the directory to serve). Multiple SPAs can be registered side by side at different
+context roots. Example:
+
+```yaml
+- binding: spa
+  options:
+    path: zac
+    location: /opt/openziti/share/console
+    indexFile: index.html
+- binding: spa
+  options:
+    path: my-app
+    location: /opt/my-app
+    indexFile: index.html
+```
+
+The previous `binding: zac` is preserved as a back-compat shim and continues to work without
+modification, but emits a deprecation warning at startup. New deployments should prefer
+`binding: spa` with an explicit `path`. The legacy shim retains a global `/assets/*` URL capture so
+ZAC bundles built with absolute asset paths keep working; new SPAs bound via `binding: spa` are
+expected to use relative URLs (or be built with `<base href>` matching their `path`).
+
+The SPA file-serving handler also gained defense-in-depth path-traversal checks (boundary-aware
+prefix matching plus a `filepath.Rel`-based containment check on every served file) so that a
+crafted URL cannot escape the configured `location` even if the standard library's own protections
+ever change.
+
 ### Legacy Session Deprecation
 
 OIDC sessions are now preferred. They are the default, or will become the default for SDKs and tunnelers. They are also required

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -370,8 +370,14 @@ func (c *Controller) initWeb() {
 		logrus.WithError(err).Fatalf("failed to create metrics api factory")
 	}
 
-	if err = c.xweb.GetRegistry().Add(webapis.NewZitiAdminConsoleFactory()); err != nil {
+	if err = c.xweb.GetRegistry().Add(webapis.NewSpaFactory()); err != nil {
 		logrus.WithError(err).Fatalf("failed to create single page application factory")
+	}
+
+	// Back-compat: preserve the legacy `binding: zac` so existing controller configs keep working.
+	// New configs should use `binding: spa` with an explicit `path`.
+	if err = c.xweb.GetRegistry().Add(webapis.NewZitiAdminConsoleFactory()); err != nil {
+		logrus.WithError(err).Fatalf("failed to create legacy ZAC factory")
 	}
 
 	if c.IsEdgeEnabled() {

--- a/controller/oidc_auth/parse.go
+++ b/controller/oidc_auth/parse.go
@@ -87,7 +87,7 @@ func mapToStruct(depth int, src map[string][]string, dst interface{}, translator
 	}
 
 	rv := reflect.ValueOf(dst)
-	if rv.Kind() != reflect.Ptr || rv.Elem().Kind() != reflect.Struct {
+	if rv.Kind() != reflect.Pointer || rv.Elem().Kind() != reflect.Struct {
 		return fmt.Errorf("expected a pointer to a struct")
 	}
 
@@ -124,7 +124,7 @@ func mapToStruct(depth int, src map[string][]string, dst interface{}, translator
 				return err
 			}
 			continue
-		} else if field.Kind() == reflect.Ptr && field.Type().Elem().Kind() == reflect.Struct {
+		} else if field.Kind() == reflect.Pointer && field.Type().Elem().Kind() == reflect.Struct {
 			var fieldPtr interface{}
 
 			newPaths := make([]string, len(paths))

--- a/controller/webapis/generic-http.go
+++ b/controller/webapis/generic-http.go
@@ -27,6 +27,10 @@ type GenericHttpHandler struct {
 	HttpHandler http.Handler
 	BindingKey  string
 	ContextRoot string
+	// ExtraPrefixes lets a SPA claim additional URL prefixes outside its context root.
+	// Used by the legacy ZAC handler to keep matching absolute "/assets" URLs from bundles
+	// that weren't built with a base href.
+	ExtraPrefixes []string
 }
 
 func (spa *GenericHttpHandler) Binding() string {
@@ -42,7 +46,28 @@ func (spa *GenericHttpHandler) RootPath() string {
 }
 
 func (spa *GenericHttpHandler) IsHandler(r *http.Request) bool {
-	return strings.HasPrefix(r.URL.Path, spa.ContextRoot) || strings.HasPrefix(r.URL.Path, "/assets")
+	if matchesPrefix(r.URL.Path, spa.ContextRoot) {
+		return true
+	}
+	for _, p := range spa.ExtraPrefixes {
+		if matchesPrefix(r.URL.Path, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchesPrefix returns true only if path is exactly prefix or prefix followed by '/'. This
+// prevents "/zac" from matching "/zacanything" or "/zac../foo", which would let a request
+// slip past the handler boundary check and into the SPA file resolution path.
+func matchesPrefix(path, prefix string) bool {
+	if path == prefix {
+		return true
+	}
+	if strings.HasPrefix(path, prefix+"/") {
+		return true
+	}
+	return false
 }
 
 func (spa *GenericHttpHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
@@ -60,24 +85,48 @@ type spaHandler struct {
 // Falls back to a supplied index (indexFile) when either condition is true:
 // (1) Request (file) path is not found
 // (2) Request path is a directory
+// (3) Resolved file path escapes the content root (defense in depth against directory traversal)
 // Otherwise serves the requested file.
 func (h *spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r.URL.Path = strings.TrimPrefix(r.URL.Path, h.contextRoot)
-	p := filepath.Join(h.content, filepath.Clean(r.URL.Path))
+	p := filepath.Join(h.content, filepath.Clean("/"+r.URL.Path))
+
+	indexPath := filepath.Join(h.content, h.indexFile)
+
+	if !pathContainedIn(p, h.content) {
+		http.ServeFile(w, r, indexPath)
+		return
+	}
 
 	if info, err := os.Stat(p); err != nil {
-		http.ServeFile(w, r, filepath.Join(h.content, h.indexFile))
+		http.ServeFile(w, r, indexPath)
 		return
 	} else if info.IsDir() {
-		http.ServeFile(w, r, filepath.Join(h.content, h.indexFile))
+		http.ServeFile(w, r, indexPath)
 		return
 	}
 
 	http.ServeFile(w, r, p)
 }
 
+// pathContainedIn returns true if candidate resolves to a path inside (or equal to) root. Both
+// inputs are cleaned and compared via filepath.Rel so we don't depend on lexical prefix tricks
+// or symlink-free assumptions. This is the canonical containment check that keeps SPA file
+// serving from escaping its configured location even if the URL routing layer ever lets a
+// path with traversal sequences through.
+func pathContainedIn(candidate, root string) bool {
+	rel, err := filepath.Rel(root, candidate)
+	if err != nil {
+		return false
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	return true
+}
+
 // SpaHandler returns a request handler (http.Handler) that serves a single
 // page application from a given public directory (location).
 func SpaHandler(location string, contextRoot string, indexFile string) http.Handler {
-	return &spaHandler{location, contextRoot, indexFile}
+	return &spaHandler{filepath.Clean(location), contextRoot, indexFile}
 }

--- a/controller/webapis/generic-http_test.go
+++ b/controller/webapis/generic-http_test.go
@@ -1,0 +1,125 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package webapis
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMatchesPrefix(t *testing.T) {
+	cases := []struct {
+		path, prefix string
+		want         bool
+	}{
+		{"/zac", "/zac", true},
+		{"/zac/", "/zac", true},
+		{"/zac/foo", "/zac", true},
+		{"/zac/foo/bar", "/zac", true},
+		{"/zacfoo", "/zac", false},
+		{"/zac../etc", "/zac", false},
+		{"/zac..", "/zac", false},
+		{"/", "/zac", false},
+		{"/other", "/zac", false},
+	}
+	for _, c := range cases {
+		if got := matchesPrefix(c.path, c.prefix); got != c.want {
+			t.Errorf("matchesPrefix(%q,%q)=%v want %v", c.path, c.prefix, got, c.want)
+		}
+	}
+}
+
+func TestPathContainedIn(t *testing.T) {
+	root := filepath.Clean("/srv/spa")
+	cases := []struct {
+		candidate string
+		want      bool
+	}{
+		{filepath.Clean("/srv/spa"), true},
+		{filepath.Clean("/srv/spa/index.html"), true},
+		{filepath.Clean("/srv/spa/sub/file"), true},
+		{filepath.Clean("/srv/spa/../escape"), false},
+		{filepath.Clean("/etc/passwd"), false},
+		{filepath.Clean("/srv/spa-evil/file"), false},
+	}
+	for _, c := range cases {
+		if got := pathContainedIn(c.candidate, root); got != c.want {
+			t.Errorf("pathContainedIn(%q,%q)=%v want %v", c.candidate, root, got, c.want)
+		}
+	}
+}
+
+// TestSpaHandlerNoTraversal exercises the full SPA file-serving pipeline against URLs that
+// attempt to escape the content directory. Any escape attempt must fall back to the index
+// file rather than serving content from outside the root.
+func TestSpaHandlerNoTraversal(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("INDEX"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "real.txt"), []byte("REAL"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	parent := filepath.Dir(dir)
+	secret := filepath.Join(parent, "secret.txt")
+	if err := os.WriteFile(secret, []byte("SECRET"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Remove(secret) })
+
+	h := SpaHandler(dir, "/zac", "index.html")
+
+	serve := func(rawPath string) (int, string) {
+		req := httptest.NewRequest(http.MethodGet, "http://example.test"+rawPath, nil)
+		req.URL.Path = rawPath
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		return rr.Code, rr.Body.String()
+	}
+
+	type expect int
+	const (
+		expectExact expect = iota
+		expectNoLeak
+	)
+	cases := []struct {
+		name string
+		path string
+		mode expect
+		body string
+	}{
+		{"happy path", "/zac/real.txt", expectExact, "REAL"},
+		{"missing file falls back to index", "/zac/missing", expectExact, "INDEX"},
+		{"traversal via dotdot does not leak", "/zac/../secret.txt", expectNoLeak, ""},
+		{"deep traversal does not leak", "/zac/a/b/../../../secret.txt", expectNoLeak, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			code, body := serve(c.path)
+			if body == "SECRET" {
+				t.Fatalf("LEAKED secret via %s (status %d)", c.path, code)
+			}
+			if c.mode == expectExact && body != c.body {
+				t.Errorf("path %s: got body %q want %q (status %d)", c.path, body, c.body, code)
+			}
+		})
+	}
+}

--- a/controller/webapis/spa.go
+++ b/controller/webapis/spa.go
@@ -1,0 +1,98 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package webapis
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/openziti/xweb/v3"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	SpaBinding = "spa"
+)
+
+type SpaFactory struct {
+}
+
+var _ xweb.ApiHandlerFactory = &SpaFactory{}
+
+func NewSpaFactory() *SpaFactory {
+	return &SpaFactory{}
+}
+
+func (factory *SpaFactory) Validate(*xweb.InstanceConfig) error {
+	return nil
+}
+
+func (factory *SpaFactory) Binding() string {
+	return SpaBinding
+}
+
+func (factory *SpaFactory) New(_ *xweb.ServerConfig, options map[interface{}]interface{}) (xweb.ApiHandler, error) {
+	urlPath, err := requiredStringOption(options, "path")
+	if err != nil {
+		return nil, err
+	}
+	if strings.ContainsAny(urlPath, "/\\") {
+		return nil, fmt.Errorf("path must not contain path separators in the %s options", SpaBinding)
+	}
+
+	location, err := requiredStringOption(options, "location")
+	if err != nil {
+		return nil, err
+	}
+
+	indexFile := "index.html"
+	if v, ok := options["indexFile"]; ok && v != nil {
+		s, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("indexFile must be a string for the %s options", SpaBinding)
+		}
+		if s = strings.TrimSpace(s); s != "" {
+			indexFile = s
+		}
+	}
+
+	contextRoot := "/" + urlPath
+	handler := &GenericHttpHandler{
+		HttpHandler: SpaHandler(location, contextRoot, indexFile),
+		BindingKey:  urlPath,
+		ContextRoot: contextRoot,
+	}
+
+	log.Infof("initializing SPA handler %q from %s", urlPath, location)
+	return handler, nil
+}
+
+func requiredStringOption(options map[interface{}]interface{}, key string) (string, error) {
+	v, ok := options[key]
+	if !ok || v == nil || v == "" {
+		return "", fmt.Errorf("%s must be supplied in the %s options", key, SpaBinding)
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", fmt.Errorf("%s must be a string for the %s options", key, SpaBinding)
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", fmt.Errorf("%s must not be empty in the %s options", key, SpaBinding)
+	}
+	return s, nil
+}

--- a/controller/webapis/zac.go
+++ b/controller/webapis/zac.go
@@ -17,70 +17,56 @@
 package webapis
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/openziti/xweb/v3"
 	log "github.com/sirupsen/logrus"
 )
 
-const (
-	Binding = "zac"
-)
+// LegacyZacBinding is the historical binding name for the Ziti Admin Console SPA. It is kept
+// as a back-compat shim so existing controller configs using `binding: zac` continue to load
+// without modification. New configs should prefer `binding: spa` with an explicit `path`.
+const LegacyZacBinding = "zac"
 
 type ZitiAdminConsoleFactory struct {
+	delegate *SpaFactory
 }
 
 var _ xweb.ApiHandlerFactory = &ZitiAdminConsoleFactory{}
 
 func NewZitiAdminConsoleFactory() *ZitiAdminConsoleFactory {
-	return &ZitiAdminConsoleFactory{}
+	return &ZitiAdminConsoleFactory{delegate: NewSpaFactory()}
 }
 
-func (factory *ZitiAdminConsoleFactory) Validate(*xweb.InstanceConfig) error {
-	return nil
+func (factory *ZitiAdminConsoleFactory) Validate(c *xweb.InstanceConfig) error {
+	return factory.delegate.Validate(c)
 }
 
 func (factory *ZitiAdminConsoleFactory) Binding() string {
-	return Binding
+	return LegacyZacBinding
 }
 
-func (factory *ZitiAdminConsoleFactory) New(_ *xweb.ServerConfig, options map[interface{}]interface{}) (xweb.ApiHandler, error) {
-	locVal := options["location"]
-	if locVal == nil || locVal == "" {
-		return nil, fmt.Errorf("location must be supplied in the %s options", Binding)
+func (factory *ZitiAdminConsoleFactory) New(serverConfig *xweb.ServerConfig, options map[interface{}]interface{}) (xweb.ApiHandler, error) {
+	log.Warnf("the %q binding is deprecated; switch to `binding: spa` with `path: zac` in your controller config", LegacyZacBinding)
+
+	// Inject the implicit path = "zac" so the generic SPA factory produces the same /zac context root
+	// the original ZAC handler used. We copy to avoid mutating the caller's map.
+	merged := make(map[interface{}]interface{}, len(options)+1)
+	for k, v := range options {
+		merged[k] = v
+	}
+	if _, hasPath := merged["path"]; !hasPath {
+		merged["path"] = LegacyZacBinding
 	}
 
-	loc, ok := locVal.(string)
-
-	if !ok {
-		return nil, fmt.Errorf("location must be a string for the %s options", Binding)
+	handler, err := factory.delegate.New(serverConfig, merged)
+	if err != nil {
+		return nil, err
 	}
 
-	indexFileVal := options["indexFile"]
-	indexFile := "index.html"
-
-	if indexFileVal != nil {
-		newFileVal, ok := indexFileVal.(string)
-
-		if !ok {
-			return nil, fmt.Errorf("indexFile must be a string for the %s options", Binding)
-		}
-
-		newFileVal = strings.TrimSpace(newFileVal)
-
-		if newFileVal != "" {
-			indexFile = newFileVal
-		}
+	// Preserve the historical behavior where the ZAC handler also matched absolute "/assets/*"
+	// URLs, since the original ZAC bundle was not built with a base href.
+	if generic, ok := handler.(*GenericHttpHandler); ok {
+		generic.ExtraPrefixes = append(generic.ExtraPrefixes, "/assets")
 	}
 
-	contextRoot := "/" + Binding
-	spa := &GenericHttpHandler{
-		HttpHandler: SpaHandler(loc, contextRoot, indexFile),
-		BindingKey:  Binding,
-		ContextRoot: contextRoot,
-	}
-
-	log.Infof("initializing ZAC SPA Handler from %s", locVal)
-	return spa, nil
+	return handler, nil
 }

--- a/router/posture/checks.go
+++ b/router/posture/checks.go
@@ -2,6 +2,7 @@ package posture
 
 import (
 	"bytes"
+	"slices"
 	"sync"
 	"time"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/openziti/ziti/v2/common"
 	"github.com/openziti/ziti/v2/common/pb/edge_ctrl_pb"
 	cmap "github.com/orcaman/concurrent-map/v2"
-	"golang.org/x/exp/slices"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/tests/cli_tests/cli_test.go
+++ b/tests/cli_tests/cli_test.go
@@ -217,7 +217,7 @@ func Test_CLI_Test_Suite(t *testing.T) {
 	s.controllerUnderTest.NetworkDialingIdFile = s.externalZiti.NetworkDialingIdFile
 	s.controllerUnderTest.NetworkBindingIdFile = s.externalZiti.NetworkBindingIdFile
 
-	s.controllerUnderTest.ConfigFile = gopath.Join(s.controllerUnderTest.Home, s.controllerUnderTest.InstanceID, "ctrl.yaml")
+	s.controllerUnderTest.ConfigFile = gopath.Join(s.controllerUnderTest.Home, "ctrl.yaml")
 	newServerCertPath := gopath.Join(s.controllerUnderTest.Home, "pki/intermediate-ca-"+s.controllerUnderTest.TrustDomain+"/certs/mgmt.ziti.chain.pem")
 	if re := s.controllerUnderTest.ReplaceConfig(newServerCertPath); re != nil {
 		t.Fatalf("failed to replace config: %v", re)

--- a/tests/cli_tests/cli_test.go
+++ b/tests/cli_tests/cli_test.go
@@ -217,7 +217,7 @@ func Test_CLI_Test_Suite(t *testing.T) {
 	s.controllerUnderTest.NetworkDialingIdFile = s.externalZiti.NetworkDialingIdFile
 	s.controllerUnderTest.NetworkBindingIdFile = s.externalZiti.NetworkBindingIdFile
 
-	s.controllerUnderTest.ConfigFile = gopath.Join(s.controllerUnderTest.Home, "ctrl.yaml")
+	s.controllerUnderTest.ConfigFile = gopath.Join(s.controllerUnderTest.Home, s.controllerUnderTest.InstanceID, "ctrl.yaml")
 	newServerCertPath := gopath.Join(s.controllerUnderTest.Home, "pki/intermediate-ca-"+s.controllerUnderTest.TrustDomain+"/certs/mgmt.ziti.chain.pem")
 	if re := s.controllerUnderTest.ReplaceConfig(newServerCertPath); re != nil {
 		t.Fatalf("failed to replace config: %v", re)

--- a/tests/entities.go
+++ b/tests/entities.go
@@ -962,11 +962,11 @@ func copyRestModelFields(source, dest interface{}, ctx *TestContext) {
 	destVal := reflect.ValueOf(dest)
 
 	// Dereference pointers
-	if srcVal.Kind() == reflect.Ptr {
+	if srcVal.Kind() == reflect.Pointer {
 		srcVal = srcVal.Elem()
 	}
 
-	if destVal.Kind() == reflect.Ptr {
+	if destVal.Kind() == reflect.Pointer {
 		destVal = destVal.Elem()
 	}
 

--- a/ziti/cmd/ascode/exporter/exporter_posture_checks.go
+++ b/ziti/cmd/ascode/exporter/exporter_posture_checks.go
@@ -17,8 +17,9 @@
 package exporter
 
 import (
+	"slices"
+
 	"github.com/openziti/edge-api/rest_management_api_client/posture_checks"
-	"golang.org/x/exp/slices"
 )
 
 func (exporter Exporter) IsPostureCheckExportRequired(args []string) bool {

--- a/ziti/cmd/create/config_templates/controller.yml
+++ b/ziti/cmd/create/config_templates/controller.yml
@@ -226,7 +226,8 @@ web:
         options: { }
       - binding: edge-oidc
         options: { }
-      {{ if not .Controller.Web.BindPoints.Console.Enabled }}#{{- end }}- binding: zac
+      {{ if not .Controller.Web.BindPoints.Console.Enabled }}#{{- end }}- binding: spa
       {{ if not .Controller.Web.BindPoints.Console.Enabled }}#{{- end }}  options:
+      {{ if not .Controller.Web.BindPoints.Console.Enabled }}#{{- end }}    path: zac
       {{ if not .Controller.Web.BindPoints.Console.Enabled }}#{{- end }}    location: {{ .Controller.Web.BindPoints.Console.Location }}
       {{ if not .Controller.Web.BindPoints.Console.Enabled }}#{{- end }}    indexFile: index.html

--- a/ziti/run/quickstart.go
+++ b/ziti/run/quickstart.go
@@ -117,7 +117,7 @@ func NewQuickStartCmd(out io.Writer, errOut io.Writer, context context.Context) 
 				options.TrustDomain = "quickstart"
 			}
 			if options.InstanceID == "" {
-				options.InstanceID = "quickstart"
+				options.InstanceID = "instance-1"
 			}
 			return options.run(context)
 		},
@@ -732,10 +732,7 @@ func (o *QuickstartOpts) scopedName(name string) string {
 }
 
 func (o *QuickstartOpts) instHome() string {
-	if o.joinCommand {
-		return path.Join(o.Home, o.InstanceID)
-	}
-	return o.Home
+	return path.Join(o.Home, o.InstanceID)
 }
 
 func (o *QuickstartOpts) configureOverlay() error {

--- a/ziti/run/quickstart.go
+++ b/ziti/run/quickstart.go
@@ -732,7 +732,10 @@ func (o *QuickstartOpts) scopedName(name string) string {
 }
 
 func (o *QuickstartOpts) instHome() string {
-	return path.Join(o.Home, o.InstanceID)
+	if o.joinCommand {
+		return path.Join(o.Home, o.InstanceID)
+	}
+	return o.Home
 }
 
 func (o *QuickstartOpts) configureOverlay() error {


### PR DESCRIPTION
When the zac SPA binding was created i didn't find a way to allow surfacing any SPA on any path but trying again it's doable.

This pr allows the controller to host any SPAs, opening the door to not only the ZAC but also docs as well or other projects/products as well. Having the docs on the same controller could allow us to do more interesting things with the docs as well such as authenticating then using the API, linking from the doc to the ZAC (and back) etc. 