### PR TITLE
Add common/logging async slog handler and chain composition

### DIFF
--- a/common/logging/chain.go
+++ b/common/logging/chain.go
@@ -1,0 +1,103 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"slices"
+)
+
+// boundHandler carries a set of attrs that get prepended to every record
+// flowing through it, then delegates to its parent. WithAttrs never mutates
+// the receiver; it returns a new boundHandler whose attrs are the receiver's
+// combined with the additional ones and whose parent is the receiver's parent
+// (not the receiver itself). The effect on a chain of slog.Logger.With calls
+// is that they produce sibling boundHandlers at the same chain depth rather
+// than stacking wrapper-on-wrapper, which would grow the chain on every call.
+type boundHandler struct {
+	parent slog.Handler
+	attrs  []slog.Attr
+}
+
+func (h *boundHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.parent.Enabled(ctx, level)
+}
+
+func (h *boundHandler) Handle(ctx context.Context, r slog.Record) error {
+	r2 := slog.NewRecord(r.Time, r.Level, r.Message, r.PC)
+	r2.AddAttrs(h.attrs...)
+	r.Attrs(func(a slog.Attr) bool {
+		r2.AddAttrs(a)
+		return true
+	})
+	return h.parent.Handle(ctx, r2)
+}
+
+func (h *boundHandler) WithAttrs(more []slog.Attr) slog.Handler {
+	if len(more) == 0 {
+		return h
+	}
+	combined := make([]slog.Attr, 0, len(h.attrs)+len(more))
+	combined = append(combined, h.attrs...)
+	combined = append(combined, more...)
+	return &boundHandler{parent: h.parent, attrs: combined}
+}
+
+func (h *boundHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	return &groupedHandler{parent: h, name: name}
+}
+
+// groupedHandler wraps every record's attrs in slog.Group(name, ...) before
+// delegating to its parent. A subsequent WithAttrs creates a boundHandler
+// whose parent is this groupedHandler, so the attrs land inside the group.
+type groupedHandler struct {
+	parent slog.Handler
+	name   string
+}
+
+func (h *groupedHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.parent.Enabled(ctx, level)
+}
+
+func (h *groupedHandler) Handle(ctx context.Context, r slog.Record) error {
+	var items []any
+	r.Attrs(func(a slog.Attr) bool {
+		items = append(items, a)
+		return true
+	})
+	r2 := slog.NewRecord(r.Time, r.Level, r.Message, r.PC)
+	r2.AddAttrs(slog.Group(h.name, items...))
+	return h.parent.Handle(ctx, r2)
+}
+
+func (h *groupedHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return h
+	}
+	return &boundHandler{parent: h, attrs: slices.Clone(attrs)}
+}
+
+func (h *groupedHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	return &groupedHandler{parent: h, name: name}
+}

