### PR TITLE
setup-cli: enhance ziti CLI version selection

### DIFF
--- a/setup-cli/action.yml
+++ b/setup-cli/action.yml
@@ -7,8 +7,7 @@ inputs:
     description: |
       version of ziti CLI to download,
       use tag regex (like v1.6) or special values:
-      'stable' (default) means latest release, 
-      `latest` means most recent tagged release,
+      'stable' (default) means latest release (GitHub marked `latest`), 
       regex can be used to pick latest release matching the pattern,
       for example, `2.0.[0-9]+$` will match latest 2.0.x release ignoring any 2.0.x-pre* releases
 outputs:
@@ -27,9 +26,6 @@ runs:
         if [[ ${{ inputs.version }} == "stable" ]]; then
            echo "fetching stable version"
            ver=$(gh release view --repo openziti/ziti | awk '/^tag/{ print $2 }')
-        elif [[ ${{ inputs.version }} == "latest" ]]; then
-          echo "fetching latest releases version"
-           ver=$(gh release list --limit 1 --repo openziti/ziti --json "tagName" --jq ".[0].tagName")
         else
            echo "computing specified[${ver}] version"
            ver=$(gh release list --repo openziti/ziti --limit 200 --json "tagName,publishedAt" --jq "sort_by(.publishedAt) | .[].tagName" | grep -E "^${ver}" | tail -1)

--- a/setup-cli/action.yml
+++ b/setup-cli/action.yml
@@ -6,24 +6,41 @@ inputs:
     default: stable
     description: |
       version of ziti CLI to download,
-      use tag (like v1.6.7) or special values:
+      use tag regex (like v1.6) or special values:
       'stable' (default) means latest release, 
-      `latest` means most recent tagged release
+      `latest` means most recent tagged release,
+      regex can be used to pick latest release matching the pattern,
+      for example, `2.0.[0-9]+$` will match latest 2.0.x release ignoring any 2.0.x-pre* releases
+outputs:
+  version:
+    value: ${{ steps.version.outputs.ZITI_VERSION }}
+    description: version of ziti CLI that was downloaded
 
 runs:
   using: composite
   steps:
     - name: process version
       shell: bash
+      id: version
       run: |
         ver=${{ inputs.version }}
         if [[ ${{ inputs.version }} == "stable" ]]; then
+           echo "fetching stable version"
            ver=$(gh release view --repo openziti/ziti | awk '/^tag/{ print $2 }')
         elif [[ ${{ inputs.version }} == "latest" ]]; then
+          echo "fetching latest releases version"
            ver=$(gh release list --limit 1 --repo openziti/ziti --json "tagName" --jq ".[0].tagName")
+        else
+           echo "computing specified[${ver}] version"
+           ver=$(gh release list --repo openziti/ziti --json "tagName,publishedAt" --jq "sort_by(.publishedAt) | .[].tagName" | grep -E "^${ver}" | tail -1)
+        fi
+        if [[ -z "$ver" ]]; then
+           echo "::error ::Failed to find version matching ${{ inputs.version }}"
+           exit 1
         fi
         echo "using version = $ver"
         echo "ZITI_VERSION=$ver" >> $GITHUB_ENV
+        echo "ZITI_VERSION=$ver" >> $GITHUB_OUTPUT
 
     - name: download ziti CLI
       shell: bash

--- a/setup-cli/action.yml
+++ b/setup-cli/action.yml
@@ -32,7 +32,7 @@ runs:
            ver=$(gh release list --limit 1 --repo openziti/ziti --json "tagName" --jq ".[0].tagName")
         else
            echo "computing specified[${ver}] version"
-           ver=$(gh release list --repo openziti/ziti --json "tagName,publishedAt" --jq "sort_by(.publishedAt) | .[].tagName" | grep -E "^${ver}" | tail -1)
+           ver=$(gh release list --repo openziti/ziti --limit 200 --json "tagName,publishedAt" --jq "sort_by(.publishedAt) | .[].tagName" | grep -E "^${ver}" | tail -1)
         fi
         if [[ -z "$ver" ]]; then
            echo "::error ::Failed to find version matching ${{ inputs.version }}"


### PR DESCRIPTION
- adds actual/resolved ziti cli version as output
- support regex version matching

examples:
`version: 'v2'` - will match latest release with `v2.` prefix including `v2.0.0-pre11`
`version: 'v2.0.[0-9]+$'` - will match latest `v2.0.*` release ignoring all `-preXX` versions

sample downstream usage is here https://github.com/openziti/ziti-sdk-c/actions/runs/26596699921