### PR TITLE
Convert router/forwarder to slog

### DIFF
--- a/router/forwarder/faulter.go
+++ b/router/forwarder/faulter.go
@@ -20,15 +20,23 @@ import (
 	"strings"
 	"time"
 
-	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/channel/v4"
 	"github.com/openziti/channel/v4/protobufs"
 	"github.com/openziti/metrics"
+	"github.com/openziti/ziti/v2/common/logging"
 	"github.com/openziti/ziti/v2/common/pb/ctrl_pb"
 	"github.com/openziti/ziti/v2/router/env"
 	cmap "github.com/orcaman/concurrent-map/v2"
-	"github.com/sirupsen/logrus"
 )
+
+// faultLog is the logger for circuit and link fault reporting. Its channel
+// name is "router.forwarder.fault"; operators can adjust fault visibility
+// with `ziti agent set-channel-log-level router.forwarder.fault <level>`.
+//
+// Fault reporting is the diagnostic surface between the router's
+// data-plane and the controllers; it lives in its own channel so a noisy
+// fault loop can be silenced without losing forward or scan output.
+var faultLog = logging.For("router.forwarder.fault")
 
 type Faulter struct {
 	ctrls         env.NetworkControllers
@@ -69,22 +77,22 @@ func (self *Faulter) Report(circuitId string, ctrlId string) {
 }
 
 func (self *Faulter) NotifyInvalidLink(linkId string) {
-	log := pfxlog.Logger()
 	self.ctrls.ForEach(func(ctrlId string, ch channel.Channel) {
 		fault := &ctrl_pb.Fault{Subject: ctrl_pb.FaultSubject_LinkFault, Id: linkId}
 		if err := protobufs.MarshalTyped(fault).WithTimeout(self.ctrls.DefaultRequestTimeout()).Send(ch); err != nil {
-			log.WithError(err).
-				WithField("ctrlId", ctrlId).
-				WithField("linkId", linkId).
-				Error("failed to notify of invalid link")
+			faultLog.Error("failed to notify of invalid link",
+				"error", err,
+				"ctrlId", ctrlId,
+				"linkId", linkId,
+			)
 		}
 	})
 	self.linkFaults.Mark(1)
 }
 
 func (self *Faulter) run() {
-	logrus.Infof("started")
-	defer logrus.Errorf("exited")
+	faultLog.Info("started")
+	defer faultLog.Error("exited")
 
 	for {
 		select {
@@ -103,7 +111,7 @@ func (self *Faulter) run() {
 				circuitIds := strings.Join(workload, " ")
 
 				if ctrlId != "" {
-					log := pfxlog.Logger().WithField("ctrlId", ctrlId)
+					log := faultLog.With("ctrlId", ctrlId)
 					ch := self.ctrls.GetChannel(ctrlId)
 					if ch == nil {
 						log.Error("unable to report circuit fault, no control channel for controller")
@@ -112,19 +120,19 @@ func (self *Faulter) run() {
 
 					fault := &ctrl_pb.Fault{Subject: ctrl_pb.FaultSubject_ForwardFault, Id: circuitIds}
 					if err := protobufs.MarshalTyped(fault).Send(ch); err == nil {
-						log.WithField("circuitCount", len(workload)).Debug("reported forwarding faults")
+						log.Debug("reported forwarding faults", "circuitCount", len(workload))
 					} else {
-						log.WithError(err).Error("error sending fault report")
+						log.Error("error sending fault report", "error", err)
 					}
 				} else { // send to all controllers
 					fault := &ctrl_pb.Fault{Subject: ctrl_pb.FaultSubject_UnknownOwnerForwardFault, Id: circuitIds}
 
 					self.ctrls.ForEach(func(ctrlId string, ch channel.Channel) {
-						log := pfxlog.Logger().WithField("ctrlId", ctrlId)
+						log := faultLog.With("ctrlId", ctrlId)
 						if err := protobufs.MarshalTyped(fault).Send(ch); err == nil {
-							log.WithField("circuitCount", len(workload)).Debug("reported forwarding faults")
+							log.Debug("reported forwarding faults", "circuitCount", len(workload))
 						} else {
-							log.WithError(err).Error("error sending fault report")
+							log.Error("error sending fault report", "error", err)
 						}
 					})
 				}

--- a/router/forwarder/forwarder.go
+++ b/router/forwarder/forwarder.go
@@ -17,22 +17,35 @@
 package forwarder
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sync/atomic"
 	"time"
 
-	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/foundation/v2/info"
+	"github.com/openziti/foundation/v2/uuidz"
 	"github.com/openziti/metrics"
 	"github.com/openziti/sdk-golang/xgress"
 	"github.com/openziti/ziti/v2/common/inspect"
+	"github.com/openziti/ziti/v2/common/logging"
 	"github.com/openziti/ziti/v2/common/pb/ctrl_pb"
 	"github.com/openziti/ziti/v2/common/trace"
 	"github.com/openziti/ziti/v2/router/env"
 	"github.com/openziti/ziti/v2/router/xlink"
-	"github.com/sirupsen/logrus"
 )
+
+// routeLog is the logger for the forwarder's circuit-routing and
+// payload/control-forwarding paths. Its channel name is
+// "router.forwarder.route"; operators adjust route visibility with
+// `ziti agent set-channel-log-level router.forwarder.route <level>`.
+//
+// The forward path is per-payload hot: every record on this channel runs
+// inside the data-plane critical section. The bridged-logrus and direct
+// slog channels both flow through the same AsyncHandler queue, so the
+// per-record cost is the same; level-gating is what keeps it cheap.
+var routeLog = logging.For("router.forwarder.route")
 
 // InvalidLinkDestinationError indicates a route referenced a link destination that does not exist.
 type InvalidLinkDestinationError struct {
@@ -90,7 +103,7 @@ func (forwarder *Forwarder) StartScanner(ctrls env.NetworkControllers) {
 	if scanner.interval > 0 {
 		go scanner.run()
 	} else {
-		logrus.Warnf("scanner disabled")
+		routeLog.Warn("scanner disabled")
 	}
 }
 
@@ -108,15 +121,15 @@ func (forwarder *Forwarder) RegisterDestination(circuitId string, address xgress
 }
 
 func (forwarder *Forwarder) UnregisterDestinations(circuitId string) {
-	log := pfxlog.Logger().WithField("circuitId", circuitId)
+	log := routeLog.With("circuitId", circuitId)
 	if addresses, found := forwarder.destinations.getAddressesForCircuit(circuitId); found {
 		for _, address := range addresses {
 			if destination, found := forwarder.destinations.getDestination(address); found {
-				log.Debugf("unregistering destination [@/%v] for circuit", address)
+				log.Debug("unregistering destination for circuit", "address", address)
 				forwarder.destinations.removeDestination(address)
 				go destination.(XgressDestination).Unrouted()
 			} else {
-				log.Debugf("no destinations found for [@/%v] for circuit", address)
+				log.Debug("no destinations found for address", "address", address)
 			}
 		}
 		forwarder.destinations.unlinkCircuit(circuitId)
@@ -159,11 +172,11 @@ func (forwarder *Forwarder) Route(ctrlId string, route *ctrl_pb.Route) error {
 			// It's an ingress destination, which isn't established until after routing has completed
 		}
 		circuitFt.setForwardAddress(xgress.Address(forward.SrcAddress), xgress.Address(forward.DstAddress))
-		pfxlog.Logger().WithFields(logrus.Fields{
-			"circuitId":   circuitId,
-			"source":      forward.SrcAddress,
-			"destination": forward.DstAddress,
-		}).Debug("route added")
+		routeLog.Debug("route added",
+			"circuitId", circuitId,
+			"source", forward.SrcAddress,
+			"destination", forward.DstAddress,
+		)
 	}
 	forwarder.circuits.setForwardTable(circuitId, circuitFt)
 	return nil
@@ -173,7 +186,7 @@ func (forwarder *Forwarder) Unroute(circuitId string, now bool) {
 	if now {
 		forwarder.circuits.removeForwardTable(circuitId)
 		forwarder.EndCircuit(circuitId)
-		pfxlog.Logger().WithField("circuitId", circuitId).Info("circuit unrouted")
+		routeLog.Info("circuit unrouted", "circuitId", circuitId)
 	} else {
 		go forwarder.unrouteTimeout(circuitId, forwarder.Options.XgressCloseCheckInterval)
 	}
@@ -192,8 +205,6 @@ func (forwarder *Forwarder) RetransmitPayload(srcAddr xgress.Address, payload *x
 }
 
 func (forwarder *Forwarder) forwardPayload(srcAddr xgress.Address, payload *xgress.Payload, markActive bool, timeout time.Duration) error {
-	log := pfxlog.ContextLogger(string(srcAddr))
-
 	circuitId := payload.GetCircuitId()
 	if forwardTable, found := forwarder.circuits.getForwardTable(circuitId, markActive); found {
 		if dstAddr, found := forwardTable.getForwardAddress(srcAddr); found {
@@ -207,7 +218,23 @@ func (forwarder *Forwarder) forwardPayload(srcAddr xgress.Address, payload *xgre
 				if err := dst.SendPayload(payload, timeout, payloadType); err != nil {
 					return err
 				}
-				log.WithFields(payload.GetLoggerFields()).Debugf("=> %s", string(dstAddr))
+				// Per-payload hot path: build the logger only if Debug is enabled, so
+				// the level check is the only cost when this channel is below Debug.
+				if routeLog.Enabled(context.Background(), slog.LevelDebug) {
+					attrs := []any{
+						"srcAddr", string(srcAddr),
+						"dstAddr", string(dstAddr),
+						"circuitId", circuitId,
+						"seq", payload.Sequence,
+						"origin", payload.GetOriginator(),
+					}
+					// Only present when the payload is being traced; lets operators
+					// correlate a single payload across hops.
+					if uuidVal, found := payload.Headers[xgress.HeaderKeyUUID]; found {
+						attrs = append(attrs, "uuid", uuidz.ToString(uuidVal))
+					}
+					routeLog.Debug("forwarded payload", attrs...)
+				}
 				return nil
 			} else {
 				return fmt.Errorf("cannot forward payload, no destination for circuit=%v src=%v dst=%v", circuitId, srcAddr, dstAddr)
@@ -221,8 +248,6 @@ func (forwarder *Forwarder) forwardPayload(srcAddr xgress.Address, payload *xgre
 }
 
 func (forwarder *Forwarder) ForwardAcknowledgement(srcAddr xgress.Address, acknowledgement *xgress.Acknowledgement) error {
-	log := pfxlog.ContextLogger(string(srcAddr))
-
 	circuitId := acknowledgement.CircuitId
 	if forwardTable, found := forwarder.circuits.getForwardTable(circuitId, true); found {
 		if dstAddr, found := forwardTable.getForwardAddress(srcAddr); found {
@@ -230,7 +255,13 @@ func (forwarder *Forwarder) ForwardAcknowledgement(srcAddr xgress.Address, ackno
 				if err := dst.SendAcknowledgement(acknowledgement); err != nil {
 					return err
 				}
-				log.Debugf("=> %s", string(dstAddr))
+				if routeLog.Enabled(context.Background(), slog.LevelDebug) {
+					routeLog.Debug("forwarded acknowledgement",
+						"srcAddr", string(srcAddr),
+						"dstAddr", string(dstAddr),
+						"circuitId", circuitId,
+					)
+				}
 				return nil
 
 			} else {
@@ -248,7 +279,7 @@ func (forwarder *Forwarder) ForwardAcknowledgement(srcAddr xgress.Address, ackno
 
 func (forwarder *Forwarder) ForwardControl(srcAddr xgress.Address, control *xgress.Control) error {
 	circuitId := control.CircuitId
-	log := pfxlog.ContextLogger(string(srcAddr)).WithField("circuitId", circuitId)
+	log := routeLog.With("srcAddr", string(srcAddr), "circuitId", circuitId)
 
 	var err error
 
@@ -263,7 +294,7 @@ func (forwarder *Forwarder) ForwardControl(srcAddr xgress.Address, control *xgre
 					}
 				}
 				err = dst.SendControl(control)
-				log.Debugf("=> %s", string(dstAddr))
+				log.Debug("forwarded control", "dstAddr", string(dstAddr))
 			} else {
 				err = fmt.Errorf("cannot forward control, no destination for circuit=%v src=%v dst=%v", circuitId, srcAddr, dstAddr)
 			}
@@ -279,10 +310,10 @@ func (forwarder *Forwarder) ForwardControl(srcAddr xgress.Address, control *xgre
 		resp.Headers.PutStringHeader(xgress.ControlError, err.Error())
 		if dst, found := forwarder.destinations.getDestination(srcAddr); found {
 			if fwdErr := dst.SendControl(resp); fwdErr != nil {
-				log.WithError(errors.Join(err, fwdErr)).Error("error sending trace error response")
+				log.Error("error sending trace error response", "error", errors.Join(err, fwdErr))
 			}
 		} else {
-			log.WithError(err).Error("unable to send trace error response as destination for source not found")
+			log.Error("unable to send trace error response as destination for source not found", "error", err)
 		}
 	}
 
@@ -300,7 +331,7 @@ func (forwarder *Forwarder) ReportForwardingFault(circuitId string, ctrlId strin
 	if forwarder.faulter != nil {
 		forwarder.faulter.Report(circuitId, ctrlId)
 	} else {
-		logrus.Error("nil faulter, cannot accept forwarding fault report")
+		routeLog.Error("nil faulter, cannot accept forwarding fault report")
 	}
 }
 
@@ -312,7 +343,7 @@ func (forwarder *Forwarder) Debug() string {
 // for a circuit, it will be checked repeatedly, looking to see if the circuit has crossed the inactivity threshold.
 // Once it crosses the inactivity threshold, it gets removed.
 func (forwarder *Forwarder) unrouteTimeout(circuitId string, interval time.Duration) {
-	log := pfxlog.ContextLogger("c/" + circuitId)
+	log := routeLog.With("circuitId", circuitId)
 	log.Debug("scheduled")
 	defer log.Debug("timeout")
 

--- a/router/forwarder/scanner.go
+++ b/router/forwarder/scanner.go
@@ -20,12 +20,20 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/channel/v4/protobufs"
+	"github.com/openziti/ziti/v2/common/logging"
 	"github.com/openziti/ziti/v2/common/pb/ctrl_pb"
 	"github.com/openziti/ziti/v2/router/env"
-	"github.com/sirupsen/logrus"
 )
+
+// scanLog is the logger for the idle-circuit scanner. Its channel name is
+// "router.forwarder.scan"; operators can turn scan output up or down with
+// `ziti agent set-channel-log-level router.forwarder.scan <level>`.
+//
+// Scanner volume is high under load (every interval emits one record per
+// scan plus one per idle circuit), so it sits in its own channel to be
+// silenceable without losing the forward and fault channels.
+var scanLog = logging.For("router.forwarder.scan")
 
 type Scanner struct {
 	ctrls       env.NetworkControllers
@@ -50,8 +58,8 @@ func (self *Scanner) setCircuitTable(circuits *circuitTable) {
 }
 
 func (self *Scanner) run() {
-	logrus.Info("started")
-	defer logrus.Warn("exited")
+	scanLog.Info("started")
+	defer scanLog.Warn("exited")
 
 	for {
 		select {
@@ -66,7 +74,7 @@ func (self *Scanner) run() {
 
 func (self *Scanner) scan() {
 	circuits := self.circuits.circuits.Items()
-	logrus.Debugf("scanning [%d] circuits", len(circuits))
+	scanLog.Debug("scanning circuits", "count", len(circuits))
 
 	now := time.Now().UnixMilli()
 	idleCircuits := map[string]map[string]int64{}
@@ -79,18 +87,19 @@ func (self *Scanner) scan() {
 				idleCircuits[ft.ctrlId] = ctrlMap
 			}
 			ctrlMap[circuitId] = int64(idleTime)
-			logrus.WithField("circuitId", circuitId).
-				WithField("ctrlId", ft.ctrlId).
-				WithField("idleTime", idleTime).
-				WithField("idleThreshold", self.timeout).
-				Warn("circuit exceeds idle threshold")
+			scanLog.Warn("circuit exceeds idle threshold",
+				"circuitId", circuitId,
+				"ctrlId", ft.ctrlId,
+				"idleTime", idleTime,
+				"idleThreshold", self.timeout,
+			)
 		}
 	}
 
 	for ctrlId, idleCircuitMap := range idleCircuits {
 		if len(idleCircuitMap) > 0 {
-			log := pfxlog.Logger().WithField("ctrlId", ctrlId)
-			log.Debugf("found [%d] idle circuits, confirming with controller", len(idleCircuitMap))
+			log := scanLog.With("ctrlId", ctrlId)
+			log.Debug("found idle circuits, confirming with controller", "count", len(idleCircuitMap))
 
 			if ctrl := self.ctrls.GetChannel(ctrlId); ctrl != nil {
 				confirm := &ctrl_pb.CircuitConfirmation{IdleTimes: idleCircuitMap}
@@ -98,12 +107,12 @@ func (self *Scanner) scan() {
 					confirm.CircuitIds = append(confirm.CircuitIds, circuitId)
 				}
 				if err := protobufs.MarshalTyped(confirm).Send(ctrl); err == nil {
-					log.WithField("circuitCount", len(idleCircuitMap)).Warnf("sent confirmation for circuits")
+					log.Warn("sent confirmation for circuits", "circuitCount", len(idleCircuitMap))
 				} else {
-					log.WithError(err).Error("error sending confirmation request")
+					log.Error("error sending confirmation request", "error", err)
 				}
 			} else {
-				log.Errorf("no ctrl channel, cannot request circuit confirmations")
+				log.Error("no ctrl channel, cannot request circuit confirmations")
 			}
 		}
 	}


### PR DESCRIPTION
First chunk of the post-foundation slog conversion. Stacked on #3911.

Fixes #3916.

## What this PR does

Converts `router/forwarder/` (3 files, ~50 pfxlog/logrus call sites)
to \`common/logging\`, splitting into three channels:

| File | Channel | Why a dedicated channel |
|---|---|---|
| forwarder.go | \`router.forwarder.route\` | Per-payload data-plane hot path; gated \`Enabled\` check before Debug emit |
| scanner.go | \`router.forwarder.scan\` | Dominant log-volume contributor (~260k records/dump in real traffic); separable so operators can silence scan without losing forward/fault |
| faulter.go | \`router.forwarder.fault\` | Diagnostic surface between data-plane and controllers; isolated so a noisy fault loop doesn't drown out the others |

The three-channel split is justified per the conversion plan's
\"sub-channels only when there's a specific operational reason
(high volume, separable failure modes)\" rule.

## Patterns demonstrated

- \`var log = logging.For(\"name\")\` at package scope. Safe pre-Configure
  because the foundation's default Registry is initialized at package
  init with a stderr bootstrap root (per #3911 follow-on).
- WithField chains -> variadic key/value pairs.
- Scoped \`log.With(...)\` for loops where multiple emits share attrs.
- Hot-path Debug guarded by \`log.Enabled(...)\` so the cost when below
  Debug is one level comparison plus an atomic load.
- Channel-name godoc on each \`var log\` declaration so operators and
  contributors can find the toggle without grep.

## Operator usage

Once this PR (and the foundation stack) lands, operators get:

\`\`\`
ziti agent set-channel-log-level router.forwarder.scan warn   # quiet the scan firehose
ziti agent set-channel-log-level router.forwarder.route debug # surgical per-packet debug
ziti agent clear-channel-log-level router.forwarder.fault     # back to global
\`\`\`