### PR TITLE
permissions fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1365,6 +1365,11 @@ be removed.
 
 * github.com/openziti/go-term-markdown: v1.0.1 (new)
 * github.com/openziti/ziti/v2: [v1.6.8 -> v2.0.0](https://github.com/openziti/ziti/compare/v1.6.8...v2.0.0)
+    * [Issue #3855](https://github.com/openziti/ziti/issues/3855) - Filter current api session certs list by current api session
+    * [Issue #3838](https://github.com/openziti/ziti/issues/3838) - List controllers on management API has incorrect permissions check
+    * [Issue #3837](https://github.com/openziti/ziti/issues/3837) - Create db snapshot with path has incorrect permissions check
+    * [Issue #3846](https://github.com/openziti/ziti/issues/3846) - OIDC token binds client cert during non-cert auth, causes PoP failures
+    * [Issue #3809](https://github.com/openziti/ziti/issues/3809) - Support CSR submission during OIDC authentication for session-bound certificates
     * [Issue #3830](https://github.com/openziti/ziti/issues/3830) - statemanager is holding on to edge connections and they're never getting cleared
     * [Issue #3824](https://github.com/openziti/ziti/issues/3824) - Allow calling inspect using the IPC agent on the controller, router and go tunnel
     * [Issue #2049](https://github.com/openziti/ziti/issues/2049) - The ziti agent command should have a controller connection status

--- a/controller/internal/routes/api_session_router.go
+++ b/controller/internal/routes/api_session_router.go
@@ -43,17 +43,17 @@ func NewApiSessionRouter() *ApiSessionHandler {
 func (ir *ApiSessionHandler) Register(ae *env.AppEnv) {
 	ae.ManagementApi.APISessionDeleteAPISessionsHandler = api_session.DeleteAPISessionsHandlerFunc(func(params api_session.DeleteAPISessionsParams, _ interface{}) middleware.Responder {
 		ae.InitPermissionsContext(params.HTTPRequest, permissions.Management, permissions.Ops, permissions.Delete)
-		return ae.IsAllowed(ir.Delete, params.HTTPRequest, params.ID, "", permissions.DefaultOpsAccess())
+		return ae.IsAllowed(ir.Delete, params.HTTPRequest, params.ID, "", permissions.DefaultManagementAccess())
 	})
 
 	ae.ManagementApi.APISessionDetailAPISessionsHandler = api_session.DetailAPISessionsHandlerFunc(func(params api_session.DetailAPISessionsParams, _ interface{}) middleware.Responder {
 		ae.InitPermissionsContext(params.HTTPRequest, permissions.Management, permissions.Ops, permissions.Read)
-		return ae.IsAllowed(ir.Detail, params.HTTPRequest, params.ID, "", permissions.DefaultOpsAccess())
+		return ae.IsAllowed(ir.Detail, params.HTTPRequest, params.ID, "", permissions.DefaultManagementAccess())
 	})
 
 	ae.ManagementApi.APISessionListAPISessionsHandler = api_session.ListAPISessionsHandlerFunc(func(params api_session.ListAPISessionsParams, _ interface{}) middleware.Responder {
 		ae.InitPermissionsContext(params.HTTPRequest, permissions.Management, permissions.Ops, permissions.Read)
-		return ae.IsAllowed(ir.List, params.HTTPRequest, "", "", permissions.DefaultOpsAccess())
+		return ae.IsAllowed(ir.List, params.HTTPRequest, "", "", permissions.DefaultManagementAccess())
 	})
 }
 

--- a/controller/internal/routes/circuit_router.go
+++ b/controller/internal/routes/circuit_router.go
@@ -43,17 +43,17 @@ func NewCircuitRouter() *CircuitRouter {
 func (r *CircuitRouter) Register(ae *env.AppEnv) {
 	ae.FabricApi.CircuitDetailCircuitHandler = circuit.DetailCircuitHandlerFunc(func(params circuit.DetailCircuitParams, _ any) middleware.Responder {
 		ae.InitPermissionsContext(params.HTTPRequest, permissions.Management, permissions.Ops, permissions.Read)
-		return ae.IsAllowed(r.Detail, params.HTTPRequest, params.ID, "", permissions.DefaultOpsAccess())
+		return ae.IsAllowed(r.Detail, params.HTTPRequest, params.ID, "", permissions.DefaultManagementAccess())
 	})
 
 	ae.FabricApi.CircuitListCircuitsHandler = circuit.ListCircuitsHandlerFunc(func(params circuit.ListCircuitsParams, _ any) middleware.Responder {
 		ae.InitPermissionsContext(params.HTTPRequest, permissions.Management, permissions.Ops, permissions.Read)
-		return ae.IsAllowed(r.ListCircuits, params.HTTPRequest, "", "", permissions.DefaultOpsAccess())
+		return ae.IsAllowed(r.ListCircuits, params.HTTPRequest, "", "", permissions.DefaultManagementAccess())
 	})
 
 	ae.FabricApi.CircuitDeleteCircuitHandler = circuit.DeleteCircuitHandlerFunc(func(params circuit.DeleteCircuitParams, _ any) middleware.Responder {
 		ae.InitPermissionsContext(params.HTTPRequest, permissions.Management, permissions.Ops, permissions.Delete)
-		return ae.IsAllowed(r.Delete, params.HTTPRequest, params.ID, "", permissions.DefaultOpsAccess())
+		return ae.IsAllowed(r.Delete, params.HTTPRequest, params.ID, "", permissions.DefaultManagementAccess())
 	})
 }
 

--- a/controller/internal/routes/controller_router.go
+++ b/controller/internal/routes/controller_router.go
@@ -43,7 +43,8 @@ func NewControllerRouter() *ControllerRouter {
 
 func (r *ControllerRouter) Register(ae *env.AppEnv) {
 	ae.ManagementApi.ControllersListControllersHandler = controllersMan.ListControllersHandlerFunc(func(params controllersMan.ListControllersParams, _ interface{}) middleware.Responder {
-		return ae.IsAllowed(r.ListManagement, params.HTTPRequest, "", "", permissions.IsAuthenticated())
+		ae.InitPermissionsContext(params.HTTPRequest, permissions.Management, EntityNameController, permissions.Read)
+		return ae.IsAllowed(r.ListManagement, params.HTTPRequest, "", "", permissions.DefaultManagementAccess())
 	})
 
 	ae.ClientApi.ControllersListControllersHandler = controllersClient.ListControllersHandlerFunc(func(params controllersClient.ListControllersParams, _ interface{}) middleware.Responder {

--- a/controller/internal/routes/current_api_session_router.go
+++ b/controller/internal/routes/current_api_session_router.go
@@ -18,6 +18,7 @@ package routes
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -31,6 +32,7 @@ import (
 	"github.com/openziti/ziti/v2/controller/model"
 	"github.com/openziti/ziti/v2/controller/permissions"
 	"github.com/openziti/ziti/v2/controller/response"
+	"github.com/openziti/ziti/v2/controller/storage/ast"
 )
 
 func init() {
@@ -130,11 +132,25 @@ func (router *CurrentSessionRouter) Delete(ae *env.AppEnv, rc *response.RequestC
 }
 
 func (router *CurrentSessionRouter) ListCertificates(ae *env.AppEnv, rc *response.RequestContext) {
+	apiSession, err := rc.SecurityCtx.GetApiSession()
+
+	if err != nil {
+		rc.RespondWithError(err)
+		return
+	}
+
 	ListWithEnvelopeFactory(rc, defaultToListEnvelope, func(rc *response.RequestContext, queryOptions *PublicQueryOptions) (*QueryResult, error) {
-		query, err := queryOptions.getFullQuery(ae.GetStores().ApiSessionCertificate)
+		store := ae.GetStores().ApiSessionCertificate
+		query, err := queryOptions.getFullQuery(store)
 		if err != nil {
 			return nil, err
 		}
+
+		scopeQuery, err := ast.Parse(store, fmt.Sprintf(`apiSession = "%s"`, apiSession.Id))
+		if err != nil {
+			return nil, err
+		}
+		query.SetPredicate(ast.NewAndExprNode(query.GetPredicate(), scopeQuery.GetPredicate()))
 
 		result, err := ae.GetManagers().ApiSessionCertificate.BasePreparedList(query)
 		if err != nil {

--- a/controller/internal/routes/current_api_session_router.go
+++ b/controller/internal/routes/current_api_session_router.go
@@ -139,6 +139,11 @@ func (router *CurrentSessionRouter) ListCertificates(ae *env.AppEnv, rc *respons
 		return
 	}
 
+	if apiSession == nil {
+		rc.RespondWithError(errors.New("api session is nil, expected a value"))
+		return
+	}
+
 	ListWithEnvelopeFactory(rc, defaultToListEnvelope, func(rc *response.RequestContext, queryOptions *PublicQueryOptions) (*QueryResult, error) {
 		store := ae.GetStores().ApiSessionCertificate
 		query, err := queryOptions.getFullQuery(store)

--- a/controller/internal/routes/database_router.go
+++ b/controller/internal/routes/database_router.go
@@ -70,7 +70,7 @@ func (r *DatabaseRouter) Register(ae *env.AppEnv) {
 	ae.FabricApi.DatabaseCreateDatabaseSnapshotWithPathHandler = fabricDatabase.CreateDatabaseSnapshotWithPathHandlerFunc(func(params fabricDatabase.CreateDatabaseSnapshotWithPathParams, _ any) middleware.Responder {
 		return ae.IsAllowed(func(ae *env.AppEnv, rc *response.RequestContext) {
 			r.CreateSnapshotWithPath(ae, rc, params.Snapshot)
-		}, params.HTTPRequest, "", "")
+		}, params.HTTPRequest, "", "", permissions.IsAdmin())
 	})
 
 	ae.FabricApi.DatabaseCheckDataIntegrityHandler = fabricDatabase.CheckDataIntegrityHandlerFunc(func(params fabricDatabase.CheckDataIntegrityParams, _ interface{}) middleware.Responder {

--- a/controller/internal/routes/link_router.go
+++ b/controller/internal/routes/link_router.go
@@ -45,22 +45,22 @@ func NewLinkRouter() *LinkRouter {
 func (r *LinkRouter) Register(ae *env.AppEnv) {
 	ae.FabricApi.LinkDetailLinkHandler = link.DetailLinkHandlerFunc(func(params link.DetailLinkParams, _ any) middleware.Responder {
 		ae.InitPermissionsContext(params.HTTPRequest, permissions.Management, permissions.Ops, permissions.Read)
-		return ae.IsAllowed(r.Detail, params.HTTPRequest, params.ID, "", permissions.DefaultOpsAccess())
+		return ae.IsAllowed(r.Detail, params.HTTPRequest, params.ID, "", permissions.DefaultManagementAccess())
 	})
 
 	ae.FabricApi.LinkListLinksHandler = link.ListLinksHandlerFunc(func(params link.ListLinksParams, _ any) middleware.Responder {
 		ae.InitPermissionsContext(params.HTTPRequest, permissions.Management, permissions.Ops, permissions.Read)
-		return ae.IsAllowed(r.ListLinks, params.HTTPRequest, "", "", permissions.DefaultOpsAccess())
+		return ae.IsAllowed(r.ListLinks, params.HTTPRequest, "", "", permissions.DefaultManagementAccess())
 	})
 
 	ae.FabricApi.LinkPatchLinkHandler = link.PatchLinkHandlerFunc(func(params link.PatchLinkParams, _ any) middleware.Responder {
 		ae.InitPermissionsContext(params.HTTPRequest, permissions.Management, permissions.Ops, permissions.Update)
-		return ae.IsAllowed(func(ae *env.AppEnv, rc *response.RequestContext) { r.Patch(ae, rc, params) }, params.HTTPRequest, params.ID, "", permissions.DefaultOpsAccess())
+		return ae.IsAllowed(func(ae *env.AppEnv, rc *response.RequestContext) { r.Patch(ae, rc, params) }, params.HTTPRequest, params.ID, "", permissions.DefaultManagementAccess())
 	})
 
 	ae.FabricApi.LinkDeleteLinkHandler = link.DeleteLinkHandlerFunc(func(params link.DeleteLinkParams, _ any) middleware.Responder {
 		ae.InitPermissionsContext(params.HTTPRequest, permissions.Management, permissions.Ops, permissions.Delete)
-		return ae.IsAllowed(r.Delete, params.HTTPRequest, params.ID, "", permissions.DefaultOpsAccess())
+		return ae.IsAllowed(r.Delete, params.HTTPRequest, params.ID, "", permissions.DefaultManagementAccess())
 	})
 }
 

--- a/controller/internal/routes/session_router.go
+++ b/controller/internal/routes/session_router.go
@@ -54,22 +54,22 @@ func (r *SessionRouter) Register(ae *env.AppEnv) {
 	//Management
 	ae.ManagementApi.SessionDeleteSessionHandler = managementSession.DeleteSessionHandlerFunc(func(params managementSession.DeleteSessionParams, _ interface{}) middleware.Responder {
 		ae.InitPermissionsContext(params.HTTPRequest, permissions.Management, permissions.Ops, permissions.Delete)
-		return ae.IsAllowed(r.Delete, params.HTTPRequest, params.ID, "", permissions.DefaultOpsAccess())
+		return ae.IsAllowed(r.Delete, params.HTTPRequest, params.ID, "", permissions.DefaultManagementAccess())
 	})
 
 	ae.ManagementApi.SessionDetailSessionHandler = managementSession.DetailSessionHandlerFunc(func(params managementSession.DetailSessionParams, _ interface{}) middleware.Responder {
 		ae.InitPermissionsContext(params.HTTPRequest, permissions.Management, permissions.Ops, permissions.Read)
-		return ae.IsAllowed(r.Detail, params.HTTPRequest, params.ID, "", permissions.DefaultOpsAccess())
+		return ae.IsAllowed(r.Detail, params.HTTPRequest, params.ID, "", permissions.DefaultManagementAccess())
 	})
 
 	ae.ManagementApi.SessionListSessionsHandler = managementSession.ListSessionsHandlerFunc(func(params managementSession.ListSessionsParams, _ interface{}) middleware.Responder {
 		ae.InitPermissionsContext(params.HTTPRequest, permissions.Management, permissions.Ops, permissions.Read)
-		return ae.IsAllowed(r.List, params.HTTPRequest, "", "", permissions.DefaultOpsAccess())
+		return ae.IsAllowed(r.List, params.HTTPRequest, "", "", permissions.DefaultManagementAccess())
 	})
 
 	ae.ManagementApi.SessionDetailSessionRoutePathHandler = managementSession.DetailSessionRoutePathHandlerFunc(func(params managementSession.DetailSessionRoutePathParams, _ interface{}) middleware.Responder {
 		ae.InitPermissionsContext(params.HTTPRequest, permissions.Management, permissions.Ops, permissions.Read)
-		return ae.IsAllowed(func(ae *env.AppEnv, rc *response.RequestContext) { r.DetailRoutePath(ae, rc, params) }, params.HTTPRequest, "", "", permissions.DefaultOpsAccess())
+		return ae.IsAllowed(func(ae *env.AppEnv, rc *response.RequestContext) { r.DetailRoutePath(ae, rc, params) }, params.HTTPRequest, "", "", permissions.DefaultManagementAccess())
 	})
 
 	//Client

--- a/controller/permissions/has_entity_action_access.go
+++ b/controller/permissions/has_entity_action_access.go
@@ -16,8 +16,6 @@
 
 package permissions
 
-import "github.com/michaelquigley/pfxlog"
-
 type RequireEntityActionAccess struct{}
 
 var requiredEntityActionAccess = RequireEntityActionAccess{}
@@ -28,6 +26,5 @@ func HasEntityActionAccess() RequireEntityActionAccess {
 
 func (ia RequireEntityActionAccess) IsAllowed(ctx Context) bool {
 	entityAction := ctx.GetEntityAction()
-	pfxlog.Logger().Infof("checking permissions for entity action %s -> %v", entityAction, ctx.HasPermission(entityAction))
 	return entityAction != "" && ctx.HasPermission(entityAction)
 }

--- a/controller/permissions/ops.go
+++ b/controller/permissions/ops.go
@@ -20,10 +20,6 @@ var opsNoReadOnlyAccess = NewRequireAllOf(
 	IsManagementApi(),
 	HasOneOf(IsAdmin(), HasEntityAccess(), HasEntityActionAccess()))
 
-func DefaultOpsAccess() Resolver {
-	return defaultManagementAccess
-}
-
 func OpsNoReadOnlyAccess() Resolver {
 	return opsNoReadOnlyAccess
 }

--- a/controller/permissions/permissions.go
+++ b/controller/permissions/permissions.go
@@ -80,6 +80,10 @@ var AllPermissions = map[string]struct{}{
 	"config-type.update": {},
 	"config-type.delete": {},
 
+	// controllers permissions (read-only listing of cluster members)
+	"controllers":      {},
+	"controllers.read": {},
+
 	// edge-router-policy permissions
 	"edge-router-policy":        {},
 	"edge-router-policy.read":   {},


### PR DESCRIPTION
- **Fix incorrect permissions check on create db snapshot with path. Fixes #3837**
- **Fix permissions check on list controllers in management API. Fixes #3838**
- **Filter current api session certs by current api session id. Fixes #3855**
- **Tidy duplicate permission types. Remove vestigial info message. Update changelog**
