### PR TITLE
rework docker depolyment

### DIFF
--- a/.github/workflows/release-quickstart.yml
+++ b/.github/workflows/release-quickstart.yml
@@ -1,72 +1,102 @@
 name: Release Quickstart Workflow
+# Publishes the openziti/quickstart Docker image and deploys the get.openziti.io
+# CloudFront function for a given release tag.
+#
+# Triggers:
+#   - release: published        (a GitHub release has been published, with its
+#                                assets already uploaded)
+#   - workflow_dispatch         (manual; required `release_tag` input)
+#
+# Both jobs are idempotent and independently re-runnable from the Actions UI.
 on:
-  pull_request:
-    types:
-      - closed
-    branches:
-      - main
-  push:
-    tags:
-      - 'v*.*.*'
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       release_tag:
-        description: 'Release tag (e.g., v1.2.3)'
+        description: 'Release tag to (re)publish, e.g. v1.6.7'
         required: true
         type: string
+      force_latest:
+        description: 'Force-move :latest to this tag even if GitHub does not mark this release as latest'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
 
 jobs:
-  release-quickstart:
+  resolve-tag:
+    name: Resolve Release Tag
+    # only run on the official upstream repo, or on a fork that overrides the
+    # quickstart image repo to a destination it can push to
+    if: github.repository_owner == 'openziti' || vars.ZITI_QUICKSTART_IMAGE != ''
+    runs-on: ubuntu-24.04
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+      sha: ${{ steps.resolve.outputs.sha }}
+    steps:
+      - name: Resolve release tag and commit SHA
+        id: resolve
+        env:
+          DISPATCH_TAG: ${{ github.event.inputs.release_tag }}
+          RELEASE_TAG:  ${{ github.event.release.tag_name }}
+          GH_TOKEN:     ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -o errexit
+          set -o pipefail
+
+          if [[ -n "${DISPATCH_TAG:-}" ]]; then
+            TAG="${DISPATCH_TAG}"
+          elif [[ -n "${RELEASE_TAG:-}" ]]; then
+            TAG="${RELEASE_TAG}"
+          else
+            echo "ERROR: no release tag provided (neither dispatch input nor release event)" >&2
+            exit 1
+          fi
+
+          if ! [[ "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: release tag '${TAG}' is not a release semver (expected vMAJOR.MINOR.PATCH)" >&2
+            exit 1
+          fi
+
+          # resolve the commit the tag points at; this is the snapshot we will
+          # check out for both jobs so the Dockerfile, routes.yml, and python
+          # deploy script all come from the released revision rather than main
+          SHA="$(gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/${TAG}" --jq '.object.sha')"
+          if [[ -z "${SHA}" || "${SHA}" == "null" ]]; then
+            echo "ERROR: failed to resolve commit SHA for tag '${TAG}'" >&2
+            exit 1
+          fi
+
+          # if the tag is annotated, dereference one level to the commit object
+          OBJ_TYPE="$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${SHA}" --jq '.object.type' 2>/dev/null || echo "commit")"
+          if [[ "${OBJ_TYPE}" == "commit" ]]; then
+            SHA="$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${SHA}" --jq '.object.sha' 2>/dev/null || echo "${SHA}")"
+          fi
+
+          echo "tag=${TAG}" | tee -a "$GITHUB_OUTPUT"
+          echo "sha=${SHA}" | tee -a "$GITHUB_OUTPUT"
+
+  release-quickstart-image:
+    # NOTE: the job display name "Release Quickstart Job" is referenced by name
+    # in .github/workflows/promote-downstreams.yml's `ignore-checks`. Don't
+    # rename without updating that file too.
     name: Release Quickstart Job
-    # this is only run on the official upstream repo when a PR is merged to the
-    # default branch "main" or a release tag is pushed or for the same
-    # conditions in a repo fork that overrides the container image repo to push
-    # to; merges to main trigger a quickstart release with a commit SHA suffix
-    # featuring the previous ziti binary release version, whereas release tag
-    # pushes trigger a quickstart release with the same tag name and the same
-    # ziti binary release version
-    if: (github.repository_owner == 'openziti' || vars.ZITI_QUICKSTART_IMAGE != '') && (
-        (startsWith(github.ref_name, 'v') && !contains(github.ref_name, '-')) || (
-          github.event.pull_request.merged == true 
-          && contains(github.event.pull_request.labels.*.name, 'quickstartrelease')
-        ) || github.event_name == 'workflow_dispatch'
-      )
+    needs: resolve-tag
     runs-on: ubuntu-24.04
     env:
       ZITI_QUICKSTART_IMAGE: ${{ vars.ZITI_QUICKSTART_IMAGE || 'docker.io/openziti/quickstart' }}
