### PR TITLE
Add named-logger registry, logrus bridge, and pfxlog-shape JSON

### DIFF
--- a/common/logging/bridge.go
+++ b/common/logging/bridge.go
@@ -1,0 +1,190 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package logging
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+
+	"github.com/sirupsen/logrus"
+)
+
+// noopFormatter is the formatter logrus uses after Install. The actual
+// dispatch happens in the slogBridge hook; the formatter's job is just to
+// return an empty payload so logrus's own write (to io.Discard) does nothing.
+type noopFormatter struct{}
+
+func (noopFormatter) Format(*logrus.Entry) ([]byte, error) {
+	return nil, nil
+}
+
+// slogBridge is the logrus.Hook that copies each logrus.Entry into a
+// slog.Record and dispatches it onto the configured root handler.
+// Fatal and Panic records bypass the async queue via SyncEmit so they are
+// durable before logrus exits the process.
+type slogBridge struct{}
+
+func (slogBridge) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+func (slogBridge) Fire(e *logrus.Entry) error {
+	level := logrusToSlog(e.Level)
+	// logrus has already resolved the caller into e.Caller (Function, File,
+	// Line). We must NOT forward e.Caller.PC and let a downstream handler
+	// re-decode it: that PC is a symbolized runtime.Frame.PC, and re-running it
+	// through runtime.CallersFrames resolves to the wrong function under inline
+	// expansion (e.g. logrus.NewEntry instead of the real call site). Instead
+	// the bridge carries the resolved location as flat file/func attrs and
+	// leaves PC == 0, which is the contract sourceFlattener and PrettyHandler
+	// expect for bridged records; direct slog records keep their PC and are
+	// decoded by those handlers instead.
+	r := slog.NewRecord(e.Time, level, e.Message, 0)
+	if e.Caller != nil {
+		r.AddAttrs(
+			slog.String("file", fmt.Sprintf("%s:%d", e.Caller.File, e.Caller.Line)),
+			slog.String("func", e.Caller.Function),
+		)
+	}
+	for k, v := range e.Data {
+		r.AddAttrs(slog.Any(k, v))
+	}
+	ctx := e.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if level >= LevelFatal {
+		return SyncEmit(ctx, r)
+	}
+	return RootHandler().Handle(ctx, r)
+}
+
+// Install wires logrus.StandardLogger() into the async slog sink: it
+// Configure's the default Registry with handler, sets the global slog level
+// (which drives both slog and logrus in lockstep), redirects logrus output to
+// io.Discard, replaces its formatter with a noop, enables ReportCaller so the
+// bridge can forward a real PC to slog, and registers the slogBridge hook so
+// every legacy log call routes through slog.
+//
+// Registering the hook replaces logrus's entire hook set, so any logrus hooks
+// added before Install are discarded. ziti adds none; a caller that does must
+// re-add them after Install.
+//
+// Calling Install more than once just replaces state; tests can call it
+// freely. Anything that runs after Install must not later mutate logrus's
+// output, formatter, or ReportCaller, or the bridge invariant breaks.
+func Install(handler slog.Handler, initialLevel slog.Level) {
+	InstallTo(logrus.StandardLogger(), handler, initialLevel)
+}
+
+// InstallTo is the testable form of Install: it wires the given *logrus.Logger
+// instead of the global standard logger. Production code calls Install; tests
+// pass logrus.New() so they can exercise the bridge without mutating global
+// logrus state.
+func InstallTo(target *logrus.Logger, handler slog.Handler, initialLevel slog.Level) {
+	Configure(handler)
+	target.SetOutput(io.Discard)
+	target.SetFormatter(noopFormatter{})
+	target.SetReportCaller(true)
+	// Replace existing hooks before adding ours so repeated Install calls
+	// don't stack multiple slogBridge instances on the same logger. The
+	// quickstart exercises this by running the controller and router from
+	// the same process, each through their own PreRun.
+	target.ReplaceHooks(logrus.LevelHooks{})
+	target.AddHook(slogBridge{})
+	target.SetLevel(slogToLogrus(initialLevel))
+	// SetGlobalLevel drives the lockstep slog + logrus.StandardLogger update.
+	// Tests that pass a non-standard target via InstallTo already had the
+	// target.SetLevel above; SetGlobalLevel still updates the standard logger
+	// (a no-op when target is the standard logger), which is the production
+	// path that the agent callbacks and CLI flags actually drive.
+	SetGlobalLevel(initialLevel)
+}
+
+// RootHandler returns the default Registry's current root handler. The
+// slogBridge dispatches records here; callers that need direct access
+// (e.g. building a custom emitter) can use this too. Pre-Configure this
+// returns the bootstrap stderr handler; post-Configure it returns
+// whatever Install put in place.
+func RootHandler() slog.Handler {
+	return defaultRegistry.Root()
+}
+
+// SyncEmit writes r through the root handler synchronously on the caller's
+// goroutine. If the root is an *AsyncHandler, the call routes through its
+// SyncEmit, which flushes the queued records and then writes r under the same
+// mutex the drain uses, so the buffered context survives a process exit right
+// after. Otherwise, it falls back to Handle, which is already synchronous for
+// any non-async handler.
+//
+// Used by the bridge for Fatal/Panic durability, and available to direct slog
+// callers that need the same guarantee.
+func SyncEmit(ctx context.Context, r slog.Record) error {
+	root := RootHandler()
+	if ah, ok := root.(*AsyncHandler); ok {
+		return ah.SyncEmit(ctx, r)
+	}
+	return root.Handle(ctx, r)
+}
+
+// logrusToSlog maps a logrus.Level to its canonical slog.Level. logrus
+// levels are densely packed (0..6, panic..trace); the seven canonical slog
+// levels we use here map one-to-one.
+func logrusToSlog(l logrus.Level) slog.Level {
+	switch l {
+	case logrus.TraceLevel:
+		return LevelTrace
+	case logrus.DebugLevel:
+		return slog.LevelDebug
+	case logrus.InfoLevel:
+		return slog.LevelInfo
+	case logrus.WarnLevel:
+		return slog.LevelWarn
+	case logrus.ErrorLevel:
+		return slog.LevelError
+	case logrus.FatalLevel:
+		return LevelFatal
+	case logrus.PanicLevel:
+		return LevelPanic
+	}
+	return slog.LevelInfo
+}
+
+// slogToLogrus is the inverse of logrusToSlog for the seven canonical
+// levels. Non-canonical slog levels (offsets between the canonical values)
+// bucket into the canonical level whose value they most recently exceeded,
+// matching the bucketing used by the drop counters.
+func slogToLogrus(l slog.Level) logrus.Level {
+	switch {
+	case l < slog.LevelDebug:
+		return logrus.TraceLevel
+	case l < slog.LevelInfo:
+		return logrus.DebugLevel
+	case l < slog.LevelWarn:
+		return logrus.InfoLevel
+	case l < slog.LevelError:
+		return logrus.WarnLevel
+	case l < LevelFatal:
+		return logrus.ErrorLevel
+	case l < LevelPanic:
+		return logrus.FatalLevel
+	default:
+		return logrus.PanicLevel
+	}
+}

