### PR TITLE
Fix/631 multiple listeners config

### DIFF
--- a/etc/edge.router.yml
+++ b/etc/edge.router.yml
@@ -54,6 +54,15 @@ ctrl:
 link:
   dialers:
     - binding:          transport
+  listeners:
+    # A router can listen for links on multiple ports or protocols by specifying multiple listeners.
+    - binding:          transport
+      bind:             tls:0.0.0.0:10086
+      advertise:        tls:127.0.0.1:10086
+    # Example of an additional link listener
+    # - binding:          transport
+    #   bind:             tls:0.0.0.0:10087
+    #   advertise:        tls:127.0.0.1:10087
 
 healthChecks:
   ctrlPingCheck:

--- a/etc/edge.router.yml
+++ b/etc/edge.router.yml
@@ -59,10 +59,11 @@ link:
     - binding:          transport
       bind:             tls:0.0.0.0:10086
       advertise:        tls:127.0.0.1:10086
-    # Example of an additional link listener
+    # Example of an additional link listener (with an optional custom link type)
     # - binding:          transport
     #   bind:             tls:0.0.0.0:10087
     #   advertise:        tls:127.0.0.1:10087
+    #   type:             cellular
 
 healthChecks:
   ctrlPingCheck:

--- a/etc/edge.router_wss.yml
+++ b/etc/edge.router_wss.yml
@@ -40,10 +40,11 @@ link:
     - binding:          transport
       bind:             tls:0.0.0.0:10086
       advertise:        tls:127.0.0.1:10086
-    # Example of an additional link listener
+    # Example of an additional link listener (with an optional custom link type)
     # - binding:          transport
     #   bind:             tls:0.0.0.0:10087
     #   advertise:        tls:127.0.0.1:10087
+    #   type:             cellular
 
 # By having an 'edge' section defined, the ziti router will attempt to parse the edge configuration. Removing this
 # section, commenting out, or altering the name of the section will cause the router to no longer operate as an Edge

--- a/etc/edge.router_wss.yml
+++ b/etc/edge.router_wss.yml
@@ -35,6 +35,15 @@ ctrl:
 link:
   dialers:
     - binding:          transport
+  listeners:
+    # A router can listen for links on multiple ports or protocols by specifying multiple listeners.
+    - binding:          transport
+      bind:             tls:0.0.0.0:10086
+      advertise:        tls:127.0.0.1:10086
+    # Example of an additional link listener
+    # - binding:          transport
+    #   bind:             tls:0.0.0.0:10087
+    #   advertise:        tls:127.0.0.1:10087
 
 # By having an 'edge' section defined, the ziti router will attempt to parse the edge configuration. Removing this
 # section, commenting out, or altering the name of the section will cause the router to no longer operate as an Edge

--- a/etc/router.yml
+++ b/etc/router.yml
@@ -58,6 +58,19 @@ forwarder:
 ctrl:
   endpoint:             tls:127.0.0.1:6262
 
+link:
+  dialers:
+    - binding:          transport
+  listeners:
+    # A router can listen for links on multiple ports or protocols by specifying multiple listeners.
+    - binding:          transport
+      bind:             tls:0.0.0.0:10086
+      advertise:        tls:127.0.0.1:10086
+    # Example of an additional link listener
+    # - binding:          transport
+    #   bind:             tls:0.0.0.0:10087
+    #   advertise:        tls:127.0.0.1:10087
+
 healthCheck:
   # Specifies the health check port. If not present, the health check will be disabled
   #port: 8081

--- a/etc/router.yml
+++ b/etc/router.yml
@@ -66,10 +66,11 @@ link:
     - binding:          transport
       bind:             tls:0.0.0.0:10086
       advertise:        tls:127.0.0.1:10086
-    # Example of an additional link listener
+    # Example of an additional link listener (with an optional custom link type)
     # - binding:          transport
     #   bind:             tls:0.0.0.0:10087
     #   advertise:        tls:127.0.0.1:10087
+    #   type:             cellular
 
 healthCheck:
   # Specifies the health check port. If not present, the health check will be disabled

--- a/etc/tmpl/edge.router.yml
+++ b/etc/tmpl/edge.router.yml
@@ -40,9 +40,14 @@ link:
   dialers:
     - binding:          transport
   listeners:
+    # A router can listen for links on multiple ports or protocols by specifying multiple listeners.
     - binding:          transport
       bind:             tls:127.0.0.1:${LINK_LISTENER_PORT}
       advertise:        tls:127.0.0.1:${LINK_LISTENER_PORT}
+    # Example of an additional link listener
+    # - binding:          transport
+    #   bind:             tls:127.0.0.1:10086
+    #   advertise:        tls:127.0.0.1:10086
 
 
 # By having an 'edge' section defined, the ziti router will attempt to parse the edge configuration. Removing this