-      # use github.ref, not github.head_ref, because this workflow should only run on merged PRs in the target/base
-      # branch context, not the PR source branch
-      GITHUB_REF:            ${{ github.ref }}
-      # use github.sha, not github.pull_request.head.sha, because this workflow should only run on merged PRs in the
-      # target/base branch, not the PR source branch
-      GITHUB_SHA:            ${{ github.sha }}
     steps:
       - name: Debug action
         uses: hmarr/debug-action@v3.0.0
 
-      - name: Wait for other builds to complete
-        uses: lewagon/wait-on-check-action@v1.5.0
-        with:
-          ref: ${{ env.GITHUB_SHA }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          # seconds between polling the checks api for job statuses
-          wait-interval: 20
-          # confusingly, this means "pause this step until all jobs from all workflows in same run have completed"
-          running-workflow-name: Release Quickstart Job
-          # comma-separated list of check names (job.<id>.name) to ignore
-          ignore-checks: Fablab Smoketest,Fablab HA Smoketest,Publish Release Candidate Linux Packages,Publish Release Candidate Docker Images,POST Webhook,Parse Tag Regex
-
-      - name: Checkout Workspace
+      - name: Checkout Workspace at Release Commit
         uses: actions/checkout@v6
-
-      - name: Install Go
-        uses: ./.github/actions/setup-go
-
-      - name: Install Ziti CI
-        uses: openziti/ziti-ci@v1
+        with:
+          ref: ${{ needs.resolve-tag.outputs.sha }}
 
       - name: Set Up QEMU
         uses: docker/setup-qemu-action@v4
@@ -74,129 +104,52 @@ jobs:
           platforms: amd64,arm64
 
       - name: Set Up Docker BuildKit
-        id: buildx
         uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Hub
         uses: docker/login-action@v4
         with:
-          # it is preferable to obtain the username from a var so that
-          # recurrences of the same string are not masked in CI output
           username: ${{ vars.DOCKER_HUB_API_USER || secrets.DOCKER_HUB_API_USER }}
           password: ${{ secrets.DOCKER_HUB_API_TOKEN }}
 
-      - name: Compute the Ziti Quickstart Version String
-        id: get_version
+      - name: Build & Push Multi-Platform Quickstart Image
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REF_NAME: ${{ github.event.inputs.release_tag || github.ref_name }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         shell: bash
         run: |
-          function validateSemver() {
-            if ! [[ "${1}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo "ERROR: ${1} is not a release semver" >&2
-              return 1
-            fi
-          }
-
-          if [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            # Set output parameters for release tags
-            QUICKSTART_VERSION="${GITHUB_REF_NAME}"
-
-          elif [[ "${GITHUB_REF_NAME}" =~ ^main$ ]]; then
-            # compute the latest release version to install in the quickstart image
-            QUICKSTART_VERSION="$($(go env GOPATH)/bin/ziti-ci -q get-current-version ${ZITI_BASE_VERSION:+--base-version $ZITI_BASE_VERSION})"
-            validateSemver "${QUICKSTART_VERSION}"
-
-            # Append short SHA to identify quickstart docker images shipped on merge to main
-            QUICKSTART_VERSION="${QUICKSTART_VERSION}-$(git rev-parse --short ${GITHUB_SHA})"
-
-          else
-            echo "ERROR: Unexpected GITHUB_REF_NAME=${GITHUB_REF_NAME}" >&2
-            exit 1
+          FORCE_LATEST_FLAG=""
+          if [[ "${{ github.event.inputs.force_latest }}" == "true" ]]; then
+            FORCE_LATEST_FLAG="--force-latest"
           fi
+          bash dist/scripts/release-quickstart-image.sh \
+            --tag "${{ needs.resolve-tag.outputs.tag }}" \
+            --image-repo "${ZITI_QUICKSTART_IMAGE}" \
+            ${FORCE_LATEST_FLAG}
 
-          # configure the env var used by the quickstart's Dockerfile to
-          # download the correct version of ziti for the target architecture of
-          # each image build by trimming the hyphenated short sha suffix so that
-          # the preceding release version of the ziti executable is installed in
-          # the quickstart container image; ensure the QUICKSTART_VERSION
-          # (container image tag) does not have a leading 'v' and the
-          # ZITI_VERSION_OVERRIDE (GitHub tag ref) does have a leading 'v'
-
-          QUICKSTART_VERSION="${QUICKSTART_VERSION#v}"
-          echo QUICKSTART_VERSION="${QUICKSTART_VERSION}" | tee -a $GITHUB_OUTPUT
-          echo ZITI_VERSION_OVERRIDE=v${QUICKSTART_VERSION%-*} | tee -a $GITHUB_OUTPUT
-
-      - name: Check if Release is Highest Version
-        id: check_highest
-        if: startsWith(github.ref_name, 'v') || github.event.inputs.release_tag != ''
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REF_NAME: ${{ github.event.inputs.release_tag || github.ref_name }}
-        shell: bash
-        run: |
-          H_HIGHEST_VERSION=$(
-            gh release list --repo "${GITHUB_REPOSITORY}" \
-                            --limit 999 \
-                            --exclude-drafts \
-                            --exclude-pre-releases \
-                            --json tagName \
-                            --jq '.[].tagName' \
-            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
-            | sort -V \
-            | tail -1
-          )
-          CURRENT_VERSION="${GITHUB_REF_NAME}"
-          
-          if [[ "$CURRENT_VERSION" == "$H_HIGHEST_VERSION" ]]; then
-            echo "highest=true" | tee -a $GITHUB_OUTPUT
-            echo "INFO: ${CURRENT_VERSION} is the highest release version"
-          else
-            echo "highest=false" | tee -a $GITHUB_OUTPUT
-            echo "INFO: ${CURRENT_VERSION} is not the highest release (highest is ${H_HIGHEST_VERSION})"
-            echo "INFO: Skipping quickstart release for hotfix"
-          fi
-
-      # container image tag :latest is published on merge to default branch "main" and on release tags
-      - name: Configure Quickstart Container
-        if: steps.check_highest.outputs.highest == 'true' || github.ref_name == 'main'
-        env:
-          IMAGE_REPO: ${{ env.ZITI_QUICKSTART_IMAGE }}
-          IMAGE_TAG:  ${{ steps.get_version.outputs.QUICKSTART_VERSION }}
-        id: tagprep_qs
-        shell: bash
-        run: |
-          DOCKER_TAGS="${IMAGE_REPO}:${IMAGE_TAG}"
-          DOCKER_TAGS+=",${IMAGE_REPO}:latest"
-          echo DOCKER_TAGS="${DOCKER_TAGS}" | tee -a $GITHUB_OUTPUT
-
-      - name: Build & Push Multi-Platform Quickstart Container Image to Hub
-        if: steps.check_highest.outputs.highest == 'true' || github.ref_name == 'main'
-        uses: docker/build-push-action@v7
+  release-quickstart-cloudfront:
+    name: Deploy get.openziti.io CloudFront Function
+    needs: resolve-tag
+    # CloudFront deploy only makes sense on the official upstream repo
+    if: github.repository_owner == 'openziti'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Workspace at Release Commit
+        uses: actions/checkout@v6
         with:
-          builder: ${{ steps.buildx.outputs.name }}
-          context: ${{ github.workspace }}/quickstart/docker/image
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.tagprep_qs.outputs.DOCKER_TAGS }}
-          build-args: |
-            ZITI_VERSION_OVERRIDE=${{ steps.get_version.outputs.ZITI_VERSION_OVERRIDE }}
-            GITHUB_REPO_OWNER=${{ github.repository_owner }}
-            GITHUB_REPO_NAME=${{ github.event.repository.name }}
-          push: true
+          ref: ${{ needs.resolve-tag.outputs.sha }}
 
       - name: Configure Python
-        if: steps.check_highest.outputs.highest == 'true' || github.ref_name == 'main'
         shell: bash
         run: |
           pip install --requirement ./dist/cloudfront/get.openziti.io/requirements.txt
           python --version
-        
-      - name: Deploy the CloudFront Function for get.openziti.io
-        if: (github.repository_owner == 'openziti') && (steps.check_highest.outputs.highest == 'true' || github.ref_name == 'main')
+
+      - name: Deploy CloudFront Function
         shell: bash
-        run: python ./dist/cloudfront/get.openziti.io/deploy-cloudfront-function.py
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_ACCESS_KEY_ID:     ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ vars.AWS_REGION || secrets.AWS_REGION }}
+          AWS_REGION:            ${{ vars.AWS_REGION || secrets.AWS_REGION }}
+          GITHUB_SHA:            ${{ needs.resolve-tag.outputs.sha }}
+        run: python ./dist/cloudfront/get.openziti.io/deploy-cloudfront-function.py

--- a/.github/workflows/release-quickstart.yml
+++ b/.github/workflows/release-quickstart.yml
@@ -112,6 +112,33 @@ jobs:
           username: ${{ vars.DOCKER_HUB_API_USER || secrets.DOCKER_HUB_API_USER }}
           password: ${{ secrets.DOCKER_HUB_API_TOKEN }}
 
+      # Build & push the openziti/quickstart image for this release tag.
+      #
+      # The script (dist/scripts/release-quickstart-image.sh) handles all the
+      # actual work and is idempotent. Two notes on the :latest tag:
+      #
+      #   1. Default behaviour: the script queries GitHub for the release
+      #      marked as "Latest" and only moves the Docker :latest tag if THIS
+      #      release tag matches that. So a hotfix on an older minor will not
+      #      clobber :latest just because someone reran the workflow against
+      #      it.
+      #
+      #   2. Manual override: the workflow_dispatch input `force_latest`
+      #      (default: false) flips this. The shell snippet below translates
+      #      that boolean input into the local variable FORCE_LATEST_FLAG,
+      #      which is either empty or the literal string "--force-latest".
+      #      FORCE_LATEST_FLAG (the YAML-side variable) and --force-latest
+      #      (the script-side flag) are the same control surface -- the
+      #      variable's only job is to conditionally pass the flag through.
+      #      When set, the script skips the GitHub "Latest release" check and
+      #      always moves :latest to this tag. Use this only when you need to
+      #      override GitHub's idea of which release is current -- e.g. you
+      #      marked the wrong release as latest in the UI and need to fix it
+      #      without re-clicking through the GitHub release UI.
+      #
+      # On `release: published` triggers, github.event.inputs is empty, so
+      # FORCE_LATEST_FLAG stays empty, --force-latest is never passed, and
+      # behaviour falls through to case (1).
       - name: Build & Push Multi-Platform Quickstart Image
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/dist/scripts/release-quickstart-image.sh
+++ b/dist/scripts/release-quickstart-image.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+#
+# Builds and pushes the openziti/quickstart multi-arch Docker image for a given
+# release tag. Idempotent:
+#
+#   - skips the :vX.Y.Z push if that tag already exists in the registry
+#   - moves :latest only when this tag IS the GitHub "Latest release" (or when
+#     --force-latest is passed), AND :latest does not already point at the same
+#     digest as :vX.Y.Z
+#
+# Designed to be safely re-runnable from CI or a developer laptop.
+#
+# Usage:
+#   release-quickstart-image.sh --tag vX.Y.Z [--image-repo R] [--force-latest] [--dry-run]
+#
+# Required environment:
+#   - docker CLI with buildx + an active builder (workflow does this)
+#   - logged in to the target registry (workflow does this)
+#   - GITHUB_TOKEN exported (used by `gh` to query the "Latest release" flag)
+#   - GITHUB_REPOSITORY  (e.g. openziti/ziti) -- set by GitHub Actions; pass
+#     explicitly when running locally
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+TAG=""
+IMAGE_REPO="${ZITI_QUICKSTART_IMAGE:-docker.io/openziti/quickstart}"
+FORCE_LATEST="false"
+DRY_RUN="false"
+CONTEXT_DIR=""
+
+usage() {
+    cat <<EOF
+Usage: $0 --tag vX.Y.Z [options]
+
+Options:
+  --tag vX.Y.Z          Release tag to build the image for (required).
+  --image-repo R        Image repo (default: \$ZITI_QUICKSTART_IMAGE or docker.io/openziti/quickstart).
+  --force-latest        Move :latest to this tag even if GitHub does not mark this release as latest.
+  --dry-run             Print actions but do not build or push.
+  --context-dir DIR     Path to the Docker build context (default: repo-relative quickstart/docker/image).
+  -h, --help            Show this help.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tag)           TAG="$2"; shift 2 ;;
+        --image-repo)    IMAGE_REPO="$2"; shift 2 ;;
+        --force-latest)  FORCE_LATEST="true"; shift ;;
+        --dry-run)       DRY_RUN="true"; shift ;;
+        --context-dir)   CONTEXT_DIR="$2"; shift 2 ;;
+        -h|--help)       usage; exit 0 ;;
+        *) echo "ERROR: unknown arg '$1'" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+if [[ -z "$TAG" ]]; then
+    echo "ERROR: --tag is required" >&2
+    usage >&2
+    exit 2
+fi
+
+if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "ERROR: --tag '$TAG' is not a release semver (expected vMAJOR.MINOR.PATCH)" >&2
+    exit 2
+fi
+
+if [[ -z "$CONTEXT_DIR" ]]; then
+    # default: assume we were invoked from a checkout root
+    CONTEXT_DIR="quickstart/docker/image"
+fi
+
+if [[ ! -d "$CONTEXT_DIR" ]]; then
+    echo "ERROR: build context dir not found: $CONTEXT_DIR" >&2
+    exit 2
+fi
+
+VERSION_NO_V="${TAG#v}"
+TAGGED_REF="${IMAGE_REPO}:${VERSION_NO_V}"
+LATEST_REF="${IMAGE_REPO}:latest"
+
+run() {
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echo "[dry-run] $*"
+    else
+        echo "+ $*"
+        eval "$@"
+    fi
+}
+
+image_exists() {
+    # returns 0 if the image ref resolves in the registry
+    docker buildx imagetools inspect "$1" >/dev/null 2>&1
+}
+
+image_digest() {
+    # prints the manifest list digest for a ref, or empty if it does not exist
+    docker buildx imagetools inspect "$1" --format '{{.Manifest.Digest}}' 2>/dev/null || true
+}
+
+echo ""
+echo "============================================================"
+echo "  Release quickstart image"
+echo "============================================================"
+echo "  Tag (input):     $TAG"
+echo "  Image repo:      $IMAGE_REPO"
+echo "  Tagged ref:      $TAGGED_REF"
+echo "  Latest ref:      $LATEST_REF"
+echo "  Force :latest:   $FORCE_LATEST"
+echo "  Build context:   $CONTEXT_DIR"
+echo "  Dry run:         $DRY_RUN"
+echo "============================================================"
+echo ""
+
+# ---------------------------------------------------------------- :vX.Y.Z push
+echo ""
+echo "---- Step 1: build & push $TAGGED_REF -----------------------"
+echo ""
+
+if image_exists "$TAGGED_REF"; then
+    echo "INFO: $TAGGED_REF already exists in the registry; skipping build & push."
+else
+    echo "INFO: $TAGGED_REF not found in the registry; building and pushing."
+    run "docker buildx build \
+        --platform linux/amd64,linux/arm64 \
+        --build-arg ZITI_VERSION_OVERRIDE=${TAG} \
+        --build-arg GITHUB_REPO_OWNER=${GITHUB_REPOSITORY%%/*} \
+        --build-arg GITHUB_REPO_NAME=${GITHUB_REPOSITORY##*/} \
+        --tag ${TAGGED_REF} \
+        --push \
+        ${CONTEXT_DIR}"
+fi
+
+# --------------------------------------------------------- :latest evaluation
+echo ""
+echo "---- Step 2: evaluate :latest promotion ---------------------"
+echo ""
+
+PROMOTE_LATEST="false"
+
+if [[ "$FORCE_LATEST" == "true" ]]; then
+    echo "INFO: --force-latest set; will move :latest to ${TAG}."
+    PROMOTE_LATEST="true"
+else
+    if [[ -z "${GITHUB_REPOSITORY:-}" ]]; then
+        echo "ERROR: GITHUB_REPOSITORY is not set; cannot query GitHub for the latest release." >&2
+        echo "       Set it (e.g. GITHUB_REPOSITORY=openziti/ziti) or pass --force-latest." >&2
+        exit 2
+    fi
+
+    LATEST_RELEASE_TAG="$(gh release view --repo "${GITHUB_REPOSITORY}" --json tagName --jq '.tagName' 2>/dev/null || true)"
+    if [[ -z "$LATEST_RELEASE_TAG" ]]; then
+        echo "WARN: could not determine GitHub's 'Latest release' tag; skipping :latest promotion."
+    elif [[ "$LATEST_RELEASE_TAG" == "$TAG" ]]; then
+        echo "INFO: GitHub marks ${TAG} as the latest release; will move :latest."
+        PROMOTE_LATEST="true"
+    else
+        echo "INFO: GitHub's latest release is ${LATEST_RELEASE_TAG}, not ${TAG}; will NOT move :latest."
+    fi
+fi
+
+# ---------------------------------------------------------- :latest retag
+echo ""
+echo "---- Step 3: move :latest if needed -------------------------"
+echo ""
+
+if [[ "$PROMOTE_LATEST" != "true" ]]; then
+    echo "INFO: :latest promotion not requested; nothing to do."
+else
+    TAGGED_DIGEST="$(image_digest "$TAGGED_REF")"
+    LATEST_DIGEST="$(image_digest "$LATEST_REF")"
+
+    if [[ -z "$TAGGED_DIGEST" ]]; then
+        if [[ "$DRY_RUN" == "true" ]]; then
+            echo "[dry-run] would have built $TAGGED_REF in step 1; skipping :latest digest compare."
+        else
+            echo "ERROR: $TAGGED_REF has no digest after the build; aborting :latest move." >&2
+            exit 1
+        fi
+    elif [[ "$TAGGED_DIGEST" == "$LATEST_DIGEST" ]]; then
+        echo "INFO: :latest already points at the same digest as ${TAG} (${TAGGED_DIGEST}); skipping."
+    else
+        echo "INFO: moving :latest from '${LATEST_DIGEST:-<none>}' to '${TAGGED_DIGEST}'."
+        run "docker buildx imagetools create --tag ${LATEST_REF} ${TAGGED_REF}"
+    fi
+fi
+
+echo ""
+echo "============================================================"
+echo "  Done."
+echo "============================================================"
+echo ""

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -13,14 +13,31 @@ The enclosing project's GitHub releases are never updated and no Git tags are cr
 
 ### Release Process
 