--- a/common/logging/bridge_test.go
+++ b/common/logging/bridge_test.go
@@ -1,0 +1,326 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package logging
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLevelMappingRoundTrip(t *testing.T) {
+	cases := []struct {
+		logrusLvl logrus.Level
+		slogLvl   slog.Level
+	}{
+		{logrus.PanicLevel, LevelPanic},
+		{logrus.FatalLevel, LevelFatal},
+		{logrus.ErrorLevel, slog.LevelError},
+		{logrus.WarnLevel, slog.LevelWarn},
+		{logrus.InfoLevel, slog.LevelInfo},
+		{logrus.DebugLevel, slog.LevelDebug},
+		{logrus.TraceLevel, LevelTrace},
+	}
+	for _, c := range cases {
+		require.Equal(t, c.slogLvl, logrusToSlog(c.logrusLvl), "logrusToSlog(%v)", c.logrusLvl)
+		require.Equal(t, c.logrusLvl, slogToLogrus(c.slogLvl), "slogToLogrus(%v)", c.slogLvl)
+	}
+}
+
+// TestSlogToLogrusBucketsNonCanonical proves non-canonical slog levels bucket
+// into the canonical level whose value they most recently exceeded, matching
+// the dropIdx bucketing used elsewhere in the package.
+func TestSlogToLogrusBucketsNonCanonical(t *testing.T) {
+	require.Equal(t, logrus.DebugLevel, slogToLogrus(slog.LevelDebug+1))
+	require.Equal(t, logrus.ErrorLevel, slogToLogrus(slog.LevelError+1))
+	require.Equal(t, logrus.PanicLevel, slogToLogrus(LevelPanic+100))
+}
+
+// TestBridgeFireInfoUsesAsyncQueue proves that a logrus Info entry routes
+// through the async queue (not visible until the drain runs).
+func TestBridgeFireInfoUsesAsyncQueue(t *testing.T) {
+	resetDefaultForTest()
+	rec := &recordingHandler{}
+	async, err := NewAsyncHandler(rec, DefaultOptions())
+	require.NoError(t, err)
+
+	Configure(async)
+	SetGlobalLevel(LevelTrace)
+
+	require.NoError(t, slogBridge{}.Fire(&logrus.Entry{
+		Level:   logrus.InfoLevel,
+		Time:    time.Now(),
+		Message: "info-msg",
+		Data:    logrus.Fields{"k": "v"},
+	}))
+
+	require.NoError(t, async.Close())
+	<-async.drainDone
+
+	require.Equal(t, 1, rec.count())
+	rec0 := rec.snapshot()[0]
+	require.Equal(t, "info-msg", rec0.Message)
+	require.Equal(t, slog.LevelInfo, rec0.Level)
+
+	attrs := map[string]any{}
+	rec0.Attrs(func(a slog.Attr) bool {
+		attrs[a.Key] = a.Value.Any()
+		return true
+	})
+	require.Equal(t, "v", attrs["k"])
+}
+
+// TestBridgeFireFatalIsSynchronous proves that a logrus Fatal entry routes
+// through SyncEmit (synchronously through the downstream), so the record is
+// durable before Fire returns. This is the durability guarantee for the
+// logrus.Fatal path that calls os.Exit(1) immediately after hooks.
+func TestBridgeFireFatalIsSynchronous(t *testing.T) {
+	resetDefaultForTest()
+	rec := &recordingHandler{}
+	async, err := NewAsyncHandler(rec, DefaultOptions())
+	require.NoError(t, err)
+	defer func() { _ = async.Close(); <-async.drainDone }()
+
+	Configure(async)
+	SetGlobalLevel(LevelTrace)
+
+	require.NoError(t, slogBridge{}.Fire(&logrus.Entry{
+		Level:   logrus.FatalLevel,
+		Time:    time.Now(),
+		Message: "fatal!",
+	}))
+
+	require.Equal(t, 1, rec.count(), "Fatal must reach downstream synchronously, before async drain")
+	require.Equal(t, LevelFatal, rec.snapshot()[0].Level)
+}
+
+// TestBridgeFirePanicIsSynchronous mirrors the Fatal test for Panic.
+func TestBridgeFirePanicIsSynchronous(t *testing.T) {
+	resetDefaultForTest()
+	rec := &recordingHandler{}
+	async, err := NewAsyncHandler(rec, DefaultOptions())
+	require.NoError(t, err)
+	defer func() { _ = async.Close(); <-async.drainDone }()
+
+	Configure(async)
+	SetGlobalLevel(LevelTrace)
+
+	require.NoError(t, slogBridge{}.Fire(&logrus.Entry{
+		Level:   logrus.PanicLevel,
+		Time:    time.Now(),
+		Message: "panic!",
+	}))
+
+	require.Equal(t, 1, rec.count(), "Panic must reach downstream synchronously")
+	require.Equal(t, LevelPanic, rec.snapshot()[0].Level)
+}
+
+// TestInstallToWiresLogrus verifies the bridge invariant: after InstallTo,
+// logrus output is io.Discard, the formatter is noopFormatter, the level is
+// the mapped equivalent, and logrus log calls route through the bridge.
+func TestInstallToWiresLogrus(t *testing.T) {
+	resetDefaultForTest()
+	rec := &recordingHandler{}
+	async, err := NewAsyncHandler(rec, DefaultOptions())
+	require.NoError(t, err)
+
+	target := logrus.New()
+	InstallTo(target, async, slog.LevelInfo)
+
+	require.Equal(t, io.Discard, target.Out)
+	require.IsType(t, noopFormatter{}, target.Formatter)
+	require.Equal(t, logrus.InfoLevel, target.Level)
+	require.Equal(t, slog.LevelInfo, GlobalLevel(), "Install should set the global slog level too")
+
+	target.WithField("k", "v").Info("hello")
+
+	require.NoError(t, async.Close())
+	<-async.drainDone
+
+	require.Equal(t, 1, rec.count())
+	require.Equal(t, "hello", rec.snapshot()[0].Message)
+	require.Equal(t, slog.LevelInfo, rec.snapshot()[0].Level)
+}
+
+// TestInstallToFiltersBelowLevel proves logrus's own pre-filter still works
+// after Install. Debug records below the configured level never reach the
+// bridge, so they never reach the slog sink either.
+func TestInstallToFiltersBelowLevel(t *testing.T) {
+	resetDefaultForTest()
+	rec := &recordingHandler{}
+	async, err := NewAsyncHandler(rec, DefaultOptions())
+	require.NoError(t, err)
+
+	target := logrus.New()
+	InstallTo(target, async, slog.LevelInfo)
+
+	target.Debug("filtered")
+	target.Info("passed")
+
+	require.NoError(t, async.Close())
+	<-async.drainDone
+
+	require.Equal(t, 1, rec.count())
+	require.Equal(t, "passed", rec.snapshot()[0].Message)
+}
+
+// TestSyncEmitFallsBackForNonAsyncRoot proves SyncEmit handles a Registry
+// whose root is not an *AsyncHandler by falling back to Handle. Handle on a
+// non-async handler is already synchronous, so durability is preserved.
+func TestSyncEmitFallsBackForNonAsyncRoot(t *testing.T) {
+	resetDefaultForTest()
+	rec := &recordingHandler{}
+	Configure(rec) // root is the plain recording handler, not an AsyncHandler
+
+	r := slog.NewRecord(time.Now(), LevelFatal, "fatal-fallback", 0)
+	require.NoError(t, SyncEmit(context.Background(), r))
+	require.Equal(t, 1, rec.count())
+}
+
+// TestSetGlobalLevelLocksLogrus proves the package-level SetGlobalLevel drives
+// logrus.StandardLogger to the mapped equivalent, so logrus's own pre-filter
+// stays consistent with the slog global. This is the entry point the agent
+// callbacks use, and the lockstep is what keeps below-threshold records out
+// of the bridge in the first place.
+func TestSetGlobalLevelLocksLogrus(t *testing.T) {
+	resetDefaultForTest()
+	rec := &recordingHandler{}
+	Configure(rec)
+
+	prev := logrus.StandardLogger().Level
+	t.Cleanup(func() { logrus.StandardLogger().SetLevel(prev) })
+
+	SetGlobalLevel(slog.LevelInfo)
+	require.Equal(t, logrus.InfoLevel, logrus.StandardLogger().Level)
+
+	SetGlobalLevel(LevelTrace)
+	require.Equal(t, logrus.TraceLevel, logrus.StandardLogger().Level)
+
+	SetGlobalLevel(LevelFatal)
+	require.Equal(t, logrus.FatalLevel, logrus.StandardLogger().Level)
+}
+
+// TestBridgeFireEmitsResolvedCallerAttrs proves the bridge carries logrus's
+// already-resolved caller as flat file/func attrs and leaves the record's PC at
+// zero. It must NOT forward entry.Caller.PC: that PC is a symbolized
+// runtime.Frame.PC, and re-decoding it downstream resolves to the wrong
+// function (logrus internals) under inline expansion. PC == 0 is the contract
+// sourceFlattener and PrettyHandler rely on to fall back to these attrs.
+func TestBridgeFireEmitsResolvedCallerAttrs(t *testing.T) {
+	resetDefaultForTest()
+	rec := &recordingHandler{}
+	async, err := NewAsyncHandler(rec, DefaultOptions())
+	require.NoError(t, err)
+
+	Configure(async)
+	SetGlobalLevel(LevelTrace)
+
+	caller := &runtime.Frame{PC: 0xDEADBEEF, File: "x.go", Line: 7, Function: "x.Y"}
+	require.NoError(t, slogBridge{}.Fire(&logrus.Entry{
+		Level:   logrus.InfoLevel,
+		Time:    time.Now(),
+		Message: "with-caller",
+		Caller:  caller,
+	}))
+
+	require.NoError(t, async.Close())
+	<-async.drainDone
+
+	require.Equal(t, 1, rec.count())
+	got := rec.snapshot()[0]
+	require.Equal(t, uintptr(0), got.PC, "bridge must not forward entry.Caller.PC; it does not re-decode")
+
+	attrs := map[string]string{}
+	got.Attrs(func(a slog.Attr) bool {
+		attrs[a.Key] = a.Value.String()
+		return true
+	})
+	require.Equal(t, "x.go:7", attrs["file"], "bridge must emit file:line from entry.Caller")
+	require.Equal(t, "x.Y", attrs["func"], "bridge must emit the resolved function from entry.Caller")
+}
+
+// TestInstallToEnablesReportCaller proves InstallTo turns on ReportCaller so
+// logrus populates entry.Caller, which the bridge reads to emit file/func.
+func TestInstallToEnablesReportCaller(t *testing.T) {
+	resetDefaultForTest()
+	rec := &recordingHandler{}
+	async, err := NewAsyncHandler(rec, DefaultOptions())
+	require.NoError(t, err)
+
+	target := logrus.New()
+	InstallTo(target, async, slog.LevelInfo)
+
+	require.True(t, target.ReportCaller, "InstallTo must enable ReportCaller so the bridge gets the resolved caller")
+}
+
+// TestBridgeEndToEndResolvesRealCaller drives a real logrus log call all the
+// way through getCaller, the bridge, and the JSON sourceFlattener, and asserts
+// the emitted "func" is the actual call site rather than a logrus or bridge
+// frame. This is the regression guard for the PC re-decode bug: forwarding
+// entry.Caller.PC and re-decoding it downstream resolved to logrus.NewEntry.
+func TestBridgeEndToEndResolvesRealCaller(t *testing.T) {
+	resetDefaultForTest()
+	var buf bytes.Buffer
+	h, err := BuildHandler(&buf, DefaultOptions())
+	require.NoError(t, err)
+
+	target := logrus.New()
+	InstallTo(target, h, slog.LevelInfo)
+
+	// A real log call so logrus's getCaller walks the live stack.
+	logrus.NewEntry(target).Info("hello from test")
+
+	require.NoError(t, h.Close())
+	<-h.drainDone
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &m))
+	fn, _ := m["func"].(string)
+	require.Contains(t, fn, "TestBridgeEndToEndResolvesRealCaller",
+		"resolved caller must be the real call site")
+	require.NotContains(t, fn, "sirupsen/logrus", "caller must not resolve to a logrus frame")
+}
+
+// TestInstallToIsIdempotent proves repeated InstallTo on the same logger
+// doesn't stack multiple slogBridge hooks. The quickstart hits this path by
+// running the controller and router from a single process, each calling
+// Install from their own PreRun: without idempotency, every bridged log line
+// would dispatch twice through the bridge.
+func TestInstallToIsIdempotent(t *testing.T) {
+	resetDefaultForTest()
+	rec := &recordingHandler{}
+	async, err := NewAsyncHandler(rec, DefaultOptions())
+	require.NoError(t, err)
+
+	target := logrus.New()
+	InstallTo(target, async, slog.LevelInfo)
+	InstallTo(target, async, slog.LevelInfo)
+	target.Info("once")
+
+	require.NoError(t, async.Close())
+	<-async.drainDone
+	require.Equal(t, 1, rec.count(), "repeated InstallTo must not stack bridges")
+}