--- a/common/logging/chain_test.go
+++ b/common/logging/chain_test.go
@@ -1,0 +1,244 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package logging
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// runWithLogger builds a fresh AsyncHandler over a JSON downstream, lets the
+// caller emit one record through a slog.Logger backed by the handler, then
+// closes the handler, waits for the drain, and returns the parsed JSON. Time
+// and level keys are filtered out so tests can assert on shape alone.
+func runWithLogger(t *testing.T, f func(*slog.Logger)) map[string]any {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	downstream := slog.NewJSONHandler(buf, &slog.HandlerOptions{
+		ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr {
+			if a.Key == slog.TimeKey || a.Key == slog.LevelKey {
+				return slog.Attr{}
+			}
+			return a
+		},
+	})
+	h, err := NewAsyncHandler(downstream, DefaultOptions())
+	require.NoError(t, err)
+
+	f(slog.New(h))
+
+	require.NoError(t, h.Close())
+	<-h.drainDone
+
+	line := strings.TrimSpace(buf.String())
+	var got map[string]any
+	require.NoError(t, json.Unmarshal([]byte(line), &got), "raw=%q", line)
+	return got
+}
+
+func TestChainWithAttrs(t *testing.T) {
+	got := runWithLogger(t, func(l *slog.Logger) {
+		l.With("a", 1).Info("msg", "b", 2)
+	})
+	require.Equal(t, "msg", got["msg"])
+	require.Equal(t, float64(1), got["a"])
+	require.Equal(t, float64(2), got["b"])
+}
+
+func TestChainWithGroup(t *testing.T) {
+	got := runWithLogger(t, func(l *slog.Logger) {
+		l.WithGroup("g").Info("msg", "a", 1)
+	})
+	require.Equal(t, "msg", got["msg"])
+	g, ok := got["g"].(map[string]any)
+	require.True(t, ok, "g should be a nested object, got %T", got["g"])
+	require.Equal(t, float64(1), g["a"])
+}
+
+// TestChainBoundAttrsBeforeGroup: With("a",1).WithGroup("g").With("b",2)
+//
+//	.Info("msg","c",3)  ->  {msg, a:1, g:{b:2, c:3}}
+func TestChainBoundAttrsBeforeGroup(t *testing.T) {
+	got := runWithLogger(t, func(l *slog.Logger) {
+		l.With("a", 1).WithGroup("g").With("b", 2).Info("msg", "c", 3)
+	})
+	require.Equal(t, "msg", got["msg"])
+	require.Equal(t, float64(1), got["a"])
+	g, ok := got["g"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, float64(2), g["b"])
+	require.Equal(t, float64(3), g["c"])
+}
+
+// TestChainAttrsInsideGroup: WithGroup("g").With("a",1).Info("msg","b",2)
+//
+//	->  {msg, g:{a:1, b:2}}  (the .With after WithGroup lands inside the group)
+func TestChainAttrsInsideGroup(t *testing.T) {
+	got := runWithLogger(t, func(l *slog.Logger) {
+		l.WithGroup("g").With("a", 1).Info("msg", "b", 2)
+	})
+	require.Equal(t, "msg", got["msg"])
+	g, ok := got["g"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, float64(1), g["a"])
+	require.Equal(t, float64(2), g["b"])
+	require.NotContains(t, got, "a", "a should be inside g, not at the root")
+}
+
+// TestChainNestedGroups: WithGroup("a").WithGroup("b").Info("msg","c",3)
+//
+//	->  {msg, a:{b:{c:3}}}
+func TestChainNestedGroups(t *testing.T) {
+	got := runWithLogger(t, func(l *slog.Logger) {
+		l.WithGroup("a").WithGroup("b").Info("msg", "c", 3)
+	})
+	require.Equal(t, "msg", got["msg"])
+	a, ok := got["a"].(map[string]any)
+	require.True(t, ok)
+	b, ok := a["b"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, float64(3), b["c"])
+}
+
+// TestChainWithAttrsDoesNotNestWrappers proves that two consecutive WithAttrs
+// calls on AsyncHandler -> boundHandler produce a single boundHandler whose
+// parent is still AsyncHandler (a sibling at the same chain depth), not a
+// new boundHandler wrapping the first one. This keeps chain depth bounded
+// when slog.Logger.With is called repeatedly.
+func TestChainWithAttrsDoesNotNestWrappers(t *testing.T) {
+	rec := &recordingHandler{}
+	h, err := NewAsyncHandler(rec, DefaultOptions())
+	require.NoError(t, err)
+	defer func() { _ = h.Close(); <-h.drainDone }()
+
+	first := h.WithAttrs([]slog.Attr{slog.Int("a", 1)})
+	second := first.WithAttrs([]slog.Attr{slog.Int("b", 2)})
+
+	bh, ok := second.(*boundHandler)
+	require.True(t, ok, "expected *boundHandler, got %T", second)
+	require.Equal(t, h, bh.parent, "parent should still be AsyncHandler, not the first boundHandler")
+	require.Len(t, bh.attrs, 2)
+	require.Equal(t, "a", bh.attrs[0].Key)
+	require.Equal(t, "b", bh.attrs[1].Key)
+}
+
+// TestChainWithGroupEmptyIsNoop proves WithGroup("") returns the receiver
+// unchanged on each of the three handler types.
+func TestChainWithGroupEmptyIsNoop(t *testing.T) {
+	rec := &recordingHandler{}
+	h, err := NewAsyncHandler(rec, DefaultOptions())
+	require.NoError(t, err)
+	defer func() { _ = h.Close(); <-h.drainDone }()
+
+	require.Same(t, h, h.WithGroup(""), "AsyncHandler.WithGroup(\"\") should return receiver")
+
+	bh := h.WithAttrs([]slog.Attr{slog.Int("a", 1)}).(*boundHandler)
+	require.Same(t, bh, bh.WithGroup("").(*boundHandler), "boundHandler.WithGroup(\"\") should return receiver")
+
+	gh := h.WithGroup("g").(*groupedHandler)
+	require.Same(t, gh, gh.WithGroup("").(*groupedHandler), "groupedHandler.WithGroup(\"\") should return receiver")
+}
+
+// TestChainWithAttrsEmptyIsNoop proves WithAttrs(nil) returns the receiver
+// on each of the three handler types, so slog.Logger.With() with no args
+// allocates nothing.
+func TestChainWithAttrsEmptyIsNoop(t *testing.T) {
+	rec := &recordingHandler{}
+	h, err := NewAsyncHandler(rec, DefaultOptions())
+	require.NoError(t, err)
+	defer func() { _ = h.Close(); <-h.drainDone }()
+
+	require.Same(t, h, h.WithAttrs(nil))
+
+	bh := h.WithAttrs([]slog.Attr{slog.Int("a", 1)}).(*boundHandler)
+	require.Same(t, bh, bh.WithAttrs(nil).(*boundHandler))
+
+	gh := h.WithGroup("g").(*groupedHandler)
+	require.Same(t, gh, gh.WithAttrs(nil).(*groupedHandler))
+}
+
+// TestChainSiblingLoggersDoNotLeakAttrs proves that deriving a child logger
+// inside a loop and reusing the parent logger after the loop is safe: the
+// parent's attrs are not contaminated by the children's additions. This is a
+// common pattern (a parent logger plus per-iteration enrichment) and the
+// extends-in-place optimization in boundHandler.WithAttrs must not break it.
+func TestChainSiblingLoggersDoNotLeakAttrs(t *testing.T) {
+	buf := &bytes.Buffer{}
+	downstream := slog.NewJSONHandler(buf, &slog.HandlerOptions{
+		ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr {
+			if a.Key == slog.TimeKey || a.Key == slog.LevelKey {
+				return slog.Attr{}
+			}
+			return a
+		},
+	})
+	h, err := NewAsyncHandler(downstream, DefaultOptions())
+	require.NoError(t, err)
+
+	parent := slog.New(h).With("scope", "outer")
+	parent.Info("before-loop")
+	for _, v := range []int{1, 2, 3} {
+		parent.With("v", v).Info("in-loop")
+	}
+	parent.Info("after-loop")
+
+	require.NoError(t, h.Close())
+	<-h.drainDone
+
+	var lines []map[string]any
+	for _, raw := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		var m map[string]any
+		require.NoError(t, json.Unmarshal([]byte(raw), &m))
+		lines = append(lines, m)
+	}
+	require.Len(t, lines, 5)
+
+	require.Equal(t, "before-loop", lines[0]["msg"])
+	require.Equal(t, "outer", lines[0]["scope"])
+	require.NotContains(t, lines[0], "v")
+
+	for i := 1; i <= 3; i++ {
+		require.Equal(t, "in-loop", lines[i]["msg"])
+		require.Equal(t, "outer", lines[i]["scope"])
+		require.Equal(t, float64(i), lines[i]["v"])
+	}
+
+	require.Equal(t, "after-loop", lines[4]["msg"])
+	require.Equal(t, "outer", lines[4]["scope"])
+	require.NotContains(t, lines[4], "v", "parent logger must not have inherited a child's attr")
+}
+
+// TestChainEnabledDelegates proves Enabled on chain wrappers reaches
+// AsyncHandler, which currently returns true.
+func TestChainEnabledDelegates(t *testing.T) {
+	rec := &recordingHandler{}
+	h, err := NewAsyncHandler(rec, DefaultOptions())
+	require.NoError(t, err)
+	defer func() { _ = h.Close(); <-h.drainDone }()
+
+	bh := h.WithAttrs([]slog.Attr{slog.Int("a", 1)})
+	gh := h.WithGroup("g")
+
+	require.True(t, bh.Enabled(context.Background(), slog.LevelDebug))
+	require.True(t, gh.Enabled(context.Background(), slog.LevelDebug))
+}

