### PR TITLE
Add agent IPC capability discovery and channel-based log-level commands

### DIFF
--- a/common/agent/README.md
+++ b/common/agent/README.md
@@ -1,0 +1,112 @@
+# common/agent
+
+This package is the in-tree home of ziti's IPC agent: the `gops`-style framed
+protocol, the channel-transport upgrade, and the capability-advertisement
+primitive. It was absorbed from `github.com/openziti/agent`; see
+[doc/design/agent-capabilities.md](../../doc/design/agent-capabilities.md) for
+the full design and rationale. This note is the practical "how do I extend it"
+guide.
+
+## Capabilities: two tiers
+
+A process advertises what it supports through two capability lists, returned by
+the `AppInfoV2` command and (for agent capabilities) carried as a bitmask in the
+channel hello:
+
+- **Agent capabilities** are owned by this package. They describe features the
+  agent machinery itself provides, like the v2 log-level commands. They have a
+  stable bit position (for the hello bitmask) and a stable hierarchical-dotted
+  string name (for `AppInfoV2`). Today there is one: `logging.slog-levels`.
+- **App capabilities** are owned by the embedding application. The package does
+  not interpret them, it just passes the strings through. ziti can register
+  strings of its own (e.g. `ziti.something`) at startup; none are registered
+  yet.
+
+The two live in separate fields, so even an identical string in both namespaces
+cannot collide.
+
+A capability is only advertised when its handler is actually wired up. This
+keeps a binary from claiming a feature it did not install: a controller built
+without the logging wiring simply does not advertise `logging.slog-levels`, and
+capability-aware clients fall back to the legacy commands.
+
+## Adding an agent capability
+
+Agent capabilities are defined here, in `capabilities.go`:
+
+1. Add a bit constant. Bits are append-only and never renamed; if a capability
+   needs to change shape, add a new one.
+
+   ```go
+   const (
+       CapabilityLoggingSlogLevels int = 1
+       CapabilitySomethingNew      int = 2 // new
+   )
+   ```
+
+2. Add its canonical name to the `agentCapabilityNames` table. The string is the
+   identifier clients match on; the prefix should name the subsystem
+   (`logging.*`, `ipc.*`, ...).
+
+   ```go
+   var agentCapabilityNames = map[int]string{
+       CapabilityLoggingSlogLevels: "logging.slog-levels",
+       CapabilitySomethingNew:      "something.new",
+   }
+   ```
+
+3. Mark it active only when its handler is registered, by calling
+   `markAgentCapabilityActive(bit)` from the registration entry point (the way
+   `RegisterLogLevelHandlers` does for `CapabilityLoggingSlogLevels`). That is what
+   makes advertisement conditional. Registration must happen before
+   `Listen`; the capability set freezes once the listener starts.
+
+Clients check an agent capability by bit:
+
+```go
+if opts.HasAgentCapability(agent.CapabilityLoggingSlogLevels) { ... }
+```
+
+## Registering an app capability
+
+App capabilities need no changes here. The application keeps its own constants
+in its own package and registers the strings at startup, before `agent.Listen`:
+
+```go
+agent.RegisterAppCapabilities("ziti.something")
+```
+
+App capabilities are strings only, with no bit position. Registering a new
+name after the listener has started panics, because the advertised set must
+stay consistent across every connection; re-registering a name that is already
+known is a no-op. Clients check an app capability by name:
+
+```go
+if opts.HasAppCapability("ziti.something") { ... }
+```
+
+## Adding a v2 channel command
+
+The v2 log-level commands (`loglevel_commands.go`) are the worked example. To
+add another channel command:
+
+- Reserve a content-type ID in the agent band. Application protocols already use
+  the 1000s (ctrl_pb) and 10000s (mgmt_pb) on the agent channel, so this package
+  reserves **30000-30999** for its own messages. Carry parameters as string
+  channel headers in the same band (see `LogLevelHeader` / `LogChannelHeader`).
+- Bind the server handler so it rides every agent channel. The log-level handlers
+  are bound automatically by `HandleChannelConnection` when callbacks are
+  registered; follow that pattern rather than making each application bind it.
+- Gate the new command behind a capability so clients can detect it, and tie that
+  capability's `markAgentCapabilityActive` call to the same registration that
+  installs the handler.
+
+## Wire compatibility
+
+Never re-encode an existing command. New behavior goes in net-new commands. The
+legacy framed commands (including `AppInfo`, which old clients parse as
+`map[string]string`) keep their wire shape forever, so a new server stays
+readable by old clients. Capability discovery is the net-new `AppInfoV2`
+command: an old server has no handler for it, closes the connection with no
+write, and the client reads a clean EOF and falls back to `AppInfo` with an
+empty capability set.

--- a/common/agent/agent.go
+++ b/common/agent/agent.go
@@ -162,6 +162,10 @@ func Listen(opts Options) error {
 		listener: listener,
 	}
 
+	// Freeze the capability set; no further capability or handler registration
+	// is accepted once we start accepting connections.
+	freezeCapabilities()
+
 	go h.listen()
 	return nil
 }
