### PR TITLE
Set fsm.startIndex on FSM init. Fixes #3860

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1365,6 +1365,7 @@ be removed.
 
 * github.com/openziti/go-term-markdown: v1.0.1 (new)
 * github.com/openziti/ziti/v2: [v1.6.8 -> v2.0.0](https://github.com/openziti/ziti/compare/v1.6.8...v2.0.0)
+    * [Issue #3860](https://github.com/openziti/ziti/issues/3860) - Router data model index resets to 0 on controller restart
     * [Issue #3855](https://github.com/openziti/ziti/issues/3855) - Filter current api session certs list by current api session
     * [Issue #3838](https://github.com/openziti/ziti/issues/3838) - List controllers on management API has incorrect permissions check
     * [Issue #3837](https://github.com/openziti/ziti/issues/3837) - Create db snapshot with path has incorrect permissions check

--- a/controller/raft/fsm.go
+++ b/controller/raft/fsm.go
@@ -107,6 +107,7 @@ func (self *BoltDbFsm) Init() error {
 		return err
 	}
 
+	self.startIndex = startIndex
 	self.index = startIndex
 	self.indexTracker.NotifyOfIndex(startIndex)
 

--- a/controller/raft/fsm_test.go
+++ b/controller/raft/fsm_test.go
@@ -1,0 +1,51 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package raft
+
+import (
+	"testing"
+
+	"github.com/openziti/ziti/v2/controller/command"
+	"github.com/openziti/ziti/v2/controller/event"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBoltDbFsm_GetStartIndex_AfterRestart guards against a regression where
+// BoltDbFsm.Init() loaded the persisted raft index into self.index but failed
+// to also populate self.startIndex. That left GetStartIndex() returning 0 on
+// every restart, which in turn caused the RDM to seed its RaftIndexProvider
+// at 0 and report a stale index until the next command flowed through.
+func TestBoltDbFsm_GetStartIndex_AfterRestart(t *testing.T) {
+	req := require.New(t)
+
+	dataDir := t.TempDir()
+	fsm := NewFsm(dataDir, false, command.GetDefaultDecoders(), NewIndexTracker(), event.DispatcherMock{})
+	req.NoError(fsm.Init())
+	req.Equal(uint64(0), fsm.GetStartIndex(), "fresh fsm should start at index 0")
+
+	const persistedIndex uint64 = 42
+	req.NoError(fsm.db.Update(nil, func(ctx boltz.MutateContext) error {
+		return fsm.updateIndexInTx(ctx.Tx(), persistedIndex)
+	}))
+	req.NoError(fsm.Close())
+
+	fsm2 := NewFsm(dataDir, false, command.GetDefaultDecoders(), NewIndexTracker(), event.DispatcherMock{})
+	req.NoError(fsm2.Init())
+	req.Equal(persistedIndex, fsm2.GetStartIndex(), "GetStartIndex should reflect the persisted raft index after restart")
+	req.NoError(fsm2.Close())
+}


### PR DESCRIPTION
- adds the missing self.startIndex assignment in BoltDbFsm.Init so
  GetStartRaftIndex() returns the persisted raft index instead of 0,
  which was leaving the RDM's RaftIndexProvider seeded at 0 on every
  restart and reporting a stale index until the next command applied
- adds a regression test that opens an FSM, persists a raft index,
  reopens it, and asserts GetStartIndex reflects the persisted value
- notes the fix in CHANGELOG.md under the ziti/v2 issue list