--- a/common/logging/format.go
+++ b/common/logging/format.go
@@ -1,0 +1,116 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package logging
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"runtime"
+)
+
+// ReplaceAttr is the slog.HandlerOptions.ReplaceAttr callback that coerces
+// the standard slog JSON output into the pfxlog-shape downstream parsers
+// already consume:
+//
+//   - the "level" key's value is the canonical lowercase name (via LevelName)
+//     rather than slog's uppercase default;
+//   - the nested "source" attr is suppressed entirely; sourceFlattener emits
+//     "file" and "func" as flat top-level keys instead.
+//
+// Modifications apply only at the top level; attrs nested inside groups are
+// passed through unchanged.
+func ReplaceAttr(groups []string, a slog.Attr) slog.Attr {
+	if len(groups) > 0 {
+		return a
+	}
+	switch a.Key {
+	case slog.LevelKey:
+		if lvl, ok := a.Value.Any().(slog.Level); ok {
+			return slog.String(slog.LevelKey, LevelName(lvl))
+		}
+	case slog.SourceKey:
+		return slog.Attr{}
+	}
+	return a
+}
+
+// sourceFlattener decodes a record's PC and emits "file" and "func" as flat
+// top-level attrs, matching pfxlog's existing JSON shape. The slog JSONHandler
+// underneath has AddSource: false; this handler is the source of the file/func
+// attrs in the output.
+//
+// Only records with a PC are decoded here. Direct slog records carry one, set
+// by slog at the call site, and it re-decodes cleanly. Bridged-logrus records
+// instead arrive with PC == 0 and their location already resolved into "file"
+// and "func" attrs by the bridge (logrus's Entry.Caller.PC cannot be re-decoded
+// reliably, so the bridge does not forward it); those records skip the decode
+// here and pass their attrs through unchanged. Records built without any PC,
+// like the AsyncHandler's drop-summary line, simply carry no file/func.
+type sourceFlattener struct {
+	parent slog.Handler
+}
+
+func (h *sourceFlattener) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.parent.Enabled(ctx, level)
+}
+
+func (h *sourceFlattener) Handle(ctx context.Context, r slog.Record) error {
+	if r.PC == 0 {
+		return h.parent.Handle(ctx, r)
+	}
+	frames := runtime.CallersFrames([]uintptr{r.PC})
+	frame, _ := frames.Next()
+	r2 := slog.NewRecord(r.Time, r.Level, r.Message, 0)
+	r2.AddAttrs(slog.String("file", fmt.Sprintf("%s:%d", frame.File, frame.Line)))
+	r2.AddAttrs(slog.String("func", frame.Function))
+	r.Attrs(func(a slog.Attr) bool {
+		r2.AddAttrs(a)
+		return true
+	})
+	return h.parent.Handle(ctx, r2)
+}
+
+func (h *sourceFlattener) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &sourceFlattener{parent: h.parent.WithAttrs(attrs)}
+}
+
+func (h *sourceFlattener) WithGroup(name string) slog.Handler {
+	return &sourceFlattener{parent: h.parent.WithGroup(name)}
+}
+
+// BuildHandler constructs the standard async slog handler chain that ziti
+// uses in production: a JSON handler over out, wrapped in sourceFlattener
+// for the pfxlog-shape file/func keys, wrapped in an AsyncHandler so writes
+// happen off the caller's goroutine. The JSON handler itself does no level
+// gating; gating lives upstream in the named-logger registry (Phase 5).
+//
+// out defaults to os.Stderr when nil.
+func BuildHandler(out io.Writer, opts AsyncOptions) (*AsyncHandler, error) {
+	if out == nil {
+		out = os.Stderr
+	}
+	json := slog.NewJSONHandler(out, &slog.HandlerOptions{
+		AddSource:   false,
+		Level:       LevelTrace,
+		ReplaceAttr: ReplaceAttr,
+	})
+	flat := &sourceFlattener{parent: json}
+	return NewAsyncHandler(flat, opts)
+}

