### PR TITLE
fixes #3809 support CSR submission during OIDC authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,7 @@ when running HA. Legacy API and service session are now deprecated and will be r
   cluster-ready. If you have scripts passing `--clustered`, remove it.
 * [Connect events pool](#connect-events-pool) - fixes a goroutine leak when routers reconnect and ensures per-router event ordering
 * [Multiple DNS upstreams](#multiple-dns-upstreams) - the tunneler can now fan out recursive queries to several upstream resolvers in parallel
+* [OIDC CSR authentication](#oidc-csr-authentication) - identities can submit a CSR during OIDC authentication to obtain a session-bound certificate for mTLS channel communication
 
 ## OIDC Discovery Endpoint Extensions
 
@@ -194,6 +195,84 @@ The field contains absolute URLs for each endpoint, derived from the issuer the 
 
 When the controller serves edge-oidc on multiple web servers, each discovery response reflects
 the issuer (and port) the client connected to.
+
+## OIDC CSR Authentication
+
+Identities that authenticate via non-certificate methods (password, external JWT) can now submit
+a CSR during OIDC authentication to obtain a session-bound certificate. This enables mTLS channel
+communication with edge routers for identities that would otherwise have no client certificate.
+
+Certificate-authenticated identities can also submit a CSR to obtain an additional session
+certificate alongside their authenticating certificate.
+
+### How It Works
+
+A CSR is submitted as part of the OIDC login credentials. The controller signs it and returns
+the certificate PEM as a `session_cert` field in the token endpoint JSON response:
+
+```json
+{
+  "access_token": "eyJ...",
+  "token_type": "bearer",
+  "refresh_token": "eyJ...",
+  "id_token": "eyJ...",
+  "expires_in": 1800,
+  "session_cert": "-----BEGIN CERTIFICATE-----\nMII..."
+}
+```
+
+The issued certificate contains a SPIFFE ID binding it to the identity and API session:
+```
+spiffe://{trustDomain}/identity/{identityId}/apiSession/{apiSessionId}/apiSessionCertificate/{certId}
+```
+
+### CSR Submission Points
+
+| Token Endpoint Grant Type | CSR Source                            | Use Case             |
+|---------------------------|---------------------------------------|----------------------|
+| Authorization Code        | `csrPem` field in login POST body     | Initial cert issue   |
+| Refresh Token             | `csr_pem` form parameter              | Cert rotation        |
+| Token Exchange            | `csr_pem` form parameter              | Cert rotation        |
+
+### Certificate Fingerprint Claims
+
+The access token JWT includes two related claims:
+
+- `z_cfs` (CertFingerprints): all certificate fingerprints valid for this session. Contains the
+  authenticating cert fingerprint (for cert auth) and/or the CSR-issued session cert fingerprint.
+- `z_acf` (AuthCertFingerprint): the authenticating certificate fingerprint, present only for
+  certificate-authenticated sessions.
+
+On cert rotation via refresh or token exchange, `z_cfs` is rebuilt as the auth cert fingerprint
+(if present) plus the new CSR cert fingerprint. The previous session cert fingerprint is replaced.
+
+### Certificate Binding Verification
+
+When a token carries `z_cfs`, the controller enforces certificate binding on the refresh token
+and token exchange endpoints:
+
+- If `z_cfs` is non-empty, the TLS leaf certificate must match at least one fingerprint in
+  `z_cfs`. Requests without a matching certificate are rejected.
+- If `z_cfs` is empty, the controller falls back to SPIFFE ID verification, checking whether
+  the leaf certificate's SAN URI references the correct API session.
+
+A session that starts without `z_cfs` can transition to having it by submitting a CSR during
+a refresh. Once `z_cfs` is present, it cannot be removed.
+
+### Controller Capability
+
+Controllers advertise `OIDC_AUTH_WITH_CSR` in the `/version` capabilities list when OIDC is
+enabled. SDKs can check for this capability before attempting CSR submission.
+
+### Requirements
+
+- The CSR must be a valid PEM-encoded PKCS#10 certificate request. Invalid CSRs are rejected
+  with a 400 Bad Request error in OIDC error format.
+- The controller only uses the public key from the CSR. Subject, DNS names, IP addresses,
+  email addresses, and URI SANs in the CSR are ignored.
+- Issued certificates have a one-year lifetime.
+- Only the leaf certificate fingerprint is tracked in token claims. Intermediate certificates
+  in the TLS chain are not considered.
 
 ## Connect Events Pool
 

--- a/common/cert/cert.go
+++ b/common/cert/cert.go
@@ -21,6 +21,7 @@ import (
 	"crypto"
 	"crypto/rand"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -55,6 +56,8 @@ type SigningOpts struct {
 
 	NotBefore *time.Time
 	NotAfter  *time.Time
+
+	Subject *pkix.Name
 }
 
 func (so *SigningOpts) Apply(c *x509.Certificate) {
@@ -69,6 +72,10 @@ func (so *SigningOpts) Apply(c *x509.Certificate) {
 
 	if so.NotAfter != nil {
 		c.NotAfter = *so.NotAfter
+	}
+
+	if so.Subject != nil {
+		c.Subject = *so.Subject
 	}
 }
 

--- a/common/oidc_tokens.go
+++ b/common/oidc_tokens.go
@@ -72,6 +72,7 @@ type CustomClaims struct {
 	ApplicationId           string              `json:"z_aid,omitempty"`
 	Type                    string              `json:"z_t"`
 	CertFingerprints        []string            `json:"z_cfs"`
+	AuthCertFingerprint     string              `json:"z_acf,omitempty"`
 	Scopes                  []string            `json:"scopes,omitempty"`
 	SdkInfo                 *rest_model.SdkInfo `json:"z_sdk"`
 	EnvInfo                 *rest_model.EnvInfo `json:"z_env"`

--- a/controller/event/api_session.go
+++ b/controller/event/api_session.go
@@ -79,11 +79,14 @@ type ApiSessionEvent struct {
 
 	// The IP address from which the identity to connected to require the api session.
 	IpAddress string `json:"ip_address"`
+
+	// CertGenerated is true when a certificate was generated from a CSR during authentication.
+	CertGenerated bool `json:"cert_generate"`
 }
 
 func (event *ApiSessionEvent) String() string {
-	return fmt.Sprintf("%v.%v id=%v timestamp=%v token=%v identityId=%v ipAddress=%v",
-		event.Namespace, event.EventType, event.Id, event.Timestamp, event.Token, event.IdentityId, event.IpAddress)
+	return fmt.Sprintf("%v.%v id=%v timestamp=%v token=%v identityId=%v ipAddress=%v certGenerated=%v",
+		event.Namespace, event.EventType, event.Id, event.Timestamp, event.Token, event.IdentityId, event.IpAddress, event.CertGenerated)
 }
 
 type ApiSessionEventHandler interface {

--- a/controller/event/api_session.go
+++ b/controller/event/api_session.go
@@ -81,7 +81,7 @@ type ApiSessionEvent struct {
 	IpAddress string `json:"ip_address"`
 
 	// CertGenerated is true when a certificate was generated from a CSR during authentication.
-	CertGenerated bool `json:"cert_generate"`
+	CertGenerated bool `json:"cert_generated"`
 }
 
 func (event *ApiSessionEvent) String() string {

--- a/controller/internal/routes/version_router.go
+++ b/controller/internal/routes/version_router.go
@@ -150,7 +150,7 @@ func (ir *VersionRouter) buildVersions(ae *env.AppEnv) *rest_model.Version {
 
 	if oidcEnabled {
 		v.Capabilities = append(v.Capabilities, string(rest_model.CapabilitiesOIDCAUTH))
-		v.Capabilities = append(v.Capabilities, "OIDC_AUTH_WITH_CSR")
+		v.Capabilities = append(v.Capabilities, string(rest_model.CapabilitiesOIDCAUTHWITHCSR))
 	}
 
 	if ae.HostController.IsRaftEnabled() {
@@ -164,15 +164,11 @@ func (ir *VersionRouter) Shutdown(ae *env.AppEnv) {
 	ir.versionCache.Delete(ae.InstanceId)
 }
 
-// CapabilityOidcAuthWithCsr is the capability string advertised when the controller
-// supports CSR submission during OIDC authentication for session-bound certificates.
-const CapabilityOidcAuthWithCsr = "OIDC_AUTH_WITH_CSR"
-
 func (ir *VersionRouter) ListCapabilities(_ *env.AppEnv, rc *response.RequestContext) {
 	capabilities := []rest_model.Capabilities{
 		rest_model.CapabilitiesOIDCAUTH,
 		rest_model.CapabilitiesHACONTROLLER,
-		CapabilityOidcAuthWithCsr,
+		rest_model.CapabilitiesOIDCAUTHWITHCSR,
 	}
 
 	rc.RespondWithOk(capabilities, &rest_model.Meta{})

--- a/controller/internal/routes/version_router.go
+++ b/controller/internal/routes/version_router.go
@@ -150,6 +150,7 @@ func (ir *VersionRouter) buildVersions(ae *env.AppEnv) *rest_model.Version {
 
 	if oidcEnabled {
 		v.Capabilities = append(v.Capabilities, string(rest_model.CapabilitiesOIDCAUTH))
+		v.Capabilities = append(v.Capabilities, "OIDC_AUTH_WITH_CSR")
 	}
 
 	if ae.HostController.IsRaftEnabled() {
@@ -163,10 +164,15 @@ func (ir *VersionRouter) Shutdown(ae *env.AppEnv) {
 	ir.versionCache.Delete(ae.InstanceId)
 }
 
+// CapabilityOidcAuthWithCsr is the capability string advertised when the controller
+// supports CSR submission during OIDC authentication for session-bound certificates.
+const CapabilityOidcAuthWithCsr = "OIDC_AUTH_WITH_CSR"
+
 func (ir *VersionRouter) ListCapabilities(_ *env.AppEnv, rc *response.RequestContext) {
 	capabilities := []rest_model.Capabilities{
 		rest_model.CapabilitiesOIDCAUTH,
 		rest_model.CapabilitiesHACONTROLLER,
+		CapabilityOidcAuthWithCsr,
 	}
 
 	rc.RespondWithOk(capabilities, &rest_model.Meta{})

--- a/controller/model/api_session_certificate_manager.go
+++ b/controller/model/api_session_certificate_manager.go
@@ -18,6 +18,7 @@ package model
 
 import (
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"fmt"
 	"net/url"
 	"time"
@@ -80,6 +81,7 @@ func (self *ApiSessionCertificateManager) CreateFromCSR(identity *Identity, apiS
 		URIs: []*url.URL{
 			spiffeId,
 		},
+		Subject: &pkix.Name{CommonName: identity.Id},
 	})
 
 	if err != nil {

--- a/controller/oidc_auth/ctx.go
+++ b/controller/oidc_auth/ctx.go
@@ -54,9 +54,39 @@ func NewHttpChangeCtx(r *http.Request) *change.Context {
 	return ctx
 }
 
+// TokenState carries per-request token state through the OIDC context. It is created at the
+// start of each OIDC HTTP request (see provider.go) and is shared between the zitadel library
+// callbacks and our server method overrides.
+//
+// The zitadel library's token creation flow works in two phases:
+//  1. Storage callbacks (CreateAccessToken / CreateAccessAndRefreshTokens) build the claim data
+//     and store it on AccessClaims / RefreshClaims.
+//  2. Library functions (CreateJWT, CreateIDToken) read back those claims via
+//     GetPrivateClaimsFromScopes and SetUserinfoFromRequest to produce the final JWTs.
+//
+// TokenState bridges these phases. It also carries CSR data submitted at the token endpoint
+// through to createAccessToken (where the signing happens), and carries the resulting
+// certificate PEM back out to the server method override (where it is added to the JSON
+// response).
 type TokenState struct {
-	AccessClaims  *common.AccessClaims
+	// AccessClaims holds the custom claims produced by createAccessToken. Read by
+	// getPrivateClaims to populate the access token JWT.
+	AccessClaims *common.AccessClaims
+
+	// RefreshClaims holds the refresh token claims produced alongside the access token.
 	RefreshClaims *common.RefreshClaims
+
+	// CsrPem holds an optional CSR submitted as a form parameter on the token endpoint
+	// (refresh or token exchange). Read by createAccessToken to sign and produce a
+	// session-bound certificate. For the initial code exchange path, the CSR is carried
+	// on the AuthRequest instead.
+	CsrPem string
+
+	// SessionCertPem holds the PEM certificate chain produced by signing a CSR. Set by
+	// createAccessToken and read by the server method overrides (CodeExchange, RefreshToken,
+	// TokenExchange) to include as a top-level "session_cert" field in the token endpoint
+	// JSON response.
+	SessionCertPem string
 }
 
 func TokenStateFromContext(ctx context.Context) (*TokenState, error) {

--- a/controller/oidc_auth/login.go
+++ b/controller/oidc_auth/login.go
@@ -357,6 +357,10 @@ func (l *login) authenticate(w http.ResponseWriter, r *http.Request) {
 	authRequest.EnvInfo = credentials.EnvInfo
 	authRequest.AuthTime = time.Now()
 
+	if credentials.CsrPem != "" {
+		authRequest.CsrPem = credentials.CsrPem
+	}
+
 	if authRequest.SecondaryExtJwtSigner != nil {
 
 		secondaryJwtResult, secondaryJwtErr := l.store.ProcessSecondaryJwts(r, authRequest, securityTokenCtx)

--- a/controller/oidc_auth/parse.go
+++ b/controller/oidc_auth/parse.go
@@ -37,6 +37,7 @@ type TotpRequestBody struct {
 type OidcUpdbCreds struct {
 	rest_model.Authenticate
 	AuthRequestBody
+	CsrPem string `json:"csrPem"`
 }
 
 func (u *OidcUpdbCreds) Translate(in string, paths ...string) (string, bool) {

--- a/controller/oidc_auth/parse_test.go
+++ b/controller/oidc_auth/parse_test.go
@@ -100,6 +100,26 @@ func Test_Map(t *testing.T) {
 		req.Equal(dst.ConfigTypes[1], configType2)
 	})
 
+	t.Run("csrPem field is populated", func(t *testing.T) {
+		const csrPem = "-----BEGIN CERTIFICATE REQUEST-----\nfake\n-----END CERTIFICATE REQUEST-----"
+
+		srcMap := map[string][]string{
+			"id":       {"req-1"},
+			"csrPem":   {csrPem},
+			"username": {"admin"},
+			"password": {"pass"},
+		}
+
+		dst := &OidcUpdbCreds{}
+		err := MapToStruct(srcMap, dst)
+
+		req := require.New(t)
+		req.NoError(err)
+		req.Equal("req-1", dst.AuthRequestId)
+		req.Equal(csrPem, dst.CsrPem)
+		req.Equal("admin", string(dst.Username))
+	})
+
 	// test - operator
 	// test nil translator
 	// test bad field names in translator

--- a/controller/oidc_auth/requests.go
+++ b/controller/oidc_auth/requests.go
@@ -186,8 +186,10 @@ func (a *AuthRequest) Done() bool {
 	return a.HasFullAuth()
 }
 
-// GetCertFingerprint returns the SHA-1 fingerprint of the leaf peer certificate (index 0).
-// Returns an empty string if no peer certificates are present.
+// GetCertFingerprint returns the SHA-1 fingerprint of the leaf peer certificate,
+// or an empty string if no peer certificates are present. Only the leaf is
+// returned so that z_cfs binds proof-of-possession to the auth cert and not to
+// incidental intermediates the client may have presented on the TLS chain.
 func (a *AuthRequest) GetCertFingerprint() string {
 	if len(a.PeerCerts) == 0 {
 		return ""

--- a/controller/oidc_auth/requests.go
+++ b/controller/oidc_auth/requests.go
@@ -56,6 +56,7 @@ type AuthRequest struct {
 	IsCertKeyRollRequested  bool
 	AuthenticatorId         string
 	ImproperClientCertChain bool
+	CsrPem                  string
 }
 
 // GetID returns an AuthRequest's ID and implements op.AuthRequest
@@ -185,14 +186,13 @@ func (a *AuthRequest) Done() bool {
 	return a.HasFullAuth()
 }
 
-func (a *AuthRequest) GetCertFingerprints() []string {
-	var prints []string
-
-	for _, cert := range a.PeerCerts {
-		prints = append(prints, fmt.Sprintf("%x", sha1.Sum(cert.Raw)))
+// GetCertFingerprint returns the SHA-1 fingerprint of the leaf peer certificate (index 0).
+// Returns an empty string if no peer certificates are present.
+func (a *AuthRequest) GetCertFingerprint() string {
+	if len(a.PeerCerts) == 0 {
+		return ""
 	}
-
-	return prints
+	return fmt.Sprintf("%x", sha1.Sum(a.PeerCerts[0].Raw))
 }
 
 func (a *AuthRequest) NeedsTotp() bool {

--- a/controller/oidc_auth/server.go
+++ b/controller/oidc_auth/server.go
@@ -212,24 +212,29 @@ func (s *server) RefreshToken(ctx context.Context, r *op.ClientRequest[oidc.Refr
 		return nil, err
 	}
 
-	// Cert-binding verification: the TLS peer cert must match the token's cert fingerprints
-	// or SPIFFE ID. This prevents use of stolen refresh tokens.
 	refreshReq, ok := request.(*RefreshTokenRequest)
 	if !ok {
 		return nil, oidc.ErrServerError().WithDescription("unexpected refresh token request type")
 	}
-	httpReq, _ := HttpRequestFromContext(ctx)
-	leafCert := tlsLeafCert(httpReq)
 
-	if err := verifyCertBinding(leafCert, refreshReq.ApiSessionId, refreshReq.Subject, refreshReq.CertFingerprints); err != nil {
-		return nil, err
-	}
-
-	// Accept optional CSR for cert rotation
+	// Cert binding and CSR rotation only apply when the session is in PoP mode
+	// (z_cfs non-empty). A session that authenticated without a cert and never
+	// submitted a CSR at code exchange remains a bearer-token session: any TLS
+	// client cert the SDK happens to present is incidental and ignored, and a
+	// CSR submitted now is ignored.
 	ts, _ := TokenStateFromContext(ctx)
-	if ts != nil {
-		if csrPem := r.Form.Get("csr_pem"); csrPem != "" {
-			ts.CsrPem = csrPem
+	if len(refreshReq.CertFingerprints) > 0 {
+		httpReq, _ := HttpRequestFromContext(ctx)
+		leafCert := tlsLeafCert(httpReq)
+
+		if err := verifyCertBinding(leafCert, refreshReq.ApiSessionId, refreshReq.Subject, refreshReq.CertFingerprints); err != nil {
+			return nil, err
+		}
+
+		if ts != nil {
+			if csrPem := r.Form.Get("csr_pem"); csrPem != "" {
+				ts.CsrPem = csrPem
+			}
 		}
 	}
 
@@ -258,23 +263,27 @@ func (s *server) TokenExchange(ctx context.Context, r *op.ClientRequest[oidc.Tok
 		return nil, oidc.ErrUnsupportedGrantType().WithDescription("token exchange not supported")
 	}
 
-	// Parse the subject token to verify cert binding before proceeding
 	storage := s.Provider().Storage().(*HybridStorage)
 	_, subjectClaims, parseErr := storage.parseAccessToken(r.Data.SubjectToken)
-	if parseErr == nil && subjectClaims != nil {
+
+	// Cert binding and CSR rotation only apply when the session is in PoP mode
+	// (z_cfs non-empty). A session that authenticated without a cert and never
+	// submitted a CSR at code exchange remains a bearer-token session: any TLS
+	// client cert the SDK happens to present is incidental and ignored, and a
+	// CSR submitted now is ignored.
+	ts, _ := TokenStateFromContext(ctx)
+	if parseErr == nil && subjectClaims != nil && len(subjectClaims.CertFingerprints) > 0 {
 		httpReq, _ := HttpRequestFromContext(ctx)
 		leafCert := tlsLeafCert(httpReq)
 
 		if err := verifyCertBinding(leafCert, subjectClaims.ApiSessionId, subjectClaims.Subject, subjectClaims.CertFingerprints); err != nil {
 			return nil, err
 		}
-	}
 
-	// Accept optional CSR for cert rotation
-	ts, _ := TokenStateFromContext(ctx)
-	if ts != nil {
-		if csrPem := r.Form.Get("csr_pem"); csrPem != "" {
-			ts.CsrPem = csrPem
+		if ts != nil {
+			if csrPem := r.Form.Get("csr_pem"); csrPem != "" {
+				ts.CsrPem = csrPem
+			}
 		}
 	}
 

--- a/controller/oidc_auth/server.go
+++ b/controller/oidc_auth/server.go
@@ -60,6 +60,9 @@ type openZitiEndpoints struct {
 // helper functions re-wrap storage errors with empty descriptions, discarding
 // the error_description that storage set. The overrides call storage directly
 // and pass errors through so that WriteError serializes the original description.
+//
+// It also overrides CodeExchange, RefreshToken, and TokenExchange to support
+// CSR submission and cert-binding verification.
 type server struct {
 	*op.LegacyServer
 }
@@ -70,6 +73,20 @@ func newServer(provider op.OpenIDProvider, endpoints op.Endpoints) *server {
 	return &server{
 		LegacyServer: op.NewLegacyServer(provider, endpoints),
 	}
+}
+
+// accessTokenResponseWithCert extends the standard OIDC access token response
+// with a session certificate PEM returned from CSR signing.
+type accessTokenResponseWithCert struct {
+	*oidc.AccessTokenResponse
+	SessionCert string `json:"session_cert,omitempty"`
+}
+
+// tokenExchangeResponseWithCert extends the standard OIDC token exchange response
+// with a session certificate PEM returned from CSR signing.
+type tokenExchangeResponseWithCert struct {
+	*oidc.TokenExchangeResponse
+	SessionCert string `json:"session_cert,omitempty"`
 }
 
 // Discovery returns the OpenID Provider Configuration with OpenZiti-specific endpoint
@@ -138,11 +155,45 @@ func (s *server) VerifyClient(ctx context.Context, r *op.Request[op.ClientCreden
 	return client, nil
 }
 
+// CodeExchange handles authorization code exchange. It overrides
+// LegacyServer.CodeExchange to return a session certificate PEM when a CSR
+// was submitted during the OIDC login flow.
+func (s *server) CodeExchange(ctx context.Context, r *op.ClientRequest[oidc.AccessTokenRequest]) (*op.Response, error) {
+	authReq, err := op.AuthRequestByCode(ctx, s.Provider().Storage(), r.Data.Code)
+	if err != nil {
+		return nil, err
+	}
+	if r.Client.AuthMethod() == oidc.AuthMethodNone || r.Data.CodeVerifier != "" {
+		if err = op.AuthorizeCodeChallenge(r.Data.CodeVerifier, authReq.GetCodeChallenge()); err != nil {
+			return nil, err
+		}
+	}
+	if r.Data.RedirectURI != authReq.GetRedirectURI() {
+		return nil, oidc.ErrInvalidGrant().WithDescription("redirect_uri does not correspond")
+	}
+
+	resp, err := op.CreateTokenResponse(ctx, authReq, r.Client, s.Provider(), true, r.Data.Code, "")
+	if err != nil {
+		return nil, err
+	}
+
+	ts, _ := TokenStateFromContext(ctx)
+	if ts != nil && ts.SessionCertPem != "" {
+		return op.NewResponse(&accessTokenResponseWithCert{
+			AccessTokenResponse: resp,
+			SessionCert:         ts.SessionCertPem,
+		}), nil
+	}
+
+	return op.NewResponse(resp), nil
+}
+
 // RefreshToken handles refresh token requests. It overrides
-// LegacyServer.RefreshToken to call storage.TokenRequestByRefreshToken
-// directly instead of through the library's RefreshTokenRequestByRefreshToken
-// helper, which re-wraps errors in a new oidc.ErrInvalidGrant with an empty
-// description.
+// LegacyServer.RefreshToken to:
+//   - call storage.TokenRequestByRefreshToken directly (preserving error descriptions)
+//   - verify cert binding against the refresh token's certificate fingerprints
+//   - accept an optional CSR for cert rotation
+//   - return a session certificate PEM when a CSR was signed
 func (s *server) RefreshToken(ctx context.Context, r *op.ClientRequest[oidc.RefreshTokenRequest]) (*op.Response, error) {
 	if !s.Provider().GrantTypeRefreshTokenSupported() {
 		return nil, oidc.ErrInvalidRequest().WithDescription("grant_type refresh_token not supported")
@@ -161,9 +212,85 @@ func (s *server) RefreshToken(ctx context.Context, r *op.ClientRequest[oidc.Refr
 		return nil, err
 	}
 
+	// Cert-binding verification: the TLS peer cert must match the token's cert fingerprints
+	// or SPIFFE ID. This prevents use of stolen refresh tokens.
+	if refreshReq, ok := request.(*RefreshTokenRequest); ok {
+		httpReq, _ := HttpRequestFromContext(ctx)
+		leafCert := tlsLeafCert(httpReq)
+
+		if err := verifyCertBinding(leafCert, refreshReq.ApiSessionId, refreshReq.Subject, refreshReq.CertFingerprints); err != nil {
+			return nil, err
+		}
+	}
+
+	// Accept optional CSR for cert rotation
+	ts, _ := TokenStateFromContext(ctx)
+	if ts != nil {
+		if csrPem := r.Form.Get("csr_pem"); csrPem != "" {
+			ts.CsrPem = csrPem
+		}
+	}
+
 	resp, err := op.CreateTokenResponse(ctx, request, r.Client, s.Provider(), true, "", r.Data.RefreshToken)
 	if err != nil {
 		return nil, err
+	}
+
+	if ts != nil && ts.SessionCertPem != "" {
+		return op.NewResponse(&accessTokenResponseWithCert{
+			AccessTokenResponse: resp,
+			SessionCert:         ts.SessionCertPem,
+		}), nil
+	}
+
+	return op.NewResponse(resp), nil
+}
+
+// TokenExchange handles token exchange requests. It overrides
+// LegacyServer.TokenExchange to:
+//   - verify cert binding against the subject token's certificate fingerprints
+//   - accept an optional CSR for cert rotation
+//   - return a session certificate PEM when a CSR was signed
+func (s *server) TokenExchange(ctx context.Context, r *op.ClientRequest[oidc.TokenExchangeRequest]) (*op.Response, error) {
+	if !s.Provider().GrantTypeTokenExchangeSupported() {
+		return nil, oidc.ErrUnsupportedGrantType().WithDescription("token exchange not supported")
+	}
+
+	// Parse the subject token to verify cert binding before proceeding
+	storage := s.Provider().Storage().(*HybridStorage)
+	_, subjectClaims, parseErr := storage.parseAccessToken(r.Data.SubjectToken)
+	if parseErr == nil && subjectClaims != nil {
+		httpReq, _ := HttpRequestFromContext(ctx)
+		leafCert := tlsLeafCert(httpReq)
+
+		if err := verifyCertBinding(leafCert, subjectClaims.ApiSessionId, subjectClaims.Subject, subjectClaims.CertFingerprints); err != nil {
+			return nil, err
+		}
+	}
+
+	// Accept optional CSR for cert rotation
+	ts, _ := TokenStateFromContext(ctx)
+	if ts != nil {
+		if csrPem := r.Form.Get("csr_pem"); csrPem != "" {
+			ts.CsrPem = csrPem
+		}
+	}
+
+	tokenExchangeRequest, err := op.CreateTokenExchangeRequest(ctx, r.Data, r.Client, s.Provider())
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := op.CreateTokenExchangeResponse(ctx, tokenExchangeRequest, r.Client, s.Provider())
+	if err != nil {
+		return nil, err
+	}
+
+	if ts != nil && ts.SessionCertPem != "" {
+		return op.NewResponse(&tokenExchangeResponseWithCert{
+			TokenExchangeResponse: resp,
+			SessionCert:           ts.SessionCertPem,
+		}), nil
 	}
 
 	return op.NewResponse(resp), nil

--- a/controller/oidc_auth/server.go
+++ b/controller/oidc_auth/server.go
@@ -214,13 +214,15 @@ func (s *server) RefreshToken(ctx context.Context, r *op.ClientRequest[oidc.Refr
 
 	// Cert-binding verification: the TLS peer cert must match the token's cert fingerprints
 	// or SPIFFE ID. This prevents use of stolen refresh tokens.
-	if refreshReq, ok := request.(*RefreshTokenRequest); ok {
-		httpReq, _ := HttpRequestFromContext(ctx)
-		leafCert := tlsLeafCert(httpReq)
+	refreshReq, ok := request.(*RefreshTokenRequest)
+	if !ok {
+		return nil, oidc.ErrServerError().WithDescription("unexpected refresh token request type")
+	}
+	httpReq, _ := HttpRequestFromContext(ctx)
+	leafCert := tlsLeafCert(httpReq)
 
-		if err := verifyCertBinding(leafCert, refreshReq.ApiSessionId, refreshReq.Subject, refreshReq.CertFingerprints); err != nil {
-			return nil, err
-		}
+	if err := verifyCertBinding(leafCert, refreshReq.ApiSessionId, refreshReq.Subject, refreshReq.CertFingerprints); err != nil {
+		return nil, err
 	}
 
 	// Accept optional CSR for cert rotation

--- a/controller/oidc_auth/storage.go
+++ b/controller/oidc_auth/storage.go
@@ -659,6 +659,8 @@ func (s *HybridStorage) createAccessToken(ctx context.Context, request op.TokenR
 	}
 
 	var eventType = "unhandled"
+	var csrPem string
+	var csrApiSessionId string
 
 	switch req := request.(type) {
 	case *AuthRequest:
@@ -683,12 +685,22 @@ func (s *HybridStorage) createAccessToken(ctx context.Context, request op.TokenR
 		claims.AuthTime = oidc.Time(req.AuthTime.Unix())
 		claims.AccessTokenClaims.AuthenticationMethodsReferences = req.GetAMR()
 		claims.ClientID = req.ClientID
+
+		if req.CsrPem != "" {
+			csrPem = req.CsrPem
+			csrApiSessionId = req.ApiSessionId
+		}
 	case *RefreshTokenRequest:
 		eventType = event.ApiSessionEventTypeRefreshed
 		claims.CustomClaims = req.CustomClaims
 		claims.AuthTime = req.AuthTime
 		claims.AccessTokenClaims.AuthenticationMethodsReferences = req.GetAMR()
 		claims.ClientID = req.ClientID
+
+		if ts, tsErr := TokenStateFromContext(ctx); tsErr == nil && ts.CsrPem != "" {
+			csrPem = ts.CsrPem
+			csrApiSessionId = req.CustomClaims.ApiSessionId
+		}
 	case op.TokenExchangeRequest:
 		eventType = event.ApiSessionEventTypeExchanged
 		mapClaims := req.GetExchangeSubjectTokenClaims()
@@ -723,6 +735,11 @@ func (s *HybridStorage) createAccessToken(ctx context.Context, request op.TokenR
 		claims.CustomClaims = subjectClaims.CustomClaims
 		claims.AccessTokenClaims.AuthenticationMethodsReferences = req.GetAMR()
 		claims.ClientID = req.GetClientID()
+
+		if ts, tsErr := TokenStateFromContext(ctx); tsErr == nil && ts.CsrPem != "" {
+			csrPem = ts.CsrPem
+			csrApiSessionId = subjectClaims.CustomClaims.ApiSessionId
+		}
 	}
 
 	claims.AccessTokenClaims.Scopes = request.GetScopes()
@@ -742,20 +759,43 @@ func (s *HybridStorage) createAccessToken(ctx context.Context, request op.TokenR
 	claims.CustomClaims.IsAdmin = identity.IsAdmin
 	claims.CustomClaims.ExternalId = stringz.OrEmpty(identity.ExternalId)
 
+	certGenerated := false
+	if csrPem != "" {
+		csrChangeCtx := NewChangeCtx()
+		apiSession := &model.ApiSession{BaseEntity: models.BaseEntity{Id: csrApiSessionId}}
+		apiSessionCert, csrErr := s.env.GetManagers().ApiSessionCertificate.CreateFromCSR(
+			identity, apiSession, true, 365*24*time.Hour, []byte(csrPem), csrChangeCtx,
+		)
+		if csrErr != nil {
+			return "", nil, oidc.ErrInvalidRequest().WithDescription("invalid CSR: %s", csrErr.Error())
+		}
+
+		if claims.CustomClaims.AuthCertFingerprint != "" {
+			claims.CustomClaims.CertFingerprints = []string{claims.CustomClaims.AuthCertFingerprint, apiSessionCert.Fingerprint}
+		} else {
+			claims.CustomClaims.CertFingerprints = []string{apiSessionCert.Fingerprint}
+		}
+		if ts, tsErr := TokenStateFromContext(ctx); tsErr == nil {
+			ts.SessionCertPem = apiSessionCert.PEM
+		}
+		certGenerated = true
+	}
+
 	ipAddr := ""
 	if httpRequest, _ := HttpRequestFromContext(ctx); httpRequest != nil {
 		ipAddr = httpRequest.RemoteAddr
 	}
 
 	evt := &event.ApiSessionEvent{
-		Namespace:  event.ApiSessionEventNS,
-		EventType:  eventType,
-		EventSrcId: s.env.GetId(),
-		Id:         claims.ApiSessionId,
-		Type:       event.ApiSessionTypeJwt,
-		Timestamp:  time.Now(),
-		IdentityId: identity.Id,
-		IpAddress:  ipAddr,
+		Namespace:     event.ApiSessionEventNS,
+		EventType:     eventType,
+		EventSrcId:    s.env.GetId(),
+		Id:            claims.ApiSessionId,
+		Type:          event.ApiSessionTypeJwt,
+		Timestamp:     time.Now(),
+		IdentityId:    identity.Id,
+		IpAddress:     ipAddr,
+		CertGenerated: certGenerated,
 	}
 	s.env.GetEventDispatcher().AcceptApiSessionEvent(evt)
 
@@ -788,7 +828,7 @@ func (s *HybridStorage) CreateAccessAndRefreshTokens(ctx context.Context, reques
 		return accessTokenId, refreshToken, accessClaims.Expiration.AsTime(), nil
 	}
 
-	refreshToken, refreshClaims, err := s.renewRefreshToken(currentRefreshToken)
+	refreshToken, refreshClaims, err := s.renewRefreshToken(currentRefreshToken, accessClaims)
 	tokenState.RefreshClaims = refreshClaims
 
 	if err != nil {
@@ -1094,7 +1134,7 @@ func (s *HybridStorage) saveRevocation(revocation *model.Revocation) error {
 	return s.env.GetManagers().Revocation.Create(revocation, change.New())
 }
 
-func (s *HybridStorage) renewRefreshToken(currentRefreshToken string) (string, *common.RefreshClaims, error) {
+func (s *HybridStorage) renewRefreshToken(currentRefreshToken string, accessClaims *common.AccessClaims) (string, *common.RefreshClaims, error) {
 	_, refreshClaims, err := s.parseRefreshToken(currentRefreshToken)
 
 	if err != nil {
@@ -1108,10 +1148,14 @@ func (s *HybridStorage) renewRefreshToken(currentRefreshToken string) (string, *
 		s.batcher.Add(NewRevocation(refreshClaims.JWTID, expiresAt))
 	}
 
+	// Use the access claims' CustomClaims so that any updates from CSR signing
+	// (CertFingerprints, AuthCertFingerprint) are propagated to the new refresh token.
 	newRefreshClaims := &common.RefreshClaims{
 		IDTokenClaims: refreshClaims.IDTokenClaims,
-		CustomClaims:  refreshClaims.CustomClaims,
+		CustomClaims:  accessClaims.CustomClaims,
 	}
+	newRefreshClaims.CustomClaims.Type = common.TokenTypeRefresh
+
 	now := time.Now()
 	newRefreshClaims.JWTID = uuid.NewString()
 	newRefreshClaims.IssuedAt = oidc.Time(now.Unix())

--- a/controller/oidc_auth/storage.go
+++ b/controller/oidc_auth/storage.go
@@ -671,7 +671,10 @@ func (s *HybridStorage) createAccessToken(ctx context.Context, request op.TokenR
 		claims.AuthenticationMethodsReferences = req.GetAMR()
 		// cert backed auth should bind tokens for cert pop, avoid for auth requests that do not establish cert pop prior or during the request
 		if req.HasAmr(AuthMethodCert) {
-			claims.CustomClaims.CertFingerprints = req.GetCertFingerprints()
+			if fp := req.GetCertFingerprint(); fp != "" {
+				claims.CustomClaims.CertFingerprints = []string{fp}
+				claims.CustomClaims.AuthCertFingerprint = fp
+			}
 		}
 		claims.CustomClaims.EnvInfo = req.EnvInfo
 		claims.CustomClaims.SdkInfo = req.SdkInfo

--- a/controller/oidc_auth/verify.go
+++ b/controller/oidc_auth/verify.go
@@ -1,0 +1,98 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package oidc_auth
+
+import (
+	"crypto/sha1"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/zitadel/oidc/v3/pkg/oidc"
+)
+
+// verifyCertBinding checks that the TLS leaf certificate is bound to the token claims.
+// Only the leaf certificate (index 0 of PeerCertificates) is examined; intermediates
+// are unverified public certs used only for chain building and are not relevant here.
+//
+// If certFingerprints (z_cfs) is non-empty, the leaf cert fingerprint must match at least
+// one entry. This is a strict check and fails if no match is found.
+//
+// If certFingerprints is empty, falls back to SPIFFE ID verification: the leaf cert's
+// SAN URIs must contain a SPIFFE ID referencing the apiSessionId.
+//
+// Returns nil if verification passes or is not applicable (no leaf cert and no z_cfs).
+func verifyCertBinding(leafCert *x509.Certificate, apiSessionId, identityId string, certFingerprints []string) error {
+	if len(certFingerprints) > 0 {
+		return verifyByFingerprint(leafCert, certFingerprints)
+	}
+	return verifyBySpiffeId(leafCert, apiSessionId, identityId)
+}
+
+// verifyByFingerprint performs a strict check: the leaf cert's SHA-1 fingerprint
+// must appear in the allowed fingerprints list.
+func verifyByFingerprint(leafCert *x509.Certificate, certFingerprints []string) error {
+	if leafCert == nil {
+		return oidc.ErrAccessDenied().WithDescription("peer certificate fingerprint does not match token")
+	}
+
+	fp := fmt.Sprintf("%x", sha1.Sum(leafCert.Raw))
+
+	for _, allowed := range certFingerprints {
+		if fp == allowed {
+			return nil
+		}
+	}
+
+	return oidc.ErrAccessDenied().WithDescription("peer certificate fingerprint does not match token")
+}
+
+// verifyBySpiffeId checks whether the leaf cert has a SPIFFE ID SAN URI that references the
+// expected identity and API session. The SPIFFE path format is:
+// identity/{identityId}/apiSession/{apiSessionId}/apiSessionCertificate/{certId}
+func verifyBySpiffeId(leafCert *x509.Certificate, apiSessionId, identityId string) error {
+	if apiSessionId == "" {
+		return nil
+	}
+
+	if leafCert == nil {
+		return nil
+	}
+
+	identitySegment := "identity/" + identityId + "/"
+	sessionSegment := "apiSession/" + apiSessionId + "/"
+
+	for _, uri := range leafCert.URIs {
+		if uri.Scheme != "spiffe" {
+			continue
+		}
+		if strings.Contains(uri.Path, identitySegment) && strings.Contains(uri.Path, sessionSegment) {
+			return nil
+		}
+	}
+
+	return oidc.ErrAccessDenied().WithDescription("peer certificate SPIFFE ID does not match API session")
+}
+
+// tlsLeafCert returns the leaf TLS peer certificate from the HTTP request, or nil if unavailable.
+func tlsLeafCert(r *http.Request) *x509.Certificate {
+	if r == nil || r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
+		return nil
+	}
+	return r.TLS.PeerCertificates[0]
+}

--- a/controller/oidc_auth/verify_test.go
+++ b/controller/oidc_auth/verify_test.go
@@ -1,0 +1,224 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package oidc_auth
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha1"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// testCert creates a self-signed certificate with the given SAN URIs.
+func testCert(t *testing.T, uris ...*url.URL) *x509.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		URIs:         uris,
+	}
+	raw, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	cert, err := x509.ParseCertificate(raw)
+	require.NoError(t, err)
+	return cert
+}
+
+// testCertFingerprint returns the SHA-1 fingerprint of a certificate in the same hex format
+// used by the production code.
+func testCertFingerprint(cert *x509.Certificate) string {
+	return fmt.Sprintf("%x", sha1.Sum(cert.Raw))
+}
+
+func Test_verifyByFingerprint(t *testing.T) {
+	certA := testCert(t)
+	certB := testCert(t)
+	fpA := testCertFingerprint(certA)
+	fpB := testCertFingerprint(certB)
+
+	t.Run("matching fingerprint passes", func(t *testing.T) {
+		err := verifyByFingerprint(certA, []string{fpA})
+		require.NoError(t, err)
+	})
+
+	t.Run("one of multiple allowed fingerprints matches", func(t *testing.T) {
+		err := verifyByFingerprint(certB, []string{fpA, fpB})
+		require.NoError(t, err)
+	})
+
+	t.Run("no matching fingerprint fails", func(t *testing.T) {
+		err := verifyByFingerprint(certA, []string{fpB})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "fingerprint")
+	})
+
+	t.Run("nil leaf cert fails", func(t *testing.T) {
+		err := verifyByFingerprint(nil, []string{fpA})
+		require.Error(t, err)
+	})
+}
+
+func Test_verifyBySpiffeId(t *testing.T) {
+	const (
+		identityId   = "id-001"
+		apiSessionId = "as-002"
+		certId       = "cert-003"
+	)
+
+	spiffeURL := &url.URL{
+		Scheme: "spiffe",
+		Host:   "example.trust.domain",
+		Path:   fmt.Sprintf("identity/%s/apiSession/%s/apiSessionCertificate/%s", identityId, apiSessionId, certId),
+	}
+
+	t.Run("matching SPIFFE ID passes", func(t *testing.T) {
+		cert := testCert(t, spiffeURL)
+		err := verifyBySpiffeId(cert, apiSessionId, identityId)
+		require.NoError(t, err)
+	})
+
+	t.Run("wrong apiSessionId fails", func(t *testing.T) {
+		cert := testCert(t, spiffeURL)
+		err := verifyBySpiffeId(cert, "wrong-session", identityId)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "SPIFFE")
+	})
+
+	t.Run("wrong identityId fails", func(t *testing.T) {
+		cert := testCert(t, spiffeURL)
+		err := verifyBySpiffeId(cert, apiSessionId, "wrong-identity")
+		require.Error(t, err)
+	})
+
+	t.Run("non-spiffe URI fails", func(t *testing.T) {
+		httpURL := &url.URL{
+			Scheme: "https",
+			Host:   "example.com",
+			Path:   fmt.Sprintf("identity/%s/apiSession/%s/apiSessionCertificate/%s", identityId, apiSessionId, certId),
+		}
+		cert := testCert(t, httpURL)
+		err := verifyBySpiffeId(cert, apiSessionId, identityId)
+		require.Error(t, err)
+	})
+
+	t.Run("nil leaf cert passes (not applicable)", func(t *testing.T) {
+		err := verifyBySpiffeId(nil, apiSessionId, identityId)
+		require.NoError(t, err)
+	})
+
+	t.Run("empty apiSessionId passes (not applicable)", func(t *testing.T) {
+		cert := testCert(t)
+		err := verifyBySpiffeId(cert, "", identityId)
+		require.NoError(t, err)
+	})
+
+	t.Run("cert with multiple URIs matches on spiffe", func(t *testing.T) {
+		otherURL := &url.URL{Scheme: "https", Host: "example.com", Path: "/other"}
+		cert := testCert(t, otherURL, spiffeURL)
+		err := verifyBySpiffeId(cert, apiSessionId, identityId)
+		require.NoError(t, err)
+	})
+}
+
+func Test_verifyCertBinding(t *testing.T) {
+	const (
+		identityId   = "id-100"
+		apiSessionId = "as-200"
+	)
+
+	spiffeURL := &url.URL{
+		Scheme: "spiffe",
+		Host:   "trust.domain",
+		Path:   fmt.Sprintf("identity/%s/apiSession/%s/apiSessionCertificate/cert-300", identityId, apiSessionId),
+	}
+
+	certWithSpiffe := testCert(t, spiffeURL)
+	certPlain := testCert(t)
+	fpSpiffe := testCertFingerprint(certWithSpiffe)
+
+	t.Run("z_cfs present uses strict fingerprint check", func(t *testing.T) {
+		err := verifyCertBinding(certWithSpiffe, apiSessionId, identityId, []string{fpSpiffe})
+		require.NoError(t, err)
+	})
+
+	t.Run("z_cfs present with wrong cert fails even if SPIFFE matches", func(t *testing.T) {
+		err := verifyCertBinding(certPlain, apiSessionId, identityId, []string{fpSpiffe})
+		require.Error(t, err)
+	})
+
+	t.Run("no z_cfs falls back to SPIFFE verification", func(t *testing.T) {
+		err := verifyCertBinding(certWithSpiffe, apiSessionId, identityId, nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("no z_cfs and no SPIFFE match fails", func(t *testing.T) {
+		err := verifyCertBinding(certPlain, apiSessionId, identityId, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("no z_cfs and nil leaf cert passes", func(t *testing.T) {
+		err := verifyCertBinding(nil, apiSessionId, identityId, nil)
+		require.NoError(t, err)
+	})
+}
+
+func Test_tlsLeafCert(t *testing.T) {
+	t.Run("nil request returns nil", func(t *testing.T) {
+		require.Nil(t, tlsLeafCert(nil))
+	})
+
+	t.Run("request without TLS returns nil", func(t *testing.T) {
+		r := &http.Request{}
+		require.Nil(t, tlsLeafCert(r))
+	})
+
+	t.Run("request with empty peer certs returns nil", func(t *testing.T) {
+		r := &http.Request{
+			TLS: &tls.ConnectionState{},
+		}
+		require.Nil(t, tlsLeafCert(r))
+	})
+
+	t.Run("request with TLS returns leaf cert", func(t *testing.T) {
+		leaf := testCert(t)
+		intermediate := testCert(t)
+		r := &http.Request{
+			TLS: &tls.ConnectionState{
+				PeerCertificates: []*x509.Certificate{leaf, intermediate},
+			},
+		}
+		result := tlsLeafCert(r)
+		require.Equal(t, leaf, result)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/openziti/agent v1.0.33
 	github.com/openziti/channel/v4 v4.3.11
 	github.com/openziti/cobra-to-md v1.0.1
-	github.com/openziti/edge-api v0.28.1
+	github.com/openziti/edge-api v0.31.0
 	github.com/openziti/foundation/v2 v2.0.90
 	github.com/openziti/identity v1.0.128
 	github.com/openziti/jwks v1.0.6

--- a/go.sum
+++ b/go.sum
@@ -538,8 +538,8 @@ github.com/openziti/channel/v4 v4.3.11 h1:ugezUhTEuSQnVFKUioN1gh6f+ZF4eBqx6mOrT5
 github.com/openziti/channel/v4 v4.3.11/go.mod h1:WZpOeuPliA7mJ3m7Pal8WdYu74eHMzkM/1Z9AMLmUAg=
 github.com/openziti/cobra-to-md v1.0.1 h1:WRinNoIRmwWUSJm+pSNXMjOrtU48oxXDZgeCYQfVXxE=
 github.com/openziti/cobra-to-md v1.0.1/go.mod h1:FjCpk/yzHF7/r28oSTNr5P57yN5VolpdAtS/g7KNi2c=
-github.com/openziti/edge-api v0.28.1 h1:Dx+yUwdZSVpztzOkduak55TqWJPw8tq3nq3IC01uOPw=
-github.com/openziti/edge-api v0.28.1/go.mod h1:pDtCR6Mq0h5e8ulJhmuhPshEBa39hpQy+yTtLpUSBOs=
+github.com/openziti/edge-api v0.31.0 h1:QdaaPnKQj4B40q404+c8VZxMsoVpfGpfOhzs3LLCd/A=
+github.com/openziti/edge-api v0.31.0/go.mod h1:pDtCR6Mq0h5e8ulJhmuhPshEBa39hpQy+yTtLpUSBOs=
 github.com/openziti/foundation/v2 v2.0.90 h1:1+Xbug8gQgi656yq+mvKvzROmmX/Lsrgt/s12l1Wz3s=
 github.com/openziti/foundation/v2 v2.0.90/go.mod h1:mJT858owwwcM6XvpEawdKM+7UAjc+ftIlpD/6toCTCg=
 github.com/openziti/go-term-markdown v1.0.1 h1:9uzMpK4tav6OtvRxRt99WwPTzAzCh+Pj9zWU2FBp3Qg=

--- a/tests/auth_oidc_csr_forging_test.go
+++ b/tests/auth_oidc_csr_forging_test.go
@@ -92,21 +92,33 @@ func Test_OIDC_CSR_Forging(t *testing.T) {
 		return certs[0], result, resp.StatusCode()
 	}
 
-	t.Run("CSR subject fields are copied to issued cert", func(t *testing.T) {
+	t.Run("CSR Subject fields are not accepted", func(t *testing.T) {
 		ctx.NextTest(t)
 
-		// NOTE: The current CSR signer (ClientSigner.SignCsr) copies the CSR Subject into the
-		// issued certificate. This is existing behavior. The test documents it rather than
-		// asserting the Subject is stripped. SANs (DNS, IP, email, URI) are the critical
-		// fields that are controlled by the signer, not the Subject.
 		csrPem := generateForgedCsrPem(t)
-		cert, _, statusCode := refreshWithCsr(t, csrPem)
+		cert, result, statusCode := refreshWithCsr(t, csrPem)
 		ctx.Req.Equal(http.StatusOK, statusCode)
 		ctx.Req.NotNil(cert)
+		ctx.Req.NotNil(result)
 
-		// The Subject is copied from the CSR (documenting existing behavior).
-		ctx.Req.Contains(cert.Subject.Organization, "Evil Corp",
-			"CSR Subject Organization is currently copied to issued cert")
+		parser := jwt.NewParser()
+		accessClaims := &common.AccessClaims{}
+		_, _, parseErr := parser.ParseUnverified(result.AccessToken, accessClaims)
+		ctx.Req.NoError(parseErr)
+		ctx.Req.NotEmpty(accessClaims.Subject)
+
+		// Subject CN must be the controller-set identity id, not anything from the CSR.
+		ctx.Req.Equal(accessClaims.Subject, cert.Subject.CommonName,
+			"issued cert Subject CN must be the identity id")
+
+		// All other Subject fields from the CSR (Organization=Evil Corp, Country=RU, etc.)
+		// must be stripped.
+		ctx.Req.Empty(cert.Subject.Organization,
+			"CSR Subject Organization must not be copied to issued cert")
+		ctx.Req.Empty(cert.Subject.Country,
+			"CSR Subject Country must not be copied to issued cert")
+		ctx.Req.Empty(cert.Subject.OrganizationalUnit,
+			"CSR Subject OrganizationalUnit must not be copied to issued cert")
 	})
 
 	t.Run("CSR SAN URIs are not in issued cert", func(t *testing.T) {

--- a/tests/auth_oidc_csr_forging_test.go
+++ b/tests/auth_oidc_csr_forging_test.go
@@ -1,0 +1,273 @@
+//go:build apitests
+
+package tests
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	nfpem "github.com/openziti/foundation/v2/pem"
+	edge_apis "github.com/openziti/sdk-golang/edge-apis"
+	"github.com/openziti/ziti/v2/common"
+	"github.com/openziti/ziti/v2/controller/oidc_auth"
+	"github.com/zitadel/oidc/v3/pkg/oidc"
+)
+
+// Test_OIDC_CSR_Forging verifies that the controller ignores attacker-controlled fields in a
+// CSR submitted during OIDC token refresh, using only the public key from the CSR when signing
+// the session certificate. The issued certificate must not contain any Subject, DNS, IP, email,
+// or URI SAN values from the CSR; the only URI SAN must be the controller-generated SPIFFE ID.
+func Test_OIDC_CSR_Forging(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+
+	managementHelper := ctx.NewEdgeManagementApi(nil)
+	clientHelper := ctx.NewEdgeClientApi(nil)
+
+	adminCreds := edge_apis.NewUpdbCredentials(ctx.AdminAuthenticator.Username, ctx.AdminAuthenticator.Password)
+	adminCreds.CaPool = ctx.ControllerCaPool()
+	_, err := managementHelper.Authenticate(adminCreds, nil)
+	ctx.Req.NoError(err)
+
+	// refreshWithCsr authenticates fresh, then performs a token refresh with the given CSR PEM.
+	// Each call gets its own tokens to avoid z_cfs binding from a previous CSR-bearing refresh
+	// preventing subsequent refreshes.
+	type forgingTokenResponse struct {
+		AccessToken  string `json:"access_token"`
+		TokenType    string `json:"token_type"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresIn    uint64 `json:"expires_in"`
+		IDToken      string `json:"id_token"`
+		SessionCert  string `json:"session_cert"`
+	}
+
+	refreshWithCsr := func(t *testing.T, csrPem string) (*x509.Certificate, *forgingTokenResponse, int) {
+		t.Helper()
+
+		tokens, _, authErr := clientHelper.RawOidcAuthRequest(adminCreds)
+		ctx.Req.NoError(authErr)
+		ctx.Req.NotNil(tokens)
+		ctx.Req.NotEmpty(tokens.RefreshToken)
+
+		req := &oidc.RefreshTokenRequest{
+			RefreshToken: tokens.RefreshToken,
+			ClientID:     tokens.IDTokenClaims.ClientID,
+			Scopes:       []string{oidc.ScopeOpenID, oidc.ScopeOfflineAccess},
+		}
+
+		enc := oidc.NewEncoder()
+		dst := map[string][]string{}
+		encErr := enc.Encode(req, dst)
+		ctx.Req.NoError(encErr)
+
+		dst["grant_type"] = []string{string(req.GrantType())}
+		dst["csr_pem"] = []string{csrPem}
+
+		result := &forgingTokenResponse{}
+		resp, httpErr := ctx.newAnonymousClientApiRequest().
+			SetHeader("content-type", oidc_auth.FormContentType).
+			SetMultiValueFormData(dst).
+			SetResult(result).
+			Post("https://" + ctx.ApiHost + "/oidc/oauth/token")
+		ctx.Req.NoError(httpErr)
+
+		if resp.StatusCode() != http.StatusOK || result.SessionCert == "" {
+			return nil, result, resp.StatusCode()
+		}
+
+		certs := nfpem.PemStringToCertificates(result.SessionCert)
+		ctx.Req.NotEmpty(certs, "expected at least one certificate in session_cert")
+
+		return certs[0], result, resp.StatusCode()
+	}
+
+	t.Run("CSR subject fields are copied to issued cert", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		// NOTE: The current CSR signer (ClientSigner.SignCsr) copies the CSR Subject into the
+		// issued certificate. This is existing behavior. The test documents it rather than
+		// asserting the Subject is stripped. SANs (DNS, IP, email, URI) are the critical
+		// fields that are controlled by the signer, not the Subject.
+		csrPem := generateForgedCsrPem(t)
+		cert, _, statusCode := refreshWithCsr(t, csrPem)
+		ctx.Req.Equal(http.StatusOK, statusCode)
+		ctx.Req.NotNil(cert)
+
+		// The Subject is copied from the CSR (documenting existing behavior).
+		ctx.Req.Contains(cert.Subject.Organization, "Evil Corp",
+			"CSR Subject Organization is currently copied to issued cert")
+	})
+
+	t.Run("CSR SAN URIs are not in issued cert", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		csrPem := generateForgedCsrPem(t)
+		cert, _, statusCode := refreshWithCsr(t, csrPem)
+		ctx.Req.Equal(http.StatusOK, statusCode)
+		ctx.Req.NotNil(cert)
+
+		// The only URI SAN should be the controller-generated SPIFFE ID.
+		ctx.Req.NotEmpty(cert.URIs, "expected at least one URI SAN (the SPIFFE ID)")
+
+		for _, u := range cert.URIs {
+			ctx.Req.NotContains(u.String(), "evil.trust.domain",
+				"issued cert must not contain forged SPIFFE URI")
+		}
+
+		// Verify the SPIFFE ID has the expected structure.
+		foundSpiffe := false
+		for _, u := range cert.URIs {
+			if u.Scheme == "spiffe" {
+				foundSpiffe = true
+				ctx.Req.True(strings.Contains(u.Path, "identity/"),
+					"SPIFFE URI path must contain 'identity/' segment, got: %s", u.String())
+				ctx.Req.True(strings.Contains(u.Path, "apiSession/"),
+					"SPIFFE URI path must contain 'apiSession/' segment, got: %s", u.String())
+			}
+		}
+		ctx.Req.True(foundSpiffe, "expected a spiffe:// URI SAN in the issued cert")
+	})
+
+	t.Run("CSR SAN DNS names are not in issued cert", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		csrPem := generateForgedCsrPem(t)
+		cert, _, statusCode := refreshWithCsr(t, csrPem)
+		ctx.Req.Equal(http.StatusOK, statusCode)
+		ctx.Req.NotNil(cert)
+
+		ctx.Req.Empty(cert.DNSNames, "issued cert must not contain any DNS SANs from the CSR")
+	})
+
+	t.Run("CSR SAN IP addresses are not in issued cert", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		csrPem := generateForgedCsrPem(t)
+		cert, _, statusCode := refreshWithCsr(t, csrPem)
+		ctx.Req.Equal(http.StatusOK, statusCode)
+		ctx.Req.NotNil(cert)
+
+		ctx.Req.Empty(cert.IPAddresses, "issued cert must not contain any IP SANs from the CSR")
+	})
+
+	t.Run("CSR SAN email addresses are not in issued cert", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		csrPem := generateForgedCsrPem(t)
+		cert, _, statusCode := refreshWithCsr(t, csrPem)
+		ctx.Req.Equal(http.StatusOK, statusCode)
+		ctx.Req.NotNil(cert)
+
+		ctx.Req.Empty(cert.EmailAddresses, "issued cert must not contain any email SANs from the CSR")
+	})
+
+	t.Run("issued cert SPIFFE ID matches token apiSessionId", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		csrPem := generateForgedCsrPem(t)
+		cert, result, statusCode := refreshWithCsr(t, csrPem)
+		ctx.Req.Equal(http.StatusOK, statusCode)
+		ctx.Req.NotNil(cert)
+		ctx.Req.NotNil(result)
+
+		// Parse the access token to extract the identity ID and API session ID.
+		parser := jwt.NewParser()
+		accessClaims := &common.AccessClaims{}
+		_, _, parseErr := parser.ParseUnverified(result.AccessToken, accessClaims)
+		ctx.Req.NoError(parseErr)
+		ctx.Req.NotEmpty(accessClaims.Subject)
+		ctx.Req.NotEmpty(accessClaims.ApiSessionId)
+
+		// Find the SPIFFE URI in the issued cert and verify it references the correct IDs.
+		var spiffeUri *url.URL
+		for _, u := range cert.URIs {
+			if u.Scheme == "spiffe" {
+				spiffeUri = u
+				break
+			}
+		}
+		ctx.Req.NotNil(spiffeUri, "expected a spiffe:// URI SAN in the issued cert")
+		ctx.Req.True(strings.Contains(spiffeUri.Path, "identity/"+accessClaims.Subject),
+			"SPIFFE URI must contain identity ID %q, got path: %s", accessClaims.Subject, spiffeUri.Path)
+		ctx.Req.True(strings.Contains(spiffeUri.Path, "apiSession/"+accessClaims.ApiSessionId),
+			"SPIFFE URI must contain apiSessionId %q, got path: %s", accessClaims.ApiSessionId, spiffeUri.Path)
+	})
+
+	t.Run("CSR signature is verified", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		// Generate a valid CSR, then corrupt its base64 body to produce an invalid signature.
+		validCsrPem := generateForgedCsrPem(t)
+		corruptedCsrPem := corruptCsrPem(t, validCsrPem)
+
+		_, _, statusCode := refreshWithCsr(t, corruptedCsrPem)
+		ctx.Req.NotEqual(http.StatusOK, statusCode,
+			"corrupted CSR must be rejected, but got status %d", statusCode)
+	})
+}
+
+// generateForgedCsrPem creates a CSR with attacker-controlled Subject, DNS, IP, email, and URI
+// SAN fields. The CSR is valid (properly signed) but contains values that the controller must
+// ignore when issuing the session certificate.
+func generateForgedCsrPem(t *testing.T) string {
+	t.Helper()
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	evilSpiffe, err := url.Parse("spiffe://evil.trust.domain/identity/hacked-id/apiSession/hacked-session/apiSessionCertificate/hacked-cert")
+	if err != nil {
+		t.Fatalf("failed to parse evil SPIFFE URL: %v", err)
+	}
+
+	template := &x509.CertificateRequest{
+		Subject: pkix.Name{
+			Organization: []string{"Evil Corp"},
+			CommonName:   "admin",
+			Country:      []string{"RU"},
+		},
+		DNSNames:       []string{"evil.example.com", "*.internal.corp"},
+		IPAddresses:    []net.IP{net.ParseIP("10.0.0.1"), net.ParseIP("192.168.1.1")},
+		EmailAddresses: []string{"admin@evil.com"},
+		URIs:           []*url.URL{evilSpiffe},
+	}
+
+	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, template, privateKey)
+	if err != nil {
+		t.Fatalf("failed to create CSR: %v", err)
+	}
+
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrBytes}))
+}
+
+// corruptCsrPem takes a valid CSR PEM string and flips a byte in the base64 body to produce a
+// CSR that will fail signature verification.
+func corruptCsrPem(t *testing.T, csrPem string) string {
+	t.Helper()
+
+	block, rest := pem.Decode([]byte(csrPem))
+	if block == nil {
+		t.Fatalf("failed to decode PEM block, remaining: %s", string(rest))
+	}
+
+	// Flip a byte near the end of the DER data (in the signature area).
+	if len(block.Bytes) < 10 {
+		t.Fatalf("CSR DER data too short to corrupt")
+	}
+	block.Bytes[len(block.Bytes)-5] ^= 0xFF
+
+	return string(pem.EncodeToMemory(block))
+}

--- a/tests/auth_oidc_csr_forging_test.go
+++ b/tests/auth_oidc_csr_forging_test.go
@@ -40,9 +40,12 @@ func Test_OIDC_CSR_Forging(t *testing.T) {
 	_, err := managementHelper.Authenticate(adminCreds, nil)
 	ctx.Req.NoError(err)
 
-	// refreshWithCsr authenticates fresh, then performs a token refresh with the given CSR PEM.
-	// Each call gets its own tokens to avoid z_cfs binding from a previous CSR-bearing refresh
-	// preventing subsequent refreshes.
+	// Forging the CSR signing path requires a session that is already in PoP mode
+	_, certCreds, err := managementHelper.CreateAndEnrollOttIdentity(false)
+	ctx.Req.NoError(err)
+	certCreds.CaPool = ctx.ControllerCaPool()
+	authTlsCerts := certCreds.TlsCerts()
+
 	type forgingTokenResponse struct {
 		AccessToken  string `json:"access_token"`
 		TokenType    string `json:"token_type"`
@@ -55,7 +58,7 @@ func Test_OIDC_CSR_Forging(t *testing.T) {
 	refreshWithCsr := func(t *testing.T, csrPem string) (*x509.Certificate, *forgingTokenResponse, int) {
 		t.Helper()
 
-		tokens, _, authErr := clientHelper.RawOidcAuthRequest(adminCreds)
+		tokens, _, authErr := clientHelper.RawOidcAuthRequest(certCreds)
 		ctx.Req.NoError(authErr)
 		ctx.Req.NotNil(tokens)
 		ctx.Req.NotEmpty(tokens.RefreshToken)
@@ -75,7 +78,7 @@ func Test_OIDC_CSR_Forging(t *testing.T) {
 		dst["csr_pem"] = []string{csrPem}
 
 		result := &forgingTokenResponse{}
-		resp, httpErr := ctx.newAnonymousClientApiRequest().
+		resp, httpErr := ctx.newRequestWithTlsCerts(authTlsCerts).
 			SetHeader("content-type", oidc_auth.FormContentType).
 			SetMultiValueFormData(dst).
 			SetResult(result).

--- a/tests/auth_oidc_csr_refresh_test.go
+++ b/tests/auth_oidc_csr_refresh_test.go
@@ -1,0 +1,964 @@
+//go:build apitests
+
+package tests
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	cryptoTls "crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/openziti/edge-api/rest_model"
+	"github.com/openziti/edge-api/rest_util"
+	nfpem "github.com/openziti/foundation/v2/pem"
+	edge_apis "github.com/openziti/sdk-golang/edge-apis"
+	"github.com/openziti/ziti/v2/common"
+	"github.com/openziti/ziti/v2/controller/oidc_auth"
+	"github.com/zitadel/oidc/v3/pkg/oidc"
+	"gopkg.in/resty.v1"
+)
+
+// tokenResponseWithSessionCert captures the token endpoint response including the
+// session_cert field that is returned when a CSR is submitted during auth or refresh.
+type tokenResponseWithSessionCert struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    uint64 `json:"expires_in"`
+	IDToken      string `json:"id_token"`
+	SessionCert  string `json:"session_cert"`
+}
+
+// parseAccessClaims parses an access token without signature verification and returns
+// the custom access claims.
+func parseAccessClaims(accessToken string) (*common.AccessClaims, error) {
+	parser := jwt.NewParser()
+	claims := &common.AccessClaims{}
+	_, _, err := parser.ParseUnverified(accessToken, claims)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse access token: %w", err)
+	}
+	return claims, nil
+}
+
+// buildTlsCertFromPem constructs a []cryptoTls.Certificate from a PEM-encoded certificate
+// string and the private key that was used to generate the CSR.
+func buildTlsCertFromPem(certPemStr string, privateKey crypto.PrivateKey) ([]cryptoTls.Certificate, error) {
+	certPem := []byte(certPemStr)
+
+	var keyPemBytes []byte
+	switch k := privateKey.(type) {
+	case *ecdsa.PrivateKey:
+		der, err := x509.MarshalECPrivateKey(k)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal EC private key: %w", err)
+		}
+		keyPemBytes = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der})
+	default:
+		der, err := x509.MarshalPKCS8PrivateKey(privateKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal private key: %w", err)
+		}
+		keyPemBytes = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	}
+
+	tlsCert, err := cryptoTls.X509KeyPair(certPem, keyPemBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create X509 key pair: %w", err)
+	}
+	return []cryptoTls.Certificate{tlsCert}, nil
+}
+
+// generateSelfSignedCertAndKey creates a throwaway self-signed certificate and private key
+// for use as a "wrong" client certificate in negative test scenarios.
+func generateSelfSignedCertAndKey() ([]cryptoTls.Certificate, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: mustRandomSerial(),
+	}
+
+	certDer, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		return nil, err
+	}
+
+	certPem := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDer})
+	keyDer, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, err
+	}
+	keyPem := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDer})
+
+	tlsCert, err := cryptoTls.X509KeyPair(certPem, keyPem)
+	if err != nil {
+		return nil, err
+	}
+	return []cryptoTls.Certificate{tlsCert}, nil
+}
+
+// mustRandomSerial produces a random certificate serial number.
+func mustRandomSerial() *big.Int {
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		panic(err)
+	}
+	return serial
+}
+
+// fingerprintFromPem returns the SHA-1 hex fingerprint of the first certificate in a PEM string.
+func fingerprintFromPem(pemStr string) string {
+	return nfpem.FingerprintFromPemString(pemStr)
+}
+
+// doRefreshRequest performs a refresh token grant against the OIDC token endpoint.
+// If tlsCerts is non-nil, the request presents those client certificates.
+// If csrPem is non-empty, it is included as csr_pem in the form data.
+// When expectSessionCert is true, the response is unmarshalled into tokenResponseWithSessionCert.
+func doRefreshRequest(
+	ctx *TestContext,
+	refreshToken string,
+	clientID string,
+	tlsCerts []cryptoTls.Certificate,
+	csrPem string,
+	expectSessionCert bool,
+) (accessToken string, newRefreshToken string, sessionCert string, statusCode int) {
+	req := &oidc.RefreshTokenRequest{
+		RefreshToken: refreshToken,
+		ClientID:     clientID,
+		Scopes:       []string{oidc.ScopeOpenID, oidc.ScopeOfflineAccess},
+	}
+
+	enc := oidc.NewEncoder()
+	dst := map[string][]string{}
+	err := enc.Encode(req, dst)
+	ctx.Req.NoError(err)
+	dst["grant_type"] = []string{string(req.GrantType())}
+
+	if csrPem != "" {
+		dst["csr_pem"] = []string{csrPem}
+	}
+
+	if expectSessionCert {
+		result := &tokenResponseWithSessionCert{}
+		var r *resty.Request
+		if tlsCerts != nil {
+			r = ctx.newRequestWithTlsCerts(tlsCerts)
+		} else {
+			r = ctx.newAnonymousClientApiRequest()
+		}
+		r.SetHeader("content-type", oidc_auth.FormContentType).
+			SetMultiValueFormData(dst).
+			SetResult(result)
+
+		resp, postErr := r.Post("https://" + ctx.ApiHost + "/oidc/oauth/token")
+		ctx.Req.NoError(postErr)
+		return result.AccessToken, result.RefreshToken, result.SessionCert, resp.StatusCode()
+	}
+
+	result := &oidc.TokenExchangeResponse{}
+	var r *resty.Request
+	if tlsCerts != nil {
+		r = ctx.newRequestWithTlsCerts(tlsCerts)
+	} else {
+		r = ctx.newAnonymousClientApiRequest()
+	}
+	r.SetHeader("content-type", oidc_auth.FormContentType).
+		SetMultiValueFormData(dst).
+		SetResult(result)
+
+	resp, postErr := r.Post("https://" + ctx.ApiHost + "/oidc/oauth/token")
+	ctx.Req.NoError(postErr)
+	return result.AccessToken, result.RefreshToken, "", resp.StatusCode()
+}
+
+// doTokenExchangeRequest performs a token exchange grant against the OIDC token endpoint.
+func doTokenExchangeRequest(
+	ctx *TestContext,
+	accessToken string,
+	tlsCerts []cryptoTls.Certificate,
+	csrPem string,
+	expectSessionCert bool,
+) (newAccessToken string, newRefreshToken string, sessionCert string, statusCode int) {
+	dst := map[string][]string{
+		"grant_type":         {"urn:ietf:params:oauth:grant-type:token-exchange"},
+		"subject_token":      {accessToken},
+		"subject_token_type": {"urn:ietf:params:oauth:token-type:access_token"},
+		"scope":              {"openid offline_access"},
+	}
+
+	if csrPem != "" {
+		dst["csr_pem"] = []string{csrPem}
+	}
+
+	if expectSessionCert {
+		result := &tokenResponseWithSessionCert{}
+		var r *resty.Request
+		if tlsCerts != nil {
+			r = ctx.newRequestWithTlsCerts(tlsCerts)
+		} else {
+			r = ctx.newAnonymousClientApiRequest()
+		}
+		r.SetHeader("content-type", oidc_auth.FormContentType).
+			SetMultiValueFormData(dst).
+			SetResult(result)
+
+		resp, postErr := r.Post("https://" + ctx.ApiHost + "/oidc/oauth/token")
+		ctx.Req.NoError(postErr)
+		return result.AccessToken, result.RefreshToken, result.SessionCert, resp.StatusCode()
+	}
+
+	result := &oidc.TokenExchangeResponse{}
+	var r *resty.Request
+	if tlsCerts != nil {
+		r = ctx.newRequestWithTlsCerts(tlsCerts)
+	} else {
+		r = ctx.newAnonymousClientApiRequest()
+	}
+	r.SetHeader("content-type", oidc_auth.FormContentType).
+		SetMultiValueFormData(dst).
+		SetResult(result)
+
+	resp, postErr := r.Post("https://" + ctx.ApiHost + "/oidc/oauth/token")
+	ctx.Req.NoError(postErr)
+	return result.AccessToken, result.RefreshToken, "", resp.StatusCode()
+}
+
+// oidcAuthWithCsr performs an OIDC UPDB auth flow with a CSR, returning tokens and the
+// session cert PEM. The caller provides credentials and CSR PEM string.
+func oidcAuthWithCsr(
+	ctx *TestContext,
+	clientHelper *ClientHelperClient,
+	creds edge_apis.Credentials,
+	csrPem string,
+) (accessToken string, refreshToken string, idToken string, sessionCert string, clientID string) {
+	result, err := clientHelper.OidcAuthorize(creds)
+	ctx.Req.NoError(err)
+
+	opLoginUri := "https://" + ctx.ApiHost + "/oidc/login/username?id=" + result.AuthRequestId
+
+	// Build the login payload with the CSR.
+	switch c := creds.(type) {
+	case *edge_apis.UpdbCredentials:
+		payload := &oidc_auth.OidcUpdbCreds{
+			Authenticate: rest_model.Authenticate{
+				Password: rest_model.Password(c.Password),
+				Username: rest_model.Username(c.Username),
+			},
+			AuthRequestBody: oidc_auth.AuthRequestBody{
+				AuthRequestId: result.AuthRequestId,
+			},
+			CsrPem: csrPem,
+		}
+
+		resp, postErr := result.Client.R().SetBody(payload).Post(opLoginUri)
+		ctx.Req.NoError(postErr)
+		ctx.Req.Equal(http.StatusFound, resp.StatusCode(),
+			"expected redirect after UPDB+CSR login, got %d: %s", resp.StatusCode(), resp.String())
+
+		locUrl, parseErr := url.Parse(resp.Header().Get("Location"))
+		ctx.Req.NoError(parseErr)
+		code := locUrl.Query().Get("code")
+		ctx.Req.NotEmpty(code, "expected authorization code in redirect")
+
+		tokens, exchErr := result.Exchange(code)
+		ctx.Req.NoError(exchErr)
+		ctx.Req.NotNil(tokens)
+
+		// The standard exchange returns oidc.Tokens which does not capture session_cert.
+		// Re-read the access/refresh/id tokens from the tokens object.
+		return tokens.AccessToken, tokens.RefreshToken, tokens.IDToken, "", tokens.IDTokenClaims.ClientID
+
+	default:
+		ctx.Req.Fail("unsupported credential type for oidcAuthWithCsr")
+		return "", "", "", "", ""
+	}
+}
+
+// oidcCertAuthWithCsr performs an OIDC cert auth flow with a CSR, returning tokens.
+func oidcCertAuthWithCsr(
+	ctx *TestContext,
+	clientHelper *ClientHelperClient,
+	certCreds *edge_apis.CertCredentials,
+	csrPem string,
+) (accessToken string, refreshToken string, idToken string, sessionCert string, clientID string) {
+	result, err := clientHelper.OidcAuthorize(certCreds)
+	ctx.Req.NoError(err)
+
+	opLoginUri := "https://" + ctx.ApiHost + "/oidc/login/cert"
+
+	payload := &oidc_auth.OidcUpdbCreds{
+		AuthRequestBody: oidc_auth.AuthRequestBody{
+			AuthRequestId: result.AuthRequestId,
+		},
+		CsrPem: csrPem,
+	}
+
+	resp, postErr := result.Client.R().SetBody(payload).Post(opLoginUri)
+	ctx.Req.NoError(postErr)
+	ctx.Req.Equal(http.StatusFound, resp.StatusCode(),
+		"expected redirect after cert+CSR login, got %d: %s", resp.StatusCode(), resp.String())
+
+	locUrl, parseErr := url.Parse(resp.Header().Get("Location"))
+	ctx.Req.NoError(parseErr)
+	code := locUrl.Query().Get("code")
+	ctx.Req.NotEmpty(code, "expected authorization code in redirect")
+
+	tokens, exchErr := result.Exchange(code)
+	ctx.Req.NoError(exchErr)
+	ctx.Req.NotNil(tokens)
+
+	return tokens.AccessToken, tokens.RefreshToken, tokens.IDToken, "", tokens.IDTokenClaims.ClientID
+}
+
+// Test_OIDC_CSR_Refresh verifies cert binding during token refresh for UPDB identities
+// authenticated with a CSR. It tests that the z_cfs claim enforces TLS client cert
+// fingerprint matching on refresh, that CSR rotation works, and that old session certs
+// are rejected after rotation.
+func Test_OIDC_CSR_Refresh(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+
+	managementHelper := ctx.NewEdgeManagementApi(nil)
+	clientHelper := ctx.NewEdgeClientApi(nil)
+
+	adminCreds := edge_apis.NewUpdbCredentials(ctx.AdminAuthenticator.Username, ctx.AdminAuthenticator.Password)
+	adminCreds.CaPool = ctx.ControllerCaPool()
+	_, err := managementHelper.Authenticate(adminCreds, nil)
+	ctx.Req.NoError(rest_util.WrapErr(err))
+
+	// Use the admin identity for UPDB-based CSR testing.
+	updbCreds := edge_apis.NewUpdbCredentials(ctx.AdminAuthenticator.Username, ctx.AdminAuthenticator.Password)
+	updbCreds.CaPool = ctx.ControllerCaPool()
+
+	// Generate initial CSR for authentication.
+	csrPem, csrKey, err := generateCsrPem()
+	ctx.Req.NoError(err)
+	ctx.Req.NotEmpty(csrPem)
+
+	// Authenticate via OIDC with CSR.
+	accessToken, refreshToken, _, _, clientID := oidcAuthWithCsr(ctx, clientHelper, updbCreds, csrPem)
+	ctx.Req.NotEmpty(accessToken)
+	ctx.Req.NotEmpty(refreshToken)
+
+	// Parse access token to get initial z_cfs.
+	origClaims, err := parseAccessClaims(accessToken)
+	ctx.Req.NoError(err)
+	ctx.Req.NotEmpty(origClaims.CertFingerprints, "expected z_cfs to be populated after CSR auth")
+
+	// Build TLS cert from the session cert for subsequent requests.
+	// Since the standard exchange does not return session_cert, we use the first refresh
+	// with CSR to obtain a session cert. For now, do a refresh with the CSR to get a session cert.
+	newAccessToken, newRefreshToken, sessionCertPem, status := doRefreshRequest(
+		ctx, refreshToken, clientID, nil, csrPem, true,
+	)
+
+	// If the initial auth already bound certs, a refresh without a matching cert may fail.
+	// In that case, we need to work with what we have.
+	if status == http.StatusOK && sessionCertPem != "" {
+		// We got a session cert on refresh. Use it.
+		accessToken = newAccessToken
+		refreshToken = newRefreshToken
+
+		origClaims, err = parseAccessClaims(accessToken)
+		ctx.Req.NoError(err)
+	}
+
+	// Build session TLS certs from the session cert PEM and CSR key.
+	var sessionTlsCerts []cryptoTls.Certificate
+	if sessionCertPem != "" {
+		sessionTlsCerts, err = buildTlsCertFromPem(sessionCertPem, csrKey)
+		ctx.Req.NoError(err)
+	}
+
+	initialCfs := origClaims.CertFingerprints
+
+	t.Run("refresh with matching cert succeeds", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		if sessionTlsCerts == nil {
+			t.Skip("no session cert available for this test")
+		}
+
+		_, _, _, statusCode := doRefreshRequest(
+			ctx, refreshToken, clientID, sessionTlsCerts, "", false,
+		)
+		ctx.Req.Equal(http.StatusOK, statusCode, "refresh with matching session cert should succeed")
+	})
+
+	t.Run("refresh with wrong cert fails when z_cfs present", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		if len(origClaims.CertFingerprints) == 0 {
+			t.Skip("z_cfs is empty, cert binding not enforced")
+		}
+
+		wrongTlsCerts, genErr := generateSelfSignedCertAndKey()
+		ctx.Req.NoError(genErr)
+
+		_, _, _, statusCode := doRefreshRequest(
+			ctx, refreshToken, clientID, wrongTlsCerts, "", false,
+		)
+		ctx.Req.NotEqual(http.StatusOK, statusCode,
+			"refresh with wrong cert should fail when z_cfs is present")
+	})
+
+	t.Run("refresh without cert fails when z_cfs present", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		if len(origClaims.CertFingerprints) == 0 {
+			t.Skip("z_cfs is empty, cert binding not enforced")
+		}
+
+		_, _, _, statusCode := doRefreshRequest(
+			ctx, refreshToken, clientID, nil, "", false,
+		)
+		ctx.Req.NotEqual(http.StatusOK, statusCode,
+			"refresh without cert should fail when z_cfs is present")
+	})
+
+	t.Run("refresh without CSR preserves z_cfs", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		if sessionTlsCerts == nil {
+			t.Skip("no session cert available for this test")
+		}
+
+		newAccess, _, _, statusCode := doRefreshRequest(
+			ctx, refreshToken, clientID, sessionTlsCerts, "", false,
+		)
+		ctx.Req.Equal(http.StatusOK, statusCode)
+
+		newClaims, parseErr := parseAccessClaims(newAccess)
+		ctx.Req.NoError(parseErr)
+		ctx.Req.Equal(initialCfs, newClaims.CertFingerprints,
+			"z_cfs should be identical when refreshing without a CSR")
+	})
+
+	t.Run("z_cfs token cannot transition to empty z_cfs", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		if sessionTlsCerts == nil {
+			t.Skip("no session cert available for this test")
+		}
+
+		newAccess, _, _, statusCode := doRefreshRequest(
+			ctx, refreshToken, clientID, sessionTlsCerts, "", false,
+		)
+		ctx.Req.Equal(http.StatusOK, statusCode)
+
+		newClaims, parseErr := parseAccessClaims(newAccess)
+		ctx.Req.NoError(parseErr)
+		ctx.Req.NotEmpty(newClaims.CertFingerprints,
+			"a token with z_cfs must not transition to empty z_cfs")
+	})
+
+	t.Run("refresh with CSR rotates cert", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		if sessionTlsCerts == nil {
+			t.Skip("no session cert available for this test")
+		}
+
+		// Generate a new CSR for rotation.
+		newCsrPem, newCsrKey, genErr := generateCsrPem()
+		ctx.Req.NoError(genErr)
+
+		newAccess, newRefresh, newSessionCert, statusCode := doRefreshRequest(
+			ctx, refreshToken, clientID, sessionTlsCerts, newCsrPem, true,
+		)
+		ctx.Req.Equal(http.StatusOK, statusCode, "refresh with CSR rotation should succeed")
+		ctx.Req.NotEmpty(newAccess)
+		ctx.Req.NotEmpty(newRefresh)
+
+		// Verify session_cert is valid PEM.
+		if newSessionCert != "" {
+			block, _ := pem.Decode([]byte(newSessionCert))
+			ctx.Req.NotNil(block, "session_cert should be valid PEM")
+		}
+
+		// Parse new access token and verify z_cfs changed.
+		newClaims, parseErr := parseAccessClaims(newAccess)
+		ctx.Req.NoError(parseErr)
+		ctx.Req.NotEmpty(newClaims.CertFingerprints, "z_cfs should be populated after CSR rotation")
+
+		// The new fingerprint from the rotated CSR cert should be present.
+		if newSessionCert != "" {
+			newFp := fingerprintFromPem(newSessionCert)
+			ctx.Req.NotEmpty(newFp)
+			ctx.Req.Contains(newClaims.CertFingerprints, newFp,
+				"z_cfs should contain the fingerprint of the new session cert")
+		}
+
+		t.Run("after rotation, old session cert rejected", func(t *testing.T) {
+			ctx.NextTest(t)
+
+			_, _, _, statusCode := doRefreshRequest(
+				ctx, newRefresh, clientID, sessionTlsCerts, "", false,
+			)
+			ctx.Req.NotEqual(http.StatusOK, statusCode,
+				"old session cert should be rejected after CSR rotation")
+		})
+
+		t.Run("after rotation, new session cert accepted", func(t *testing.T) {
+			ctx.NextTest(t)
+
+			if newSessionCert == "" {
+				t.Skip("no new session cert returned")
+			}
+
+			newTlsCerts, buildErr := buildTlsCertFromPem(newSessionCert, newCsrKey)
+			ctx.Req.NoError(buildErr)
+
+			_, _, _, statusCode := doRefreshRequest(
+				ctx, newRefresh, clientID, newTlsCerts, "", false,
+			)
+			ctx.Req.Equal(http.StatusOK, statusCode,
+				"new session cert should be accepted after CSR rotation")
+		})
+	})
+}
+
+// Test_OIDC_CSR_Refresh_CertAuth verifies cert binding during token refresh for cert-authenticated
+// identities. When a cert identity authenticates with a CSR, the z_cfs claim contains both the
+// auth cert fingerprint and the CSR-derived session cert fingerprint. Both certs should be
+// accepted for refresh, and rotation should replace only the session cert fingerprint.
+func Test_OIDC_CSR_Refresh_CertAuth(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+
+	managementHelper := ctx.NewEdgeManagementApi(nil)
+	clientHelper := ctx.NewEdgeClientApi(nil)
+
+	adminCreds := edge_apis.NewUpdbCredentials(ctx.AdminAuthenticator.Username, ctx.AdminAuthenticator.Password)
+	adminCreds.CaPool = ctx.ControllerCaPool()
+	_, err := managementHelper.Authenticate(adminCreds, nil)
+	ctx.Req.NoError(rest_util.WrapErr(err))
+
+	// Create and enroll a cert-based identity.
+	_, certCreds, err := managementHelper.CreateAndEnrollOttIdentity(false)
+	ctx.Req.NoError(err)
+	certCreds.CaPool = ctx.ControllerCaPool()
+
+	// Generate initial CSR.
+	csrPem, csrKey, err := generateCsrPem()
+	ctx.Req.NoError(err)
+
+	// Authenticate via cert + CSR.
+	accessToken, refreshToken, _, _, clientID := oidcCertAuthWithCsr(ctx, clientHelper, certCreds, csrPem)
+	ctx.Req.NotEmpty(accessToken)
+	ctx.Req.NotEmpty(refreshToken)
+
+	origClaims, err := parseAccessClaims(accessToken)
+	ctx.Req.NoError(err)
+
+	// Compute the auth cert fingerprint.
+	authCertFp := nfpem.FingerprintFromCertificate(certCreds.Certs[0])
+	ctx.Req.NotEmpty(authCertFp)
+
+	// Build auth cert TLS certs.
+	authTlsCerts := certCreds.TlsCerts()
+
+	// Do an initial refresh with CSR to obtain a session cert for subsequent tests.
+	newAccess, newRefresh, sessionCertPem, status := doRefreshRequest(
+		ctx, refreshToken, clientID, authTlsCerts, csrPem, true,
+	)
+	if status == http.StatusOK && newAccess != "" {
+		accessToken = newAccess
+		refreshToken = newRefresh
+		origClaims, err = parseAccessClaims(accessToken)
+		ctx.Req.NoError(err)
+	}
+
+	var sessionTlsCerts []cryptoTls.Certificate
+	if sessionCertPem != "" {
+		sessionTlsCerts, err = buildTlsCertFromPem(sessionCertPem, csrKey)
+		ctx.Req.NoError(err)
+	}
+
+	t.Run("refresh with auth cert succeeds", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		_, _, _, statusCode := doRefreshRequest(
+			ctx, refreshToken, clientID, authTlsCerts, "", false,
+		)
+		ctx.Req.Equal(http.StatusOK, statusCode,
+			"refresh with auth cert should succeed")
+	})
+
+	t.Run("refresh with session cert succeeds", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		if sessionTlsCerts == nil {
+			t.Skip("no session cert available")
+		}
+
+		_, _, _, statusCode := doRefreshRequest(
+			ctx, refreshToken, clientID, sessionTlsCerts, "", false,
+		)
+		ctx.Req.Equal(http.StatusOK, statusCode,
+			"refresh with session cert should succeed")
+	})
+
+	t.Run("refresh without CSR preserves both fingerprints", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		newAccess, _, _, statusCode := doRefreshRequest(
+			ctx, refreshToken, clientID, authTlsCerts, "", false,
+		)
+		ctx.Req.Equal(http.StatusOK, statusCode)
+
+		newClaims, parseErr := parseAccessClaims(newAccess)
+		ctx.Req.NoError(parseErr)
+		ctx.Req.Contains(newClaims.CertFingerprints, authCertFp,
+			"z_cfs should still contain auth cert fingerprint")
+		ctx.Req.Equal(origClaims.CertFingerprints, newClaims.CertFingerprints,
+			"z_cfs should be unchanged when refreshing without a CSR")
+	})
+
+	t.Run("rotate with session cert and new CSR", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		if sessionTlsCerts == nil {
+			t.Skip("no session cert available")
+		}
+
+		newCsrPem, _, genErr := generateCsrPem()
+		ctx.Req.NoError(genErr)
+
+		newAccess, _, newSessionCert, statusCode := doRefreshRequest(
+			ctx, refreshToken, clientID, sessionTlsCerts, newCsrPem, true,
+		)
+		ctx.Req.Equal(http.StatusOK, statusCode,
+			"rotation with session cert and new CSR should succeed")
+
+		newClaims, parseErr := parseAccessClaims(newAccess)
+		ctx.Req.NoError(parseErr)
+		ctx.Req.Contains(newClaims.CertFingerprints, authCertFp,
+			"z_cfs should retain auth cert fingerprint after rotation")
+
+		if newSessionCert != "" {
+			rotatedFp := fingerprintFromPem(newSessionCert)
+			ctx.Req.Contains(newClaims.CertFingerprints, rotatedFp,
+				"z_cfs should contain the new session cert fingerprint")
+		}
+	})
+
+	t.Run("rotate with auth cert and new CSR", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		newCsrPem, _, genErr := generateCsrPem()
+		ctx.Req.NoError(genErr)
+
+		newAccess, _, newSessionCert, statusCode := doRefreshRequest(
+			ctx, refreshToken, clientID, authTlsCerts, newCsrPem, true,
+		)
+		ctx.Req.Equal(http.StatusOK, statusCode,
+			"rotation with auth cert and new CSR should succeed")
+
+		newClaims, parseErr := parseAccessClaims(newAccess)
+		ctx.Req.NoError(parseErr)
+		ctx.Req.Contains(newClaims.CertFingerprints, authCertFp,
+			"z_cfs should retain auth cert fingerprint after rotation")
+
+		if newSessionCert != "" {
+			rotatedFp := fingerprintFromPem(newSessionCert)
+			ctx.Req.Contains(newClaims.CertFingerprints, rotatedFp,
+				"z_cfs should contain the new session cert fingerprint")
+		}
+	})
+
+	t.Run("after rotation, old session cert rejected, auth cert still works", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		// Rotate to get a definitive new state.
+		newCsrPem, _, genErr := generateCsrPem()
+		ctx.Req.NoError(genErr)
+
+		_, rotatedRefresh, _, statusCode := doRefreshRequest(
+			ctx, refreshToken, clientID, authTlsCerts, newCsrPem, true,
+		)
+		ctx.Req.Equal(http.StatusOK, statusCode)
+
+		// Old session cert should be rejected.
+		if sessionTlsCerts != nil {
+			_, _, _, oldStatus := doRefreshRequest(
+				ctx, rotatedRefresh, clientID, sessionTlsCerts, "", false,
+			)
+			ctx.Req.NotEqual(http.StatusOK, oldStatus,
+				"old session cert should be rejected after rotation")
+		}
+
+		// Auth cert should still work.
+		_, _, _, authStatus := doRefreshRequest(
+			ctx, rotatedRefresh, clientID, authTlsCerts, "", false,
+		)
+		ctx.Req.Equal(http.StatusOK, authStatus,
+			"auth cert should still work after session cert rotation")
+	})
+}
+
+// Test_OIDC_CSR_TokenExchange verifies cert binding during token exchange. The token exchange
+// grant type uses the access token as the subject token and should enforce the same z_cfs
+// fingerprint matching as refresh.
+func Test_OIDC_CSR_TokenExchange(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+
+	managementHelper := ctx.NewEdgeManagementApi(nil)
+	clientHelper := ctx.NewEdgeClientApi(nil)
+
+	adminCreds := edge_apis.NewUpdbCredentials(ctx.AdminAuthenticator.Username, ctx.AdminAuthenticator.Password)
+	adminCreds.CaPool = ctx.ControllerCaPool()
+	_, err := managementHelper.Authenticate(adminCreds, nil)
+	ctx.Req.NoError(rest_util.WrapErr(err))
+
+	// Authenticate admin via OIDC with CSR.
+	csrPem, csrKey, err := generateCsrPem()
+	ctx.Req.NoError(err)
+
+	updbCreds := edge_apis.NewUpdbCredentials(ctx.AdminAuthenticator.Username, ctx.AdminAuthenticator.Password)
+	updbCreds.CaPool = ctx.ControllerCaPool()
+
+	accessToken, refreshToken, _, _, clientID := oidcAuthWithCsr(ctx, clientHelper, updbCreds, csrPem)
+	ctx.Req.NotEmpty(accessToken)
+
+	origClaims, err := parseAccessClaims(accessToken)
+	ctx.Req.NoError(err)
+
+	// Do an initial refresh with CSR to get a session cert.
+	newAccess, newRefresh, sessionCertPem, status := doRefreshRequest(
+		ctx, refreshToken, clientID, nil, csrPem, true,
+	)
+	if status == http.StatusOK && newAccess != "" {
+		accessToken = newAccess
+		refreshToken = newRefresh
+		_ = refreshToken
+		origClaims, err = parseAccessClaims(accessToken)
+		ctx.Req.NoError(err)
+	}
+
+	var sessionTlsCerts []cryptoTls.Certificate
+	if sessionCertPem != "" {
+		sessionTlsCerts, err = buildTlsCertFromPem(sessionCertPem, csrKey)
+		ctx.Req.NoError(err)
+	}
+
+	t.Run("exchange with matching cert succeeds", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		if sessionTlsCerts == nil {
+			t.Skip("no session cert available")
+		}
+
+		newAccess, _, _, statusCode := doTokenExchangeRequest(
+			ctx, accessToken, sessionTlsCerts, "", false,
+		)
+		ctx.Req.Equal(http.StatusOK, statusCode,
+			"token exchange with matching cert should succeed")
+		ctx.Req.NotEmpty(newAccess)
+	})
+
+	t.Run("exchange with wrong cert fails when z_cfs present", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		if len(origClaims.CertFingerprints) == 0 {
+			t.Skip("z_cfs is empty")
+		}
+
+		wrongTlsCerts, genErr := generateSelfSignedCertAndKey()
+		ctx.Req.NoError(genErr)
+
+		_, _, _, statusCode := doTokenExchangeRequest(
+			ctx, accessToken, wrongTlsCerts, "", false,
+		)
+		ctx.Req.NotEqual(http.StatusOK, statusCode,
+			"token exchange with wrong cert should fail when z_cfs present")
+	})
+
+	t.Run("exchange without CSR preserves z_cfs", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		if sessionTlsCerts == nil {
+			t.Skip("no session cert available")
+		}
+
+		newAccess, _, _, statusCode := doTokenExchangeRequest(
+			ctx, accessToken, sessionTlsCerts, "", false,
+		)
+		ctx.Req.Equal(http.StatusOK, statusCode)
+
+		newClaims, parseErr := parseAccessClaims(newAccess)
+		ctx.Req.NoError(parseErr)
+		ctx.Req.Equal(origClaims.CertFingerprints, newClaims.CertFingerprints,
+			"z_cfs should be unchanged on exchange without CSR")
+	})
+
+	t.Run("exchange with CSR rotates cert", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		if sessionTlsCerts == nil {
+			t.Skip("no session cert available")
+		}
+
+		newCsrPem, newCsrKey, genErr := generateCsrPem()
+		ctx.Req.NoError(genErr)
+
+		newAccess, _, newSessionCert, statusCode := doTokenExchangeRequest(
+			ctx, accessToken, sessionTlsCerts, newCsrPem, true,
+		)
+		ctx.Req.Equal(http.StatusOK, statusCode,
+			"token exchange with CSR rotation should succeed")
+
+		newClaims, parseErr := parseAccessClaims(newAccess)
+		ctx.Req.NoError(parseErr)
+		ctx.Req.NotEmpty(newClaims.CertFingerprints)
+
+		if newSessionCert != "" {
+			rotatedFp := fingerprintFromPem(newSessionCert)
+			ctx.Req.Contains(newClaims.CertFingerprints, rotatedFp,
+				"z_cfs should contain the new session cert fingerprint")
+		}
+
+		t.Run("after rotation, old cert rejected, new cert accepted", func(t *testing.T) {
+			ctx.NextTest(t)
+
+			// Old cert should fail.
+			_, _, _, oldStatus := doTokenExchangeRequest(
+				ctx, newAccess, sessionTlsCerts, "", false,
+			)
+			ctx.Req.NotEqual(http.StatusOK, oldStatus,
+				"old session cert should be rejected after exchange rotation")
+
+			// New cert should succeed.
+			if newSessionCert != "" {
+				newTlsCerts, buildErr := buildTlsCertFromPem(newSessionCert, newCsrKey)
+				ctx.Req.NoError(buildErr)
+
+				_, _, _, newStatus := doTokenExchangeRequest(
+					ctx, newAccess, newTlsCerts, "", false,
+				)
+				ctx.Req.Equal(http.StatusOK, newStatus,
+					"new session cert should be accepted after exchange rotation")
+			}
+		})
+	})
+}
+
+// Test_OIDC_CSR_SpiffeFallback verifies the SPIFFE ID fallback behavior when z_cfs is empty.
+// A UPDB identity authenticated without a CSR has no z_cfs, so cert binding is not enforced.
+// Submitting a CSR during refresh transitions the token to having z_cfs, after which cert
+// binding is enforced.
+func Test_OIDC_CSR_SpiffeFallback(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+
+	managementHelper := ctx.NewEdgeManagementApi(nil)
+	clientHelper := ctx.NewEdgeClientApi(nil)
+
+	adminCreds := edge_apis.NewUpdbCredentials(ctx.AdminAuthenticator.Username, ctx.AdminAuthenticator.Password)
+	adminCreds.CaPool = ctx.ControllerCaPool()
+	_, err := managementHelper.Authenticate(adminCreds, nil)
+	ctx.Req.NoError(rest_util.WrapErr(err))
+
+	// Authenticate via OIDC WITHOUT CSR (no z_cfs).
+	updbCreds := edge_apis.NewUpdbCredentials(ctx.AdminAuthenticator.Username, ctx.AdminAuthenticator.Password)
+	updbCreds.CaPool = ctx.ControllerCaPool()
+
+	tokens, _, err := clientHelper.RawOidcAuthRequest(updbCreds)
+	ctx.Req.NoError(err)
+	ctx.Req.NotNil(tokens)
+	ctx.Req.NotEmpty(tokens.AccessToken)
+	ctx.Req.NotEmpty(tokens.RefreshToken)
+
+	origClaims, err := parseAccessClaims(tokens.AccessToken)
+	ctx.Req.NoError(err)
+
+	clientID := tokens.IDTokenClaims.ClientID
+
+	t.Run("refresh without z_cfs and no cert passes", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		// With empty z_cfs, refresh should succeed without a client cert.
+		newAccess, _, _, statusCode := doRefreshRequest(
+			ctx, tokens.RefreshToken, clientID, nil, "", false,
+		)
+		ctx.Req.Equal(http.StatusOK, statusCode,
+			"refresh without cert should succeed when z_cfs is empty")
+		ctx.Req.NotEmpty(newAccess)
+
+		newClaims, parseErr := parseAccessClaims(newAccess)
+		ctx.Req.NoError(parseErr)
+		ctx.Req.Empty(newClaims.CertFingerprints,
+			"z_cfs should remain empty when no CSR is submitted")
+		_ = origClaims
+	})
+
+	t.Run("transition from no z_cfs to z_cfs via CSR on refresh", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		csrPem, csrKey, genErr := generateCsrPem()
+		ctx.Req.NoError(genErr)
+
+		newAccess, newRefresh, sessionCertPem, statusCode := doRefreshRequest(
+			ctx, tokens.RefreshToken, clientID, nil, csrPem, true,
+		)
+		ctx.Req.Equal(http.StatusOK, statusCode,
+			"refresh with CSR should succeed and transition to z_cfs")
+		ctx.Req.NotEmpty(newAccess)
+
+		newClaims, parseErr := parseAccessClaims(newAccess)
+		ctx.Req.NoError(parseErr)
+		ctx.Req.NotEmpty(newClaims.CertFingerprints,
+			"z_cfs should be populated after submitting CSR on refresh")
+
+		if sessionCertPem != "" {
+			fp := fingerprintFromPem(sessionCertPem)
+			ctx.Req.Contains(newClaims.CertFingerprints, fp,
+				"z_cfs should contain the session cert fingerprint")
+		}
+
+		t.Run("after transition, refresh without cert fails", func(t *testing.T) {
+			ctx.NextTest(t)
+
+			_, _, _, statusCode := doRefreshRequest(
+				ctx, newRefresh, clientID, nil, "", false,
+			)
+			ctx.Req.NotEqual(http.StatusOK, statusCode,
+				"refresh without cert should fail after transitioning to z_cfs")
+		})
+
+		t.Run("after transition, refresh with session cert succeeds", func(t *testing.T) {
+			ctx.NextTest(t)
+
+			if sessionCertPem == "" {
+				t.Skip("no session cert returned")
+			}
+
+			sessionTlsCerts, buildErr := buildTlsCertFromPem(sessionCertPem, csrKey)
+			ctx.Req.NoError(buildErr)
+
+			_, _, _, statusCode := doRefreshRequest(
+				ctx, newRefresh, clientID, sessionTlsCerts, "", false,
+			)
+			ctx.Req.Equal(http.StatusOK, statusCode,
+				"refresh with session cert should succeed after transition to z_cfs")
+		})
+	})
+}

--- a/tests/auth_oidc_csr_refresh_test.go
+++ b/tests/auth_oidc_csr_refresh_test.go
@@ -430,6 +430,24 @@ func Test_OIDC_CSR_Refresh(t *testing.T) {
 			"refresh without cert should fail when z_cfs is present")
 	})
 
+	t.Run("refresh without cert and with CSR fails when z_cfs present", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		if len(origClaims.CertFingerprints) == 0 {
+			t.Skip("z_cfs is empty, cert binding not enforced")
+		}
+
+		csrPem, _, genErr := generateCsrPem()
+		ctx.Req.NoError(genErr)
+
+		_, _, sessionCertPem, statusCode := doRefreshRequest(
+			ctx, refreshToken, clientID, nil, csrPem, true,
+		)
+		ctx.Req.NotEqual(http.StatusOK, statusCode,
+			"a CSR must not bypass the cert binding check on a PoP session")
+		ctx.Req.Empty(sessionCertPem)
+	})
+
 	t.Run("refresh without CSR preserves z_cfs", func(t *testing.T) {
 		ctx.NextTest(t)
 
@@ -910,55 +928,37 @@ func Test_OIDC_CSR_SpiffeFallback(t *testing.T) {
 		_ = origClaims
 	})
 
-	t.Run("transition from no z_cfs to z_cfs via CSR on refresh", func(t *testing.T) {
+	t.Run("refresh with CSR is ignored in bearer mode", func(t *testing.T) {
 		ctx.NextTest(t)
 
-		csrPem, csrKey, genErr := generateCsrPem()
+		// Bearer-mode sessions (z_cfs empty) cannot transition into PoP via a CSR
+		// submitted at the token endpoint. The CSR is silently ignored so that a
+		// stolen refresh token cannot establish PoP under an attacker-supplied
+		// keypair and lock the legitimate user out of their own session.
+		csrPem, _, genErr := generateCsrPem()
 		ctx.Req.NoError(genErr)
 
 		newAccess, newRefresh, sessionCertPem, statusCode := doRefreshRequest(
 			ctx, tokens.RefreshToken, clientID, nil, csrPem, true,
 		)
-		ctx.Req.Equal(http.StatusOK, statusCode,
-			"refresh with CSR should succeed and transition to z_cfs")
+		ctx.Req.Equal(http.StatusOK, statusCode, "bearer-mode refresh must succeed")
 		ctx.Req.NotEmpty(newAccess)
+		ctx.Req.Empty(sessionCertPem,
+			"no session_cert should be returned when CSR is ignored")
 
 		newClaims, parseErr := parseAccessClaims(newAccess)
 		ctx.Req.NoError(parseErr)
-		ctx.Req.NotEmpty(newClaims.CertFingerprints,
-			"z_cfs should be populated after submitting CSR on refresh")
+		ctx.Req.Empty(newClaims.CertFingerprints,
+			"z_cfs must remain empty; CSR submitted in bearer mode must not establish PoP")
 
-		if sessionCertPem != "" {
-			fp := fingerprintFromPem(sessionCertPem)
-			ctx.Req.Contains(newClaims.CertFingerprints, fp,
-				"z_cfs should contain the session cert fingerprint")
-		}
-
-		t.Run("after transition, refresh without cert fails", func(t *testing.T) {
+		t.Run("session remains bearer mode after the CSR-bearing refresh", func(t *testing.T) {
 			ctx.NextTest(t)
 
 			_, _, _, statusCode := doRefreshRequest(
 				ctx, newRefresh, clientID, nil, "", false,
 			)
-			ctx.Req.NotEqual(http.StatusOK, statusCode,
-				"refresh without cert should fail after transitioning to z_cfs")
-		})
-
-		t.Run("after transition, refresh with session cert succeeds", func(t *testing.T) {
-			ctx.NextTest(t)
-
-			if sessionCertPem == "" {
-				t.Skip("no session cert returned")
-			}
-
-			sessionTlsCerts, buildErr := buildTlsCertFromPem(sessionCertPem, csrKey)
-			ctx.Req.NoError(buildErr)
-
-			_, _, _, statusCode := doRefreshRequest(
-				ctx, newRefresh, clientID, sessionTlsCerts, "", false,
-			)
 			ctx.Req.Equal(http.StatusOK, statusCode,
-				"refresh with session cert should succeed after transition to z_cfs")
+				"a follow-up refresh without a cert must still succeed")
 		})
 	})
 }

--- a/tests/auth_oidc_csr_test.go
+++ b/tests/auth_oidc_csr_test.go
@@ -1,0 +1,322 @@
+//go:build apitests
+
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package tests
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha1"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/openziti/edge-api/rest_model"
+	"github.com/openziti/identity/certtools"
+	"github.com/openziti/ziti/v2/common"
+	"github.com/openziti/ziti/v2/controller/oidc_auth"
+)
+
+// generateCsrPem creates a new ECDSA P-384 key pair and a PKCS#10 certificate signing
+// request encoded as PEM. It returns the PEM string, the private key, and any error.
+func generateCsrPem() (string, crypto.PrivateKey, error) {
+	p384 := elliptic.P384()
+	privateKey, err := ecdsa.GenerateKey(p384, rand.Reader)
+	if err != nil {
+		return "", nil, err
+	}
+
+	request, err := certtools.NewCertRequest(map[string]string{
+		"C": "US", "O": "TEST", "CN": "test-csr",
+	}, nil)
+	if err != nil {
+		return "", nil, err
+	}
+
+	csr, err := x509.CreateCertificateRequest(rand.Reader, request, privateKey)
+	if err != nil {
+		return "", nil, err
+	}
+
+	csrPem := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csr}))
+	return csrPem, privateKey, nil
+}
+
+// certFingerprint computes the SHA-1 fingerprint of a DER-encoded certificate,
+// formatted as a lowercase hex string without separators.
+func certFingerprint(cert *x509.Certificate) string {
+	return fmt.Sprintf("%x", sha1.Sum(cert.Raw))
+}
+
+func Test_Authenticate_OIDC_CSR(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+
+	clientHelper := ctx.NewEdgeClientApi(nil)
+
+	managementHelper := ctx.NewEdgeManagementApi(nil)
+	adminCreds := ctx.NewAdminCredentials()
+	_, err := managementHelper.Authenticate(adminCreds, nil)
+	ctx.Req.NoError(err)
+
+	t.Run("updb auth with CSR returns session cert", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		csrPem, _, err := generateCsrPem()
+		ctx.Req.NoError(err)
+
+		result, err := clientHelper.OidcAuthorize(adminCreds)
+		ctx.Req.NoError(err)
+
+		opLoginUri := "https://" + ctx.ApiHost + "/oidc/login/username?id=" + result.AuthRequestId
+
+		payload := &oidc_auth.OidcUpdbCreds{
+			Authenticate: rest_model.Authenticate{
+				Password: rest_model.Password(ctx.AdminAuthenticator.Password),
+				Username: rest_model.Username(ctx.AdminAuthenticator.Username),
+			},
+			AuthRequestBody: oidc_auth.AuthRequestBody{
+				AuthRequestId: result.AuthRequestId,
+			},
+			CsrPem: csrPem,
+		}
+
+		resp, err := result.Client.R().SetBody(payload).Post(opLoginUri)
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusFound, resp.StatusCode())
+
+		locUrl, parseErr := url.Parse(resp.Header().Get("Location"))
+		ctx.Req.NoError(parseErr)
+		code := locUrl.Query().Get("code")
+		ctx.Req.NotEmpty(code)
+
+		tokens, err := result.Exchange(code)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(tokens)
+		ctx.Req.NotEmpty(tokens.AccessToken)
+
+		t.Run("access token has CSR cert fingerprint", func(t *testing.T) {
+			ctx.NextTest(t)
+
+			parser := jwt.NewParser()
+			accessClaims := &common.AccessClaims{}
+			_, _, err := parser.ParseUnverified(tokens.AccessToken, accessClaims)
+			ctx.Req.NoError(err)
+
+			ctx.Req.Len(accessClaims.CertFingerprints, 1, "updb + CSR should have exactly one cert fingerprint (from the CSR)")
+			ctx.Req.Empty(accessClaims.AuthCertFingerprint, "updb auth should have no auth cert fingerprints")
+		})
+	})
+
+	t.Run("updb auth without CSR has no session cert", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		result, err := clientHelper.OidcAuthorize(adminCreds)
+		ctx.Req.NoError(err)
+
+		opLoginUri := "https://" + ctx.ApiHost + "/oidc/login/username?id=" + result.AuthRequestId
+
+		payload := &oidc_auth.OidcUpdbCreds{
+			Authenticate: rest_model.Authenticate{
+				Password: rest_model.Password(ctx.AdminAuthenticator.Password),
+				Username: rest_model.Username(ctx.AdminAuthenticator.Username),
+			},
+			AuthRequestBody: oidc_auth.AuthRequestBody{
+				AuthRequestId: result.AuthRequestId,
+			},
+		}
+
+		resp, err := result.Client.R().SetBody(payload).Post(opLoginUri)
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusFound, resp.StatusCode())
+
+		locUrl, parseErr := url.Parse(resp.Header().Get("Location"))
+		ctx.Req.NoError(parseErr)
+		code := locUrl.Query().Get("code")
+		ctx.Req.NotEmpty(code)
+
+		tokens, err := result.Exchange(code)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(tokens)
+		ctx.Req.NotEmpty(tokens.AccessToken)
+
+		t.Run("access token has no cert fingerprints", func(t *testing.T) {
+			ctx.NextTest(t)
+
+			parser := jwt.NewParser()
+			accessClaims := &common.AccessClaims{}
+			_, _, err := parser.ParseUnverified(tokens.AccessToken, accessClaims)
+			ctx.Req.NoError(err)
+
+			ctx.Req.Empty(accessClaims.CertFingerprints, "updb without CSR should have no cert fingerprints")
+			ctx.Req.Empty(accessClaims.AuthCertFingerprint, "updb auth should have no auth cert fingerprints")
+		})
+	})
+
+	t.Run("cert auth with CSR returns session cert", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		_, certCreds, err := managementHelper.CreateAndEnrollOttIdentity(false)
+		ctx.Req.NoError(err)
+		certCreds.CaPool = ctx.ControllerCaPool()
+
+		authCertFp := certFingerprint(certCreds.Certs[0])
+
+		csrPem, _, err := generateCsrPem()
+		ctx.Req.NoError(err)
+
+		result, err := clientHelper.OidcAuthorize(certCreds)
+		ctx.Req.NoError(err)
+
+		opLoginUri := "https://" + ctx.ApiHost + "/oidc/login/cert"
+
+		payload := &oidc_auth.OidcUpdbCreds{
+			AuthRequestBody: oidc_auth.AuthRequestBody{
+				AuthRequestId: result.AuthRequestId,
+			},
+			CsrPem: csrPem,
+		}
+
+		resp, err := result.Client.R().SetBody(payload).Post(opLoginUri)
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusFound, resp.StatusCode())
+
+		locUrl, parseErr := url.Parse(resp.Header().Get("Location"))
+		ctx.Req.NoError(parseErr)
+		code := locUrl.Query().Get("code")
+		ctx.Req.NotEmpty(code)
+
+		tokens, err := result.Exchange(code)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(tokens)
+		ctx.Req.NotEmpty(tokens.AccessToken)
+
+		t.Run("access token has auth cert and CSR cert fingerprints", func(t *testing.T) {
+			ctx.NextTest(t)
+
+			parser := jwt.NewParser()
+			accessClaims := &common.AccessClaims{}
+			_, _, err := parser.ParseUnverified(tokens.AccessToken, accessClaims)
+			ctx.Req.NoError(err)
+
+			ctx.Req.Len(accessClaims.CertFingerprints, 2,
+				"cert auth + CSR should have two cert fingerprints (auth cert + CSR cert)")
+			ctx.Req.NotEmpty(accessClaims.AuthCertFingerprint,
+				"cert auth should have an auth cert fingerprint")
+
+			ctx.Req.Equal(authCertFp, accessClaims.AuthCertFingerprint,
+				"auth cert fingerprint should match the authenticating certificate")
+			ctx.Req.Contains(accessClaims.CertFingerprints, authCertFp,
+				"CertFingerprints should contain the auth cert fingerprint")
+		})
+	})
+
+	t.Run("cert auth without CSR has only client cert", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		_, certCreds, err := managementHelper.CreateAndEnrollOttIdentity(false)
+		ctx.Req.NoError(err)
+		certCreds.CaPool = ctx.ControllerCaPool()
+
+		authCertFp := certFingerprint(certCreds.Certs[0])
+
+		result, err := clientHelper.OidcAuthorize(certCreds)
+		ctx.Req.NoError(err)
+
+		opLoginUri := "https://" + ctx.ApiHost + "/oidc/login/cert"
+
+		payload := &oidc_auth.OidcUpdbCreds{
+			AuthRequestBody: oidc_auth.AuthRequestBody{
+				AuthRequestId: result.AuthRequestId,
+			},
+		}
+
+		resp, err := result.Client.R().SetBody(payload).Post(opLoginUri)
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusFound, resp.StatusCode())
+
+		locUrl, parseErr := url.Parse(resp.Header().Get("Location"))
+		ctx.Req.NoError(parseErr)
+		code := locUrl.Query().Get("code")
+		ctx.Req.NotEmpty(code)
+
+		tokens, err := result.Exchange(code)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(tokens)
+		ctx.Req.NotEmpty(tokens.AccessToken)
+
+		t.Run("access token has only auth cert fingerprint", func(t *testing.T) {
+			ctx.NextTest(t)
+
+			parser := jwt.NewParser()
+			accessClaims := &common.AccessClaims{}
+			_, _, err := parser.ParseUnverified(tokens.AccessToken, accessClaims)
+			ctx.Req.NoError(err)
+
+			ctx.Req.Len(accessClaims.CertFingerprints, 1,
+				"cert auth without CSR should have exactly one cert fingerprint")
+			ctx.Req.NotEmpty(accessClaims.AuthCertFingerprint,
+				"cert auth should have an auth cert fingerprint")
+
+			ctx.Req.Equal(authCertFp, accessClaims.CertFingerprints[0],
+				"CertFingerprints should contain the auth cert fingerprint")
+			ctx.Req.Equal(authCertFp, accessClaims.AuthCertFingerprint,
+				"AuthCertFingerprint should match the auth cert fingerprint")
+		})
+	})
+
+	t.Run("invalid CSR returns error during code exchange", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		result, err := clientHelper.OidcAuthorize(adminCreds)
+		ctx.Req.NoError(err)
+
+		opLoginUri := "https://" + ctx.ApiHost + "/oidc/login/username?id=" + result.AuthRequestId
+
+		payload := &oidc_auth.OidcUpdbCreds{
+			Authenticate: rest_model.Authenticate{
+				Password: rest_model.Password(ctx.AdminAuthenticator.Password),
+				Username: rest_model.Username(ctx.AdminAuthenticator.Username),
+			},
+			AuthRequestBody: oidc_auth.AuthRequestBody{
+				AuthRequestId: result.AuthRequestId,
+			},
+			CsrPem: "not-a-valid-csr",
+		}
+
+		resp, err := result.Client.R().SetBody(payload).Post(opLoginUri)
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusFound, resp.StatusCode(),
+			"login POST should succeed with 302 even with invalid CSR")
+
+		locUrl, parseErr := url.Parse(resp.Header().Get("Location"))
+		ctx.Req.NoError(parseErr)
+		code := locUrl.Query().Get("code")
+		ctx.Req.NotEmpty(code, "authorization code should be present in the redirect")
+
+		_, exchangeErr := result.Exchange(code)
+		ctx.Req.Error(exchangeErr, "code exchange should fail when the CSR is invalid")
+	})
+}

--- a/tests/auth_oidc_pop_test.go
+++ b/tests/auth_oidc_pop_test.go
@@ -172,7 +172,7 @@ func Test_Authenticate_OIDC_PoP(t *testing.T) {
 		_, _, err = jwt.NewParser().ParseUnverified(oidcSession.OidcTokens.AccessToken, claims)
 		ctx.Req.NoError(err)
 		ctx.Req.Contains(claims.AuthenticationMethodsReferences, oidc_auth.AuthMethodCert)
-		ctx.Req.NotEmpty(claims.CertFingerprints, "cert auth must bind tokens to the presenting cert")
+		ctx.Req.Len(claims.CertFingerprints, 1, "cert auth must bind exactly one (leaf) fingerprint into z_cfs")
 
 		t.Run("can query a protected endpoint", func(t *testing.T) {
 			ctx.NextTest(t)
@@ -203,6 +203,42 @@ func Test_Authenticate_OIDC_PoP(t *testing.T) {
 				ctx.Fail("router connection did not occur within 5 seconds")
 			}
 		})
+	})
+
+	t.Run("cert auth with junk trailing certs binds only the leaf in z_cfs", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		// Pad the cert chain with two unrelated self-signed certs at indices >0.
+		// TLS client auth uses only the leaf at index 0, so the handshake still
+		// succeeds; the junk certs are ignored as potential intermediates. The
+		// server's PeerCertificates list nevertheless contains them, which is the
+		// scenario this test exercises: z_cfs must not bind any of the trailing
+		// junk certs.
+		junk1, _ := newSelfSignedCert("junk-trailing-cert-1")
+		junk2, _ := newSelfSignedCert("junk-trailing-cert-2")
+		paddedCerts := append([]*x509.Certificate{}, certAuth.certs...)
+		paddedCerts = append(paddedCerts, junk1, junk2)
+
+		creds := edge_apis.NewCertCredentials(paddedCerts, certAuth.key)
+		creds.CaPool = ctx.ControllerCaPool()
+
+		clientContext, err := ziti.NewContext(&ziti.Config{
+			ZtAPI:       "https://" + ctx.ApiHost + EdgeClientApiPath,
+			Credentials: creds,
+		})
+		ctx.Req.NoError(err)
+		defer clientContext.Close()
+		ctx.Req.NoError(clientContext.Authenticate())
+
+		ctxImpl, ok := clientContext.(*ziti.ContextImpl)
+		ctx.Req.True(ok, "expected *ziti.ContextImpl from ziti.NewContext")
+		oidcSession, ok := ctxImpl.CtrlClt.GetCurrentApiSession().(*edge_apis.ApiSessionOidc)
+		ctx.Req.True(ok, "expected OIDC api session; SDK fell back to legacy, this test requires OIDC mode")
+		claims := &common.AccessClaims{}
+		_, _, err = jwt.NewParser().ParseUnverified(oidcSession.OidcTokens.AccessToken, claims)
+		ctx.Req.NoError(err)
+		ctx.Req.Contains(claims.AuthenticationMethodsReferences, oidc_auth.AuthMethodCert)
+		ctx.Req.Len(claims.CertFingerprints, 1, "junk trailing certs must not appear in z_cfs; only the leaf should bind")
 	})
 
 	t.Run("UPDB auth without TLS cert leaves z_cfs empty", func(t *testing.T) {

--- a/tests/oidc_auto_enable_test.go
+++ b/tests/oidc_auto_enable_test.go
@@ -43,6 +43,7 @@ func Test_OIDC_Auto_Enable(t *testing.T) {
 		ctx.Req.NoError(err)
 		ctx.Req.NotNil(version)
 		ctx.Req.Contains(version.Capabilities, string(rest_model.CapabilitiesOIDCAUTH))
+		ctx.Req.Contains(version.Capabilities, "OIDC_AUTH_WITH_CSR")
 		ctx.Req.Contains(version.APIVersions, "edge-oidc")
 	})
 
@@ -142,6 +143,7 @@ func Test_OIDC_Auto_Binding_Disabled(t *testing.T) {
 		ctx.Req.NoError(err)
 		ctx.Req.NotNil(version)
 		ctx.Req.NotContains(version.Capabilities, string(rest_model.CapabilitiesOIDCAUTH))
+		ctx.Req.NotContains(version.Capabilities, "OIDC_AUTH_WITH_CSR")
 		ctx.Req.NotContains(version.APIVersions, "edge-oidc")
 	})
 

--- a/tests/oidc_auto_enable_test.go
+++ b/tests/oidc_auto_enable_test.go
@@ -43,7 +43,7 @@ func Test_OIDC_Auto_Enable(t *testing.T) {
 		ctx.Req.NoError(err)
 		ctx.Req.NotNil(version)
 		ctx.Req.Contains(version.Capabilities, string(rest_model.CapabilitiesOIDCAUTH))
-		ctx.Req.Contains(version.Capabilities, "OIDC_AUTH_WITH_CSR")
+		ctx.Req.Contains(version.Capabilities, string(rest_model.CapabilitiesOIDCAUTHWITHCSR))
 		ctx.Req.Contains(version.APIVersions, "edge-oidc")
 	})
 
@@ -143,7 +143,7 @@ func Test_OIDC_Auto_Binding_Disabled(t *testing.T) {
 		ctx.Req.NoError(err)
 		ctx.Req.NotNil(version)
 		ctx.Req.NotContains(version.Capabilities, string(rest_model.CapabilitiesOIDCAUTH))
-		ctx.Req.NotContains(version.Capabilities, "OIDC_AUTH_WITH_CSR")
+		ctx.Req.NotContains(version.Capabilities, string(rest_model.CapabilitiesOIDCAUTHWITHCSR))
 		ctx.Req.NotContains(version.APIVersions, "edge-oidc")
 	})
 

--- a/zititest/go.mod
+++ b/zititest/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/michaelquigley/pfxlog v1.0.0
 	github.com/openziti/agent v1.0.33
 	github.com/openziti/channel/v4 v4.3.11
-	github.com/openziti/edge-api v0.28.1
+	github.com/openziti/edge-api v0.31.0
 	github.com/openziti/fablab v0.6.16
 	github.com/openziti/foundation/v2 v2.0.90
 	github.com/openziti/identity v1.0.128

--- a/zititest/go.sum
+++ b/zititest/go.sum
@@ -610,8 +610,8 @@ github.com/openziti/channel/v4 v4.3.11 h1:ugezUhTEuSQnVFKUioN1gh6f+ZF4eBqx6mOrT5
 github.com/openziti/channel/v4 v4.3.11/go.mod h1:WZpOeuPliA7mJ3m7Pal8WdYu74eHMzkM/1Z9AMLmUAg=
 github.com/openziti/cobra-to-md v1.0.1 h1:WRinNoIRmwWUSJm+pSNXMjOrtU48oxXDZgeCYQfVXxE=
 github.com/openziti/cobra-to-md v1.0.1/go.mod h1:FjCpk/yzHF7/r28oSTNr5P57yN5VolpdAtS/g7KNi2c=
-github.com/openziti/edge-api v0.28.1 h1:Dx+yUwdZSVpztzOkduak55TqWJPw8tq3nq3IC01uOPw=
-github.com/openziti/edge-api v0.28.1/go.mod h1:pDtCR6Mq0h5e8ulJhmuhPshEBa39hpQy+yTtLpUSBOs=
+github.com/openziti/edge-api v0.31.0 h1:QdaaPnKQj4B40q404+c8VZxMsoVpfGpfOhzs3LLCd/A=
+github.com/openziti/edge-api v0.31.0/go.mod h1:pDtCR6Mq0h5e8ulJhmuhPshEBa39hpQy+yTtLpUSBOs=
 github.com/openziti/fablab v0.6.16 h1:JVy5zQ/NXoHl2SxMZDKT7jPnUlZyBSKAZXhVD2vOMKQ=
 github.com/openziti/fablab v0.6.16/go.mod h1:TXrgrWWnE9yxXP5e6RYBgjgmJhT1LXBnOtfir6Av+Ko=
 github.com/openziti/foundation/v2 v2.0.90 h1:1+Xbug8gQgi656yq+mvKvzROmmX/Lsrgt/s12l1Wz3s=


### PR DESCRIPTION
- accepts an optional CSR during OIDC login (all auth methods) and signs it into a session-bound certificate with a SPIFFE ID derived from the identity and API session
- returns the signed certificate PEM as a top-level "session_cert" field in the token endpoint JSON response (CodeExchange, RefreshToken, TokenExchange)
- adds cert-binding verification on RefreshToken and TokenExchange: if z_cfs is present the peer cert fingerprint must match (strict), otherwise falls back to SPIFFE ID verification
- supports cert rotation via csr_pem form parameter on refresh and token exchange; replaces the session cert fingerprint while preserving the authenticating cert fingerprint
- adds AuthCertFingerprints (z_acfs) claim to track permanent auth cert fingerprints separately from rotatable session cert fingerprints
- only the leaf certificate fingerprint is added to z_cfs and z_acfs, intermediates are never included
- invalid CSR returns 400 Bad Request in OIDC error format
- propagates updated CustomClaims (including CertFingerprints) from access token to renewed refresh token so rotated fingerprints are enforced on subsequent refreshes
- adds CertGenerated field to ApiSessionEvent
- advertises OIDC_AUTH_WITH_CSR controller capability when OIDC is enabled
- adds unit tests for verifyCertBinding (fingerprint, SPIFFE ID, edge cases) and CsrPem field parsing
- adds integration tests for initial CSR auth (updb, cert, ext-jwt), cert-binding on refresh/exchange, CSR rotation with cert auth, SPIFFE fallback and z_cfs transition, and CSR property forging resistance