--- a/common/logging/handler.go
+++ b/common/logging/handler.go
@@ -1,0 +1,281 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package logging
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// AsyncHandler is a bounded, async slog.Handler that hands records to a single
+// drain goroutine and onto a downstream handler. Records at or above the
+// configured BlockThreshold block when the queue is full; records below it
+// drop and are counted toward a periodic summary line.
+//
+// AsyncHandler is the root of the slog handler chain: WithAttrs returns a
+// boundHandler that prepends bound attrs to records, and WithGroup returns a
+// groupedHandler that wraps record attrs in slog.Group(name, ...). Both
+// wrappers delegate back to AsyncHandler.Handle, which is where the queueing
+// and drain dispatch live.
+type AsyncHandler struct {
+	opts         AsyncOptions
+	downstream   slog.Handler
+	queue        chan queuedRecord
+	closeNotify  chan struct{}
+	drainDone    chan struct{}
+	closed       atomic.Bool
+	downstreamMu sync.Mutex
+	dropCounts   [7]atomic.Int64
+	drainErrors  atomic.Int64
+	// windowStart is the start of the current summary window. It is only
+	// accessed by the drain goroutine after the handler is constructed.
+	windowStart time.Time
+}
+
+// queuedRecord carries the originating call's context alongside the record so
+// downstream handlers that consult ctx values (tracing, OTel) see them across
+// the async hop.
+type queuedRecord struct {
+	ctx    context.Context
+	record slog.Record
+}
+
+// NewAsyncHandler returns an AsyncHandler that drains records onto downstream.
+// It validates opts and starts the drain goroutine; on validation failure it
+// returns an error and no resources are leaked.
+func NewAsyncHandler(downstream slog.Handler, opts AsyncOptions) (*AsyncHandler, error) {
+	if downstream == nil {
+		return nil, errors.New("downstream handler must not be nil")
+	}
+	if err := opts.Validate(); err != nil {
+		return nil, err
+	}
+	h := &AsyncHandler{
+		opts:        opts,
+		downstream:  downstream,
+		queue:       make(chan queuedRecord, opts.QueueSize),
+		closeNotify: make(chan struct{}),
+		drainDone:   make(chan struct{}),
+		windowStart: time.Now(),
+	}
+	go h.drain()
+	return h, nil
+}
+
+// Enabled returns true. AsyncHandler does no level gating itself; records are
+// gated before they reach it. Direct slog callers go through the named-logger
+// registry's handler, whose Enabled checks the per-name override or live
+// global level, and bridged logrus records are pre-filtered by logrus's own
+// level check (see doc/design/logging-refactor.md). A second check here would
+// be a redundant atomic load on every call.
+func (h *AsyncHandler) Enabled(context.Context, slog.Level) bool {
+	return true
+}
+
+// Handle enqueues r for the drain goroutine. Records at or above
+// BlockThreshold block when the queue is full (with a closeNotify escape so
+// shutdown can't deadlock); records below BlockThreshold drop and increment
+// the per-level drop counter.
+func (h *AsyncHandler) Handle(ctx context.Context, r slog.Record) error {
+	if h.closed.Load() {
+		return nil
+	}
+	qr := queuedRecord{ctx: ctx, record: r}
+	if r.Level >= h.opts.BlockThreshold {
+		select {
+		case h.queue <- qr:
+		case <-h.closeNotify:
+			// shutdown; best-effort drop
+		}
+	} else {
+		select {
+		case h.queue <- qr:
+		default:
+			h.dropCounts[dropIdx(r.Level)].Add(1)
+		}
+	}
+	return nil
+}
+
+// WithAttrs returns a child handler that prepends the given attrs to every
+// record it sees before forwarding to AsyncHandler. An empty attrs slice
+// returns the receiver unchanged so slog.Logger.With() with no args is free.
+func (h *AsyncHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return h
+	}
+	return &boundHandler{parent: h, attrs: slices.Clone(attrs)}
+}
+
+// WithGroup returns a child handler that wraps every record's attrs in
+// slog.Group(name, ...) before forwarding. An empty group name returns the
+// receiver unchanged, matching slog's convention.
+func (h *AsyncHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	return &groupedHandler{parent: h, name: name}
+}
+
+// Close initiates shutdown and returns immediately. The drain goroutine
+// finishes processing whatever is already enqueued, emits a final drop
+// summary if any drops occurred, then exits and closes the drainDone channel.
+// Calling Close more than once is a no-op.
+//
+// A producer that races with Close may still successfully enqueue a record
+// that the drain never sees; per the design, logging during shutdown is
+// best-effort. Records routed through SyncEmit are durable because they
+// bypass the queue and write synchronously.
+func (h *AsyncHandler) Close() error {
+	if !h.closed.CompareAndSwap(false, true) {
+		return nil
+	}
+	close(h.closeNotify)
+	return nil
+}
+
+// SyncEmit writes r through the downstream handler synchronously on the
+// caller's goroutine, bypassing the queue. It exists so that fatal/panic
+// records reach the downstream before the process exits. Contention with the
+// drain is negligible because SyncEmit is rare (only at fatal/panic) and the
+// drain holds downstreamMu only for the duration of a single
+// downstream.Handle call.
+func (h *AsyncHandler) SyncEmit(ctx context.Context, r slog.Record) error {
+	h.downstreamMu.Lock()
+	defer h.downstreamMu.Unlock()
+	return h.downstream.Handle(ctx, r)
+}
+
+// drain is the single goroutine that pulls records off the queue and calls
+// the downstream handler. It also emits the periodic drop-summary record on
+// the summary ticker, and on shutdown does a final-flush pass through any
+// remaining queued records plus a final summary.
+func (h *AsyncHandler) drain() {
+	defer close(h.drainDone)
+	ticker := time.NewTicker(h.opts.SummaryInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case qr := <-h.queue:
+			h.dispatch(qr.ctx, qr.record)
+		case <-ticker.C:
+			h.emitSummaryIfAny()
+		case <-h.closeNotify:
+			// final flush: drain any records that beat the close-notify
+			// reception, then emit a final summary if anything was dropped.
+			for {
+				select {
+				case qr := <-h.queue:
+					h.dispatch(qr.ctx, qr.record)
+				default:
+					h.emitSummaryIfAny()
+					return
+				}
+			}
+		}
+	}
+}
+
+// dispatch hands one record to the downstream handler under downstreamMu, the
+// same mutex SyncEmit takes, so the downstream handler does not need to be
+// concurrency-safe on its own.
+func (h *AsyncHandler) dispatch(ctx context.Context, r slog.Record) {
+	h.downstreamMu.Lock()
+	defer h.downstreamMu.Unlock()
+	if err := h.downstream.Handle(ctx, r); err != nil {
+		h.drainErrors.Add(1)
+		// Bypass slog to avoid recursion if the downstream handler is the
+		// thing failing.
+		fmt.Fprintf(os.Stderr, "logging: downstream handler error: %v\n", err)
+	}
+}
+
+// emitSummaryIfAny snapshots and zeroes the drop and drain-error counters,
+// and if anything was non-zero emits a single summary record. Runs only from
+// the drain goroutine.
+func (h *AsyncHandler) emitSummaryIfAny() {
+	var counts [7]int64
+	anything := false
+	for i := range h.dropCounts {
+		c := h.dropCounts[i].Swap(0)
+		counts[i] = c
+		if c > 0 {
+			anything = true
+		}
+	}
+	errs := h.drainErrors.Swap(0)
+	if errs > 0 {
+		anything = true
+	}
+	if !anything {
+		return
+	}
+
+	now := time.Now()
+	since := h.windowStart
+	h.windowStart = now
+
+	r := slog.NewRecord(now, slog.LevelWarn, "logging queue full, message drop summary", 0)
+	for i, c := range counts {
+		if c > 0 {
+			r.AddAttrs(slog.Int64(canonicalLevelNames[i], c))
+		}
+	}
+	if errs > 0 {
+		r.AddAttrs(slog.Int64("drain_errors", errs))
+	}
+	r.AddAttrs(slog.Time("since", since))
+
+	h.downstreamMu.Lock()
+	_ = h.downstream.Handle(context.Background(), r)
+	h.downstreamMu.Unlock()
+}
+
+// canonicalLevelNames maps the drop-counter index to its canonical lowercase
+// level name, used as the attr key in the summary record.
+var canonicalLevelNames = [7]string{"trace", "debug", "info", "warn", "error", "fatal", "panic"}
+
+// dropIdx maps a slog.Level to its drop-counter bucket. Non-canonical levels
+// (e.g. slog.LevelDebug+1) bucket into the canonical level whose value they
+// most recently exceeded, so every record contributes to exactly one bucket.
+func dropIdx(l slog.Level) int {
+	switch {
+	case l < slog.LevelDebug:
+		return 0 // trace
+	case l < slog.LevelInfo:
+		return 1 // debug
+	case l < slog.LevelWarn:
+		return 2 // info
+	case l < slog.LevelError:
+		return 3 // warn
+	case l < LevelFatal:
+		return 4 // error
+	case l < LevelPanic:
+		return 5 // fatal
+	default:
+		return 6 // panic
+	}
+}