--- a/common/logging/format_test.go
+++ b/common/logging/format_test.go
@@ -1,0 +1,154 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package logging
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplaceAttrRenamesLevelLowercase(t *testing.T) {
+	cases := []struct {
+		lvl  slog.Level
+		want string
+	}{
+		{LevelTrace, "trace"},
+		{slog.LevelDebug, "debug"},
+		{slog.LevelInfo, "info"},
+		{slog.LevelWarn, "warn"},
+		{slog.LevelError, "error"},
+		{LevelFatal, "fatal"},
+		{LevelPanic, "panic"},
+	}
+	for _, c := range cases {
+		got := ReplaceAttr(nil, slog.Any(slog.LevelKey, c.lvl))
+		require.Equal(t, slog.LevelKey, got.Key)
+		require.Equal(t, c.want, got.Value.String())
+	}
+}
+
+func TestReplaceAttrSuppressesSourceAtTopLevel(t *testing.T) {
+	src := &slog.Source{Function: "f", File: "f.go", Line: 1}
+	got := ReplaceAttr(nil, slog.Any(slog.SourceKey, src))
+	require.Equal(t, slog.Attr{}, got, "source should be suppressed")
+}
+
+// TestReplaceAttrIgnoresInsideGroups proves the rename/suppression only
+// applies to top-level attrs. A nested attr with key "level" (perhaps from
+// caller code that happens to use that key inside a group) passes through
+// unchanged.
+func TestReplaceAttrIgnoresInsideGroups(t *testing.T) {
+	a := slog.Any(slog.LevelKey, slog.LevelInfo)
+	got := ReplaceAttr([]string{"g"}, a)
+	require.Equal(t, a.Key, got.Key)
+	require.Equal(t, a.Value, got.Value)
+}
+
+func TestReplaceAttrPassesThroughOtherAttrs(t *testing.T) {
+	a := slog.String("k", "v")
+	got := ReplaceAttr(nil, a)
+	require.Equal(t, a, got)
+}
+
+// TestSourceFlattenerPassesThroughWhenPCZero proves records with no PC
+// (e.g. those bridged from logrus, which sets file/func in Entry.Data) pass
+// through the flattener unchanged.
+func TestSourceFlattenerPassesThroughWhenPCZero(t *testing.T) {
+	rec := &recordingHandler{}
+	flat := &sourceFlattener{parent: rec}
+
+	r := slog.NewRecord(time.Now(), slog.LevelInfo, "msg", 0)
+	r.AddAttrs(slog.String("k", "v"))
+	require.NoError(t, flat.Handle(context.Background(), r))
+
+	require.Equal(t, 1, rec.count())
+	attrs := map[string]any{}
+	rec.snapshot()[0].Attrs(func(a slog.Attr) bool {
+		attrs[a.Key] = a.Value.Any()
+		return true
+	})
+	require.NotContains(t, attrs, "file", "no file attr should be added when PC is zero")
+	require.NotContains(t, attrs, "func")
+	require.Equal(t, "v", attrs["k"])
+}
+
+// TestBuildHandlerEmitsPfxlogShape covers the BuildHandler end-to-end:
+// asyncHandler -> sourceFlattener -> JSONHandler. A direct slog.Logger call
+// produces JSON with lowercase level, flat file/func keys, no nested source
+// object, and the caller's attrs preserved.
+func TestBuildHandlerEmitsPfxlogShape(t *testing.T) {
+	buf := &bytes.Buffer{}
+	opts := DefaultOptions()
+	opts.SummaryInterval = time.Hour
+	h, err := BuildHandler(buf, opts)
+	require.NoError(t, err)
+
+	slog.New(h).Info("hello", "k", "v")
+
+	require.NoError(t, h.Close())
+	<-h.drainDone
+
+	line := strings.TrimSpace(buf.String())
+	var got map[string]any
+	require.NoError(t, json.Unmarshal([]byte(line), &got), "raw=%q", line)
+
+	require.Equal(t, "hello", got["msg"])
+	require.Equal(t, "info", got["level"], "level must be lowercase")
+	require.Equal(t, "v", got["k"])
+
+	require.NotContains(t, got, "source", "nested source must be suppressed")
+	require.Contains(t, got, "file", "flat file key must be present")
+	require.Contains(t, got, "func", "flat func key must be present")
+
+	file, _ := got["file"].(string)
+	require.Contains(t, file, ":", "file should be filename:line")
+	require.NotEmpty(t, got["func"])
+}
+
+// TestBuildHandlerEmitsCustomLevels confirms LevelTrace, LevelFatal, and
+// LevelPanic render with their canonical lowercase names rather than slog's
+// offset form ("DEBUG-4" / "ERROR+4" / "ERROR+8").
+func TestBuildHandlerEmitsCustomLevels(t *testing.T) {
+	buf := &bytes.Buffer{}
+	opts := DefaultOptions()
+	opts.SummaryInterval = time.Hour
+	h, err := BuildHandler(buf, opts)
+	require.NoError(t, err)
+
+	logger := slog.New(h)
+	logger.Log(context.Background(), LevelTrace, "t")
+	logger.Log(context.Background(), LevelFatal, "f")
+	logger.Log(context.Background(), LevelPanic, "p")
+
+	require.NoError(t, h.Close())
+	<-h.drainDone
+
+	var levels []string
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		var m map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &m))
+		levels = append(levels, m["level"].(string))
+	}
+	require.Equal(t, []string{"trace", "fatal", "panic"}, levels)
+}