@@ -370,6 +374,22 @@ func (self *handler) handle(conn net.Conn, op byte) (bool, error) {
 		_, err = conn.Write(marshalled)
 		return false, err
 
+	case AppInfoV2:
+		result := AppInfoV2Response{
+			Type:              self.options.AppType,
+			Id:                self.options.AppId,
+			Alias:             self.options.AppAlias,
+			Version:           self.options.AppVersion,
+			AgentCapabilities: GetAgentCapabilityStringList(),
+			AppCapabilities:   getAppCapabilities(),
+		}
+		marshalled, err := json.Marshal(result)
+		if err != nil {
+			return false, err
+		}
+		_, err = conn.Write(marshalled)
+		return false, err
+
 	case SetLogLevel:
 		param, err := bufio.NewReader(conn).ReadByte()
 		if err != nil {
@@ -379,12 +399,21 @@ func (self *handler) handle(conn net.Conn, op byte) (bool, error) {
 			return false, errors.Errorf("invalid log level %v", param)
 		}
 
-		oldLevel := logrus.GetLevel()
-		newLevel := logrus.Level(param)
-		logrus.SetLevel(newLevel)
+		// The framed command carries a logrus.Level byte; the agent LogLevel
+		// enum is defined in the same order, so the byte maps directly.
+		if cbs := getLogLevelCallbacks(); cbs != nil {
+			level := LogLevel(param)
+			cbs.SetLogLevel(level)
+			pfxlog.Logger().Infof("log level set to %v", level)
+			_, _ = fmt.Fprintf(conn, "log level set to %v\n", level)
+		} else {
+			oldLevel := logrus.GetLevel()
+			newLevel := logrus.Level(param)
+			logrus.SetLevel(newLevel)
 
-		pfxlog.Logger().Infof("log level set to from %v to %v", oldLevel, newLevel)
-		_, _ = fmt.Fprintf(conn, "log level set from %v to %v\n", oldLevel, newLevel)
+			pfxlog.Logger().Infof("log level set to from %v to %v", oldLevel, newLevel)
+			_, _ = fmt.Fprintf(conn, "log level set from %v to %v\n", oldLevel, newLevel)
+		}
 
 	case SetChannelLogLevel:
 		reader := bufio.NewReader(conn)
@@ -402,20 +431,27 @@ func (self *handler) handle(conn net.Conn, op byte) (bool, error) {
 			return false, errors.Errorf("invalid log level %v", level)
 		}
 
-		var prevLevel string
-		newLevel := logrus.Level(level)
-		pfxlog.GlobalConfig(func(options *pfxlog.Options) *pfxlog.Options {
-			if val, found := options.ChannelLogLevelOverrides[channel]; found {
-				prevLevel = val.String()
-			} else {
-				prevLevel = "default"
-			}
-			options.SetChannelLogLevel(channel, newLevel)
-			return options
-		})
+		if cbs := getLogLevelCallbacks(); cbs != nil {
+			lvl := LogLevel(level)
+			cbs.SetChannelLogLevel(channel, lvl)
+			pfxlog.Logger().Infof("log level for channel %v set to %v", channel, lvl)
+			_, _ = fmt.Fprintf(conn, "log level for channel %v set to %v\n", channel, lvl)
+		} else {
+			var prevLevel string
+			newLevel := logrus.Level(level)
+			pfxlog.GlobalConfig(func(options *pfxlog.Options) *pfxlog.Options {
+				if val, found := options.ChannelLogLevelOverrides[channel]; found {
+					prevLevel = val.String()
+				} else {
+					prevLevel = "default"
+				}
+				options.SetChannelLogLevel(channel, newLevel)
+				return options
+			})
 
-		pfxlog.Logger().Infof("log level for channel %v set from %v to %v", channel, prevLevel, newLevel)
-		_, _ = fmt.Fprintf(conn, "log level for channel %v set from %v to %v\n", channel, prevLevel, newLevel)
+			pfxlog.Logger().Infof("log level for channel %v set from %v to %v", channel, prevLevel, newLevel)
+			_, _ = fmt.Fprintf(conn, "log level for channel %v set from %v to %v\n", channel, prevLevel, newLevel)
+		}
 
 	case ClearChannelLogLevel:
 		reader := bufio.NewReader(conn)
@@ -424,19 +460,25 @@ func (self *handler) handle(conn net.Conn, op byte) (bool, error) {
 			return false, err
 		}
 
-		var prevLevel string
-		pfxlog.GlobalConfig(func(options *pfxlog.Options) *pfxlog.Options {
-			if val, found := options.ChannelLogLevelOverrides[channel]; found {
-				prevLevel = val.String()
-			} else {
-				prevLevel = "default"
-			}
-			options.ClearChannelLogLevel(channel)
-			return options
-		})
+		if cbs := getLogLevelCallbacks(); cbs != nil {
+			cbs.ClearChannelLogLevel(channel)
+			pfxlog.Logger().Infof("log level for channel %v cleared", channel)
+			_, _ = fmt.Fprintf(conn, "log level for channel %v cleared\n", channel)
+		} else {
+			var prevLevel string
+			pfxlog.GlobalConfig(func(options *pfxlog.Options) *pfxlog.Options {
+				if val, found := options.ChannelLogLevelOverrides[channel]; found {
+					prevLevel = val.String()
+				} else {
+					prevLevel = "default"
+				}
+				options.ClearChannelLogLevel(channel)
+				return options
+			})
 
-		pfxlog.Logger().Infof("log level for channel %v cleared, was %v", channel, prevLevel)
-		_, _ = fmt.Fprintf(conn, "log level for channel %v cleared, was %v\n", channel, prevLevel)
+			pfxlog.Logger().Infof("log level for channel %v cleared, was %v", channel, prevLevel)
+			_, _ = fmt.Fprintf(conn, "log level for channel %v cleared, was %v\n", channel, prevLevel)
+		}
 
 	case HeapDump:
 		reader := bufio.NewReader(conn)

--- a/common/agent/appinfo.go
+++ b/common/agent/appinfo.go
@@ -1,0 +1,54 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package agent
+
+import (
+	"encoding/json"
+	"io"
+	"net"
+)
+
+// AppInfoV2Response is the JSON body returned by the AppInfoV2 command. It
+// carries the same identity fields as the legacy AppInfo command plus the two
+// capability lists.
+type AppInfoV2Response struct {
+	Type              string   `json:"type,omitempty"`
+	Id                string   `json:"id,omitempty"`
+	Alias             string   `json:"alias,omitempty"`
+	Version           string   `json:"version,omitempty"`
+	AgentCapabilities []string `json:"agent_capabilities,omitempty"`
+	AppCapabilities   []string `json:"app_capabilities,omitempty"`
+}
+
+// ReadAppInfoV2Response reads an AppInfoV2 response from conn. A zero-byte read
+// (clean EOF) means the server has no AppInfoV2 handler, i.e. it predates the
+// command; in that case it returns (nil, false, nil) so the caller can fall
+// back to the legacy AppInfo command and treat the capability set as empty.
+func ReadAppInfoV2Response(conn net.Conn) (*AppInfoV2Response, bool, error) {
+	data, err := io.ReadAll(conn)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(data) == 0 {
+		return nil, false, nil
+	}
+	resp := &AppInfoV2Response{}
+	if err := json.Unmarshal(data, resp); err != nil {
+		return nil, false, err
+	}
+	return resp, true, nil
+}

--- a/common/agent/appinfo_test.go
+++ b/common/agent/appinfo_test.go
@@ -1,0 +1,90 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package agent
+
+import (
+	"encoding/json"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadAppInfoV2ResponsePopulated(t *testing.T) {
+	body, err := json.Marshal(AppInfoV2Response{
+		Type:              "controller",
+		AgentCapabilities: []string{"logging.slog-levels"},
+		AppCapabilities:   []string{"ziti.foo"},
+	})
+	require.NoError(t, err)
+
+	client, server := net.Pipe()
+	go func() {
+		_, _ = server.Write(body)
+		_ = server.Close()
+	}()
+
+	resp, ok, err := ReadAppInfoV2Response(client)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "controller", resp.Type)
+	require.Equal(t, []string{"logging.slog-levels"}, resp.AgentCapabilities)
+	require.Equal(t, []string{"ziti.foo"}, resp.AppCapabilities)
+}
+
+// TestReadAppInfoV2ResponseCleanEOF proves an old server (no AppInfoV2 handler)
+// that closes the connection with no write is detected as "unsupported".
+func TestReadAppInfoV2ResponseCleanEOF(t *testing.T) {
+	client, server := net.Pipe()
+	go func() {
+		_ = server.Close()
+	}()
+
+	resp, ok, err := ReadAppInfoV2Response(client)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, resp)
+}
+
+func TestCapabilitiesHelloRoundTrip(t *testing.T) {
+	resetCaps()
+	markAgentCapabilityActive(CapabilityLoggingSlogLevels)
+
+	headers := map[int32][]byte{
+		CapabilitiesHeader: GetAgentCapabilitiesMask().Bytes(),
+	}
+	mask := CapabilitiesFromHeaders(headers)
+
+	names := GetAgentCapabilityStringList()
+	require.NotEmpty(t, names)
+	for _, name := range names {
+		bit, ok := AgentCapabilityBitFromString(name)
+		require.True(t, ok)
+		require.Equal(t, uint(1), mask.Bit(bit))
+	}
+
+	require.Equal(t, 0, CapabilitiesFromHeaders(map[int32][]byte{}).BitLen())
+}
+
+func TestAgentCapabilityName(t *testing.T) {
+	name, ok := AgentCapabilityName(CapabilityLoggingSlogLevels)
+	require.True(t, ok)
+	require.Equal(t, "logging.slog-levels", name)
+
+	_, ok = AgentCapabilityName(99)
+	require.False(t, ok)
+}

--- a/common/agent/capabilities.go
+++ b/common/agent/capabilities.go
@@ -1,0 +1,181 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package agent
+
+import (
+	"math/big"
+	"slices"
+	"sort"
+	"sync"
+)
+
+// Agent capabilities. Each is owned by common/agent and has a stable bit
+// position (used in the channel-hello bitmask) and a stable
+// hierarchical-dotted string name (used in AppInfoV2.agent_capabilities). The
+// two encodings stay in sync via agentCapabilityNames.
+const (
+	// CapabilityLoggingSlogLevels indicates the agent supports the channel-based v2
+	// log-level commands (SetLogLevelV2, SetChannelLogLevelV2,
+	// ClearChannelLogLevelV2), which carry string level names.
+	CapabilityLoggingSlogLevels int = 1
+)
+
+// CapabilitiesHeader is the channel-hello header carrying the agent
+// capability bitmask (the bytes of GetAgentCapabilitiesMask), in the
+// agent-reserved header band.
+const CapabilitiesHeader int32 = 30102
+
+// agentCapabilityNames maps each agent capability bit to its canonical
+// hierarchical-dotted string name. It is the single source of truth tying the
+// bitmask encoding to the string-list encoding.
+var agentCapabilityNames = map[int]string{
+	CapabilityLoggingSlogLevels: "logging.slog-levels",
+}
+
+var (
+	capsMu     sync.Mutex
+	activeCaps = map[int]bool{} // agent caps whose handler is registered
+	appCaps    []string         // app-registered capability strings, in registration order
+	capsFrozen bool             // set once the agent listener starts
+)
+
+// markAgentCapabilityActive records that the handler backing an agent
+// capability has been registered, so the capability becomes advertised. It is
+// called by the registration entry points (e.g. RegisterLogLevelHandlers)
+// before the listener starts.
+func markAgentCapabilityActive(bit int) {
+	capsMu.Lock()
+	defer capsMu.Unlock()
+	activeCaps[bit] = true
+}
+
+// GetAgentCapabilitiesMask returns the bitmask form of the active agent
+// capabilities, for use in the channel hello.
+func GetAgentCapabilitiesMask() *big.Int {
+	capsMu.Lock()
+	defer capsMu.Unlock()
+	mask := &big.Int{}
+	for bit := range activeCaps {
+		mask.SetBit(mask, bit, 1)
+	}
+	return mask
+}
+
+// GetAgentCapabilityStringList returns the string-list form of the active agent
+// capabilities, for use in AppInfoV2.agent_capabilities. Order is deterministic
+// (sorted by bit position) so the JSON shape is stable.
+func GetAgentCapabilityStringList() []string {
+	capsMu.Lock()
+	defer capsMu.Unlock()
+	bits := make([]int, 0, len(activeCaps))
+	for bit := range activeCaps {
+		bits = append(bits, bit)
+	}
+	sort.Ints(bits)
+	names := make([]string, 0, len(bits))
+	for _, bit := range bits {
+		if name, ok := agentCapabilityNames[bit]; ok {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// AgentCapabilityBitFromString is the inverse of agentCapabilityNames, used
+// client-side to turn a name read from AppInfoV2 back into a bit. It consults
+// the full registry, not just the active set.
+func AgentCapabilityBitFromString(s string) (bit int, ok bool) {
+	for b, name := range agentCapabilityNames {
+		if name == s {
+			return b, true
+		}
+	}
+	return 0, false
+}
+
+// AgentCapabilityName returns the canonical string name for an agent capability
+// bit, used client-side to check a bit constant against the AppInfoV2 string
+// list.
+func AgentCapabilityName(bit int) (string, bool) {
+	name, ok := agentCapabilityNames[bit]
+	return name, ok
+}
+
+// CapabilitiesFromHeaders decodes the agent capability bitmask from channel
+// hello headers, returning an empty mask if the header is absent.
+func CapabilitiesFromHeaders(headers map[int32][]byte) *big.Int {
+	if val, ok := headers[CapabilitiesHeader]; ok {
+		return new(big.Int).SetBytes(val)
+	}
+	return new(big.Int)
+}
+
+// RegisterAppCapabilities adds application-defined capability strings to the
+// app_capabilities list emitted in AppInfoV2. The strings are passed through
+// uninterpreted and deduplicated. Re-registering names that are already known
+// is a no-op even after the listener has started, so multiple in-process apps
+// can each declare the same capability without ordering concerns; introducing
+// a new name after the listener starts panics, because that would drift the
+// advertised set across connections.
+func RegisterAppCapabilities(names ...string) {
+	capsMu.Lock()
+	defer capsMu.Unlock()
+	for _, name := range names {
+		// if we already have the capability, skip further processing
+		if slices.Contains(appCaps, name) {
+			continue
+		}
+		// First time we've seen this name, so registering it would change the
+		// advertised set; that's only allowed before the listener starts.
+		assertCapsMutable("RegisterAppCapabilities")
+		appCaps = append(appCaps, name)
+	}
+}
+
+// assertCapsMutable panics if the advertised capability set is sealed. Callers
+// hold capsMu and only invoke this once they have determined the current call
+// would actually change the set. The freeze rule exists so the bits and names
+// reported in the channel hello stay consistent across every connection.
+func assertCapsMutable(who string) {
+	if capsFrozen {
+		panic("agent: " + who + " would change the advertised capability set after the listener started")
+	}
+}
+
+// agentCapAlreadyActive reports whether bit is already present in the
+// advertised agent-capability set. A registration call that finds its bit
+// already active is a callback/handler refresh, not a set change, so it is
+// accepted post-freeze.
+func agentCapAlreadyActive(bit int) bool {
+	return activeCaps[bit]
+}
+
+// getAppCapabilities returns a copy of the registered app capability strings,
+// in registration order.
+func getAppCapabilities() []string {
+	capsMu.Lock()
+	defer capsMu.Unlock()
+	return append([]string(nil), appCaps...)
+}
+
+// freezeCapabilities locks the capability set so no further registration is
+// accepted. It is called when the agent listener starts.
+func freezeCapabilities() {
+	capsMu.Lock()
+	defer capsMu.Unlock()
+	capsFrozen = true
+}

--- a/common/agent/capabilities_test.go
+++ b/common/agent/capabilities_test.go
@@ -1,0 +1,110 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// resetCaps restores the package-level capability registry to its zero state
+// so each test starts clean despite the registry being process-global.
+func resetCaps() {
+	capsMu.Lock()
+	defer capsMu.Unlock()
+	activeCaps = map[int]bool{}
+	appCaps = nil
+	capsFrozen = false
+	logLevelCallbacks = nil
+}
+
+func TestAgentCapabilitiesInactiveByDefault(t *testing.T) {
+	resetCaps()
+	require.Empty(t, GetAgentCapabilityStringList())
+	require.Equal(t, 0, GetAgentCapabilitiesMask().BitLen())
+}
+
+func TestAgentCapabilityActivation(t *testing.T) {
+	resetCaps()
+	markAgentCapabilityActive(CapabilityLoggingSlogLevels)
+	require.Equal(t, []string{"logging.slog-levels"}, GetAgentCapabilityStringList())
+	require.Equal(t, uint(1), GetAgentCapabilitiesMask().Bit(CapabilityLoggingSlogLevels))
+}
+
+func TestMaskMatchesStringList(t *testing.T) {
+	resetCaps()
+	markAgentCapabilityActive(CapabilityLoggingSlogLevels)
+	mask := GetAgentCapabilitiesMask()
+	names := GetAgentCapabilityStringList()
+	require.NotEmpty(t, names)
+	for _, name := range names {
+		bit, ok := AgentCapabilityBitFromString(name)
+		require.True(t, ok)
+		require.Equal(t, uint(1), mask.Bit(bit))
+	}
+}
+
+func TestAgentCapabilityBitFromString(t *testing.T) {
+	bit, ok := AgentCapabilityBitFromString("logging.slog-levels")
+	require.True(t, ok)
+	require.Equal(t, CapabilityLoggingSlogLevels, bit)
+
+	_, ok = AgentCapabilityBitFromString("nope")
+	require.False(t, ok)
+}
+
+func TestRegisterAppCapabilitiesDedupOrder(t *testing.T) {
+	resetCaps()
+	RegisterAppCapabilities("ziti.foo", "ziti.foo", "ziti.bar")
+	RegisterAppCapabilities("ziti.foo")
+	require.Equal(t, []string{"ziti.foo", "ziti.bar"}, getAppCapabilities())
+}
+
+// TestAgentAndAppNamespacesIndependent proves the same string registered as
+// both an agent capability and an app capability is reported on each list
+// independently, with no merging.
+func TestAgentAndAppNamespacesIndependent(t *testing.T) {
+	resetCaps()
+	markAgentCapabilityActive(CapabilityLoggingSlogLevels)
+	RegisterAppCapabilities("logging.slog-levels")
+	require.Equal(t, []string{"logging.slog-levels"}, GetAgentCapabilityStringList())
+	require.Equal(t, []string{"logging.slog-levels"}, getAppCapabilities())
+}
+
+// TestRegisterAppCapabilitiesPanicsOnNewNameAfterFreeze proves a name that
+// would add to the advertised list still panics post-freeze.
+func TestRegisterAppCapabilitiesPanicsOnNewNameAfterFreeze(t *testing.T) {
+	resetCaps()
+	freezeCapabilities()
+	require.Panics(t, func() {
+		RegisterAppCapabilities("ziti.late")
+	})
+}
+
+// TestRegisterAppCapabilitiesIdempotentAfterFreeze proves a name that is
+// already in the advertised set passes through post-freeze without panic; the
+// freeze rule only protects against set changes.
+func TestRegisterAppCapabilitiesIdempotentAfterFreeze(t *testing.T) {
+	resetCaps()
+	RegisterAppCapabilities("ziti.foo", "ziti.bar")
+	freezeCapabilities()
+	require.NotPanics(t, func() {
+		RegisterAppCapabilities("ziti.foo", "ziti.bar")
+	})
+	require.Equal(t, []string{"ziti.foo", "ziti.bar"}, getAppCapabilities())
+}

--- a/common/agent/channel.go
+++ b/common/agent/channel.go
@@ -40,11 +40,37 @@ func HandleChannelConnection(conn net.Conn, id *identity.TokenId, appId byte, bi
 		return errors.Errorf("invalid app id %v", got)
 	}
 
+	// When log-level callbacks are registered, bind the v2 log-level handlers
+	// on every agent channel alongside the application's own handlers.
+	bindHandler := bind
+	if cbs := getLogLevelCallbacks(); cbs != nil {
+		bindHandler = composeBindHandlers(bind, logLevelBindHandler(cbs))
+	}
+
 	options := channel.DefaultOptions()
 	options.ConnectTimeout = time.Second
-	listener := channel.NewExistingConnListener(id, conn, nil)
-	_, err := channel.NewChannel("agent", listener, bind, options)
+	helloHeaders := map[int32][]byte{
+		CapabilitiesHeader: GetAgentCapabilitiesMask().Bytes(),
+	}
+	listener := channel.NewExistingConnListener(id, conn, helloHeaders)
+	_, err := channel.NewChannel("agent", listener, bindHandler, options)
 	return err
+}
+
+// composeBindHandlers returns a BindHandler that applies each of the given
+// handlers in order, skipping nil entries.
+func composeBindHandlers(handlers ...channel.BindHandler) channel.BindHandler {
+	return channel.BindHandlerF(func(binding channel.Binding) error {
+		for _, h := range handlers {
+			if h == nil {
+				continue
+			}
+			if err := binding.Bind(h); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }
 
 // NewChannel wraps an established agent connection in a channel/v4 client

--- a/common/agent/loglevel.go
+++ b/common/agent/loglevel.go
@@ -1,0 +1,81 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package agent
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// LogLevel is the agent's transport-neutral log level. It is the type carried
+// across the log-level callback boundary so that common/agent stays agnostic
+// of any particular logging implementation (logrus, slog, ...); the embedding
+// application maps LogLevel onto its own loggers.
+type LogLevel int
+
+const (
+	PanicLevel LogLevel = iota
+	FatalLevel
+	ErrorLevel
+	WarnLevel
+	InfoLevel
+	DebugLevel
+	TraceLevel
+)
+
+var logLevelNames = map[LogLevel]string{
+	PanicLevel: "panic",
+	FatalLevel: "fatal",
+	ErrorLevel: "error",
+	WarnLevel:  "warn",
+	InfoLevel:  "info",
+	DebugLevel: "debug",
+	TraceLevel: "trace",
+}
+
+// String returns the canonical lowercase wire name for the level, or "unknown"
+// for values outside the defined set.
+func (l LogLevel) String() string {
+	if name, ok := logLevelNames[l]; ok {
+		return name
+	}
+	return "unknown"
+}
+
+// ParseLogLevel converts a canonical wire name (case-insensitive) into a
+// LogLevel, returning an error for unrecognized names.
+func ParseLogLevel(s string) (LogLevel, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "panic":
+		return PanicLevel, nil
+	case "fatal":
+		return FatalLevel, nil
+	case "error":
+		return ErrorLevel, nil
+	case "warn", "warning":
+		return WarnLevel, nil
+	case "info":
+		return InfoLevel, nil
+	case "debug":
+		return DebugLevel, nil
+	case "trace":
+		return TraceLevel, nil
+	default:
+		return 0, errors.Errorf("invalid log level %q", s)
+	}
+}

--- a/common/agent/loglevel_commands.go
+++ b/common/agent/loglevel_commands.go
@@ -1,0 +1,178 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package agent
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/michaelquigley/pfxlog"
+	"github.com/openziti/channel/v4"
+	"github.com/openziti/ziti/v2/common/handler_common"
+	"github.com/pkg/errors"
+)
+
+// Content-type IDs for the v2 log-level channel messages. These ride the same
+// "agent" channel as application message types (ctrl_pb in the 1000s, mgmt_pb
+// in the 10000s), so common/agent reserves the 30000-30999 band for its own
+// messages.
+const (
+	SetLogLevelV2RequestType          int32 = 30000
+	SetChannelLogLevelV2RequestType   int32 = 30001
+	ClearChannelLogLevelV2RequestType int32 = 30002
+)
+
+// String header IDs carrying the v2 log-level message parameters, in the
+// agent-reserved band.
+const (
+	LogLevelHeader   int32 = 30100
+	LogChannelHeader int32 = 30101
+)
+
+// LogLevelCallbacks holds the application-supplied side effects for the
+// log-level commands. The application maps the agent-neutral LogLevel onto its
+// own loggers. The struct shape leaves room to add fields later without
+// breaking callers.
+type LogLevelCallbacks struct {
+	SetLogLevel          func(level LogLevel)
+	SetChannelLogLevel   func(channel string, level LogLevel)
+	ClearChannelLogLevel func(channel string)
+}
+
+// logLevelCallbacks holds the registered callbacks, guarded by capsMu. It is
+// nil until RegisterLogLevelHandlers is called.
+var logLevelCallbacks *LogLevelCallbacks
+
+// RegisterLogLevelHandlers registers the application's log-level side effects.
+// All three callbacks must be supplied. The first call advertises
+// logging.slog-levels and binds the v2 log-level channel commands on every
+// subsequent agent channel; the framed log-level commands route through the
+// same callbacks. Subsequent calls replace the callbacks in place, so multiple
+// in-process apps (e.g. the quickstart's controller and router) can share the
+// agent listener without fighting over registration order. The first call must
+// happen before the agent listener starts; later first-time registration panics
+// because it would add a new capability bit and the advertised set must stay
+// consistent across every connection.
+func RegisterLogLevelHandlers(cbs LogLevelCallbacks) error {
+	if cbs.SetLogLevel == nil || cbs.SetChannelLogLevel == nil || cbs.ClearChannelLogLevel == nil {
+		return errors.New("all log-level callbacks must be set")
+	}
+
+	capsMu.Lock()
+	defer capsMu.Unlock()
+	if !agentCapAlreadyActive(CapabilityLoggingSlogLevels) {
+		// First registration: the call would advertise a new bit, so the freeze
+		// rule applies. Subsequent calls only refresh callbacks and pass through.
+		assertCapsMutable("RegisterLogLevelHandlers")
+	}
+	cb := cbs
+	logLevelCallbacks = &cb
+	activeCaps[CapabilityLoggingSlogLevels] = true
+	return nil
+}
+
+// getLogLevelCallbacks returns the registered callbacks, or nil if none were
+// registered.
+func getLogLevelCallbacks() *LogLevelCallbacks {
+	capsMu.Lock()
+	defer capsMu.Unlock()
+	return logLevelCallbacks
+}
+
+// logLevelBindHandler binds the v2 log-level message handlers onto an agent
+// channel. HandleChannelConnection adds it automatically when callbacks are
+// registered.
+func logLevelBindHandler(cbs *LogLevelCallbacks) channel.BindHandler {
+	return channel.BindHandlerF(func(binding channel.Binding) error {
+		binding.AddReceiveHandlerF(SetLogLevelV2RequestType, func(m *channel.Message, ch channel.Channel) {
+			levelStr, _ := m.GetStringHeader(LogLevelHeader)
+			level, err := ParseLogLevel(levelStr)
+			if err != nil {
+				handler_common.SendOpResult(m, ch, "set-log-level", err.Error(), false)
+				return
+			}
+			cbs.SetLogLevel(level)
+			pfxlog.Logger().Infof("log level set to %v", level)
+			handler_common.SendOpResult(m, ch, "set-log-level", "log level set to "+level.String(), true)
+		})
+
+		binding.AddReceiveHandlerF(SetChannelLogLevelV2RequestType, func(m *channel.Message, ch channel.Channel) {
+			channelName, _ := m.GetStringHeader(LogChannelHeader)
+			levelStr, _ := m.GetStringHeader(LogLevelHeader)
+			level, err := ParseLogLevel(levelStr)
+			if err != nil {
+				handler_common.SendOpResult(m, ch, "set-channel-log-level", err.Error(), false)
+				return
+			}
+			cbs.SetChannelLogLevel(channelName, level)
+			pfxlog.Logger().Infof("log level for channel %v set to %v", channelName, level)
+			handler_common.SendOpResult(m, ch, "set-channel-log-level", fmt.Sprintf("log level for channel %v set to %v", channelName, level), true)
+		})
+
+		binding.AddReceiveHandlerF(ClearChannelLogLevelV2RequestType, func(m *channel.Message, ch channel.Channel) {
+			channelName, _ := m.GetStringHeader(LogChannelHeader)
+			cbs.ClearChannelLogLevel(channelName)
+			pfxlog.Logger().Infof("log level for channel %v cleared", channelName)
+			handler_common.SendOpResult(m, ch, "clear-channel-log-level", "log level for channel "+channelName+" cleared", true)
+		})
+
+		return nil
+	})
+}
+
+// SendSetLogLevelV2 sends a SetLogLevelV2 request over the given agent channel
+// and returns the server's result message.
+func SendSetLogLevelV2(ch channel.Channel, level LogLevel, timeout time.Duration) (string, error) {
+	msg := channel.NewMessage(SetLogLevelV2RequestType, nil)
+	msg.PutStringHeader(LogLevelHeader, level.String())
+	return sendForResult(ch, msg, timeout)
+}
+
+// SendSetChannelLogLevelV2 sends a SetChannelLogLevelV2 request over the given
+// agent channel and returns the server's result message.
+func SendSetChannelLogLevelV2(ch channel.Channel, channelName string, level LogLevel, timeout time.Duration) (string, error) {
+	msg := channel.NewMessage(SetChannelLogLevelV2RequestType, nil)
+	msg.PutStringHeader(LogChannelHeader, channelName)
+	msg.PutStringHeader(LogLevelHeader, level.String())
+	return sendForResult(ch, msg, timeout)
+}
+
+// SendClearChannelLogLevelV2 sends a ClearChannelLogLevelV2 request over the
+// given agent channel and returns the server's result message.
+func SendClearChannelLogLevelV2(ch channel.Channel, channelName string, timeout time.Duration) (string, error) {
+	msg := channel.NewMessage(ClearChannelLogLevelV2RequestType, nil)
+	msg.PutStringHeader(LogChannelHeader, channelName)
+	return sendForResult(ch, msg, timeout)
+}
+
+// sendForResult sends a request and waits for the standard channel Result
+// reply, returning its message on success or an error on transport failure or
+// a non-success result.
+func sendForResult(ch channel.Channel, msg *channel.Message, timeout time.Duration) (string, error) {
+	reply, err := msg.WithTimeout(timeout).SendForReply(ch)
+	if err != nil {
+		return "", err
+	}
+	if reply.ContentType != channel.ContentTypeResultType {
+		return "", errors.Errorf("unexpected response type %v", reply.ContentType)
+	}
+	result := channel.UnmarshalResult(reply)
+	if !result.Success {
+		return "", errors.New(result.Message)
+	}
+	return result.Message, nil
+}

--- a/common/agent/loglevel_commands_test.go
+++ b/common/agent/loglevel_commands_test.go
@@ -1,0 +1,83 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func completeCallbacks() LogLevelCallbacks {
+	return LogLevelCallbacks{
+		SetLogLevel:          func(LogLevel) {},
+		SetChannelLogLevel:   func(string, LogLevel) {},
+		ClearChannelLogLevel: func(string) {},
+	}
+}
+
+func TestRegisterLogLevelHandlersRequiresAllCallbacks(t *testing.T) {
+	resetCaps()
+	err := RegisterLogLevelHandlers(LogLevelCallbacks{})
+	require.Error(t, err)
+	require.Nil(t, getLogLevelCallbacks())
+	require.Empty(t, GetAgentCapabilityStringList())
+}
+
+func TestRegisterLogLevelHandlersMarksCapabilityActive(t *testing.T) {
+	resetCaps()
+	require.NoError(t, RegisterLogLevelHandlers(completeCallbacks()))
+	require.NotNil(t, getLogLevelCallbacks())
+	require.Equal(t, []string{"logging.slog-levels"}, GetAgentCapabilityStringList())
+	require.Equal(t, uint(1), GetAgentCapabilitiesMask().Bit(CapabilityLoggingSlogLevels))
+}
+
+// TestRegisterLogLevelHandlersPanicsOnFirstRegistrationAfterFreeze proves the
+// freeze rule still bites when a call would actually add the capability bit.
+func TestRegisterLogLevelHandlersPanicsOnFirstRegistrationAfterFreeze(t *testing.T) {
+	resetCaps()
+	freezeCapabilities()
+	require.Panics(t, func() {
+		_ = RegisterLogLevelHandlers(completeCallbacks())
+	})
+}
+
+// TestRegisterLogLevelHandlersIdempotentAfterFreeze proves a second call after
+// freeze succeeds when the capability bit is already active. The advertised
+// set doesn't change, so only the callbacks get updated. This is the path
+// taken in the quickstart, where the controller registers before Listen
+// freezes, and the router registers again afterwards.
+func TestRegisterLogLevelHandlersIdempotentAfterFreeze(t *testing.T) {
+	resetCaps()
+	require.NoError(t, RegisterLogLevelHandlers(completeCallbacks()))
+	freezeCapabilities()
+
+	calls := 0
+	updated := LogLevelCallbacks{
+		SetLogLevel:          func(LogLevel) { calls++ },
+		SetChannelLogLevel:   func(string, LogLevel) {},
+		ClearChannelLogLevel: func(string) {},
+	}
+	require.NotPanics(t, func() {
+		require.NoError(t, RegisterLogLevelHandlers(updated))
+	})
+
+	cbs := getLogLevelCallbacks()
+	require.NotNil(t, cbs)
+	cbs.SetLogLevel(InfoLevel)
+	require.Equal(t, 1, calls, "second registration must replace the callbacks in place")
+}

--- a/common/agent/loglevel_e2e_test.go
+++ b/common/agent/loglevel_e2e_test.go
@@ -1,0 +1,153 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package agent
+
+import (
+	"net"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openziti/channel/v4"
+	"github.com/openziti/identity"
+	"github.com/openziti/ziti/v2/common/agentid"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingCallbacks records the arguments passed to each log-level callback so
+// the end-to-end test can assert that commands reached the handlers correctly.
+type recordingCallbacks struct {
+	mu              sync.Mutex
+	globalLevel     LogLevel
+	globalSet       bool
+	channelName     string
+	channelLevel    LogLevel
+	channelSet      bool
+	clearedChannel  string
+	clearedChannelN int
+}
+
+func (r *recordingCallbacks) asCallbacks() LogLevelCallbacks {
+	return LogLevelCallbacks{
+		SetLogLevel: func(l LogLevel) {
+			r.mu.Lock()
+			defer r.mu.Unlock()
+			r.globalLevel = l
+			r.globalSet = true
+		},
+		SetChannelLogLevel: func(c string, l LogLevel) {
+			r.mu.Lock()
+			defer r.mu.Unlock()
+			r.channelName = c
+			r.channelLevel = l
+			r.channelSet = true
+		},
+		ClearChannelLogLevel: func(c string) {
+			r.mu.Lock()
+			defer r.mu.Unlock()
+			r.clearedChannel = c
+			r.clearedChannelN++
+		},
+	}
+}
+
+func TestLogLevelCommandsEndToEnd(t *testing.T) {
+	resetCaps()
+
+	rec := &recordingCallbacks{}
+	require.NoError(t, RegisterLogLevelHandlers(rec.asCallbacks()))
+
+	sock := filepath.Join(t.TempDir(), "agent.sock")
+	cleanup := false
+	require.NoError(t, Listen(Options{
+		Addr:            "unix:" + sock,
+		ShutdownCleanup: &cleanup,
+		AppType:         "test-app",
+		AppId:           "test-1",
+		CustomOps: map[byte]func(conn net.Conn) error{
+			CustomOpAsync: func(conn net.Conn) error {
+				return HandleChannelConnection(conn, &identity.TokenId{Token: "test"}, 99, nil)
+			},
+		},
+	}))
+	t.Cleanup(func() {
+		Close()
+		mu.Lock()
+		listener = nil
+		tmpfile = ""
+		mu.Unlock()
+	})
+
+	dial := func() net.Conn {
+		conn, err := net.Dial("unix", sock)
+		require.NoError(t, err)
+		return conn
+	}
+
+	// AppInfoV2 advertises the capability now that handlers are registered.
+	require.NoError(t, MakeRequestToConn(dial(), AppInfoV2, nil, func(conn net.Conn) error {
+		resp, ok, err := ReadAppInfoV2Response(conn)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, "test-app", resp.Type)
+		require.Contains(t, resp.AgentCapabilities, "logging.slog-levels")
+		return nil
+	}))
+
+	// v2 set-log-level over the channel reaches the global callback.
+	require.NoError(t, MakeRequestToConn(dial(), CustomOpAsync, []byte{agentid.AppIdAny}, ConnToChannel(func(ch channel.Channel) error {
+		msg, err := SendSetLogLevelV2(ch, DebugLevel, time.Second)
+		require.NoError(t, err)
+		require.Contains(t, msg, "debug")
+		return nil
+	})))
+	rec.mu.Lock()
+	require.True(t, rec.globalSet)
+	require.Equal(t, DebugLevel, rec.globalLevel)
+	rec.mu.Unlock()
+
+	// v2 set-channel-log-level reaches the per-channel callback.
+	require.NoError(t, MakeRequestToConn(dial(), CustomOpAsync, []byte{agentid.AppIdAny}, ConnToChannel(func(ch channel.Channel) error {
+		_, err := SendSetChannelLogLevelV2(ch, "network.gossip", TraceLevel, time.Second)
+		return err
+	})))
+	rec.mu.Lock()
+	require.True(t, rec.channelSet)
+	require.Equal(t, "network.gossip", rec.channelName)
+	require.Equal(t, TraceLevel, rec.channelLevel)
+	rec.mu.Unlock()
+
+	// v2 clear-channel-log-level reaches the clear callback.
+	require.NoError(t, MakeRequestToConn(dial(), CustomOpAsync, []byte{agentid.AppIdAny}, ConnToChannel(func(ch channel.Channel) error {
+		_, err := SendClearChannelLogLevelV2(ch, "network.gossip", time.Second)
+		return err
+	})))
+	rec.mu.Lock()
+	require.Equal(t, "network.gossip", rec.clearedChannel)
+	require.Equal(t, 1, rec.clearedChannelN)
+	rec.mu.Unlock()
+
+	// The framed set-log-level command routes through the same callback.
+	require.NoError(t, MakeRequestToConn(dial(), SetLogLevel, []byte{byte(InfoLevel)}, func(conn net.Conn) error {
+		_, _ = conn.Read(make([]byte, 256))
+		return nil
+	}))
+	rec.mu.Lock()
+	require.Equal(t, InfoLevel, rec.globalLevel)
+	rec.mu.Unlock()
+}

--- a/common/agent/loglevel_test.go
+++ b/common/agent/loglevel_test.go
@@ -1,0 +1,52 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogLevelStringRoundTrip(t *testing.T) {
+	for _, lvl := range []LogLevel{PanicLevel, FatalLevel, ErrorLevel, WarnLevel, InfoLevel, DebugLevel, TraceLevel} {
+		name := lvl.String()
+		require.NotEqual(t, "unknown", name)
+		parsed, err := ParseLogLevel(name)
+		require.NoError(t, err)
+		require.Equal(t, lvl, parsed)
+	}
+}
+
+func TestLogLevelString(t *testing.T) {
+	require.Equal(t, "info", InfoLevel.String())
+	require.Equal(t, "trace", TraceLevel.String())
+	require.Equal(t, "unknown", LogLevel(99).String())
+}
+
+func TestParseLogLevel(t *testing.T) {
+	l, err := ParseLogLevel("DEBUG")
+	require.NoError(t, err)
+	require.Equal(t, DebugLevel, l)
+
+	l, err = ParseLogLevel("warning")
+	require.NoError(t, err)
+	require.Equal(t, WarnLevel, l)
+
+	_, err = ParseLogLevel("bogus")
+	require.Error(t, err)
+}

--- a/common/agent/signal.go
+++ b/common/agent/signal.go
@@ -69,4 +69,8 @@ const (
 
 	// CustomOpAsync reserved for application specific operations which execute async
 	CustomOpAsync = byte(0x15)
+
+	// AppInfoV2 returns application identity plus the agent and app capability
+	// lists. It is a net-new command; the legacy AppInfo (0xa) is unchanged.
+	AppInfoV2 = byte(0x16)
 )

--- a/common/agentlog/callbacks.go
+++ b/common/agentlog/callbacks.go
@@ -1,0 +1,50 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+// Package agentlog provides the ziti agent log-level callbacks. It is the one
+// place that maps the agent's transport-neutral LogLevel onto ziti's loggers,
+// so controller, router, and tunnel all register identical behavior.
+package agentlog
+
+import (
+	"github.com/michaelquigley/pfxlog"
+	"github.com/openziti/ziti/v2/common/agent"
+	"github.com/sirupsen/logrus"
+)
+
+// DefaultLogLevelCallbacks returns the agent log-level callbacks that drive
+// logrus (global level) and pfxlog (per-channel overrides), matching the
+// behavior of the legacy framed log-level handlers. The agent LogLevel enum is
+// ordered to match logrus.Level, so the conversion is a direct cast.
+func DefaultLogLevelCallbacks() agent.LogLevelCallbacks {
+	return agent.LogLevelCallbacks{
+		SetLogLevel: func(level agent.LogLevel) {
+			logrus.SetLevel(logrus.Level(level))
+		},
+		SetChannelLogLevel: func(channel string, level agent.LogLevel) {
+			pfxlog.GlobalConfig(func(options *pfxlog.Options) *pfxlog.Options {
+				options.SetChannelLogLevel(channel, logrus.Level(level))
+				return options
+			})
+		},
+		ClearChannelLogLevel: func(channel string) {
+			pfxlog.GlobalConfig(func(options *pfxlog.Options) *pfxlog.Options {
+				options.ClearChannelLogLevel(channel)
+				return options
+			})
+		},
+	}
+}

--- a/doc/design/agent-capabilities.md
+++ b/doc/design/agent-capabilities.md
@@ -242,11 +242,11 @@ only writer; consumers only read.
 // in common/agent, e.g. common/agent/capabilities.go
 
 const (
-    // AgentLoggingSlogLevels indicates the agent supports the channel-
+    // CapabilityLoggingSlogLevels indicates the agent supports the channel-
     // based v2 log-level commands (SetLogLevelV2,
     // SetChannelLogLevelV2, ClearChannelLogLevelV2) which carry
     // slog-style string level names.
-    AgentLoggingSlogLevels int = 1
+    CapabilityLoggingSlogLevels int = 1
 )
 
 // agentCapabilityNames maps each agent bit to the canonical
@@ -254,7 +254,7 @@ const (
 // The two encodings (int bit position for channel hello bitmask,
 // string for AppInfo JSON) stay in sync via this single table.
 var agentCapabilityNames = map[int]string{
-    AgentLoggingSlogLevels: "logging.slog-levels",
+    CapabilityLoggingSlogLevels: "logging.slog-levels",
 }
 
 // GetAgentCapabilitiesMask returns the bitmask form, used in the
@@ -360,7 +360,7 @@ func (c *agentClient) HasAppCapability(name string) bool {
 
 Two checking methods, one per field. Callers pick the namespace
 their capability lives in - typically the agent-defined ones
-(like `agent.AgentLoggingSlogLevels`) go through
+(like `agent.CapabilityLoggingSlogLevels`) go through
 `HasAgentCapability`; application-defined ones go through
 `HasAppCapability`.
 
@@ -466,7 +466,7 @@ if c.HasAgentCapability("logging.slog-levels") {
 ```
 
 (`HasAgentCapability` takes either a name string or a bit; tests
-usually use the constant `agent.AgentLoggingSlogLevels` form.)
+usually use the constant `agent.CapabilityLoggingSlogLevels` form.)
 
 Legacy framed `set-log-level` / `set-channel-log-level` /
 `clear-channel-log-level` stay on the server forever. Old clients
@@ -515,7 +515,7 @@ A reasonable bar for "this branch is done":
    tunnel, demo) collapse into that one API; no copy remains.
    Wire shape for any existing channel command is unchanged.
 2. `common/agent` gains a capability registry: bit constant
-   `AgentLoggingSlogLevels`, the `agentCapabilityNames` table,
+   `CapabilityLoggingSlogLevels`, the `agentCapabilityNames` table,
    and the `GetAgentCapabilitiesMask`,
    `GetAgentCapabilityStringList`, `AgentCapabilityBitFromString`
    helpers. `common/agent` is the only writer of this registry.

--- a/doc/design/logging-refactor-progress.md
+++ b/doc/design/logging-refactor-progress.md
@@ -92,7 +92,7 @@ design.
   These start importing `channel/v4` + `identity`, which are already
   root-module deps, so there is no `go.mod` or Go-version change.
   Existing channel commands unchanged on the wire.
-- **Capability registry:** bit constant `AgentLoggingSlogLevels`,
+- **Capability registry:** bit constant `CapabilityLoggingSlogLevels`,
   `agentCapabilityNames` table, `GetAgentCapabilitiesMask`,
   `GetAgentCapabilityStringList`, `AgentCapabilityBitFromString`.
   `common/agent` is the only writer.

--- a/router/router.go
+++ b/router/router.go
@@ -51,6 +51,7 @@ import (
 	"github.com/openziti/xweb/v3"
 	"github.com/openziti/ziti/v2/common"
 	"github.com/openziti/ziti/v2/common/agent"
+	"github.com/openziti/ziti/v2/common/agentlog"
 	"github.com/openziti/ziti/v2/common/alert"
 	"github.com/openziti/ziti/v2/common/capabilities"
 	"github.com/openziti/ziti/v2/common/config"
@@ -421,6 +422,10 @@ func (self *Router) RunCliAgent(agentAddr, appAlias string) {
 	options.CustomOps = map[byte]func(conn net.Conn) error{
 		agent.CustomOp:      self.HandleAgentOp,
 		agent.CustomOpAsync: self.HandleAgentAsyncOp,
+	}
+
+	if err := agent.RegisterLogLevelHandlers(agentlog.DefaultLogLevelCallbacks()); err != nil {
+		pfxlog.Logger().WithError(err).Error("unable to register agent log-level handlers")
 	}
 
 	if err := agent.Listen(options); err != nil {

--- a/ziti/cmd/agentcli/agent.go
+++ b/ziti/cmd/agentcli/agent.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"slices"
 	"strings"
 	"time"
 
@@ -128,6 +129,48 @@ type AgentOptions struct {
 	appAlias    string
 	appAddr     string
 	timeout     time.Duration
+
+	agentCaps   []string
+	appCaps     []string
+	capsFetched bool
+}
+
+// fetchCaps lazily fetches the target's capability lists via AppInfoV2 and
+// caches them for the lifetime of this AgentOptions. A server that predates
+// AppInfoV2 (or any fetch error) leaves the lists empty, which yields legacy
+// behavior.
+func (self *AgentOptions) fetchCaps() {
+	if self.capsFetched {
+		return
+	}
+	self.capsFetched = true
+	_ = self.MakeRequest(agent.AppInfoV2, nil, func(conn net.Conn) error {
+		resp, ok, err := agent.ReadAppInfoV2Response(conn)
+		if err != nil || !ok {
+			return nil
+		}
+		self.agentCaps = resp.AgentCapabilities
+		self.appCaps = resp.AppCapabilities
+		return nil
+	})
+}
+
+// HasAgentCapability reports whether the target advertises the agent capability
+// identified by the given bit (e.g. agent.AgentLoggingSlogLevels).
+func (self *AgentOptions) HasAgentCapability(bit int) bool {
+	self.fetchCaps()
+	name, ok := agent.AgentCapabilityName(bit)
+	if !ok {
+		return false
+	}
+	return slices.Contains(self.agentCaps, name)
+}
+
+// HasAppCapability reports whether the target advertises the named application
+// capability.
+func (self *AgentOptions) HasAppCapability(name string) bool {
+	self.fetchCaps()
+	return slices.Contains(self.appCaps, name)
 }
 
 func (self *AgentOptions) AddAgentOptions(cmd *cobra.Command) {

--- a/ziti/cmd/agentcli/agent.go
+++ b/ziti/cmd/agentcli/agent.go
@@ -156,7 +156,7 @@ func (self *AgentOptions) fetchCaps() {
 }
 
 // HasAgentCapability reports whether the target advertises the agent capability
-// identified by the given bit (e.g. agent.AgentLoggingSlogLevels).
+// identified by the given bit (e.g. agent.CapabilityLoggingSlogLevels).
 func (self *AgentOptions) HasAgentCapability(bit int) bool {
 	self.fetchCaps()
 	name, ok := agent.AgentCapabilityName(bit)

--- a/ziti/cmd/agentcli/agent_clear_channel_log_level.go
+++ b/ziti/cmd/agentcli/agent_clear_channel_log_level.go
@@ -19,8 +19,10 @@ package agentcli
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"os"
 
+	"github.com/openziti/channel/v4"
 	"github.com/openziti/ziti/v2/common/agent"
 	"github.com/openziti/ziti/v2/ziti/cmd/common"
 	"github.com/spf13/cobra"
@@ -61,6 +63,20 @@ func (self *AgentClearChannelLogLevelAction) Run() error {
 		channelArg = self.Args[0]
 	} else {
 		channelArg = self.Args[1]
+	}
+
+	// The one-arg form targets via the standard flags and can use the v2
+	// channel command when available. The two-arg positional-address form
+	// stays on the framed command.
+	if len(self.Args) == 1 && self.HasAgentCapability(agent.CapabilityLoggingSlogLevels) {
+		return self.MakeChannelRequest(byte(AgentAppAny), func(ch channel.Channel) error {
+			msg, err := agent.SendClearChannelLogLevelV2(ch, channelArg, self.timeout)
+			if err != nil {
+				return err
+			}
+			fmt.Println(msg)
+			return nil
+		})
 	}
 
 	lenBuf := make([]byte, 8)

--- a/ziti/cmd/agentcli/agent_set_channel_log_level.go
+++ b/ziti/cmd/agentcli/agent_set_channel_log_level.go
@@ -19,13 +19,12 @@ package agentcli
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"os"
-	"strings"
 
+	"github.com/openziti/channel/v4"
 	"github.com/openziti/ziti/v2/common/agent"
 	"github.com/openziti/ziti/v2/ziti/cmd/common"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -59,19 +58,20 @@ func NewSetChannelLogLevelCmd(p common.OptionsProvider) *cobra.Command {
 // Run implements the command
 func (self *AgentSetChannelLogLevelAction) Run() error {
 	channelArg := self.Args[0]
-	levelArg := self.Args[1]
-
-	var level logrus.Level
-	var found bool
-	for _, l := range logrus.AllLevels {
-		if strings.EqualFold(l.String(), levelArg) {
-			level = l
-			found = true
-		}
+	level, err := agent.ParseLogLevel(self.Args[1])
+	if err != nil {
+		return err
 	}
 
-	if !found {
-		return errors.Errorf("invalid log level %v", levelArg)
+	if self.HasAgentCapability(agent.CapabilityLoggingSlogLevels) {
+		return self.MakeChannelRequest(byte(AgentAppAny), func(ch channel.Channel) error {
+			msg, err := agent.SendSetChannelLogLevelV2(ch, channelArg, level, self.timeout)
+			if err != nil {
+				return err
+			}
+			fmt.Println(msg)
+			return nil
+		})
 	}
 
 	lenBuf := make([]byte, 8)

--- a/ziti/cmd/agentcli/agent_set_log_level.go
+++ b/ziti/cmd/agentcli/agent_set_log_level.go
@@ -17,13 +17,12 @@
 package agentcli
 
 import (
+	"fmt"
 	"os"
-	"strings"
 
+	"github.com/openziti/channel/v4"
 	"github.com/openziti/ziti/v2/common/agent"
 	"github.com/openziti/ziti/v2/ziti/cmd/common"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -56,19 +55,20 @@ func NewSetLogLevelCmd(p common.OptionsProvider) *cobra.Command {
 
 // Run implements the command
 func (self *AgentSetLogLevelAction) Run() error {
-	levelArg := self.Args[0]
-
-	var level logrus.Level
-	var found bool
-	for _, l := range logrus.AllLevels {
-		if strings.EqualFold(l.String(), levelArg) {
-			level = l
-			found = true
-		}
+	level, err := agent.ParseLogLevel(self.Args[0])
+	if err != nil {
+		return err
 	}
 
-	if !found {
-		return errors.Errorf("invalid log level %v", levelArg)
+	if self.HasAgentCapability(agent.CapabilityLoggingSlogLevels) {
+		return self.MakeChannelRequest(byte(AgentAppAny), func(ch channel.Channel) error {
+			msg, err := agent.SendSetLogLevelV2(ch, level, self.timeout)
+			if err != nil {
+				return err
+			}
+			fmt.Println(msg)
+			return nil
+		})
 	}
 
 	buf := []byte{byte(level)}

--- a/ziti/run/run_controller.go
+++ b/ziti/run/run_controller.go
@@ -32,6 +32,7 @@ import (
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/foundation/v2/errorz"
 	"github.com/openziti/ziti/v2/common/agent"
+	"github.com/openziti/ziti/v2/common/agentlog"
 	"github.com/openziti/ziti/v2/common/version"
 	"github.com/openziti/ziti/v2/controller"
 	"github.com/openziti/ziti/v2/controller/server"
@@ -150,6 +151,9 @@ func (self *ControllerAction) Run(cmd *cobra.Command, args []string) {
 		}
 		options.CustomOps = map[byte]func(conn net.Conn) error{
 			agent.CustomOpAsync: self.fabricController.HandleCustomAgentAsyncOp,
+		}
+		if err := agent.RegisterLogLevelHandlers(agentlog.DefaultLogLevelCallbacks()); err != nil {
+			pfxlog.Logger().WithError(err).Error("unable to register agent log-level handlers")
 		}
 		if err := agent.Listen(options); err != nil {
 			pfxlog.Logger().WithError(err).Error("unable to start CLI agent")

--- a/ziti/tunnel/root.go
+++ b/ziti/tunnel/root.go
@@ -30,6 +30,7 @@ import (
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/sdk-golang/ziti"
 	"github.com/openziti/ziti/v2/common/agent"
+	"github.com/openziti/ziti/v2/common/agentlog"
 	"github.com/openziti/ziti/v2/common/version"
 	"github.com/openziti/ziti/v2/tunnel"
 	"github.com/openziti/ziti/v2/tunnel/dns"
@@ -127,6 +128,9 @@ func rootPostRun(cmd *cobra.Command, _ []string) {
 		// don't use the agent's shutdown handler. it calls os.Exit on SIGINT
 		// which interferes with the servicePoller shutdown
 		cleanup := false
+		if err := agent.RegisterLogLevelHandlers(agentlog.DefaultLogLevelCallbacks()); err != nil {
+			log.WithError(err).Error("failed to register agent log-level handlers")
+		}
 		err := agent.Listen(agent.Options{
 			Addr:            cliAgentAddr,
 			ShutdownCleanup: &cleanup,


### PR DESCRIPTION
## Summary

Follow-up to #3895, adding capability discovery and the typed v2 log-level
channel commands on top of the absorbed `common/agent`. Old clients keep
working unchanged; new clients prefer the typed v2 commands when the target
advertises them.

Fixes #3902.

**Stacked on #3895** — this PR's base is `agent-prep`, so the diff shows only
the 8 commits of new work. Merge #3895 first, then this rebases cleanly onto
`main`.

## What's in this PR

**Capability primitive** (`common/agent`)

A net-new `AppInfoV2` framed command (op `0x16`) returns identity plus two
capability lists: `agent_capabilities` (package-owned) and `app_capabilities`
(registered by the embedding application). Legacy `AppInfo` (`0xa`,
`map[string]string`) is untouched. A new client hitting an old server reads a
clean zero-byte EOF on the unknown op and falls back. Capabilities also ride
the channel hello as a `*big.Int` bitmask.

Advertisement is conditional: a capability is only emitted when its handler is
registered. `RegisterAppCapabilities` and `RegisterLogLevelHandlers` freeze
once `Listen` starts (panic on late registration).

**Three v2 log-level channel commands**

`SetLogLevelV2`, `SetChannelLogLevelV2`, `ClearChannelLogLevelV2`. Content-type
IDs in the agent-reserved `30000+` band (clear of ctrl_pb's 1000s and
mgmt_pb's 10000s, both of which ride the agent channel). Parameters are
carried as channel string headers.

`common/agent` stays logger-agnostic: it defines its own `LogLevel` enum,
parses the wire string once, and hands callbacks an `agent.LogLevel`. The
embedding application maps onto its loggers.

**Callbacks**

`LogLevelCallbacks` + `RegisterLogLevelHandlers`. Both the v2 channel handlers
and the legacy framed handlers route through these callbacks. Embedders that
don't register get today's logrus / pfxlog behavior unchanged.
`HandleChannelConnection` auto-binds the v2 handlers on every agent channel
when callbacks are registered.

**ziti wiring**

`common/agentlog.DefaultLogLevelCallbacks` is the one place mapping
`agent.LogLevel` onto logrus and pfxlog. Controller, router, and tunnel
register it at startup, before `Listen`. The CLI commands
(`agent set-log-level`, `set-channel-log-level`, `clear-channel-log-level`)
pick the v2 channel command when the target advertises `logging.slog-levels`,
falling back to the framed command otherwise. The `clear-channel-log-level`
two-arg positional-address form stays framed (it doesn't use the standard
targeting flags).

**Developer note and tests**

`common/agent/README.md` documents the two-tier capability model and how to
extend it (add an agent capability, register an app capability, add a v2
channel command, preserve wire compatibility). An in-process end-to-end test
exercises `AppInfoV2`, each of the three v2 channel commands, and the framed
path-through-the-callbacks.

## Backwards compatibility

- Legacy framed `set-log-level` / `set-channel-log-level` /
  `clear-channel-log-level` stay forever and now route through the same
  callbacks when registered, with a logrus/pfxlog fallback when not.
- Legacy `AppInfo` (`map[string]string`) is byte-identical to before, so old
  `ziti agent ps` / `list` keeps working against new servers.
- An old `ziti agent` CLI against a new server uses the legacy framed
  commands; the v2 capability simply isn't observed.

## Not in scope

The slog-based logging refactor itself (`AsyncHandler`, async sink, named
loggers, format compatibility). That sits on top of this work and will be a
separate follow-up.