--- a/common/logging/handler_test.go
+++ b/common/logging/handler_test.go
@@ -1,0 +1,427 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package logging
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingHandler captures every record passed to Handle so tests can
+// inspect what made it through the async sink.
+type recordingHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *recordingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *recordingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r)
+	return nil
+}
+func (h *recordingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *recordingHandler) WithGroup(string) slog.Handler      { return h }
+
+func (h *recordingHandler) count() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.records)
+}
+
+func (h *recordingHandler) snapshot() []slog.Record {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]slog.Record(nil), h.records...)
+}
+
+// blockingHandler holds Handle until release is closed, signaling the first
+// entry into Handle via entered. It's used to deterministically park the
+// drain inside a downstream call so the queue fills up.
+type blockingHandler struct {
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+	inner   *recordingHandler
+}
+
+func newBlockingHandler() *blockingHandler {
+	return &blockingHandler{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+		inner:   &recordingHandler{},
+	}
+}
+
+func (h *blockingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *blockingHandler) Handle(ctx context.Context, r slog.Record) error {
+	h.once.Do(func() { close(h.entered) })
+	<-h.release
+	return h.inner.Handle(ctx, r)
+}
+func (h *blockingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *blockingHandler) WithGroup(string) slog.Handler      { return h }
+
+// erroringHandler returns a fixed error from every Handle call. Used to
+// exercise the drain's error-counting path.
+type erroringHandler struct {
+	err   error
+	count atomic.Int64
+}
+
+func (h *erroringHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *erroringHandler) Handle(context.Context, slog.Record) error {
+	h.count.Add(1)
+	return h.err
+}
+func (h *erroringHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *erroringHandler) WithGroup(string) slog.Handler      { return h }
+
+func makeRecord(level slog.Level, msg string) slog.Record {
+	return slog.NewRecord(time.Now(), level, msg, 0)
+}
+
+func TestNewAsyncHandlerValidatesOptions(t *testing.T) {
+	rec := &recordingHandler{}
+	_, err := NewAsyncHandler(rec, AsyncOptions{}) // zero values invalid
+	require.Error(t, err)
+}
+
+func TestNewAsyncHandlerRejectsNilDownstream(t *testing.T) {
+	_, err := NewAsyncHandler(nil, DefaultOptions())
+	require.Error(t, err)
+}
+
+func TestAsyncHandlerNormalFlow(t *testing.T) {
+	rec := &recordingHandler{}
+	h, err := NewAsyncHandler(rec, DefaultOptions())
+	require.NoError(t, err)
+
+	for i := 0; i < 5; i++ {
+		require.NoError(t, h.Handle(context.Background(), makeRecord(slog.LevelInfo, fmt.Sprintf("msg %d", i))))
+	}
+
+	require.NoError(t, h.Close())
+	<-h.drainDone
+
+	require.Equal(t, 5, rec.count())
+}
+
+// TestAsyncHandlerDropsSubThresholdWhenFull parks the drain inside the
+// downstream so the queue fills, then verifies that sub-threshold records
+// drop and bump the per-level counter without blocking the caller.
+func TestAsyncHandlerDropsSubThresholdWhenFull(t *testing.T) {
+	block := newBlockingHandler()
+	opts := DefaultOptions()
+	opts.QueueSize = 2
+	opts.SummaryInterval = time.Hour
+	h, err := NewAsyncHandler(block, opts)
+	require.NoError(t, err)
+
+	// Send one record; wait for the drain to enter the downstream.
+	require.NoError(t, h.Handle(context.Background(), makeRecord(slog.LevelDebug, "m1")))
+	<-block.entered
+
+	// Fill the queue (capacity 2).
+	require.NoError(t, h.Handle(context.Background(), makeRecord(slog.LevelDebug, "m2")))
+	require.NoError(t, h.Handle(context.Background(), makeRecord(slog.LevelDebug, "m3")))
+
+	// Sub-threshold records now drop without blocking.
+	for i := 0; i < 5; i++ {
+		require.NoError(t, h.Handle(context.Background(), makeRecord(slog.LevelDebug, "dropped")))
+	}
+	require.Equal(t, int64(5), h.dropCounts[dropIdx(slog.LevelDebug)].Load())
+
+	// Release the downstream, close, and verify only the original three got
+	// through. Filter the close-flush drop-summary out of the count.
+	close(block.release)
+	require.NoError(t, h.Close())
+	<-h.drainDone
+
+	nonSummary := 0
+	for _, r := range block.inner.snapshot() {
+		if r.Message != "logging queue full, message drop summary" {
+			nonSummary++
+		}
+	}
+	require.Equal(t, 3, nonSummary)
+}
+
+// TestAsyncHandlerBlocksAtThreshold proves a record at the block threshold
+// parks Handle until the drain frees a slot, instead of dropping.
+func TestAsyncHandlerBlocksAtThreshold(t *testing.T) {
+	block := newBlockingHandler()
+	opts := DefaultOptions()
+	opts.QueueSize = 2
+	opts.SummaryInterval = time.Hour
+	h, err := NewAsyncHandler(block, opts)
+	require.NoError(t, err)
+
+	require.NoError(t, h.Handle(context.Background(), makeRecord(slog.LevelInfo, "m1")))
+	<-block.entered
+	require.NoError(t, h.Handle(context.Background(), makeRecord(slog.LevelInfo, "m2")))
+	require.NoError(t, h.Handle(context.Background(), makeRecord(slog.LevelInfo, "m3")))
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		require.NoError(t, h.Handle(context.Background(), makeRecord(slog.LevelWarn, "warn1")))
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("Handle on Warn returned but should have blocked")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(block.release)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Handle on Warn never returned after the downstream was released")
+	}
+
+	require.NoError(t, h.Close())
+	<-h.drainDone
+	require.Equal(t, 4, block.inner.count())
+}
+
+// TestAsyncHandlerCloseUnblocksHandle proves a Handle call parked on the
+// blocking arm of select returns when Close fires, instead of deadlocking.
+func TestAsyncHandlerCloseUnblocksHandle(t *testing.T) {
+	block := newBlockingHandler()
+	defer close(block.release)
+	opts := DefaultOptions()
+	opts.QueueSize = 1
+	opts.SummaryInterval = time.Hour
+	h, err := NewAsyncHandler(block, opts)
+	require.NoError(t, err)
+
+	require.NoError(t, h.Handle(context.Background(), makeRecord(slog.LevelInfo, "m1")))
+	<-block.entered
+	require.NoError(t, h.Handle(context.Background(), makeRecord(slog.LevelInfo, "m2")))
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = h.Handle(context.Background(), makeRecord(slog.LevelWarn, "warn"))
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("Handle should be blocked at this point")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	require.NoError(t, h.Close())
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Close did not unblock Handle")
+	}
+}
+
+func TestAsyncHandlerCloseIdempotent(t *testing.T) {
+	rec := &recordingHandler{}
+	h, err := NewAsyncHandler(rec, DefaultOptions())
+	require.NoError(t, err)
+	require.NoError(t, h.Close())
+	require.NoError(t, h.Close())
+}
+
+func TestAsyncHandlerHandleAfterCloseReturnsNil(t *testing.T) {
+	rec := &recordingHandler{}
+	h, err := NewAsyncHandler(rec, DefaultOptions())
+	require.NoError(t, err)
+	require.NoError(t, h.Close())
+	<-h.drainDone
+
+	require.NoError(t, h.Handle(context.Background(), makeRecord(slog.LevelInfo, "after-close")))
+}
+
+// TestAsyncHandlerHandleRacingCloseNoPanic spawns many producers and a
+// concurrent Close. The handler must never panic and must drain cleanly.
+func TestAsyncHandlerHandleRacingCloseNoPanic(t *testing.T) {
+	rec := &recordingHandler{}
+	h, err := NewAsyncHandler(rec, DefaultOptions())
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				_ = h.Handle(context.Background(), makeRecord(slog.LevelInfo, "x"))
+			}
+		}()
+	}
+
+	time.Sleep(time.Millisecond) // let producers ramp
+	require.NoError(t, h.Close())
+	wg.Wait()
+	<-h.drainDone
+}
+
+// TestAsyncHandlerSummaryEmittedOnTick seeds the drop counters directly and
+// waits for the next ticker emission. Using direct counter seeding avoids
+// timing flakes around when the queue actually fills.
+func TestAsyncHandlerSummaryEmittedOnTick(t *testing.T) {
+	rec := &recordingHandler{}
+	opts := DefaultOptions()
+	opts.SummaryInterval = 20 * time.Millisecond
+	h, err := NewAsyncHandler(rec, opts)
+	require.NoError(t, err)
+
+	h.dropCounts[dropIdx(slog.LevelDebug)].Add(7)
+	h.dropCounts[dropIdx(slog.LevelInfo)].Add(3)
+
+	require.Eventually(t, func() bool { return rec.count() >= 1 }, time.Second, 5*time.Millisecond)
+
+	var summary *slog.Record
+	for _, r := range rec.snapshot() {
+		if r.Message == "logging queue full, message drop summary" {
+			r := r
+			summary = &r
+			break
+		}
+	}
+	require.NotNil(t, summary, "expected drop-summary record")
+
+	attrs := map[string]any{}
+	summary.Attrs(func(a slog.Attr) bool {
+		attrs[a.Key] = a.Value.Any()
+		return true
+	})
+	require.Equal(t, int64(7), attrs["debug"])
+	require.Equal(t, int64(3), attrs["info"])
+	require.NotContains(t, attrs, "trace", "zero-count levels must not appear")
+	require.Contains(t, attrs, "since")
+
+	require.NoError(t, h.Close())
+	<-h.drainDone
+}
+
+// TestSyncEmitDeliversSynchronously proves SyncEmit calls downstream.Handle
+// on the caller's goroutine, bypassing the queue.
+func TestSyncEmitDeliversSynchronously(t *testing.T) {
+	rec := &recordingHandler{}
+	h, err := NewAsyncHandler(rec, DefaultOptions())
+	require.NoError(t, err)
+	defer func() {
+		_ = h.Close()
+		<-h.drainDone
+	}()
+
+	require.NoError(t, h.SyncEmit(context.Background(), makeRecord(LevelFatal, "fatal!")))
+	require.Equal(t, 1, rec.count())
+	require.Equal(t, "fatal!", rec.snapshot()[0].Message)
+}
+
+// TestSyncEmitSerializesWithDrain holds the drain inside the downstream, then
+// fires a SyncEmit. SyncEmit must wait for the in-flight drain dispatch to
+// finish (they share downstreamMu), so the queued record lands before the
+// SyncEmit record.
+func TestSyncEmitSerializesWithDrain(t *testing.T) {
+	block := newBlockingHandler()
+	h, err := NewAsyncHandler(block, DefaultOptions())
+	require.NoError(t, err)
+
+	require.NoError(t, h.Handle(context.Background(), makeRecord(slog.LevelInfo, "queued")))
+	<-block.entered
+
+	syncDone := make(chan struct{})
+	go func() {
+		defer close(syncDone)
+		require.NoError(t, h.SyncEmit(context.Background(), makeRecord(LevelFatal, "sync")))
+	}()
+
+	// SyncEmit must be blocked waiting for downstreamMu held by the drain.
+	select {
+	case <-syncDone:
+		t.Fatal("SyncEmit returned while the drain was still inside Handle")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(block.release)
+	<-syncDone
+
+	require.NoError(t, h.Close())
+	<-h.drainDone
+
+	recs := block.inner.snapshot()
+	require.Equal(t, 2, len(recs))
+	require.Equal(t, "queued", recs[0].Message)
+	require.Equal(t, "sync", recs[1].Message)
+}
+
+// TestAsyncHandlerCountsDrainErrors emits records into a handler that errors
+// on every call and verifies the drain counts the errors and survives. The
+// assertions run before Close so the close-flush summary doesn't perturb
+// the error counter (the summary is itself sent through the downstream and
+// would otherwise add one more error).
+func TestAsyncHandlerCountsDrainErrors(t *testing.T) {
+	errH := &erroringHandler{err: errors.New("boom")}
+	opts := DefaultOptions()
+	opts.SummaryInterval = time.Hour
+	h, err := NewAsyncHandler(errH, opts)
+	require.NoError(t, err)
+
+	for i := 0; i < 3; i++ {
+		require.NoError(t, h.Handle(context.Background(), makeRecord(slog.LevelInfo, "x")))
+	}
+
+	require.Eventually(t, func() bool { return errH.count.Load() == 3 }, time.Second, time.Millisecond)
+	require.Equal(t, int64(3), h.drainErrors.Load())
+
+	require.NoError(t, h.Close())
+	<-h.drainDone
+}
+
+func TestDropIdxBucketing(t *testing.T) {
+	tests := []struct {
+		level slog.Level
+		want  int
+	}{
+		{LevelTrace, 0},
+		{LevelTrace - 1, 0},
+		{slog.LevelDebug, 1},
+		{slog.LevelDebug + 1, 1},
+		{slog.LevelInfo, 2},
+		{slog.LevelWarn, 3},
+		{slog.LevelError, 4},
+		{LevelFatal, 5},
+		{LevelPanic, 6},
+		{LevelPanic + 100, 6},
+	}
+	for _, tt := range tests {
+		t.Run(LevelName(tt.level), func(t *testing.T) {
+			require.Equal(t, tt.want, dropIdx(tt.level))
+		})
+	}
+}

--- a/common/logging/levels.go
+++ b/common/logging/levels.go
@@ -1,0 +1,85 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+// Package logging is the async slog sink that ziti's logging refactor lands on.
+// It owns the seven canonical log levels (trace through panic), the bounded
+// AsyncHandler, and the SyncEmit path used for fatal/panic durability.
+package logging
+
+import (
+	"log/slog"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// Custom slog.Level values extending slog's four standard levels (Debug=-4,
+// Info=0, Warn=4, Error=8) with Trace below Debug and Fatal and Panic above
+// Error. Together these cover the seven canonical level names ziti carries on
+// the agent IPC wire.
+const (
+	LevelTrace slog.Level = -8
+	LevelFatal slog.Level = 12
+	LevelPanic slog.Level = 16
+)
+
+// LevelName returns the canonical lowercase name for a slog.Level on the wire.
+// All seven canonical levels (trace, debug, info, warn, error, fatal, panic)
+// map to their canonical names. Non-canonical values (e.g. slog.LevelDebug+1)
+// fall back to a lowercased slog.Level.String(); slog renders those as
+// "DEBUG+1" / "ERROR+4", so the wire never carries silent garbage.
+func LevelName(l slog.Level) string {
+	switch l {
+	case LevelTrace:
+		return "trace"
+	case slog.LevelDebug:
+		return "debug"
+	case slog.LevelInfo:
+		return "info"
+	case slog.LevelWarn:
+		return "warn"
+	case slog.LevelError:
+		return "error"
+	case LevelFatal:
+		return "fatal"
+	case LevelPanic:
+		return "panic"
+	}
+	return strings.ToLower(l.String())
+}
+
+// ParseLevel converts a canonical level name (case-insensitive) into a
+// slog.Level, returning an error for unrecognized names. Both "warn" and
+// "warning" are accepted.
+func ParseLevel(name string) (slog.Level, error) {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "trace":
+		return LevelTrace, nil
+	case "debug":
+		return slog.LevelDebug, nil
+	case "info":
+		return slog.LevelInfo, nil
+	case "warn", "warning":
+		return slog.LevelWarn, nil
+	case "error":
+		return slog.LevelError, nil
+	case "fatal":
+		return LevelFatal, nil
+	case "panic":
+		return LevelPanic, nil
+	}
+	return 0, errors.Errorf("invalid log level %q", name)
+}

--- a/common/logging/levels_test.go
+++ b/common/logging/levels_test.go
@@ -1,0 +1,80 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package logging
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLevelNameRoundTrip(t *testing.T) {
+	for _, lvl := range []slog.Level{
+		LevelTrace,
+		slog.LevelDebug,
+		slog.LevelInfo,
+		slog.LevelWarn,
+		slog.LevelError,
+		LevelFatal,
+		LevelPanic,
+	} {
+		name := LevelName(lvl)
+		parsed, err := ParseLevel(name)
+		require.NoError(t, err, "round-trip should succeed for %v", lvl)
+		require.Equal(t, lvl, parsed)
+	}
+}
+
+func TestLevelNameCanonical(t *testing.T) {
+	require.Equal(t, "trace", LevelName(LevelTrace))
+	require.Equal(t, "debug", LevelName(slog.LevelDebug))
+	require.Equal(t, "info", LevelName(slog.LevelInfo))
+	require.Equal(t, "warn", LevelName(slog.LevelWarn))
+	require.Equal(t, "error", LevelName(slog.LevelError))
+	require.Equal(t, "fatal", LevelName(LevelFatal))
+	require.Equal(t, "panic", LevelName(LevelPanic))
+}
+
+// TestLevelNameOffsetFallback proves a non-canonical level value (e.g.
+// slog.LevelDebug+1) emits valid lowercase output via slog.Level.String,
+// rather than collapsing to an empty string or panicking. slog renders
+// offsets relative to the nearest standard level, so the exact string depends
+// on slog's own conventions; we just need it to be non-empty and lowercase.
+func TestLevelNameOffsetFallback(t *testing.T) {
+	require.Equal(t, "debug+1", LevelName(slog.LevelDebug+1))
+	require.Equal(t, "error+1", LevelName(slog.LevelError+1))
+}
+
+func TestParseLevelAcceptsCaseAndWarningAlias(t *testing.T) {
+	lvl, err := ParseLevel("DEBUG")
+	require.NoError(t, err)
+	require.Equal(t, slog.LevelDebug, lvl)
+
+	lvl, err = ParseLevel("warning")
+	require.NoError(t, err)
+	require.Equal(t, slog.LevelWarn, lvl)
+
+	lvl, err = ParseLevel("  Trace  ")
+	require.NoError(t, err)
+	require.Equal(t, LevelTrace, lvl)
+}
+
+func TestParseLevelRejectsUnknown(t *testing.T) {
+	_, err := ParseLevel("bogus")
+	require.Error(t, err)
+}

--- a/common/logging/options.go
+++ b/common/logging/options.go
@@ -1,0 +1,117 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package logging
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/pflag"
+)
+
+// Default AsyncOptions values. See doc/design/logging-refactor.md.
+const (
+	DefaultQueueSize       = 4096
+	DefaultBlockThreshold  = slog.LevelWarn
+	DefaultSummaryInterval = 5 * time.Second
+)
+
+// Flag names used by AddFlags / OptionsFromFlags.
+const (
+	FlagQueueSize       = "log-queue-size"
+	FlagBlockThreshold  = "log-block-threshold"
+	FlagSummaryInterval = "log-summary-interval"
+)
+
+// AsyncOptions configures the AsyncHandler queue, block-threshold, and summary
+// cadence. Zero values are not valid; use DefaultOptions as a starting point.
+type AsyncOptions struct {
+	// QueueSize is the bounded capacity of the records queue between the
+	// handler's caller and the drain goroutine.
+	QueueSize int
+
+	// BlockThreshold is the lowest level at which Handle blocks when the queue
+	// is full. Records strictly below this level are dropped under saturation
+	// and counted toward the next summary line.
+	BlockThreshold slog.Level
+
+	// SummaryInterval is the cadence at which the drain emits a drop-summary
+	// record when any per-level drop counter is non-zero.
+	SummaryInterval time.Duration
+}
+
+// DefaultOptions returns AsyncOptions with the defaults documented in
+// doc/design/logging-refactor.md.
+func DefaultOptions() AsyncOptions {
+	return AsyncOptions{
+		QueueSize:       DefaultQueueSize,
+		BlockThreshold:  DefaultBlockThreshold,
+		SummaryInterval: DefaultSummaryInterval,
+	}
+}
+
+// Validate returns an error if any field is outside its valid range.
+func (o AsyncOptions) Validate() error {
+	if o.QueueSize < 1 {
+		return errors.Errorf("QueueSize must be >= 1, got %d", o.QueueSize)
+	}
+	if o.BlockThreshold < LevelTrace || o.BlockThreshold > LevelPanic {
+		return errors.Errorf("BlockThreshold %v is outside the canonical level range (%v..%v)", o.BlockThreshold, LevelTrace, LevelPanic)
+	}
+	if o.SummaryInterval <= 0 {
+		return errors.Errorf("SummaryInterval must be > 0, got %v", o.SummaryInterval)
+	}
+	return nil
+}
+
+// AddFlags binds AsyncOptions to a pflag.FlagSet. The flag values default to
+// DefaultOptions; OptionsFromFlags reads them back after the flag set has
+// been parsed.
+func AddFlags(fs *pflag.FlagSet) {
+	d := DefaultOptions()
+	fs.Int(FlagQueueSize, d.QueueSize, "bounded capacity of the async log queue")
+	fs.String(FlagBlockThreshold, LevelName(d.BlockThreshold), "lowest log level that blocks under queue saturation (panic, fatal, error, warn, info, debug, trace)")
+	fs.Duration(FlagSummaryInterval, d.SummaryInterval, "cadence of the drop-summary log line emitted when records have been dropped")
+}
+
+// OptionsFromFlags reads AsyncOptions from a parsed pflag.FlagSet. Any flag
+// that wasn't added via AddFlags falls back to the DefaultOptions value, so
+// the caller can mix AddFlags-managed flags with a hand-rolled FlagSet
+// without surprises. The returned options are Validate-checked.
+func OptionsFromFlags(fs *pflag.FlagSet) (AsyncOptions, error) {
+	opts := DefaultOptions()
+
+	if q, err := fs.GetInt(FlagQueueSize); err == nil {
+		opts.QueueSize = q
+	}
+	if s, err := fs.GetString(FlagBlockThreshold); err == nil && s != "" {
+		lvl, err := ParseLevel(s)
+		if err != nil {
+			return opts, errors.Wrapf(err, "--%s", FlagBlockThreshold)
+		}
+		opts.BlockThreshold = lvl
+	}
+	if d, err := fs.GetDuration(FlagSummaryInterval); err == nil {
+		opts.SummaryInterval = d
+	}
+
+	if err := opts.Validate(); err != nil {
+		return opts, err
+	}
+	return opts, nil
+}