--- a/common/logging/handler.go
+++ b/common/logging/handler.go
@@ -156,16 +156,40 @@ func (h *AsyncHandler) Close() error {
 	return nil
 }
 
-// SyncEmit writes r through the downstream handler synchronously on the
-// caller's goroutine, bypassing the queue. It exists so that fatal/panic
-// records reach the downstream before the process exits. Contention with the
-// drain is negligible because SyncEmit is rare (only at fatal/panic) and the
-// drain holds downstreamMu only for the duration of a single
-// downstream.Handle call.
+// SyncEmit flushes the records currently queued, then writes r through the
+// downstream handler synchronously on the caller's goroutine. It exists so
+// that fatal/panic records reach the downstream before the process exits, and
+// flushing first means the buffered context leading up to the fatal/panic
+// (the very records an operator wants in a post-mortem) lands ahead of it
+// rather than being lost when the process exits out from under the drain.
+//
+// The flush is bounded and non-blocking, so a producer still enqueuing cannot
+// make it spin and the drain goroutine cannot deadlock it. A single record the
+// drain has already pulled but not yet written may still land after r; ordering
+// on the exit path is best-effort, not exact.
 func (h *AsyncHandler) SyncEmit(ctx context.Context, r slog.Record) error {
 	h.downstreamMu.Lock()
 	defer h.downstreamMu.Unlock()
+	h.flushQueuedLocked()
 	return h.downstream.Handle(ctx, r)
+}
+
+// flushQueuedLocked drains the records sitting in the queue through the
+// downstream handler. The caller must hold downstreamMu. It is bounded by the
+// queue capacity and stops at the first empty receive, so a producer still
+// enqueuing cannot make it spin, and the drain goroutine (which may be parked
+// on downstreamMu) cannot deadlock it. Records the concurrent drain pulls
+// first are written by the drain; the rest are written here, all under the
+// same mutex so no downstream.Handle calls interleave.
+func (h *AsyncHandler) flushQueuedLocked() {
+	for i := cap(h.queue); i > 0; i-- {
+		select {
+		case qr := <-h.queue:
+			h.handleLocked(qr.ctx, qr.record)
+		default:
+			return
+		}
+	}
 }
 
 // drain is the single goroutine that pulls records off the queue and calls
