### PR TITLE
e2ee: make sure public key returned in DialSuccess is propagated

### DIFF
--- a/router/xgress_edge/dialer.go
+++ b/router/xgress_edge/dialer.go
@@ -198,7 +198,11 @@ func (dialer *dialer) Dial(params xgress_router.DialParams) (xt.PeerData, error)
 	}
 	log.Debug("dial success")
 
-	return nil, nil
+	peerData := xt.PeerData{}
+	if pk := reply.Headers[edgeSdk.PublicKeyHeader]; len(pk) > 0 {
+		peerData[uint32(edgeSdk.PublicKeyHeader)] = pk
+	}
+	return peerData, nil
 }
 
 func (dialer *dialer) dialSdkXgress(terminator *edgeTerminator, params xgress_router.DialParams) (xt.PeerData, error) {
@@ -290,8 +294,12 @@ func (dialer *dialer) dialSdkXgress(terminator *edgeTerminator, params xgress_ro
 		return nil, errors.New(msg)
 	}
 	log.Debug("dial success")
+	peerData := xt.PeerData{}
+	if pk := reply.Headers[edgeSdk.PublicKeyHeader]; len(pk) > 0 {
+		peerData[uint32(edgeSdk.PublicKeyHeader)] = pk
+	}
 
-	return nil, nil
+	return peerData, nil
 }
 
 func (dialer *dialer) dialLegacy(terminator *edgeTerminator, params xgress_router.DialParams) (xt.PeerData, error) {
@@ -371,7 +379,16 @@ func (dialer *dialer) dialLegacy(terminator *edgeTerminator, params xgress_route
 
 	start := edgeSdk.NewStateConnectedMsg(result.ConnId)
 	start.ReplyTo(reply)
-	return nil, terminator.SendState(start)
+	err = terminator.SendState(start)
+	if err != nil {
+		return nil, err
+	}
+
+	peerData := xt.PeerData{}
+	if pk := reply.Headers[edgeSdk.PublicKeyHeader]; len(pk) > 0 {
+		peerData[uint32(edgeSdk.PublicKeyHeader)] = pk
+	}
+	return peerData, nil
 }
 
 func (dialer *dialer) Inspect(key string, timeout time.Duration) any {

--- a/router/xgress_edge/dialer.go
+++ b/router/xgress_edge/dialer.go
@@ -133,6 +133,10 @@ func (dialer *dialer) Dial(params xgress_router.DialParams) (xt.PeerData, error)
 		dialRequest.Headers[edgeSdk.PublicKeyHeader] = pk
 	}
 
+	if meth, ok := circuitId.Data[uint32(edgeSdk.CryptoMethodHeader)]; ok {
+		dialRequest.Headers[edgeSdk.CryptoMethodHeader] = meth
+	}
+
 	if marker, ok := circuitId.Data[uint32(edgeSdk.ConnectionMarkerHeader)]; ok {
 		dialRequest.Headers[edgeSdk.ConnectionMarkerHeader] = marker
 	}
@@ -231,6 +235,10 @@ func (dialer *dialer) dialSdkXgress(terminator *edgeTerminator, params xgress_ro
 		dialRequest.Headers[edgeSdk.PublicKeyHeader] = pk
 	}
 
+	if meth, ok := circuitId.Data[uint32(edgeSdk.CryptoMethodHeader)]; ok {
+		dialRequest.Headers[edgeSdk.CryptoMethodHeader] = meth
+	}
+
 	if marker, ok := circuitId.Data[uint32(edgeSdk.ConnectionMarkerHeader)]; ok {
 		dialRequest.Headers[edgeSdk.ConnectionMarkerHeader] = marker
 	}
@@ -326,6 +334,9 @@ func (dialer *dialer) dialLegacy(terminator *edgeTerminator, params xgress_route
 
 	if pk, ok := circuitId.Data[uint32(edgeSdk.PublicKeyHeader)]; ok {
 		dialRequest.Headers[edgeSdk.PublicKeyHeader] = pk
+	}
+	if meth, ok := circuitId.Data[uint32(edgeSdk.CryptoMethodHeader)]; ok {
+		dialRequest.Headers[edgeSdk.CryptoMethodHeader] = meth
 	}
 
 	if marker, ok := circuitId.Data[uint32(edgeSdk.ConnectionMarkerHeader)]; ok {

--- a/router/xgress_edge/listener.go
+++ b/router/xgress_edge/listener.go
@@ -57,6 +57,7 @@ import (
 
 var peerHeaderRequestMappings = map[uint32]uint32{
 	uint32(sdkedge.PublicKeyHeader):        uint32(sdkedge.PublicKeyHeader),
+	uint32(sdkedge.CryptoMethodHeader):     uint32(sdkedge.CryptoMethodHeader),
 	uint32(sdkedge.CallerIdHeader):         uint32(sdkedge.CallerIdHeader),
 	uint32(sdkedge.AppDataHeader):          uint32(sdkedge.AppDataHeader),
 	uint32(sdkedge.ConnectionMarkerHeader): uint32(sdkedge.ConnectionMarkerHeader),


### PR DESCRIPTION
fixes #3864 propagate hosting SDK public key from DialSuccess

- reads PublicKeyHeader from the dial reply in all three xgress_edge dial paths (Dial, dialSdkXgress, dialLegacy)
- returns it via PeerData so it flows through RouteResultSuccess and CircuitSuccess to the initiator SDK
- splits dialLegacy's previous combined `return nil, SendState(...)` so the success path can return PeerData while the SendState error path is preserved