-A quickstart release is created when either of the following conditions are met:
+A quickstart release is triggered automatically when a GitHub release of the enclosing project is
+**published** (i.e., the `release: published` event fires, after the release assets have been uploaded).
 
-1. OpenZiti, the enclosing project, is released by the OpenZiti team
-1. A pull request is merged into the trunk branch `main` with the label `quickstartrelease`
+The release-quickstart workflow can also be invoked manually from the GitHub Actions UI
+(`workflow_dispatch`) with an explicit release tag (e.g., `v1.6.7`). Use this when:
+
+- the automatic run failed for transient reasons and you want to rerun it, or
+- you need to republish the quickstart artifacts for an existing release without cutting a new one.
+
+Both jobs in the workflow are **idempotent and independently re-runnable**:
+
+- The Docker image push step checks the registry first and skips if `openziti/quickstart:vX.Y.Z`
+  already exists. The `:latest` tag is only moved when the input tag matches GitHub's "Latest release"
+  flag (or you pass `force_latest: true` on a manual run).
+- The CloudFront deploy is a re-publish each time; AWS handles repeated identical configurations
+  cleanly.
+
+If one job succeeds and the other fails, you can rerun the failed job alone from the Actions UI without
+redoing the work that already succeeded.
 
 ### Release Machinery
 
 The release process is encoded in [a GitHub workflow](../.github/workflows/release-quickstart.yml).
+The bulk of the Docker logic lives in [`dist/scripts/release-quickstart-image.sh`](../dist/scripts/release-quickstart-image.sh),
+which is runnable locally for testing.
 
 ### GitHub Raw Reverse Proxy
 

--- a/quickstart/docker/pushLatestDocker.sh
+++ b/quickstart/docker/pushLatestDocker.sh
@@ -1,4 +1,16 @@
 #!/usr/bin/env bash
+#
+# Local developer helper for building (and optionally pushing) the
+# openziti/quickstart Docker image. The canonical release path is the
+# `release-quickstart.yml` GitHub workflow, which calls
+# `dist/scripts/release-quickstart-image.sh`. Do not use this script to push
+# production tags -- it does not coordinate with GitHub's "Latest release" flag
+# and does not perform any idempotency checks against the registry.
+#
+# Typical local usage:
+#     ./pushLatestDocker.sh local           # build & load into local docker daemon
+#     ./pushLatestDocker.sh local mytag     # same, custom tag name
+#
 
 set -o errexit
 set -o nounset


### PR DESCRIPTION
allow docker images to be triggered by the ziti release and add a manual option to deploy from a release version with less ceremony