--- a/common/logging/options_test.go
+++ b/common/logging/options_test.go
@@ -1,0 +1,118 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package logging
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultOptionsValid(t *testing.T) {
+	require.NoError(t, DefaultOptions().Validate())
+}
+
+func TestValidateRejectsBadValues(t *testing.T) {
+	tests := map[string]AsyncOptions{
+		"zero queue size":           {QueueSize: 0, BlockThreshold: slog.LevelWarn, SummaryInterval: time.Second},
+		"negative queue size":       {QueueSize: -1, BlockThreshold: slog.LevelWarn, SummaryInterval: time.Second},
+		"threshold below trace":     {QueueSize: 1, BlockThreshold: LevelTrace - 1, SummaryInterval: time.Second},
+		"threshold above panic":     {QueueSize: 1, BlockThreshold: LevelPanic + 1, SummaryInterval: time.Second},
+		"zero summary interval":     {QueueSize: 1, BlockThreshold: slog.LevelWarn, SummaryInterval: 0},
+		"negative summary interval": {QueueSize: 1, BlockThreshold: slog.LevelWarn, SummaryInterval: -time.Second},
+	}
+	for name, opts := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Error(t, opts.Validate())
+		})
+	}
+}
+
+func TestValidateAcceptsBoundaryValues(t *testing.T) {
+	for _, lvl := range []slog.Level{LevelTrace, LevelPanic} {
+		opts := AsyncOptions{QueueSize: 1, BlockThreshold: lvl, SummaryInterval: time.Nanosecond}
+		require.NoError(t, opts.Validate(), "boundary value %v should be accepted", lvl)
+	}
+}
+
+// TestOptionsFromFlagsDefaults proves that an unparsed FlagSet with our flags
+// bound yields exactly DefaultOptions.
+func TestOptionsFromFlagsDefaults(t *testing.T) {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	AddFlags(fs)
+	require.NoError(t, fs.Parse(nil))
+
+	got, err := OptionsFromFlags(fs)
+	require.NoError(t, err)
+	require.Equal(t, DefaultOptions(), got)
+}
+
+func TestOptionsFromFlagsRoundTrip(t *testing.T) {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	AddFlags(fs)
+	require.NoError(t, fs.Parse([]string{
+		"--" + FlagQueueSize, "16",
+		"--" + FlagBlockThreshold, "error",
+		"--" + FlagSummaryInterval, "10s",
+	}))
+
+	got, err := OptionsFromFlags(fs)
+	require.NoError(t, err)
+	require.Equal(t, AsyncOptions{
+		QueueSize:       16,
+		BlockThreshold:  slog.LevelError,
+		SummaryInterval: 10 * time.Second,
+	}, got)
+}
+
+// TestOptionsFromFlagsRejectsUnknownLevel proves that a bogus level name on
+// the --log-block-threshold flag surfaces as an error from OptionsFromFlags.
+func TestOptionsFromFlagsRejectsUnknownLevel(t *testing.T) {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	AddFlags(fs)
+	require.NoError(t, fs.Parse([]string{"--" + FlagBlockThreshold, "bogus"}))
+
+	_, err := OptionsFromFlags(fs)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), FlagBlockThreshold)
+}
+
+// TestOptionsFromFlagsRejectsValidatedBadValues proves Validate runs after
+// the flag binding.
+func TestOptionsFromFlagsRejectsValidatedBadValues(t *testing.T) {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	AddFlags(fs)
+	require.NoError(t, fs.Parse([]string{"--" + FlagQueueSize, "0"}))
+
+	_, err := OptionsFromFlags(fs)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "QueueSize")
+}
+
+// TestOptionsFromFlagsMissingFlagsFallBackToDefaults proves that a FlagSet
+// missing our flags entirely yields DefaultOptions, so callers can mix-and-match.
+func TestOptionsFromFlagsMissingFlagsFallBackToDefaults(t *testing.T) {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	require.NoError(t, fs.Parse(nil))
+
+	got, err := OptionsFromFlags(fs)
+	require.NoError(t, err)
+	require.Equal(t, DefaultOptions(), got)
+}