@@ -205,10 +229,16 @@ func (h *AsyncHandler) drain() {
 func (h *AsyncHandler) dispatch(ctx context.Context, r slog.Record) {
 	h.downstreamMu.Lock()
 	defer h.downstreamMu.Unlock()
+	h.handleLocked(ctx, r)
+}
+
+// handleLocked hands one record to the downstream handler, counting and
+// reporting a downstream error. The caller must hold downstreamMu. On error it
+// bumps drainErrors and writes once to os.Stderr, bypassing slog to avoid
+// recursion if the downstream handler is the thing failing.
+func (h *AsyncHandler) handleLocked(ctx context.Context, r slog.Record) {
 	if err := h.downstream.Handle(ctx, r); err != nil {
 		h.drainErrors.Add(1)
-		// Bypass slog to avoid recursion if the downstream handler is the
-		// thing failing.
 		fmt.Fprintf(os.Stderr, "logging: downstream handler error: %v\n", err)
 	}
 }

--- a/common/logging/handler_test.go
+++ b/common/logging/handler_test.go
@@ -380,6 +380,36 @@ func TestSyncEmitSerializesWithDrain(t *testing.T) {
 	require.Equal(t, "sync", recs[1].Message)
 }
 
+// TestSyncEmitFlushesQueuedRecords proves SyncEmit drains the records already
+// sitting in the queue before writing its own record, so the buffered context
+// leading up to a fatal/panic survives a process exit that happens right after
+// the call. The drain goroutine is stopped first (Close, then drainDone) so the
+// flush runs in isolation with no concurrent consumer racing for the queue;
+// records are staged directly because Handle no-ops post-Close.
+func TestSyncEmitFlushesQueuedRecords(t *testing.T) {
+	rec := &recordingHandler{}
+	opts := DefaultOptions()
+	opts.QueueSize = 8
+	h, err := NewAsyncHandler(rec, opts)
+	require.NoError(t, err)
+
+	require.NoError(t, h.Close())
+	<-h.drainDone
+	require.Equal(t, 0, rec.count(), "no records should have been written before staging")
+
+	h.queue <- queuedRecord{ctx: context.Background(), record: makeRecord(slog.LevelInfo, "q1")}
+	h.queue <- queuedRecord{ctx: context.Background(), record: makeRecord(slog.LevelWarn, "q2")}
+
+	require.NoError(t, h.SyncEmit(context.Background(), makeRecord(LevelFatal, "fatal")))
+
+	recs := rec.snapshot()
+	got := make([]string, len(recs))
+	for i, r := range recs {
+		got[i] = r.Message
+	}
+	require.Equal(t, []string{"q1", "q2", "fatal"}, got)
+}
+
 // TestAsyncHandlerCountsDrainErrors emits records into a handler that errors
 // on every call and verifies the drain counts the errors and survives. The
 // assertions run before Close so the close-flush summary doesn't perturb

--- a/common/logging/registry.go
+++ b/common/logging/registry.go
@@ -1,0 +1,275 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"slices"
+	"sync"
+	"sync/atomic"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Registry tracks the global log level, per-name level overrides, and the
+// root handler that named loggers attach to. Levels are stored in
+// *slog.LevelVar so any *slog.Logger constructed via For sees subsequent
+// level changes on its next Enabled check, without re-creation.
+//
+// The root handler is held in an atomic.Pointer so SetRoot can swap it
+// without re-creating the Registry: existing Loggers keep pointing at this
+// Registry instance and pick up the new root on their next Handle call.
+// This makes `var log = logging.For(...)` at package-init time safe, since
+// the bootstrap Registry created at init can be re-rooted by Install later
+// without orphaning any loggers.
+//
+// Reads (Enabled checks, For lookups in the cache) take RLock; mutations
+// take the write lock. Level changes are operator actions and not a hot
+// path, so the lock cost on Set/Clear is fine.
+type Registry struct {
+	mu          sync.RWMutex
+	global      *slog.LevelVar
+	overrides   map[string]*slog.LevelVar
+	loggerCache map[string]*slog.Logger
+	root        atomic.Pointer[slog.Handler]
+}
+
+// NewRegistry returns a Registry that sends records to root. Panics if root
+// is nil.
+func NewRegistry(root slog.Handler) *Registry {
+	if root == nil {
+		panic("logging: NewRegistry requires a non-nil root handler")
+	}
+	r := &Registry{
+		global:      new(slog.LevelVar),
+		overrides:   map[string]*slog.LevelVar{},
+		loggerCache: map[string]*slog.Logger{},
+	}
+	r.root.Store(&root)
+	return r
+}
+
+// SetGlobalLevel sets the level used when no per-name override exists.
+// Loggers already constructed via For pick up the new level on their next
+// Enabled check. Pure slog-side; lockstep with logrus happens at the
+// package-level SetGlobalLevel.
+func (r *Registry) SetGlobalLevel(level slog.Level) {
+	r.global.Set(level)
+}
+
+// GlobalLevel returns the current global level.
+func (r *Registry) GlobalLevel() slog.Level {
+	return r.global.Level()
+}
+
+// SetNamedLevel installs or updates a per-name override. The override is
+// held in a *slog.LevelVar created on first use for the name; subsequent
+// SetNamedLevel calls update the same LevelVar, so any Logger view of the
+// name sees the new level live.
+func (r *Registry) SetNamedLevel(name string, level slog.Level) {
+	r.mu.Lock()
+	lv, ok := r.overrides[name]
+	if !ok {
+		lv = new(slog.LevelVar)
+		r.overrides[name] = lv
+	}
+	r.mu.Unlock()
+	lv.Set(level)
+}
+
+// ClearNamedLevel removes the override for name. After clear, the name
+// falls back to the live global level; this is deliberately not "set to
+// the current global" so a later SetGlobalLevel propagates to the
+// previously-overridden name automatically.
+func (r *Registry) ClearNamedLevel(name string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.overrides, name)
+}
+
+// For returns the *slog.Logger for a named scope, constructed on first use
+// and cached thereafter. Subsequent calls with the same name return the
+// same pointer. The logger's handler chain binds "channel": name as the
+// first attr, so output records always carry the logger name. Panics on
+// empty name (almost always a caller bug).
+func (r *Registry) For(name string) *slog.Logger {
+	if name == "" {
+		panic("logging: For called with empty name")
+	}
+	r.mu.RLock()
+	cached, ok := r.loggerCache[name]
+	r.mu.RUnlock()
+	if ok {
+		return cached
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if cached, ok := r.loggerCache[name]; ok {
+		return cached
+	}
+	nh := &namedHandler{registry: r, name: name}
+	h := nh.WithAttrs([]slog.Attr{slog.String("channel", name)})
+	logger := slog.New(h)
+	r.loggerCache[name] = logger
+	return logger
+}
+
+// HandlerFor returns the bare namedHandler for name, without the
+// channel-attr wrap For provides. Useful for embedding the level-gating
+// handler in a custom chain. Panics on empty name.
+func (r *Registry) HandlerFor(name string) slog.Handler {
+	if name == "" {
+		panic("logging: HandlerFor called with empty name")
+	}
+	return &namedHandler{registry: r, name: name}
+}
+
+// Root returns the registry's current root handler. The package-level
+// RootHandler reads from the default Registry via this method; the logrus
+// bridge uses it to dispatch records, and SyncEmit uses it to find the
+// underlying AsyncHandler when the root is one. Safe under concurrent
+// SetRoot.
+func (r *Registry) Root() slog.Handler {
+	return *r.root.Load()
+}
+
+// SetRoot replaces the registry's root handler atomically. Existing Loggers
+// (constructed by For at any earlier point) pick up the new root on their
+// next Handle call. Configure uses this to install the production handler
+// chain after package init has already handed out loggers via For. Panics
+// if root is nil so the Registry never has a missing destination.
+func (r *Registry) SetRoot(root slog.Handler) {
+	if root == nil {
+		panic("logging: SetRoot requires a non-nil root handler")
+	}
+	r.root.Store(&root)
+}
+
+// resolveLevel returns the effective level for name: the override's level
+// if one is set, otherwise the live global level.
+func (r *Registry) resolveLevel(name string) slog.Level {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if lv, ok := r.overrides[name]; ok {
+		return lv.Level()
+	}
+	return r.global.Level()
+}
+
+// namedHandler is the chain node that does per-name level gating and
+// forwards records to the registry's root handler. Records pass through
+// unchanged; the "channel" attr is added by For's WithAttrs wrap, not here.
+type namedHandler struct {
+	registry *Registry
+	name     string
+}
+
+func (h *namedHandler) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= h.registry.resolveLevel(h.name)
+}
+
+func (h *namedHandler) Handle(ctx context.Context, r slog.Record) error {
+	return h.registry.Root().Handle(ctx, r)
+}
+
+func (h *namedHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return h
+	}
+	return &boundHandler{parent: h, attrs: slices.Clone(attrs)}
+}
+
+func (h *namedHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	return &groupedHandler{parent: h, name: name}
+}
+
+// defaultRegistry is the process-wide Registry. It is created at package
+// init with a stderr bootstrap root, so For and the other package-level
+// entry points work immediately - including at package-init time, before
+// any process startup code has called Configure. Anything that emits
+// during the bootstrap window (cobra flag parsing, package init) lands on
+// stderr in plain text, so a real startup problem stays visible rather
+// than being silently dropped. Configure later swaps the root handler in
+// place; existing loggers keep working and pick up the new root
+// transparently. The Registry itself is never replaced, so per-name
+// overrides set before Configure persist across it.
+var defaultRegistry = NewRegistry(newBootstrapHandler())
+
+// newBootstrapHandler returns the slog.Handler used as the default
+// Registry's root before Configure runs. Plain text to stderr at the
+// lowest level: gating still happens upstream in namedHandler against
+// the Registry's global level, so this handler accepts whatever passes
+// that gate. Once Install calls Configure, this handler is replaced.
+func newBootstrapHandler() slog.Handler {
+	return slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: LevelTrace})
+}
+
+// DefaultRegistry returns the package-level default Registry. Useful for
+// tests that need a stable handle to reset state, and for code that wants
+// to bypass the package-level conveniences entirely.
+func DefaultRegistry() *Registry {
+	return defaultRegistry
+}
+
+// Configure installs root as the default Registry's root handler. It
+// replaces the bootstrap stderr root from init time (or whatever a prior
+// Configure call set) without re-creating the Registry, so existing
+// loggers and per-name overrides survive. Install calls this from PreRun.
+func Configure(root slog.Handler) {
+	defaultRegistry.SetRoot(root)
+}
+
+// For returns the named logger from the default Registry.
+func For(name string) *slog.Logger {
+	return defaultRegistry.For(name)
+}
+
+// HandlerFor returns the bare named handler from the default Registry.
+func HandlerFor(name string) slog.Handler {
+	return defaultRegistry.HandlerFor(name)
+}
+
+// SetGlobalLevel sets the global level on the default Registry and the
+// logrus standard logger in lockstep: logrus's pre-filter drops records
+// below the level before they ever reach the bridge, while named slog
+// loggers see the same threshold on their next Enabled check. Agent
+// log-level callbacks, --verbose-style boot flags, and any other operator
+// surface should go through this entry point so the two worlds never drift.
+func SetGlobalLevel(level slog.Level) {
+	defaultRegistry.SetGlobalLevel(level)
+	logrus.SetLevel(slogToLogrus(level))
+}
+
+// GlobalLevel returns the global level on the default Registry.
+func GlobalLevel() slog.Level {
+	return defaultRegistry.GlobalLevel()
+}
+
+// SetNamedLevel sets a per-name override on the default Registry.
+func SetNamedLevel(name string, level slog.Level) {
+	defaultRegistry.SetNamedLevel(name, level)
+}
+
+// ClearNamedLevel removes a per-name override on the default Registry.
+func ClearNamedLevel(name string) {
+	defaultRegistry.ClearNamedLevel(name)
+}