--- a/etc/tmpl/edge.router.yml
+++ b/etc/tmpl/edge.router.yml
@@ -44,10 +44,11 @@ link:
     - binding:          transport
       bind:             tls:127.0.0.1:${LINK_LISTENER_PORT}
       advertise:        tls:127.0.0.1:${LINK_LISTENER_PORT}
-    # Example of an additional link listener
+    # Example of an additional link listener (with an optional custom link type)
     # - binding:          transport
     #   bind:             tls:127.0.0.1:10086
     #   advertise:        tls:127.0.0.1:10086
+    #   type:             cellular
 
 
 # By having an 'edge' section defined, the ziti router will attempt to parse the edge configuration. Removing this

--- a/ziti/cmd/create/config_templates/router.yml
+++ b/ziti/cmd/create/config_templates/router.yml
@@ -32,10 +32,11 @@ link:
 {{ if .Router.IsPrivate }}#{{ end }}      advertise:        tls:{{ .Router.Edge.AdvertisedHost }}:{{ .Router.Edge.ListenerBindPort }}
 {{ if .Router.IsPrivate }}#{{ end }}      options:
 {{ if .Router.IsPrivate }}#{{ end }}        outQueueSize:   {{ .Router.Listener.OutQueueSize }}
-{{ if .Router.IsPrivate }}#{{ end }}    # Example of an additional link listener
+{{ if .Router.IsPrivate }}#{{ end }}    # Example of an additional link listener (with an optional custom link type)
 {{ if .Router.IsPrivate }}#{{ end }}    # - binding:          transport
 {{ if .Router.IsPrivate }}#{{ end }}    #   bind:             tls:0.0.0.0:10086
 {{ if .Router.IsPrivate }}#{{ end }}    #   advertise:        tls:{{ .Router.Edge.AdvertisedHost }}:10086
+{{ if .Router.IsPrivate }}#{{ end }}    #   type:             cellular
 
 {{ if .Router.IsFabric }}#{{ end }}listeners:
 # bindings of edge and tunnel requires an "edge" section below

--- a/ziti/cmd/create/config_templates/router.yml
+++ b/ziti/cmd/create/config_templates/router.yml
@@ -26,11 +26,16 @@ link:
   dialers:
     - binding: transport
 {{ if .Router.IsPrivate }}#{{ end }}  listeners:
+{{ if .Router.IsPrivate }}#{{ end }}    # A router can listen for links on multiple ports or protocols by specifying multiple listeners.
 {{ if .Router.IsPrivate }}#{{ end }}    - binding:          transport
 {{ if .Router.IsPrivate }}#{{ end }}      bind:             tls:0.0.0.0:{{ .Router.Edge.ListenerBindPort }}
 {{ if .Router.IsPrivate }}#{{ end }}      advertise:        tls:{{ .Router.Edge.AdvertisedHost }}:{{ .Router.Edge.ListenerBindPort }}
 {{ if .Router.IsPrivate }}#{{ end }}      options:
 {{ if .Router.IsPrivate }}#{{ end }}        outQueueSize:   {{ .Router.Listener.OutQueueSize }}
+{{ if .Router.IsPrivate }}#{{ end }}    # Example of an additional link listener
+{{ if .Router.IsPrivate }}#{{ end }}    # - binding:          transport
+{{ if .Router.IsPrivate }}#{{ end }}    #   bind:             tls:0.0.0.0:10086
+{{ if .Router.IsPrivate }}#{{ end }}    #   advertise:        tls:{{ .Router.Edge.AdvertisedHost }}:10086
 
 {{ if .Router.IsFabric }}#{{ end }}listeners:
 # bindings of edge and tunnel requires an "edge" section below


### PR DESCRIPTION
### Summary
This PR updates the router configuration templates and sample config files to show examples of configuring multiple link listeners, specifically highlighting the `type` attribute option (e.g. `type: cellular`) introduced in release v0.25.x (PR #628).

Closes #631

### Proposed Changes
Added explanatory comments and commented-out examples of secondary link listeners in the following files:
- `ziti/cmd/create/config_templates/router.yml` (embedded template used by the `ziti create config` command)
- `etc/tmpl/edge.router.yml` (edge router template file)
- `etc/edge.router.yml` (static config example)
- `etc/edge.router_wss.yml` (static config example)
- `etc/router.yml` (static config example)

### Verification
- Rebuilt the `ziti` CLI tool and successfully tested config generation using:
  `ziti create config router edge --routerName test-router`
- Verified unit and integration tests:
  `go test ./ziti/cmd/create/...` (all tests passed)