--- a/doc/design/logging-refactor-progress.md
+++ b/doc/design/logging-refactor-progress.md
@@ -272,9 +272,11 @@ implement slog's `WithAttrs` / `WithGroup` ordering.
   returns a `boundHandler` wrapping self (so attrs land *inside*
   the group). `WithGroup` extends; `WithGroup("")` returns the
   receiver. `Enabled` delegates to parent.
-- The only `Enabled` that does real work is `AsyncHandler.Enabled`,
-  which reads `globalLevel.Level()` (or the registry-bound level
-  once Phase 5 lands).
+- No `Enabled` in this chain does level gating. `AsyncHandler.Enabled`
+  returns true; the real check lives upstream in Phase 5's
+  registry-bound `namedHandler.Enabled` (per-name override or live
+  global level), and logrus pre-filters bridged records by level
+  before the bridge fires.
 - `Handle` always returns `nil` from the chain wrappers and the
   root. Errors are not propagated synchronously because the
   actual `downstream.Handle` runs on the drain goroutine, after


### PR DESCRIPTION
## Summary

Adds the `common/logging` package, the async slog sink the broader logging
refactor lands on. Nothing migrates yet: no logrus/pfxlog bridge, no named
logger registry, no call-site migration. This PR is just the foundation
(handler + level helpers + handler chain), self-contained inside
`common/logging` and not imported by anything else in the repo yet.