--- a/common/logging/registry_test.go
+++ b/common/logging/registry_test.go
@@ -1,0 +1,285 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package logging
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newTestRegistry returns a Registry whose root is an AsyncHandler over the
+// given downstream, along with the AsyncHandler so the caller can Close it
+// and wait for drain.
+func newTestRegistry(t *testing.T, downstream slog.Handler) (*Registry, *AsyncHandler) {
+	t.Helper()
+	h, err := NewAsyncHandler(downstream, DefaultOptions())
+	require.NoError(t, err)
+	return NewRegistry(h), h
+}
+
+func TestRegistryNewRejectsNilRoot(t *testing.T) {
+	require.Panics(t, func() { NewRegistry(nil) })
+}
+
+func TestRegistryForPanicsOnEmpty(t *testing.T) {
+	rec := &recordingHandler{}
+	r, async := newTestRegistry(t, rec)
+	defer func() { _ = async.Close(); <-async.drainDone }()
+	require.Panics(t, func() { r.For("") })
+	require.Panics(t, func() { r.HandlerFor("") })
+}
+
+func TestRegistryForCachesLoggers(t *testing.T) {
+	rec := &recordingHandler{}
+	r, async := newTestRegistry(t, rec)
+	defer func() { _ = async.Close(); <-async.drainDone }()
+	require.Same(t, r.For("x"), r.For("x"))
+}
+
+func TestRegistryGlobalLevelGates(t *testing.T) {
+	rec := &recordingHandler{}
+	r, async := newTestRegistry(t, rec)
+	r.SetGlobalLevel(slog.LevelInfo)
+
+	logger := r.For("x")
+	logger.Debug("dropped-debug")
+	logger.Info("kept-info")
+
+	require.NoError(t, async.Close())
+	<-async.drainDone
+
+	var msgs []string
+	for _, r := range rec.snapshot() {
+		msgs = append(msgs, r.Message)
+	}
+	require.Equal(t, []string{"kept-info"}, msgs)
+}
+
+func TestRegistryNamedLevelOverridesGlobal(t *testing.T) {
+	rec := &recordingHandler{}
+	r, async := newTestRegistry(t, rec)
+	r.SetGlobalLevel(slog.LevelInfo)
+	r.SetNamedLevel("x", slog.LevelDebug)
+
+	r.For("x").Debug("x-debug")
+	r.For("y").Debug("y-debug-dropped")
+	r.For("y").Info("y-info")
+
+	require.NoError(t, async.Close())
+	<-async.drainDone
+
+	var msgs []string
+	for _, r := range rec.snapshot() {
+		msgs = append(msgs, r.Message)
+	}
+	require.ElementsMatch(t, []string{"x-debug", "y-info"}, msgs)
+}
+
+// TestRegistryClearNamedLevelRevertsToGlobal confirms ClearNamedLevel falls
+// back to the live global, not a snapshot of it.
+func TestRegistryClearNamedLevelRevertsToGlobal(t *testing.T) {
+	rec := &recordingHandler{}
+	r, async := newTestRegistry(t, rec)
+	defer func() { _ = async.Close(); <-async.drainDone }()
+
+	r.SetGlobalLevel(slog.LevelInfo)
+	r.SetNamedLevel("x", slog.LevelDebug)
+	require.True(t, r.For("x").Enabled(context.Background(), slog.LevelDebug))
+
+	r.ClearNamedLevel("x")
+	require.False(t, r.For("x").Enabled(context.Background(), slog.LevelDebug), "after clear, x should track the global")
+
+	r.SetGlobalLevel(slog.LevelDebug)
+	require.True(t, r.For("x").Enabled(context.Background(), slog.LevelDebug), "global change should reach the previously-overridden name")
+}
+
+// TestRegistryLevelChangesAffectExistingLoggers proves a Logger created
+// before a level change reflects the new level on its next Enabled check.
+func TestRegistryLevelChangesAffectExistingLoggers(t *testing.T) {
+	rec := &recordingHandler{}
+	r, async := newTestRegistry(t, rec)
+	defer func() { _ = async.Close(); <-async.drainDone }()
+
+	r.SetGlobalLevel(slog.LevelInfo)
+	logger := r.For("x")
+	require.False(t, logger.Enabled(context.Background(), slog.LevelDebug))
+
+	r.SetGlobalLevel(slog.LevelDebug)
+	require.True(t, logger.Enabled(context.Background(), slog.LevelDebug))
+}
+
+// TestRegistryComposedNamedLogger covers the design's acceptance gate:
+//
+//	For("router.link").WithGroup("g").With("k","v").Info("msg","x",1)
+//	  -> {msg, channel:"router.link", g:{k:"v", x:1}}
+func TestRegistryComposedNamedLogger(t *testing.T) {
+	buf := &bytes.Buffer{}
+	downstream := slog.NewJSONHandler(buf, &slog.HandlerOptions{
+		ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr {
+			if a.Key == slog.TimeKey || a.Key == slog.LevelKey {
+				return slog.Attr{}
+			}
+			return a
+		},
+	})
+	r, async := newTestRegistry(t, downstream)
+	r.For("router.link").WithGroup("g").With("k", "v").Info("msg", "x", 1)
+
+	require.NoError(t, async.Close())
+	<-async.drainDone
+
+	line := strings.TrimSpace(buf.String())
+	var got map[string]any
+	require.NoError(t, json.Unmarshal([]byte(line), &got), "raw=%q", line)
+	require.Equal(t, "msg", got["msg"])
+	require.Equal(t, "router.link", got["channel"])
+	g, ok := got["g"].(map[string]any)
+	require.True(t, ok, "g should be a nested object, got %T", got["g"])
+	require.Equal(t, "v", g["k"])
+	require.Equal(t, float64(1), g["x"])
+}
+
+// TestPackageDefaultWorksBeforeConfigure proves every package-level entry
+// point is callable on the bootstrap Registry that init creates. Records
+// emitted in the pre-Configure window are dropped silently by the discard
+// root. This is the property that makes `var log = logging.For(...)` at
+// package-init time safe.
+func TestPackageDefaultWorksBeforeConfigure(t *testing.T) {
+	resetDefaultForTest()
+	require.NotPanics(t, func() { _ = For("x") })
+	require.NotPanics(t, func() { SetGlobalLevel(slog.LevelInfo) })
+	require.NotPanics(t, func() { SetNamedLevel("x", slog.LevelDebug) })
+	require.NotPanics(t, func() { ClearNamedLevel("x") })
+	require.NotPanics(t, func() { _ = GlobalLevel() })
+	require.NotPanics(t, func() { _ = HandlerFor("x") })
+
+	// A log call against For-logger goes through the bootstrap discard root
+	// without error; the discard's Enabled returns false but namedHandler's
+	// own gate is independent, so Handle is reached and silently drops the
+	// record.
+	require.NotPanics(t, func() { For("x").Info("dropped-silently") })
+}
+
+func TestPackageDefaultThroughConfigure(t *testing.T) {
+	resetDefaultForTest()
+	rec := &recordingHandler{}
+	async, err := NewAsyncHandler(rec, DefaultOptions())
+	require.NoError(t, err)
+	defer func() { _ = async.Close(); <-async.drainDone }()
+
+	Configure(async)
+	SetGlobalLevel(slog.LevelInfo)
+	require.Equal(t, slog.LevelInfo, GlobalLevel())
+
+	SetNamedLevel("x", slog.LevelDebug)
+	require.True(t, For("x").Enabled(context.Background(), slog.LevelDebug))
+
+	ClearNamedLevel("x")
+	require.False(t, For("x").Enabled(context.Background(), slog.LevelDebug))
+}
+
+// TestConfigureSwapsRootInPlace proves a second Configure call replaces the
+// default Registry's root handler without re-creating the Registry. Loggers
+// captured before the swap stay valid: their next log call goes to the new
+// root. This is the property that lets `var log = logging.For(...)`
+// declarations land at package-init time and still work after Install
+// runs from PreRun.
+func TestConfigureSwapsRootInPlace(t *testing.T) {
+	resetDefaultForTest()
+
+	rec1 := &recordingHandler{}
+	Configure(rec1)
+	SetGlobalLevel(slog.LevelInfo)
+	log := For("x")
+
+	log.Info("first")
+	require.Equal(t, 1, rec1.count(), "first record reaches the initial root")
+
+	rec2 := &recordingHandler{}
+	Configure(rec2)
+
+	log.Info("second")
+	require.Equal(t, 1, rec1.count(), "post-swap records must not reach the previous root")
+	require.Equal(t, 1, rec2.count(), "post-swap records reach the new root via the same logger")
+
+	require.Same(t, log, For("x"), "Configure swap must preserve the logger cache")
+}
+
+// TestRegistryConcurrentSetAndFor stress-tests concurrent For lookups and
+// SetNamedLevel calls. Run under -race; the test passes if nothing panics
+// and the race detector finds no data races.
+func TestRegistryConcurrentSetAndFor(t *testing.T) {
+	rec := &recordingHandler{}
+	r, async := newTestRegistry(t, rec)
+	defer func() { _ = async.Close(); <-async.drainDone }()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(3)
+		go func(i int) {
+			defer wg.Done()
+			r.For(fmt.Sprintf("logger-%d", i%4)).Info("x")
+		}(i)
+		go func(i int) {
+			defer wg.Done()
+			r.SetNamedLevel(fmt.Sprintf("logger-%d", i%4), slog.LevelDebug)
+		}(i)
+		go func(i int) {
+			defer wg.Done()
+			if i%2 == 0 {
+				r.ClearNamedLevel(fmt.Sprintf("logger-%d", i%4))
+			} else {
+				r.SetGlobalLevel(slog.LevelInfo)
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+// discardHandler is used as the test-reset root: tests don't want the
+// bootstrap stderr handler's output in their captured streams, and the
+// rooted recording handlers tests typically install replace it anyway.
+type discardHandler struct{}
+
+func (discardHandler) Enabled(context.Context, slog.Level) bool  { return false }
+func (discardHandler) Handle(context.Context, slog.Record) error { return nil }
+func (h discardHandler) WithAttrs([]slog.Attr) slog.Handler      { return h }
+func (h discardHandler) WithGroup(string) slog.Handler           { return h }
+
+// resetDefaultForTest restores the package default Registry to a clean
+// baseline: root reset to a silent discard (so test reset itself doesn't
+// emit on stderr), overrides and logger cache cleared, global level
+// reset to Info. Tests call this at start so they don't inherit state
+// from earlier tests in the same binary. The Registry itself is the
+// same instance throughout the test binary; only its internals are
+// reset.
+func resetDefaultForTest() {
+	defaultRegistry.mu.Lock()
+	defaultRegistry.overrides = map[string]*slog.LevelVar{}
+	defaultRegistry.loggerCache = map[string]*slog.Logger{}
+	defaultRegistry.mu.Unlock()
+	defaultRegistry.SetRoot(discardHandler{})
+	defaultRegistry.global.Set(slog.LevelInfo)
+}


### PR DESCRIPTION
## Summary

Stacked on #3905. Adds the next layer of `common/logging`: the named-logger
registry with runtime per-channel level control, the `logrus -> slog`
bridge plus `Install`, and the pfxlog-shape JSON output via `ReplaceAttr`
and `sourceFlattener`. Nothing in the ziti binaries opts in yet; this PR
is still self-contained inside `common/logging`.

Fixes #3906.

**Base is `slog-async-handler`** so the diff shows only the new work. Once
#3905 merges to `main`, this rebases cleanly.

## What's in this PR

**Named-logger registry** (`registry.go`)

- `Registry` (exported, for tests) holds the global `*slog.LevelVar`, a
  per-name override map of `*slog.LevelVar`, the root handler, and a
  Logger cache.
- `For(name)` returns a cached `*slog.Logger` whose handler chain binds
  `channel: name` as the first attr; panics on empty.
- `SetGlobalLevel` / `SetNamedLevel` / `ClearNamedLevel` for runtime
  control. Clear deliberately tracks the live global rather than
  snapshotting it, so later global changes still propagate to a
  previously-overridden name.
- `namedHandler` chain node gates `Enabled` on the registry-resolved
  level (override or live global) and forwards to the root.
- The package-level default `Registry` is a plain package var created at
  init with a stderr bootstrap root, so `For` and the other package-level
  entry points work before `Configure` runs, including at package-init
  time. The `atomic.Pointer` lives on the `Registry`'s root field, so
  `Configure` swaps the root handler in place via `SetRoot`, leaving the
  logger cache and per-name overrides intact.

**logrus -> slog bridge** (`bridge.go`)

- `slogBridge` (a `logrus.Hook`) copies each `logrus.Entry` into a
  `slog.Record` and dispatches via `RootHandler.Handle`. Fatal and Panic
  route through `SyncEmit` for durability before the process exits.
- `Install` / `InstallTo` redirect logrus to `io.Discard` with a noop
  formatter, set its level, and register the bridge. logrus's own
  pre-filter still keeps below-threshold records from reaching the
  bridge.
- Bidirectional level mappings between `logrus.Level` and `slog.Level`
  for the seven canonical names.
- `SyncEmit` package function type-asserts the root to `*AsyncHandler` so
  Fatal/Panic records flush the queued records and then write
  synchronously, falling back to `Handle` when the root is any other
  handler.

**Format compatibility** (`format.go`)

- `ReplaceAttr` produces pfxlog-shape JSON: lowercase level via
  `LevelName`, nested source suppressed at the top level.
- `sourceFlattener` decodes the record's PC into flat `file` and `func`
  attrs. Direct slog records carry a clean PC and are decoded here.
  Bridged-logrus records instead arrive with `PC == 0`: logrus's
  `Entry.Caller.PC` is a symbolized frame PC that does not re-decode
  reliably, so the bridge derives `file`/`func` from the resolved
  `Entry.Caller` and attaches them as attrs, which `sourceFlattener`
  passes through unchanged.
- `BuildHandler(out, opts)` constructs the production chain
  (`AsyncHandler -> sourceFlattener -> JSONHandler`) over a
  caller-supplied `io.Writer` (default `os.Stderr`).

## Not in scope

- df/dl pretty handler integration and TTY-vs-redirected format default.
- Wiring `Install` into ziti's controller + router `main` and adding the
  AsyncOptions flags to cobra commands.
- Golden-file format tests with the full fixture set.
- Startup invariant tests.
- The agent v2 callbacks driving `SetGlobalLevel` and `SetNamedLevel`.

All follow-up.