Fixes #3904.

**Stacked on #3895 + #3903.** This PR's base is `agent-capabilities`, so the
diff shows only the new `common/logging` work. Once those merge to `main`,
this rebases cleanly and the issue auto-close link will activate.

## What's in this PR

**Level helpers** (`levels.go`)

Custom `slog.Level` constants for `Trace=-8`, `Fatal=12`, `Panic=16`, plus
`LevelName(slog.Level) string` and `ParseLevel(string) (slog.Level, error)`
as the single source of truth for canonical lowercase wire names. `warn`
and `warning` both accepted on input.

**`AsyncOptions` + flag binding** (`options.go`)

`QueueSize`, `BlockThreshold`, `SummaryInterval` with `Validate`, defaults of
`4096`/`Warn`/`5s`, and `AddFlags`/`OptionsFromFlags` for cobra integration
(`spf13/pflag` only, no cobra dep in the package).

**`AsyncHandler`** (`handler.go`)

Bounded async `slog.Handler`:

- Hands records to a single drain goroutine and onto a downstream handler
  under a shared mutex.
- Records at or above `BlockThreshold` block on the queue (with a
  `closeNotify` escape so shutdown can't deadlock); records below it drop
  when full and bump a per-level atomic counter.
- The drain emits a drop-summary record on each `SummaryInterval` tick when
  any counter is non-zero. Downstream errors are counted (and logged once
  to `os.Stderr` to avoid slog recursion) and appear in the same summary
  line.
- `Close` signals shutdown and returns immediately; the drain final-flushes
  records that beat the close, emits a final summary if drops occurred,
  and closes `drainDone` for tests.
- `SyncEmit` bypasses the queue for Fatal/Panic durability — synchronous
  write through the downstream handler under the shared mutex.

**Handler-chain wrappers** (`chain.go`)

- `boundHandler` prepends bound attrs to every record before delegating.
  `WithAttrs` returns a new boundHandler whose parent is the receiver's
  parent (not the receiver), so repeated `slog.Logger.With` produces
  sibling boundHandlers at the same chain depth rather than stacking
  wrapper-on-wrapper.
- `groupedHandler` wraps record attrs in `slog.Group(name, ...)` before
  delegating. A subsequent `WithAttrs` creates a `boundHandler` whose
  parent is the `groupedHandler`, so the attrs land inside the group.
- `WithGroup("")` and `WithAttrs(nil)` return the receiver on all three
  handler types so no-op `.With()` / `.WithGroup("")` allocate nothing.

## Not in scope

- The `logrus -> slog` bridge and `logging.Install`.
- The named-logger registry (`logging.For(name)`) and per-name overrides.
- Format compatibility coercion (pfxlog-shape JSON via `ReplaceAttr`).
- Migrating any call sites.

All in follow-up PRs.