### PR TITLE
Add role-attribute usage queries. Fixes #1593

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,11 @@ release/
 # ai agents
 .claude
 
+# mercurius review tooling
+.mcp.json
+.mercurius/
+mercurius.yaml
+
 # goland
 .idea
 github_deploy_key

--- a/controller/db/edge_router_policy_store.go
+++ b/controller/db/edge_router_policy_store.go
@@ -44,6 +44,8 @@ var _ EdgeRouterPolicyStore = (*edgeRouterPolicyStoreImpl)(nil)
 type EdgeRouterPolicyStore interface {
 	NameIndexed
 	Store[*EdgeRouterPolicy]
+	GetIdentityRoleAttributesIndex() boltz.SetReadIndex
+	GetEdgeRouterRoleAttributesIndex() boltz.SetReadIndex
 }
 
 func newEdgeRouterPolicyStore(stores *stores) *edgeRouterPolicyStoreImpl {
@@ -63,12 +65,27 @@ type edgeRouterPolicyStoreImpl struct {
 	symbolIdentities      boltz.EntitySetSymbol
 	symbolEdgeRouters     boltz.EntitySetSymbol
 
+	indexIdentityRoleAttributes   boltz.SetReadIndex
+	indexEdgeRouterRoleAttributes boltz.SetReadIndex
+
 	identityCollection   boltz.LinkCollection
 	edgeRouterCollection boltz.LinkCollection
 }
 
 func (store *edgeRouterPolicyStoreImpl) GetNameIndex() boltz.ReadIndex {
 	return store.indexName
+}
+
+// GetIdentityRoleAttributesIndex returns the derived set index of identity
+// role-attribute references declared on edge-router policies.
+func (store *edgeRouterPolicyStoreImpl) GetIdentityRoleAttributesIndex() boltz.SetReadIndex {
+	return store.indexIdentityRoleAttributes
+}
+
+// GetEdgeRouterRoleAttributesIndex returns the derived set index of edge
+// router role-attribute references declared on edge-router policies.
+func (store *edgeRouterPolicyStoreImpl) GetEdgeRouterRoleAttributesIndex() boltz.SetReadIndex {
+	return store.indexEdgeRouterRoleAttributes
 }
 
 func (store *edgeRouterPolicyStoreImpl) initializeLocal() {
@@ -80,6 +97,9 @@ func (store *edgeRouterPolicyStoreImpl) initializeLocal() {
 	store.symbolEdgeRouterRoles = store.AddPublicSetSymbol(FieldEdgeRouterRoles, ast.NodeTypeString)
 	store.symbolIdentities = store.AddFkSetSymbol(EntityTypeIdentities, store.stores.identity)
 	store.symbolEdgeRouters = store.AddFkSetSymbol(EntityTypeRouters, store.stores.edgeRouter)
+
+	store.indexIdentityRoleAttributes = store.AddSetIndexWithTransform(store.symbolIdentityRoles, roleAttributeOnlyTransform)
+	store.indexEdgeRouterRoleAttributes = store.AddSetIndexWithTransform(store.symbolEdgeRouterRoles, roleAttributeOnlyTransform)
 
 	store.AddConstraint(boltz.NewSystemEntityEnforcementConstraint(store))
 }

--- a/controller/db/migration_policy_role_attr_indexes.go
+++ b/controller/db/migration_policy_role_attr_indexes.go
@@ -1,0 +1,90 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package db
+
+import (
+	"github.com/michaelquigley/pfxlog"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
+	"github.com/pkg/errors"
+)
+
+// backfillPolicyRoleAttributeIndexes populates the derived role-attribute
+// indexes added to the three policy stores for role-attribute usage queries.
+// These indexes are derived from existing persisted role fields via
+// boltz.SetIndexValueTransform, so running each index's own integrity check
+// with fix=true is sufficient to construct it from live data.
+//
+// Only the new role-attribute indexes are checked, not the entire store, so
+// the migration neither inspects nor mutates any unrelated index. This keeps
+// the per-index "fixed" counts meaningful: they reflect role-attribute index
+// entries created during the backfill, not incidental repairs elsewhere.
+//
+// Logging policy: each fixed entry is counted (not logged individually) and a
+// single per-index summary is emitted at Info. Unfixable entries are still
+// logged individually at Error so that operator-actionable problems remain
+// visible.
+func (m *Migrations) backfillPolicyRoleAttributeIndexes(step *boltz.MigrationStep) {
+	indexes := []boltz.SetReadIndex{
+		m.stores.ServicePolicy.GetIdentityRoleAttributesIndex(),
+		m.stores.ServicePolicy.GetServiceRoleAttributesIndex(),
+		m.stores.ServicePolicy.GetPostureCheckRoleAttributesIndex(),
+		m.stores.EdgeRouterPolicy.GetIdentityRoleAttributesIndex(),
+		m.stores.EdgeRouterPolicy.GetEdgeRouterRoleAttributesIndex(),
+		m.stores.ServiceEdgeRouterPolicy.GetServiceRoleAttributesIndex(),
+		m.stores.ServiceEdgeRouterPolicy.GetEdgeRouterRoleAttributesIndex(),
+	}
+
+	for _, index := range indexes {
+		symbol := index.GetSymbol()
+		entityType := symbol.GetStore().GetEntityType()
+		fieldName := symbol.GetName()
+
+		// SetReadIndex is the read-only handle; the concrete set index also
+		// implements Checkable, which is how we drive the backfill for just
+		// this one index.
+		checkable, ok := index.(boltz.Checkable)
+		if !ok {
+			step.SetError(errors.Errorf("role-attribute index %s.%s is not checkable, cannot backfill", entityType, fieldName))
+			return
+		}
+
+		var fixed, unfixable int
+		err := checkable.CheckIntegrity(step.Ctx, true, func(err error, wasFixed bool) {
+			if wasFixed {
+				fixed++
+				return
+			}
+			unfixable++
+			pfxlog.Logger().WithError(err).
+				WithField("store", entityType).
+				WithField("field", fieldName).
+				Error("unfixable error during policy role-attribute index rebuild")
+		})
+		pfxlog.Logger().
+			WithField("store", entityType).
+			WithField("field", fieldName).
+			WithField("fixed", fixed).
+			WithField("unfixable", unfixable).
+			Info("policy role-attribute index rebuild summary")
+		// SetError records only the first error, and a failed migration rolls
+		// the whole tx back anyway, so stop rather than churn through the
+		// remaining indexes in a doomed transaction.
+		if step.SetError(err) {
+			return
+		}
+	}
+}

--- a/controller/db/migration_policy_role_attr_indexes_test.go
+++ b/controller/db/migration_policy_role_attr_indexes_test.go
@@ -1,0 +1,215 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package db
+
+import (
+	"testing"
+
+	"github.com/openziti/ziti/v2/common/eid"
+	"github.com/openziti/ziti/v2/controller/change"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
+	"github.com/openziti/ziti/v2/controller/storage/boltztest"
+	"go.etcd.io/bbolt"
+)
+
+// Test_BackfillPolicyRoleAttributeIndexes simulates the upgrade path on a
+// DB that already has policies. We populate the indexes via the normal
+// create path, wipe the index buckets to mimic a DB from before the indexes
+// existed, then run backfillPolicyRoleAttributeIndexes and verify the indexes
+// recover with the same content.
+func Test_BackfillPolicyRoleAttributeIndexes(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Cleanup()
+	ctx.Init()
+	ctx.CleanupAll()
+
+	// Real entities so the policy can carry valid '@id' entity refs alongside
+	// '#attr' role refs; the backfill must index only the role attributes.
+	identity := ctx.RequireNewIdentity(eid.New(), false)
+	service := ctx.RequireNewService(eid.New())
+
+	sp := &ServicePolicy{
+		BaseExtEntity:     boltz.BaseExtEntity{Id: eid.New()},
+		Name:              eid.New(),
+		PolicyType:        PolicyTypeDial,
+		Semantic:          SemanticAllOf,
+		IdentityRoles:     []string{roleRef("sales"), roleRef("marketing"), entityRef(identity.Id)},
+		ServiceRoles:      []string{roleRef("api"), entityRef(service.Id)},
+		PostureCheckRoles: []string{roleRef("mfa")},
+	}
+	boltztest.RequireCreate(ctx, sp)
+
+	erp := &EdgeRouterPolicy{
+		BaseExtEntity:   boltz.BaseExtEntity{Id: eid.New()},
+		Name:            eid.New(),
+		Semantic:        SemanticAllOf,
+		IdentityRoles:   []string{roleRef("ops")},
+		EdgeRouterRoles: []string{roleRef("us-east")},
+	}
+	boltztest.RequireCreate(ctx, erp)
+
+	serp := &ServiceEdgeRouterPolicy{
+		BaseExtEntity:   boltz.BaseExtEntity{Id: eid.New()},
+		Name:            eid.New(),
+		Semantic:        SemanticAllOf,
+		ServiceRoles:    []string{roleRef("public")},
+		EdgeRouterRoles: []string{roleRef("eu-west")},
+	}
+	boltztest.RequireCreate(ctx, serp)
+
+	type indexLoc struct {
+		entityType string
+		field      string
+	}
+	indexLocs := []indexLoc{
+		{EntityTypeServicePolicies, FieldIdentityRoles},
+		{EntityTypeServicePolicies, FieldServiceRoles},
+		{EntityTypeServicePolicies, FieldPostureCheckRoles},
+		{EntityTypeEdgeRouterPolicies, FieldIdentityRoles},
+		{EntityTypeEdgeRouterPolicies, FieldEdgeRouterRoles},
+		{EntityTypeServiceEdgeRouterPolicies, FieldServiceRoles},
+		{EntityTypeServiceEdgeRouterPolicies, FieldEdgeRouterRoles},
+	}
+
+	// Wipe the index buckets to simulate a pre-migration DB where the derived
+	// role-attribute indexes did not exist. We delete and re-create the bucket
+	// empty so that subsequent reads see an initialized-but-empty index.
+	err := ctx.GetDb().Update(nil, func(mctx boltz.MutateContext) error {
+		for _, loc := range indexLocs {
+			parent := boltz.Path(mctx.Tx(), RootBucket, boltz.IndexesBucket, loc.entityType)
+			if parent == nil {
+				continue
+			}
+			if sub := parent.Bucket.Bucket([]byte(loc.field)); sub == nil {
+				continue
+			}
+			if delErr := parent.DeleteBucket([]byte(loc.field)); delErr != nil {
+				return delErr
+			}
+			parent.GetOrCreateBucket(loc.field)
+		}
+		return nil
+	})
+	ctx.NoError(err)
+
+	// Sanity: indexes are empty post-wipe.
+	err = ctx.GetDb().View(func(tx *bbolt.Tx) error {
+		ctx.Empty(readIndexKeys(tx, ctx.stores.ServicePolicy.GetIdentityRoleAttributesIndex()))
+		ctx.Empty(readIndexKeys(tx, ctx.stores.ServicePolicy.GetServiceRoleAttributesIndex()))
+		ctx.Empty(readIndexKeys(tx, ctx.stores.ServicePolicy.GetPostureCheckRoleAttributesIndex()))
+		ctx.Empty(readIndexKeys(tx, ctx.stores.EdgeRouterPolicy.GetIdentityRoleAttributesIndex()))
+		ctx.Empty(readIndexKeys(tx, ctx.stores.EdgeRouterPolicy.GetEdgeRouterRoleAttributesIndex()))
+		ctx.Empty(readIndexKeys(tx, ctx.stores.ServiceEdgeRouterPolicy.GetServiceRoleAttributesIndex()))
+		ctx.Empty(readIndexKeys(tx, ctx.stores.ServiceEdgeRouterPolicy.GetEdgeRouterRoleAttributesIndex()))
+		return nil
+	})
+	ctx.NoError(err)
+
+	// Run the backfill in its own update transaction, mimicking the
+	// migration manager's surrounding call.
+	migrations := &Migrations{stores: ctx.stores}
+	err = ctx.GetDb().Update(change.New().NewMutateContext(), func(mctx boltz.MutateContext) error {
+		step := &boltz.MigrationStep{
+			Component:      "edge",
+			Ctx:            mctx,
+			CurrentVersion: CurrentDbVersion - 1,
+		}
+		migrations.backfillPolicyRoleAttributeIndexes(step)
+		return step.GetError()
+	})
+	ctx.NoError(err)
+
+	// Verify the indexes are repopulated and match the expected content from
+	// the live entities.
+	err = ctx.GetDb().View(func(tx *bbolt.Tx) error {
+		idxIdSp := ctx.stores.ServicePolicy.GetIdentityRoleAttributesIndex()
+		ctx.Equal([]string{"marketing", "sales"}, readIndexKeys(tx, idxIdSp))
+		ctx.Equal([]string{sp.Id}, readIndexIds(tx, idxIdSp, "sales"))
+		ctx.Equal([]string{sp.Id}, readIndexIds(tx, idxIdSp, "marketing"))
+
+		idxSvcSp := ctx.stores.ServicePolicy.GetServiceRoleAttributesIndex()
+		ctx.Equal([]string{"api"}, readIndexKeys(tx, idxSvcSp))
+		ctx.Equal([]string{sp.Id}, readIndexIds(tx, idxSvcSp, "api"))
+
+		idxPcSp := ctx.stores.ServicePolicy.GetPostureCheckRoleAttributesIndex()
+		ctx.Equal([]string{"mfa"}, readIndexKeys(tx, idxPcSp))
+		ctx.Equal([]string{sp.Id}, readIndexIds(tx, idxPcSp, "mfa"))
+
+		idxIdErp := ctx.stores.EdgeRouterPolicy.GetIdentityRoleAttributesIndex()
+		ctx.Equal([]string{"ops"}, readIndexKeys(tx, idxIdErp))
+		ctx.Equal([]string{erp.Id}, readIndexIds(tx, idxIdErp, "ops"))
+
+		idxRouterErp := ctx.stores.EdgeRouterPolicy.GetEdgeRouterRoleAttributesIndex()
+		ctx.Equal([]string{"us-east"}, readIndexKeys(tx, idxRouterErp))
+		ctx.Equal([]string{erp.Id}, readIndexIds(tx, idxRouterErp, "us-east"))
+
+		idxSvcSerp := ctx.stores.ServiceEdgeRouterPolicy.GetServiceRoleAttributesIndex()
+		ctx.Equal([]string{"public"}, readIndexKeys(tx, idxSvcSerp))
+		ctx.Equal([]string{serp.Id}, readIndexIds(tx, idxSvcSerp, "public"))
+
+		idxRouterSerp := ctx.stores.ServiceEdgeRouterPolicy.GetEdgeRouterRoleAttributesIndex()
+		ctx.Equal([]string{"eu-west"}, readIndexKeys(tx, idxRouterSerp))
+		ctx.Equal([]string{serp.Id}, readIndexIds(tx, idxRouterSerp, "eu-west"))
+		return nil
+	})
+	ctx.NoError(err)
+
+	// Running CheckIntegrity again with fix=false should report no errors —
+	// confirming the rebuilt indexes are internally consistent.
+	err = ctx.GetDb().Update(change.New().NewMutateContext(), func(mctx boltz.MutateContext) error {
+		stores := []boltz.Store{
+			ctx.stores.ServicePolicy,
+			ctx.stores.EdgeRouterPolicy,
+			ctx.stores.ServiceEdgeRouterPolicy,
+		}
+		for _, store := range stores {
+			if checkErr := store.CheckIntegrity(mctx, false, func(err error, fixed bool) {
+				t.Fatalf("unexpected integrity error after rebuild on %s: %v", store.GetEntityType(), err)
+			}); checkErr != nil {
+				return checkErr
+			}
+		}
+		return nil
+	})
+	ctx.NoError(err)
+
+	// Idempotency: running the real backfill a second time against
+	// already-populated indexes must not error or alter content (no duplicate
+	// ids, no phantom keys).
+	err = ctx.GetDb().Update(change.New().NewMutateContext(), func(mctx boltz.MutateContext) error {
+		step := &boltz.MigrationStep{
+			Component:      "edge",
+			Ctx:            mctx,
+			CurrentVersion: CurrentDbVersion - 1,
+		}
+		migrations.backfillPolicyRoleAttributeIndexes(step)
+		return step.GetError()
+	})
+	ctx.NoError(err)
+
+	err = ctx.GetDb().View(func(tx *bbolt.Tx) error {
+		idxIdSp := ctx.stores.ServicePolicy.GetIdentityRoleAttributesIndex()
+		ctx.Equal([]string{"marketing", "sales"}, readIndexKeys(tx, idxIdSp))
+		ctx.Equal([]string{sp.Id}, readIndexIds(tx, idxIdSp, "sales"))
+
+		idxSvcSp := ctx.stores.ServicePolicy.GetServiceRoleAttributesIndex()
+		ctx.Equal([]string{"api"}, readIndexKeys(tx, idxSvcSp))
+		ctx.Equal([]string{sp.Id}, readIndexIds(tx, idxSvcSp, "api"))
+		return nil
+	})
+	ctx.NoError(err)
+}

--- a/controller/db/migrations.go
+++ b/controller/db/migrations.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	CurrentDbVersion = 45
+	CurrentDbVersion = 46
 	FieldVersion     = "version"
 )
 
@@ -211,6 +211,10 @@ func (m *Migrations) migrate(step *boltz.MigrationStep) int {
 
 	if step.CurrentVersion < 45 {
 		m.setConfigTypeTargets(step)
+	}
+
+	if step.CurrentVersion < 46 {
+		m.backfillPolicyRoleAttributeIndexes(step)
 	}
 
 	// current version

--- a/controller/db/policy_role_attribute_index_test.go
+++ b/controller/db/policy_role_attribute_index_test.go
@@ -1,0 +1,215 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package db
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/openziti/ziti/v2/common/eid"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
+	"github.com/openziti/ziti/v2/controller/storage/boltztest"
+	"go.etcd.io/bbolt"
+)
+
+// Test_PolicyRoleAttributeIndexes verifies the derived role-attribute indexes
+// installed on the three policy stores index only '#'-prefixed entries (with
+// the '#' stripped) while ignoring '@'-prefixed entity refs.
+func Test_PolicyRoleAttributeIndexes(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Cleanup()
+	ctx.Init()
+
+	t.Run("service policy role-attribute indexes", ctx.testServicePolicyRoleAttributeIndexes)
+	t.Run("edge-router policy role-attribute indexes", ctx.testEdgeRouterPolicyRoleAttributeIndexes)
+	t.Run("service-edge-router policy role-attribute indexes", ctx.testServiceEdgeRouterPolicyRoleAttributeIndexes)
+	t.Run("the #all wildcard is excluded from role-attribute indexes", ctx.testRoleAttributeIndexExcludesAllWildcard)
+}
+
+// testRoleAttributeIndexExcludesAllWildcard verifies the "#all" wildcard is not
+// indexed as a role attribute named "all", while a normal "#attr" on the same
+// policy still is.
+func (ctx *TestContext) testRoleAttributeIndexExcludesAllWildcard(_ *testing.T) {
+	ctx.CleanupAll()
+
+	// "#all" must be the only entry in its field, so it gets its own field
+	// while a sibling field carries a normal attribute reference.
+	p := &ServicePolicy{
+		BaseExtEntity: boltz.BaseExtEntity{Id: eid.New()},
+		Name:          eid.New(),
+		PolicyType:    PolicyTypeDial,
+		Semantic:      SemanticAllOf,
+		IdentityRoles: []string{AllRole},
+		ServiceRoles:  []string{roleRef("api")},
+	}
+	boltztest.RequireCreate(ctx, p)
+
+	err := ctx.GetDb().View(func(tx *bbolt.Tx) error {
+		idxIdentity := ctx.stores.ServicePolicy.GetIdentityRoleAttributesIndex()
+		idxService := ctx.stores.ServicePolicy.GetServiceRoleAttributesIndex()
+
+		// "#all" stripped to "all" must NOT appear; the normal attr must.
+		ctx.Empty(readIndexKeys(tx, idxIdentity))
+		ctx.Equal([]string{"api"}, readIndexKeys(tx, idxService))
+		return nil
+	})
+	ctx.NoError(err)
+}
+
+func readIndexKeys(tx *bbolt.Tx, idx boltz.SetReadIndex) []string {
+	var keys []string
+	idx.ReadKeys(tx, func(val []byte) { keys = append(keys, string(val)) })
+	sort.Strings(keys)
+	return keys
+}
+
+func readIndexIds(tx *bbolt.Tx, idx boltz.SetReadIndex, key string) []string {
+	var ids []string
+	idx.Read(tx, []byte(key), func(val []byte) { ids = append(ids, string(val)) })
+	sort.Strings(ids)
+	return ids
+}
+
+func (ctx *TestContext) testServicePolicyRoleAttributeIndexes(_ *testing.T) {
+	ctx.CleanupAll()
+
+	p1 := &ServicePolicy{
+		BaseExtEntity:     boltz.BaseExtEntity{Id: eid.New()},
+		Name:              eid.New(),
+		PolicyType:        PolicyTypeDial,
+		Semantic:          SemanticAllOf,
+		IdentityRoles:     []string{roleRef("sales")},
+		ServiceRoles:      []string{roleRef("api"), roleRef("public")},
+		PostureCheckRoles: []string{roleRef("mfa")},
+	}
+	boltztest.RequireCreate(ctx, p1)
+
+	p2 := &ServicePolicy{
+		BaseExtEntity: boltz.BaseExtEntity{Id: eid.New()},
+		Name:          eid.New(),
+		PolicyType:    PolicyTypeBind,
+		Semantic:      SemanticAllOf,
+		IdentityRoles: []string{roleRef("sales"), roleRef("marketing")},
+		ServiceRoles:  []string{roleRef("internal")},
+	}
+	boltztest.RequireCreate(ctx, p2)
+
+	err := ctx.GetDb().View(func(tx *bbolt.Tx) error {
+		idxIdentity := ctx.stores.ServicePolicy.GetIdentityRoleAttributesIndex()
+		idxService := ctx.stores.ServicePolicy.GetServiceRoleAttributesIndex()
+		idxPosture := ctx.stores.ServicePolicy.GetPostureCheckRoleAttributesIndex()
+
+		ctx.Equal([]string{"marketing", "sales"}, readIndexKeys(tx, idxIdentity))
+		ctx.Equal([]string{"api", "internal", "public"}, readIndexKeys(tx, idxService))
+		ctx.Equal([]string{"mfa"}, readIndexKeys(tx, idxPosture))
+
+		salesIds := readIndexIds(tx, idxIdentity, "sales")
+		expected := []string{p1.Id, p2.Id}
+		sort.Strings(expected)
+		ctx.Equal(expected, salesIds)
+
+		ctx.Equal([]string{p2.Id}, readIndexIds(tx, idxIdentity, "marketing"))
+		ctx.Equal([]string{p1.Id}, readIndexIds(tx, idxService, "api"))
+		ctx.Equal([]string{p1.Id}, readIndexIds(tx, idxService, "public"))
+		ctx.Equal([]string{p2.Id}, readIndexIds(tx, idxService, "internal"))
+		ctx.Equal([]string{p1.Id}, readIndexIds(tx, idxPosture, "mfa"))
+		return nil
+	})
+	ctx.NoError(err)
+
+	// Mutate roles and verify the indexes update correctly.
+	p1.IdentityRoles = []string{roleRef("engineering")}
+	p1.ServiceRoles = nil
+	p1.PostureCheckRoles = nil
+	boltztest.RequireUpdate(ctx, p1)
+
+	err = ctx.GetDb().View(func(tx *bbolt.Tx) error {
+		idxIdentity := ctx.stores.ServicePolicy.GetIdentityRoleAttributesIndex()
+		idxService := ctx.stores.ServicePolicy.GetServiceRoleAttributesIndex()
+		idxPosture := ctx.stores.ServicePolicy.GetPostureCheckRoleAttributesIndex()
+
+		ctx.Equal([]string{"engineering", "marketing", "sales"}, readIndexKeys(tx, idxIdentity))
+		ctx.Equal([]string{p1.Id}, readIndexIds(tx, idxIdentity, "engineering"))
+		ctx.Equal([]string{p2.Id}, readIndexIds(tx, idxIdentity, "sales"))
+
+		// Only p2 still has service roles; p1 has none.
+		ctx.Equal([]string{"internal"}, readIndexKeys(tx, idxService))
+		ctx.Empty(readIndexKeys(tx, idxPosture))
+		return nil
+	})
+	ctx.NoError(err)
+
+	// Deleting p2 should clear the remaining keys that only p2 held.
+	boltztest.RequireDelete(ctx, p2)
+
+	err = ctx.GetDb().View(func(tx *bbolt.Tx) error {
+		idxIdentity := ctx.stores.ServicePolicy.GetIdentityRoleAttributesIndex()
+		ctx.Equal([]string{"engineering"}, readIndexKeys(tx, idxIdentity))
+		return nil
+	})
+	ctx.NoError(err)
+}
+
+func (ctx *TestContext) testEdgeRouterPolicyRoleAttributeIndexes(_ *testing.T) {
+	ctx.CleanupAll()
+
+	p := &EdgeRouterPolicy{
+		BaseExtEntity:   boltz.BaseExtEntity{Id: eid.New()},
+		Name:            eid.New(),
+		Semantic:        SemanticAllOf,
+		IdentityRoles:   []string{roleRef("ops")},
+		EdgeRouterRoles: []string{roleRef("us-east"), roleRef("us-west")},
+	}
+	boltztest.RequireCreate(ctx, p)
+
+	err := ctx.GetDb().View(func(tx *bbolt.Tx) error {
+		idxIdentity := ctx.stores.EdgeRouterPolicy.GetIdentityRoleAttributesIndex()
+		idxRouter := ctx.stores.EdgeRouterPolicy.GetEdgeRouterRoleAttributesIndex()
+
+		ctx.Equal([]string{"ops"}, readIndexKeys(tx, idxIdentity))
+		ctx.Equal([]string{"us-east", "us-west"}, readIndexKeys(tx, idxRouter))
+		ctx.Equal([]string{p.Id}, readIndexIds(tx, idxIdentity, "ops"))
+		ctx.Equal([]string{p.Id}, readIndexIds(tx, idxRouter, "us-west"))
+		return nil
+	})
+	ctx.NoError(err)
+}
+
+func (ctx *TestContext) testServiceEdgeRouterPolicyRoleAttributeIndexes(_ *testing.T) {
+	ctx.CleanupAll()
+
+	p := &ServiceEdgeRouterPolicy{
+		BaseExtEntity:   boltz.BaseExtEntity{Id: eid.New()},
+		Name:            eid.New(),
+		Semantic:        SemanticAllOf,
+		ServiceRoles:    []string{roleRef("public")},
+		EdgeRouterRoles: []string{roleRef("eu-west")},
+	}
+	boltztest.RequireCreate(ctx, p)
+
+	err := ctx.GetDb().View(func(tx *bbolt.Tx) error {
+		idxService := ctx.stores.ServiceEdgeRouterPolicy.GetServiceRoleAttributesIndex()
+		idxRouter := ctx.stores.ServiceEdgeRouterPolicy.GetEdgeRouterRoleAttributesIndex()
+
+		ctx.Equal([]string{"public"}, readIndexKeys(tx, idxService))
+		ctx.Equal([]string{"eu-west"}, readIndexKeys(tx, idxRouter))
+		ctx.Equal([]string{p.Id}, readIndexIds(tx, idxService, "public"))
+		ctx.Equal([]string{p.Id}, readIndexIds(tx, idxRouter, "eu-west"))
+		return nil
+	})
+	ctx.NoError(err)
+}

--- a/controller/db/service_edge_router_policy_store.go
+++ b/controller/db/service_edge_router_policy_store.go
@@ -44,6 +44,8 @@ var _ ServiceEdgeRouterPolicyStore = (*serviceEdgeRouterPolicyStoreImpl)(nil)
 type ServiceEdgeRouterPolicyStore interface {
 	NameIndexed
 	Store[*ServiceEdgeRouterPolicy]
+	GetServiceRoleAttributesIndex() boltz.SetReadIndex
+	GetEdgeRouterRoleAttributesIndex() boltz.SetReadIndex
 }
 
 func newServiceEdgeRouterPolicyStore(stores *stores) *serviceEdgeRouterPolicyStoreImpl {
@@ -63,12 +65,27 @@ type serviceEdgeRouterPolicyStoreImpl struct {
 	symbolServices        boltz.EntitySetSymbol
 	symbolEdgeRouters     boltz.EntitySetSymbol
 
+	indexServiceRoleAttributes    boltz.SetReadIndex
+	indexEdgeRouterRoleAttributes boltz.SetReadIndex
+
 	serviceCollection    boltz.LinkCollection
 	edgeRouterCollection boltz.LinkCollection
 }
 
 func (store *serviceEdgeRouterPolicyStoreImpl) GetNameIndex() boltz.ReadIndex {
 	return store.indexName
+}
+
+// GetServiceRoleAttributesIndex returns the derived set index of service
+// role-attribute references declared on service-edge-router policies.
+func (store *serviceEdgeRouterPolicyStoreImpl) GetServiceRoleAttributesIndex() boltz.SetReadIndex {
+	return store.indexServiceRoleAttributes
+}
+
+// GetEdgeRouterRoleAttributesIndex returns the derived set index of edge
+// router role-attribute references declared on service-edge-router policies.
+func (store *serviceEdgeRouterPolicyStoreImpl) GetEdgeRouterRoleAttributesIndex() boltz.SetReadIndex {
+	return store.indexEdgeRouterRoleAttributes
 }
 
 func (store *serviceEdgeRouterPolicyStoreImpl) NewEntity() *ServiceEdgeRouterPolicy {
@@ -84,6 +101,9 @@ func (store *serviceEdgeRouterPolicyStoreImpl) initializeLocal() {
 	store.symbolEdgeRouterRoles = store.AddPublicSetSymbol(FieldEdgeRouterRoles, ast.NodeTypeString)
 	store.symbolServices = store.AddFkSetSymbol(EntityTypeServices, store.stores.edgeService)
 	store.symbolEdgeRouters = store.AddFkSetSymbol(EntityTypeRouters, store.stores.edgeRouter)
+
+	store.indexServiceRoleAttributes = store.AddSetIndexWithTransform(store.symbolServiceRoles, roleAttributeOnlyTransform)
+	store.indexEdgeRouterRoleAttributes = store.AddSetIndexWithTransform(store.symbolEdgeRouterRoles, roleAttributeOnlyTransform)
 }
 
 func (store *serviceEdgeRouterPolicyStoreImpl) initializeLinked() {

--- a/controller/db/service_policy_store.go
+++ b/controller/db/service_policy_store.go
@@ -100,6 +100,9 @@ var _ ServicePolicyStore = (*servicePolicyStoreImpl)(nil)
 type ServicePolicyStore interface {
 	NameIndexed
 	Store[*ServicePolicy]
+	GetIdentityRoleAttributesIndex() boltz.SetReadIndex
+	GetServiceRoleAttributesIndex() boltz.SetReadIndex
+	GetPostureCheckRoleAttributesIndex() boltz.SetReadIndex
 }
 
 func newServicePolicyStore(stores *stores) *servicePolicyStoreImpl {
@@ -120,6 +123,10 @@ type servicePolicyStoreImpl struct {
 	symbolServiceRoles      boltz.EntitySetSymbol
 	symbolPostureCheckRoles boltz.EntitySetSymbol
 
+	indexIdentityRoleAttributes     boltz.SetReadIndex
+	indexServiceRoleAttributes      boltz.SetReadIndex
+	indexPostureCheckRoleAttributes boltz.SetReadIndex
+
 	symbolIdentities    boltz.EntitySetSymbol
 	symbolServices      boltz.EntitySetSymbol
 	symbolPostureChecks boltz.EntitySetSymbol
@@ -127,6 +134,24 @@ type servicePolicyStoreImpl struct {
 	identityCollection     boltz.LinkCollection
 	serviceCollection      boltz.LinkCollection
 	postureCheckCollection boltz.LinkCollection
+}
+
+// GetIdentityRoleAttributesIndex returns the derived set index of identity
+// role-attribute references declared on service policies.
+func (store *servicePolicyStoreImpl) GetIdentityRoleAttributesIndex() boltz.SetReadIndex {
+	return store.indexIdentityRoleAttributes
+}
+
+// GetServiceRoleAttributesIndex returns the derived set index of service
+// role-attribute references declared on service policies.
+func (store *servicePolicyStoreImpl) GetServiceRoleAttributesIndex() boltz.SetReadIndex {
+	return store.indexServiceRoleAttributes
+}
+
+// GetPostureCheckRoleAttributesIndex returns the derived set index of posture
+// check role-attribute references declared on service policies.
+func (store *servicePolicyStoreImpl) GetPostureCheckRoleAttributesIndex() boltz.SetReadIndex {
+	return store.indexPostureCheckRoleAttributes
 }
 
 func (store *servicePolicyStoreImpl) GetNameIndex() boltz.ReadIndex {
@@ -148,6 +173,10 @@ func (store *servicePolicyStoreImpl) initializeLocal() {
 	store.symbolIdentityRoles = store.AddPublicSetSymbol(FieldIdentityRoles, ast.NodeTypeString)
 	store.symbolServiceRoles = store.AddPublicSetSymbol(FieldServiceRoles, ast.NodeTypeString)
 	store.symbolPostureCheckRoles = store.AddPublicSetSymbol(FieldPostureCheckRoles, ast.NodeTypeString)
+
+	store.indexIdentityRoleAttributes = store.AddSetIndexWithTransform(store.symbolIdentityRoles, roleAttributeOnlyTransform)
+	store.indexServiceRoleAttributes = store.AddSetIndexWithTransform(store.symbolServiceRoles, roleAttributeOnlyTransform)
+	store.indexPostureCheckRoleAttributes = store.AddSetIndexWithTransform(store.symbolPostureCheckRoles, roleAttributeOnlyTransform)
 
 	store.symbolIdentities = store.AddFkSetSymbol(EntityTypeIdentities, store.stores.identity)
 	store.symbolServices = store.AddFkSetSymbol(EntityTypeServices, store.stores.edgeService)

--- a/controller/db/util.go
+++ b/controller/db/util.go
@@ -67,6 +67,26 @@ func splitRolesAndIds(values []string) ([]string, []string, error) {
 	return roles, ids, nil
 }
 
+// roleAttributeOnlyTransform is a boltz SetIndex value transform that keeps
+// only role-attribute entries (values prefixed with RolePrefix, with a
+// non-empty suffix) and strips the prefix. It's used to build derived set
+// indexes over policy role fields that mix role-attribute refs ("#attr")
+// and entity refs ("@id").
+//
+// The "#all" wildcard is excluded: it is not a reference to a role attribute
+// named "all" but a policy-level "match everything" marker, so indexing it
+// would surface a phantom "all" attribute and miscount any real entity
+// attribute that happens to be named "all".
+var roleAttributeOnlyTransform boltz.SetIndexValueTransform = func(ft boltz.FieldType, v []byte) (bool, boltz.FieldType, []byte) {
+	if ft != boltz.TypeString || len(v) < 2 || v[0] != RolePrefix[0] {
+		return false, ft, v
+	}
+	if string(v) == AllRole {
+		return false, ft, v
+	}
+	return true, ft, v[1:]
+}
+
 func FieldValuesToIds(new []boltz.FieldTypeAndValue) []string {
 	var entityRoles []string
 	for _, fv := range new {

--- a/controller/internal/routes/role_attributes_router.go
+++ b/controller/internal/routes/role_attributes_router.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openziti/edge-api/rest_management_api_server/operations/role_attributes"
 	"github.com/openziti/edge-api/rest_model"
 	"github.com/openziti/ziti/v2/controller/env"
+	"github.com/openziti/ziti/v2/controller/model"
 	"github.com/openziti/ziti/v2/controller/models"
 	"github.com/openziti/ziti/v2/controller/permissions"
 	"github.com/openziti/ziti/v2/controller/response"
@@ -57,6 +58,41 @@ func (r *RoleAttributesRouter) Register(ae *env.AppEnv) {
 		ae.InitPermissionsContext(params.HTTPRequest, permissions.Management, "posture-check", permissions.Read)
 		return ae.IsAllowed(r.listPostureCheckAttributes, params.HTTPRequest, "", "", permissions.DefaultManagementAccess())
 	})
+
+	ae.ManagementApi.RoleAttributesListIdentityRoleAttributeUsageHandler = role_attributes.ListIdentityRoleAttributeUsageHandlerFunc(func(params role_attributes.ListIdentityRoleAttributeUsageParams, _ interface{}) middleware.Responder {
+		ae.InitPermissionsContext(params.HTTPRequest, permissions.Management, "identity", permissions.Read)
+		return ae.IsAllowed(func(ae *env.AppEnv, rc *response.RequestContext) {
+			r.listRoleAttributeUsage(ae, rc, model.RoleAttributeKindIdentity, boolOrFalse(params.WithIds))
+		}, params.HTTPRequest, "", "", permissions.DefaultManagementAccess())
+	})
+
+	ae.ManagementApi.RoleAttributesListEdgeRouterRoleAttributeUsageHandler = role_attributes.ListEdgeRouterRoleAttributeUsageHandlerFunc(func(params role_attributes.ListEdgeRouterRoleAttributeUsageParams, _ interface{}) middleware.Responder {
+		ae.InitPermissionsContext(params.HTTPRequest, permissions.Management, "router", permissions.Read)
+		return ae.IsAllowed(func(ae *env.AppEnv, rc *response.RequestContext) {
+			r.listRoleAttributeUsage(ae, rc, model.RoleAttributeKindEdgeRouter, boolOrFalse(params.WithIds))
+		}, params.HTTPRequest, "", "", permissions.DefaultManagementAccess())
+	})
+
+	ae.ManagementApi.RoleAttributesListServiceRoleAttributeUsageHandler = role_attributes.ListServiceRoleAttributeUsageHandlerFunc(func(params role_attributes.ListServiceRoleAttributeUsageParams, _ interface{}) middleware.Responder {
+		ae.InitPermissionsContext(params.HTTPRequest, permissions.Management, "service", permissions.Read)
+		return ae.IsAllowed(func(ae *env.AppEnv, rc *response.RequestContext) {
+			r.listRoleAttributeUsage(ae, rc, model.RoleAttributeKindService, boolOrFalse(params.WithIds))
+		}, params.HTTPRequest, "", "", permissions.DefaultManagementAccess())
+	})
+
+	ae.ManagementApi.RoleAttributesListPostureCheckRoleAttributeUsageHandler = role_attributes.ListPostureCheckRoleAttributeUsageHandlerFunc(func(params role_attributes.ListPostureCheckRoleAttributeUsageParams, _ interface{}) middleware.Responder {
+		ae.InitPermissionsContext(params.HTTPRequest, permissions.Management, "posture-check", permissions.Read)
+		return ae.IsAllowed(func(ae *env.AppEnv, rc *response.RequestContext) {
+			r.listRoleAttributeUsage(ae, rc, model.RoleAttributeKindPostureCheck, boolOrFalse(params.WithIds))
+		}, params.HTTPRequest, "", "", permissions.DefaultManagementAccess())
+	})
+}
+
+func boolOrFalse(p *bool) bool {
+	if p == nil {
+		return false
+	}
+	return *p
 }
 
 func (r *RoleAttributesRouter) listEdgeRouterRoleAttributes(ae *env.AppEnv, rc *response.RequestContext) {
@@ -94,4 +130,39 @@ func (r *RoleAttributesRouter) listRoleAttributes(rc *response.RequestContext, q
 
 type roleAttributeQueryable interface {
 	QueryRoleAttributes(queryString string) ([]string, *models.QueryMetaData, error)
+}
+
+func (r *RoleAttributesRouter) listRoleAttributeUsage(ae *env.AppEnv, rc *response.RequestContext, kind model.RoleAttributeKind, includeIds bool) {
+	List(rc, func(rc *response.RequestContext, queryOptions *PublicQueryOptions) (*QueryResult, error) {
+		results, qmd, err := model.QueryRoleAttributeUsage(ae, kind, queryOptions.Predicate, includeIds)
+		if err != nil {
+			return nil, err
+		}
+
+		list := make(rest_model.RoleAttributeUsageList, 0, len(results))
+		for _, result := range results {
+			attr := result.RoleAttribute
+			usage := make(map[string]rest_model.RoleAttributeSourceUsage, len(result.Usage))
+			for source, src := range result.Usage {
+				entry := rest_model.RoleAttributeSourceUsage{Count: &src.Count}
+				if includeIds {
+					// When the caller asked for ids, always emit a (possibly
+					// empty) array so a null in the response unambiguously
+					// means "ids were not requested".
+					if src.Ids == nil {
+						entry.Ids = []string{}
+					} else {
+						entry.Ids = src.Ids
+					}
+				}
+				usage[string(source)] = entry
+			}
+			list = append(list, &rest_model.RoleAttributeUsageDetail{
+				RoleAttribute: &attr,
+				Usage:         usage,
+			})
+		}
+
+		return NewQueryResult(list, qmd), nil
+	})
 }

--- a/controller/model/role_attribute_usage.go
+++ b/controller/model/role_attribute_usage.go
@@ -1,0 +1,195 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package model
+
+import (
+	"github.com/openziti/ziti/v2/controller/models"
+	"github.com/openziti/ziti/v2/controller/storage/ast"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
+	"github.com/pkg/errors"
+	"go.etcd.io/bbolt"
+)
+
+// RoleAttributeKind identifies the entity target class whose role-attribute
+// usage is being queried (e.g., "identity" means attributes that label
+// identities and are referenced by identity-role fields on policies).
+type RoleAttributeKind string
+
+const (
+	RoleAttributeKindIdentity     RoleAttributeKind = "identity"
+	RoleAttributeKindEdgeRouter   RoleAttributeKind = "edgeRouter"
+	RoleAttributeKindService      RoleAttributeKind = "service"
+	RoleAttributeKindPostureCheck RoleAttributeKind = "postureCheck"
+)
+
+// RoleAttributeSource names one source population that references a role
+// attribute: either the attribute's home-entity collection, or a policy
+// collection that references it.
+type RoleAttributeSource string
+
+const (
+	RoleAttributeSourceIdentities                RoleAttributeSource = "identities"
+	RoleAttributeSourceEdgeRouters               RoleAttributeSource = "edgeRouters"
+	RoleAttributeSourceServices                  RoleAttributeSource = "services"
+	RoleAttributeSourcePostureChecks             RoleAttributeSource = "postureChecks"
+	RoleAttributeSourceServicePolicies           RoleAttributeSource = "servicePolicies"
+	RoleAttributeSourceEdgeRouterPolicies        RoleAttributeSource = "edgeRouterPolicies"
+	RoleAttributeSourceServiceEdgeRouterPolicies RoleAttributeSource = "serviceEdgeRouterPolicies"
+)
+
+// RoleAttributeSourceUsage is a count of entities (and optionally the entity
+// ids themselves) from one source that use a particular role attribute.
+type RoleAttributeSourceUsage struct {
+	Count int64
+	Ids   []string
+}
+
+// RoleAttributeUsage is a role-attribute value paired with its per-source
+// usage breakdown across the sources relevant to its RoleAttributeKind.
+type RoleAttributeUsage struct {
+	RoleAttribute string
+	Usage         map[RoleAttributeSource]*RoleAttributeSourceUsage
+}
+
+// roleAttributeSource binds a source name to the boltz SetReadIndex that
+// serves it.
+type roleAttributeSource struct {
+	name  RoleAttributeSource
+	index boltz.SetReadIndex
+}
+
+// sourcesFor returns the ordered list of (name, index) pairs that contribute
+// to the given RoleAttributeKind. The order is stable so that the response
+// shape is predictable across calls.
+func sourcesFor(env Env, kind RoleAttributeKind) []roleAttributeSource {
+	stores := env.GetStores()
+	switch kind {
+	case RoleAttributeKindIdentity:
+		return []roleAttributeSource{
+			{RoleAttributeSourceIdentities, stores.Identity.GetRoleAttributesIndex()},
+			{RoleAttributeSourceServicePolicies, stores.ServicePolicy.GetIdentityRoleAttributesIndex()},
+			{RoleAttributeSourceEdgeRouterPolicies, stores.EdgeRouterPolicy.GetIdentityRoleAttributesIndex()},
+		}
+	case RoleAttributeKindEdgeRouter:
+		return []roleAttributeSource{
+			{RoleAttributeSourceEdgeRouters, stores.EdgeRouter.GetRoleAttributesIndex()},
+			{RoleAttributeSourceEdgeRouterPolicies, stores.EdgeRouterPolicy.GetEdgeRouterRoleAttributesIndex()},
+			{RoleAttributeSourceServiceEdgeRouterPolicies, stores.ServiceEdgeRouterPolicy.GetEdgeRouterRoleAttributesIndex()},
+		}
+	case RoleAttributeKindService:
+		return []roleAttributeSource{
+			{RoleAttributeSourceServices, stores.EdgeService.GetRoleAttributesIndex()},
+			{RoleAttributeSourceServicePolicies, stores.ServicePolicy.GetServiceRoleAttributesIndex()},
+			{RoleAttributeSourceServiceEdgeRouterPolicies, stores.ServiceEdgeRouterPolicy.GetServiceRoleAttributesIndex()},
+		}
+	case RoleAttributeKindPostureCheck:
+		return []roleAttributeSource{
+			{RoleAttributeSourcePostureChecks, stores.PostureCheck.GetRoleAttributesIndex()},
+			{RoleAttributeSourceServicePolicies, stores.ServicePolicy.GetPostureCheckRoleAttributesIndex()},
+		}
+	}
+	return nil
+}
+
+// QueryRoleAttributeUsage returns the set of distinct role-attribute values
+// that appear on any of the sources for kind, along with per-source counts
+// (and optionally the backing entity ids when includeIds is true). The
+// predicate/sort/limit/offset semantics match the existing
+// QueryRoleAttributes endpoints: the predicate is evaluated against the
+// attribute value under the symbol name `id`.
+func QueryRoleAttributeUsage(env Env, kind RoleAttributeKind, queryString string, includeIds bool) ([]*RoleAttributeUsage, *models.QueryMetaData, error) {
+	sources := sourcesFor(env, kind)
+	if len(sources) == 0 {
+		return nil, nil, errors.Errorf("unknown role attribute kind: %s", kind)
+	}
+
+	indexStore := env.GetStores().Index
+	query, err := ast.Parse(indexStore, queryString)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cursorProvider := func(tx *bbolt.Tx, forward bool) ast.SetCursor {
+		set := ast.NewTreeSet(forward)
+		seen := make(map[string]struct{})
+		for _, src := range sources {
+			if src.index == nil {
+				continue
+			}
+			src.index.ReadKeys(tx, func(val []byte) {
+				if _, ok := seen[string(val)]; ok {
+					return
+				}
+				seen[string(val)] = struct{}{}
+				set.Add(append([]byte(nil), val...))
+			})
+		}
+		// An empty TreeSet has a nil root; TreeSet.ToCursor would panic
+		// dereferencing it. A kind with no role attributes (fresh or sparse
+		// controller) is a legitimate state, so return an empty cursor.
+		if set.Size() == 0 {
+			return ast.NewEmptyCursor()
+		}
+		return set.ToCursor()
+	}
+
+	// A single read transaction covers both the attribute query and the
+	// per-source usage reads so the counts are guaranteed consistent with the
+	// returned attribute list, even under concurrent writes.
+	var count int64
+	var results []*RoleAttributeUsage
+	err = env.GetDb().View(func(tx *bbolt.Tx) error {
+		attrs, c, err := indexStore.QueryWithCursorC(tx, cursorProvider, query)
+		if err != nil {
+			return err
+		}
+		count = c
+
+		results = make([]*RoleAttributeUsage, 0, len(attrs))
+		for _, attr := range attrs {
+			usage := make(map[RoleAttributeSource]*RoleAttributeSourceUsage, len(sources))
+			for _, src := range sources {
+				entry := &RoleAttributeSourceUsage{}
+				if src.index != nil {
+					src.index.Read(tx, []byte(attr), func(val []byte) {
+						entry.Count++
+						if includeIds {
+							entry.Ids = append(entry.Ids, string(val))
+						}
+					})
+				}
+				usage[src.name] = entry
+			}
+			results = append(results, &RoleAttributeUsage{
+				RoleAttribute: attr,
+				Usage:         usage,
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	qmd := &models.QueryMetaData{
+		Count:            count,
+		Limit:            *query.GetLimit(),
+		Offset:           *query.GetSkip(),
+		FilterableFields: indexStore.GetPublicSymbols(),
+	}
+	return results, qmd, nil
+}

--- a/controller/model/role_attribute_usage_test.go
+++ b/controller/model/role_attribute_usage_test.go
@@ -1,0 +1,202 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package model
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/openziti/ziti/v2/common/eid"
+	"github.com/openziti/ziti/v2/controller/change"
+	"github.com/openziti/ziti/v2/controller/db"
+)
+
+// TestQueryRoleAttributeUsage_Identity verifies the identity-kind aggregator
+// covers three distinct cases: an attribute only declared on an identity, an
+// attribute only referenced by policies, and an attribute that appears in
+// both. Also verifies the withIds branch populates entity id arrays.
+func TestQueryRoleAttributeUsage_Identity(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Cleanup()
+	ctx.Init()
+
+	idBoth := ctx.requireNewIdentity(false)
+	idBoth.RoleAttributes = []string{"sales"}
+	ctx.NoError(ctx.managers.Identity.Update(idBoth, nil, change.New()))
+
+	idEntityOnly := ctx.requireNewIdentity(false)
+	idEntityOnly.RoleAttributes = []string{"engineering"}
+	ctx.NoError(ctx.managers.Identity.Update(idEntityOnly, nil, change.New()))
+
+	// "sales" is referenced by both a service policy and an edge-router policy.
+	sp1 := ctx.requireNewServicePolicy(db.PolicyTypeDialName, ss("#sales"), ss("#public"))
+	sp2 := ctx.requireNewServicePolicy(db.PolicyTypeDialName, ss("#marketing"), ss("#public"))
+	erp := ctx.requireNewEdgeRouterPolicy(ss("#sales"), ss("#any-router"))
+
+	// Use unique per-test identity attribute names to avoid contamination from
+	// identities created by other test setup paths.
+	results, qmd, err := QueryRoleAttributeUsage(ctx, RoleAttributeKindIdentity, `id contains "sale" or id contains "engineer" or id contains "market"`, true)
+	ctx.NoError(err)
+	ctx.NotNil(qmd)
+
+	byAttr := make(map[string]*RoleAttributeUsage)
+	for _, r := range results {
+		byAttr[r.RoleAttribute] = r
+	}
+
+	// "sales" — both sources
+	sales := byAttr["sales"]
+	ctx.NotNil(sales)
+	ctx.Equal(int64(1), sales.Usage[RoleAttributeSourceIdentities].Count)
+	ctx.Equal([]string{idBoth.Id}, sales.Usage[RoleAttributeSourceIdentities].Ids)
+	ctx.Equal(int64(1), sales.Usage[RoleAttributeSourceServicePolicies].Count)
+	ctx.Equal([]string{sp1.Id}, sales.Usage[RoleAttributeSourceServicePolicies].Ids)
+	ctx.Equal(int64(1), sales.Usage[RoleAttributeSourceEdgeRouterPolicies].Count)
+	ctx.Equal([]string{erp.Id}, sales.Usage[RoleAttributeSourceEdgeRouterPolicies].Ids)
+
+	// "engineering" — identity only
+	engineering := byAttr["engineering"]
+	ctx.NotNil(engineering)
+	ctx.Equal(int64(1), engineering.Usage[RoleAttributeSourceIdentities].Count)
+	ctx.Equal([]string{idEntityOnly.Id}, engineering.Usage[RoleAttributeSourceIdentities].Ids)
+	ctx.Equal(int64(0), engineering.Usage[RoleAttributeSourceServicePolicies].Count)
+	ctx.Empty(engineering.Usage[RoleAttributeSourceServicePolicies].Ids)
+	ctx.Equal(int64(0), engineering.Usage[RoleAttributeSourceEdgeRouterPolicies].Count)
+
+	// "marketing" — policy only (no identity declares it)
+	marketing := byAttr["marketing"]
+	ctx.NotNil(marketing)
+	ctx.Equal(int64(0), marketing.Usage[RoleAttributeSourceIdentities].Count)
+	ctx.Empty(marketing.Usage[RoleAttributeSourceIdentities].Ids)
+	ctx.Equal(int64(1), marketing.Usage[RoleAttributeSourceServicePolicies].Count)
+	ctx.Equal([]string{sp2.Id}, marketing.Usage[RoleAttributeSourceServicePolicies].Ids)
+	ctx.Equal(int64(0), marketing.Usage[RoleAttributeSourceEdgeRouterPolicies].Count)
+}
+
+// TestQueryRoleAttributeUsage_WithoutIds verifies that includeIds=false omits
+// entity id arrays but still reports accurate counts.
+func TestQueryRoleAttributeUsage_WithoutIds(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Cleanup()
+	ctx.Init()
+
+	id := ctx.requireNewIdentity(false)
+	id.RoleAttributes = []string{"ops"}
+	ctx.NoError(ctx.managers.Identity.Update(id, nil, change.New()))
+
+	ctx.requireNewServicePolicy(db.PolicyTypeDialName, ss("#ops"), ss("#whatever"))
+	ctx.requireNewServicePolicy(db.PolicyTypeDialName, ss("#ops"), ss("#whatever"))
+
+	results, _, err := QueryRoleAttributeUsage(ctx, RoleAttributeKindIdentity, `id = "ops"`, false)
+	ctx.NoError(err)
+	ctx.Len(results, 1)
+	ops := results[0]
+	ctx.Equal("ops", ops.RoleAttribute)
+	ctx.Equal(int64(1), ops.Usage[RoleAttributeSourceIdentities].Count)
+	ctx.Nil(ops.Usage[RoleAttributeSourceIdentities].Ids)
+	ctx.Equal(int64(2), ops.Usage[RoleAttributeSourceServicePolicies].Count)
+	ctx.Nil(ops.Usage[RoleAttributeSourceServicePolicies].Ids)
+}
+
+// TestQueryRoleAttributeUsage_Empty verifies that a kind with no role
+// attributes anywhere returns an empty result rather than panicking. When no
+// source index has any key the merged TreeSet has a nil root, which
+// TreeSet.ToCursor would dereference; the aggregator must return an empty
+// cursor instead. A freshly-initialized context has no posture checks and no
+// posture-check role refs, so both posture-check sources are empty.
+func TestQueryRoleAttributeUsage_Empty(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Cleanup()
+	ctx.Init()
+
+	results, qmd, err := QueryRoleAttributeUsage(ctx, RoleAttributeKindPostureCheck, "true", true)
+	ctx.NoError(err)
+	ctx.NotNil(qmd)
+	ctx.Empty(results)
+	ctx.Equal(int64(0), qmd.Count)
+}
+
+// TestQueryRoleAttributeUsage_EdgeRouter exercises the edge-router kind with
+// both home-entity and policy sources.
+func TestQueryRoleAttributeUsage_EdgeRouter(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Cleanup()
+	ctx.Init()
+
+	er := ctx.requireNewEdgeRouter()
+	er.RoleAttributes = []string{"edge-" + eid.New()}
+	ctx.NoError(ctx.managers.EdgeRouter.Update(er, false, nil, change.New()))
+
+	tag := er.RoleAttributes[0]
+	ctx.requireNewEdgeRouterPolicy(ss("#ignored"), ss("#"+tag))
+	ctx.requireNewServiceNewEdgeRouterPolicy(ss("#irrelevant"), ss("#"+tag))
+
+	results, _, err := QueryRoleAttributeUsage(ctx, RoleAttributeKindEdgeRouter, `id = "`+tag+`"`, true)
+	ctx.NoError(err)
+	ctx.Len(results, 1)
+	r := results[0]
+	ctx.Equal(tag, r.RoleAttribute)
+	ctx.Equal(int64(1), r.Usage[RoleAttributeSourceEdgeRouters].Count)
+	ctx.Equal([]string{er.Id}, r.Usage[RoleAttributeSourceEdgeRouters].Ids)
+	ctx.Equal(int64(1), r.Usage[RoleAttributeSourceEdgeRouterPolicies].Count)
+	ctx.Equal(int64(1), r.Usage[RoleAttributeSourceServiceEdgeRouterPolicies].Count)
+}
+
+// TestQueryRoleAttributeUsage_Filter_Paging confirms the shared filter/sort/
+// paging pipeline still applies: a filter restricts the result set, and
+// limit/offset bound it.
+func TestQueryRoleAttributeUsage_Filter_Paging(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Cleanup()
+	ctx.Init()
+
+	// Install a fixed set of identity attributes spanning multiple "groups"
+	// so we can exercise filter + sort + limit/offset together.
+	tagPrefix := "grp-" + eid.New() + "-"
+	var expected []string
+	for _, suffix := range []string{"alpha", "beta", "gamma", "delta"} {
+		identity := ctx.requireNewIdentity(false)
+		identity.RoleAttributes = []string{tagPrefix + suffix}
+		ctx.NoError(ctx.managers.Identity.Update(identity, nil, change.New()))
+		expected = append(expected, tagPrefix+suffix)
+	}
+	sort.Strings(expected)
+
+	// Broad filter: should match all four.
+	results, _, err := QueryRoleAttributeUsage(ctx, RoleAttributeKindIdentity, `id contains "`+tagPrefix+`" sort by id`, false)
+	ctx.NoError(err)
+	ctx.Len(results, 4)
+	got := make([]string, 0, len(results))
+	for _, r := range results {
+		got = append(got, r.RoleAttribute)
+	}
+	ctx.Equal(expected, got)
+
+	// Narrow filter: should match just alpha & gamma via contains pattern.
+	results, _, err = QueryRoleAttributeUsage(ctx, RoleAttributeKindIdentity, `id contains "`+tagPrefix+`" and (id contains "alpha" or id contains "gamma") sort by id`, false)
+	ctx.NoError(err)
+	ctx.Len(results, 2)
+	ctx.Equal(tagPrefix+"alpha", results[0].RoleAttribute)
+	ctx.Equal(tagPrefix+"gamma", results[1].RoleAttribute)
+
+	// Limit + offset.
+	results, _, err = QueryRoleAttributeUsage(ctx, RoleAttributeKindIdentity, `id contains "`+tagPrefix+`" sort by id skip 1 limit 2`, false)
+	ctx.NoError(err)
+	ctx.Len(results, 2)
+	ctx.Equal(expected[1], results[0].RoleAttribute)
+	ctx.Equal(expected[2], results[1].RoleAttribute)
+}

--- a/controller/storage/boltz/derived_set_index_test.go
+++ b/controller/storage/boltz/derived_set_index_test.go
@@ -1,0 +1,284 @@
+/*
+	Copyright NetFoundry, Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package boltz
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/openziti/ziti/v2/controller/storage/ast"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
+)
+
+const (
+	entityTypeTaggedThing = "taggedThings"
+	fieldTags             = "tags"
+)
+
+type taggedThing struct {
+	Id   string
+	Tags []string
+}
+
+func (e *taggedThing) GetId() string              { return e.Id }
+func (e *taggedThing) SetId(id string)            { e.Id = id }
+func (e *taggedThing) GetEntityType() string      { return entityTypeTaggedThing }
+
+type taggedThingEntityStrategy struct{}
+
+func (taggedThingEntityStrategy) NewEntity() *taggedThing {
+	return new(taggedThing)
+}
+
+func (taggedThingEntityStrategy) FillEntity(entity *taggedThing, bucket *TypedBucket) {
+	entity.Tags = bucket.GetStringList(fieldTags)
+}
+
+func (taggedThingEntityStrategy) PersistEntity(entity *taggedThing, ctx *PersistContext) {
+	ctx.SetStringList(fieldTags, entity.Tags)
+}
+
+type taggedThingStore struct {
+	*BaseStore[*taggedThing]
+
+	symbolTags EntitySetSymbol
+	// indexHashTags indexes only entries that start with '#', stripping the prefix.
+	indexHashTags SetReadIndex
+}
+
+// keepHashPrefixOnly is the transform used by indexHashTags. It accepts only
+// string values that start with '#' and have a non-empty suffix, yielding the
+// value with the '#' stripped. The empty-suffix guard matches the constraint
+// that a SetIndex cannot create a sub-bucket with an empty key.
+var keepHashPrefixOnly SetIndexValueTransform = func(ft FieldType, v []byte) (bool, FieldType, []byte) {
+	if ft != TypeString || len(v) < 2 || v[0] != '#' {
+		return false, ft, v
+	}
+	return true, ft, v[1:]
+}
+
+func newTaggedThingStore() *taggedThingStore {
+	storeDef := StoreDefinition[*taggedThing]{
+		EntityType:     entityTypeTaggedThing,
+		EntityStrategy: taggedThingEntityStrategy{},
+		EntityNotFoundF: func(id string) error {
+			return NewNotFoundError(entityTypeTaggedThing, "id", id)
+		},
+		BasePath: []string{"stores"},
+	}
+	store := &taggedThingStore{
+		BaseStore: NewBaseStore(storeDef),
+	}
+	store.InitImpl(store)
+
+	store.AddIdSymbol("id", ast.NodeTypeString)
+	store.symbolTags = store.AddSetSymbol(fieldTags, ast.NodeTypeString)
+	store.indexHashTags = store.AddSetIndexWithTransform(store.symbolTags, keepHashPrefixOnly)
+	return store
+}
+
+type derivedSetIndexTest struct {
+	dbTest
+	store *taggedThingStore
+}
+
+func (t *derivedSetIndexTest) init() {
+	t.dbTest.init()
+	t.store = newTaggedThingStore()
+	err := t.db.Update(func(tx *bbolt.Tx) error {
+		t.store.InitializeIndexes(tx, t)
+		return nil
+	})
+	t.NoError(err)
+}
+
+func (t *derivedSetIndexTest) sortedIds(tx *bbolt.Tx, key string) []string {
+	var out []string
+	t.store.indexHashTags.Read(tx, []byte(key), func(val []byte) {
+		out = append(out, string(val))
+	})
+	sort.Strings(out)
+	return out
+}
+
+func (t *derivedSetIndexTest) keys() []string {
+	var out []string
+	err := t.db.View(func(tx *bbolt.Tx) error {
+		t.store.indexHashTags.ReadKeys(tx, func(val []byte) {
+			out = append(out, string(val))
+		})
+		return nil
+	})
+	t.NoError(err)
+	sort.Strings(out)
+	return out
+}
+
+func (t *derivedSetIndexTest) mutate(fn func(ctx MutateContext) error) {
+	err := t.db.Update(func(tx *bbolt.Tx) error {
+		return fn(NewTxMutateContext(context.Background(), tx))
+	})
+	t.NoError(err)
+}
+
+// TestSetIndexWithTransform_CreateUpdateDelete exercises the transform on the
+// three mutating lifecycle paths and verifies only transformed values land in
+// the index while raw values with the wrong prefix are dropped.
+func TestSetIndexWithTransform_CreateUpdateDelete(t *testing.T) {
+	test := &derivedSetIndexTest{}
+	test.Assertions = require.New(t)
+	test.init()
+	defer test.cleanup()
+
+	e1 := &taggedThing{Id: uuid.New().String(), Tags: []string{"#sales", "@id-123", "#marketing", "#"}}
+	e2 := &taggedThing{Id: uuid.New().String(), Tags: []string{"@id-999", "#sales"}}
+	e3 := &taggedThing{Id: uuid.New().String(), Tags: []string{"@id-777"}}
+
+	test.mutate(func(ctx MutateContext) error {
+		test.NoError(test.store.Create(ctx, e1))
+		test.NoError(test.store.Create(ctx, e2))
+		test.NoError(test.store.Create(ctx, e3))
+		return nil
+	})
+
+	// Only '#'-prefixed entries are indexed, with the '#' stripped. '#' by
+	// itself (empty suffix) and '@'-prefixed entries are dropped.
+	test.Equal([]string{"marketing", "sales"}, test.keys())
+
+	err := test.db.View(func(tx *bbolt.Tx) error {
+		test.Equal(sortStrings([]string{e1.Id, e2.Id}), test.sortedIds(tx, "sales"))
+		test.Equal([]string{e1.Id}, test.sortedIds(tx, "marketing"))
+
+		// transformed index has no "" key since a bare "#" is filtered out
+		test.Nil(test.sortedIds(tx, ""))
+
+		// raw string with the prefix intact isn't in the index
+		test.Nil(test.sortedIds(tx, "#sales"))
+		return nil
+	})
+	test.NoError(err)
+
+	// Update: e1 drops marketing, adds finance; e2 drops sales, adds #devops
+	e1.Tags = []string{"#sales", "@id-123", "#finance"}
+	e2.Tags = []string{"@id-999", "#devops"}
+	test.mutate(func(ctx MutateContext) error {
+		test.NoError(test.store.Update(ctx, e1, nil))
+		test.NoError(test.store.Update(ctx, e2, nil))
+		return nil
+	})
+
+	test.Equal([]string{"devops", "finance", "sales"}, test.keys())
+
+	err = test.db.View(func(tx *bbolt.Tx) error {
+		test.Equal([]string{e1.Id}, test.sortedIds(tx, "sales"))
+		test.Equal([]string{e1.Id}, test.sortedIds(tx, "finance"))
+		test.Equal([]string{e2.Id}, test.sortedIds(tx, "devops"))
+		test.Nil(test.sortedIds(tx, "marketing"))
+		return nil
+	})
+	test.NoError(err)
+
+	// Delete e1; finance and sales should drop out since only e1 referenced them.
+	test.mutate(func(ctx MutateContext) error {
+		test.NoError(test.store.DeleteById(ctx, e1.Id))
+		return nil
+	})
+
+	test.Equal([]string{"devops"}, test.keys())
+}
+
+// TestSetIndexWithTransform_CheckIntegrity_Rebuild verifies CheckIntegrity(fix=true)
+// can populate an empty derived index from scratch, using the transform to compute
+// the correct keys from the entity's raw field values.
+func TestSetIndexWithTransform_CheckIntegrity_Rebuild(t *testing.T) {
+	test := &derivedSetIndexTest{}
+	test.Assertions = require.New(t)
+	test.init()
+	defer test.cleanup()
+
+	e1 := &taggedThing{Id: uuid.New().String(), Tags: []string{"#sales", "@id-1"}}
+	e2 := &taggedThing{Id: uuid.New().String(), Tags: []string{"#sales", "#marketing"}}
+
+	test.mutate(func(ctx MutateContext) error {
+		test.NoError(test.store.Create(ctx, e1))
+		test.NoError(test.store.Create(ctx, e2))
+		return nil
+	})
+
+	// Sanity: healthy index, no integrity errors.
+	test.mutate(func(ctx MutateContext) error {
+		return test.store.CheckIntegrity(ctx, false, func(err error, fixed bool) {
+			t.Fatalf("unexpected integrity error before wipe: %v", err)
+		})
+	})
+
+	// Nuke the index bucket to simulate an upgrade from a DB where the derived
+	// index didn't exist yet.
+	index := test.store.indexHashTags.(*setIndex)
+	test.mutate(func(ctx MutateContext) error {
+		indexBase := Path(ctx.Tx(), index.indexPath...)
+		test.NotNil(indexBase)
+		// Delete every sub-bucket (one per key)
+		cursor := indexBase.Cursor()
+		var keys [][]byte
+		for k, _ := cursor.First(); k != nil; k, _ = cursor.Next() {
+			keys = append(keys, append([]byte{}, k...))
+		}
+		for _, k := range keys {
+			test.NoError(indexBase.DeleteBucket(k))
+		}
+		return nil
+	})
+
+	// No keys present after wipe.
+	test.Empty(test.keys())
+
+	// CheckIntegrity(fix=true) should rebuild the index to match live data.
+	var sawErrs int
+	test.mutate(func(ctx MutateContext) error {
+		return test.store.CheckIntegrity(ctx, true, func(err error, fixed bool) {
+			sawErrs++
+			test.True(fixed)
+		})
+	})
+	test.Greater(sawErrs, 0)
+
+	// Re-verify index contents via transform.
+	test.Equal([]string{"marketing", "sales"}, test.keys())
+	err := test.db.View(func(tx *bbolt.Tx) error {
+		test.Equal(sortStrings([]string{e1.Id, e2.Id}), test.sortedIds(tx, "sales"))
+		test.Equal([]string{e2.Id}, test.sortedIds(tx, "marketing"))
+		return nil
+	})
+	test.NoError(err)
+
+	// A clean integrity run should now be silent.
+	test.mutate(func(ctx MutateContext) error {
+		return test.store.CheckIntegrity(ctx, false, func(err error, fixed bool) {
+			t.Fatalf("unexpected integrity error after rebuild: %v", err)
+		})
+	})
+}
+
+func sortStrings(in []string) []string {
+	out := append([]string(nil), in...)
+	sort.Strings(out)
+	return out
+}

--- a/controller/storage/boltz/indexes.go
+++ b/controller/storage/boltz/indexes.go
@@ -124,6 +124,35 @@ func (indexer *Indexer) AddSetIndex(symbol EntitySetSymbol) SetReadIndex {
 	return index
 }
 
+// SetIndexValueTransform filters and/or rewrites a symbol value as the index is
+// maintained: it is applied on writes (insert/update/delete) and during
+// integrity checks, NOT on reads. Returning include=false causes the value to
+// be skipped entirely.
+//
+// The lookup key is the returned outValue bytes alone: that is what gets stored
+// as the index bucket key, so the lookup methods (Read, OpenValueCursor) take
+// that already-derived value, not the raw symbol value. The returned outType
+// only feeds change-state comparisons and listeners; it does not participate in
+// the physical key, so callers must not rely on it to disambiguate keys that
+// share the same value bytes.
+//
+// Callers use this to index only a subset of a set field (e.g. role-attribute
+// refs in a mixed roles-and-ids list) without persisting a separate derived
+// field on the entity.
+type SetIndexValueTransform func(fieldType FieldType, value []byte) (include bool, outType FieldType, outValue []byte)
+
+// AddSetIndexWithTransform creates a SetIndex whose keys are derived from the
+// symbol's values via transform. See SetIndexValueTransform.
+func (indexer *Indexer) AddSetIndexWithTransform(symbol EntitySetSymbol, transform SetIndexValueTransform) SetReadIndex {
+	index := &setIndex{
+		symbol:    symbol,
+		indexPath: indexer.getIndexPath(symbol),
+		transform: transform,
+	}
+	indexer.constraints = append(indexer.constraints, index)
+	return index
+}
+
 func (indexer *Indexer) AddFkIndex(symbol EntitySymbol, fkSymbol EntitySetSymbol) {
 	indexer.addFkIndex(symbol, fkSymbol, false)
 }
@@ -432,6 +461,16 @@ type setIndex struct {
 	symbol    EntitySetSymbol
 	indexPath []string
 	listeners []SetChangeListener
+	transform SetIndexValueTransform
+}
+
+// applyTransform runs the index's value transform, if configured. When no
+// transform is set the value passes through unchanged and is always included.
+func (index *setIndex) applyTransform(fieldType FieldType, value []byte) (bool, FieldType, []byte) {
+	if index.transform == nil {
+		return true, fieldType, value
+	}
+	return index.transform(fieldType, value)
 }
 
 func (index *setIndex) Label() string {
@@ -503,7 +542,9 @@ func (index *setIndex) visitCurrent(ctx *IndexingContext, f func(fieldType Field
 	cursor := rtSymbol.OpenCursor(ctx.Tx(), ctx.RowId)
 	for cursor.IsValid() {
 		fieldType, value := rtSymbol.Eval(ctx.Tx(), ctx.RowId)
-		f(fieldType, value)
+		if include, outType, outValue := index.applyTransform(fieldType, value); include {
+			f(outType, outValue)
+		}
 		cursor.Next()
 	}
 }
@@ -629,8 +670,8 @@ func (index *setIndex) CheckIntegrity(ctx MutateContext, fix bool, errorSink fun
 						rtSymbol := index.symbol.GetRuntimeSymbol()
 						found := false
 						for setCursor := rtSymbol.OpenCursor(tx, id); setCursor.IsValid(); setCursor.Next() {
-							_, value := rtSymbol.Eval(tx, id)
-							if bytes.Equal(value, key) {
+							fieldType, value := rtSymbol.Eval(tx, id)
+							if include, _, transformed := index.applyTransform(fieldType, value); include && bytes.Equal(transformed, key) {
 								found = true
 								break
 							}
@@ -681,8 +722,12 @@ func (index *setIndex) CheckIntegrity(ctx MutateContext, fix bool, errorSink fun
 		}
 		valuesCursor := setBucket.Cursor()
 		for val, _ := valuesCursor.First(); val != nil; val, _ = valuesCursor.Next() {
-			_, value := GetTypeAndValue(val)
-			idxBucket := index.getIndexBucket(tx, value)
+			fieldType, value := GetTypeAndValue(val)
+			include, _, transformed := index.applyTransform(fieldType, value)
+			if !include {
+				continue
+			}
+			idxBucket := index.getIndexBucket(tx, transformed)
 			key := PrependFieldType(TypeString, id)
 			if !idxBucket.IsKeyPresent(key) {
 				if fix {
@@ -691,7 +736,7 @@ func (index *setIndex) CheckIntegrity(ctx MutateContext, fix bool, errorSink fun
 					}
 				}
 				errorSink(errors.Errorf("for index on %v.%v, id %v has val %v, but is not in the index",
-					index.symbol.GetStore().GetEntityType(), index.GetSymbol().GetName(), string(id), string(value)), fix)
+					index.symbol.GetStore().GetEntityType(), index.GetSymbol().GetName(), string(id), string(transformed)), fix)
 			}
 		}
 	}

--- a/tests/role_attribute_usage_test.go
+++ b/tests/role_attribute_usage_test.go
@@ -1,0 +1,387 @@
+//go:build apitests
+
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package tests
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+	"testing"
+
+	"github.com/openziti/edge-api/rest_management_api_client/role_attributes"
+	"github.com/openziti/edge-api/rest_model"
+	"github.com/openziti/foundation/v2/util"
+	"github.com/openziti/ziti/v2/common/eid"
+)
+
+// usageFilter returns a filter restricting role-attribute usage results to
+// attributes carrying the given unique test prefix, sorted by id so result
+// order is deterministic.
+func usageFilter(prefix string) *string {
+	return util.Ptr(fmt.Sprintf(`id contains "%s" sort by id`, prefix))
+}
+
+// usageByAttr returns the usage detail for the given role attribute, or nil
+// if the list doesn't contain it.
+func usageByAttr(items rest_model.RoleAttributeUsageList, attr string) *rest_model.RoleAttributeUsageDetail {
+	for _, item := range items {
+		if item.RoleAttribute != nil && *item.RoleAttribute == attr {
+			return item
+		}
+	}
+	return nil
+}
+
+// usageFor returns the usage entry for one source on a detail, failing the
+// test with a diagnostic if the detail, source entry, or required count is
+// missing, so callers can dereference Count without nil checks.
+func (ctx *TestContext) usageFor(detail *rest_model.RoleAttributeUsageDetail, source string) rest_model.RoleAttributeSourceUsage {
+	ctx.T().Helper()
+	ctx.Req.NotNil(detail, "expected a usage detail for source %s", source)
+	entry, ok := detail.Usage[source]
+	ctx.Req.True(ok, "usage map should contain source %s", source)
+	ctx.Req.NotNil(entry.Count, "count is required on source %s", source)
+	return entry
+}
+
+// sortedIds returns a sorted copy of ids so assertions don't depend on
+// server-side ordering.
+func sortedIds(ids []string) []string {
+	result := append([]string(nil), ids...)
+	sort.Strings(result)
+	return result
+}
+
+func Test_RoleAttributeUsageEndpoints(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+	ctx.RequireAdminManagementApiLogin()
+
+	mgmtClient := ctx.NewEdgeManagementApi(nil)
+	adminCreds := ctx.NewAdminCredentials()
+	_, err := mgmtClient.Authenticate(adminCreds, nil)
+	ctx.Req.NoError(err)
+
+	t.Run("identity role-attribute usage", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		prefix := "idrau-" + eid.New() + "-"
+		attrBoth := prefix + "both"
+		attrIdentityOnly := prefix + "id-only"
+		attrSpOnly := prefix + "sp-only"
+		attrErpOnly := prefix + "erp-only"
+
+		// Identities
+		idBoth := ctx.AdminManagementSession.requireNewIdentity(false, attrBoth)
+		idSolo := ctx.AdminManagementSession.requireNewIdentity(false, attrIdentityOnly)
+
+		// Service policies referencing identity role attributes
+		sp1 := ctx.AdminManagementSession.requireNewServicePolicy(
+			"Dial",
+			s("#all"),
+			s("#"+attrBoth, "#"+attrSpOnly),
+			s(),
+		)
+		sp2 := ctx.AdminManagementSession.requireNewServicePolicy(
+			"Bind",
+			s("#all"),
+			s("#"+attrSpOnly),
+			s(),
+		)
+
+		// Edge-router policy referencing identity role attributes
+		erp := ctx.AdminManagementSession.requireNewEdgeRouterPolicy(
+			s("#all"),
+			s("#"+attrBoth, "#"+attrErpOnly),
+		)
+
+		t.Run("default (no withIds) returns all four attributes with accurate counts", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			resp, err := mgmtClient.API.RoleAttributes.ListIdentityRoleAttributeUsage(&role_attributes.ListIdentityRoleAttributeUsageParams{
+				Filter: usageFilter(prefix),
+			}, nil)
+			ctx.Req.NoError(err)
+			ctx.Req.NotNil(resp.Payload.Meta, "list responses must carry a meta section")
+
+			items := resp.Payload.Data
+			ctx.Req.Len(items, 4)
+
+			// items are sorted by roleAttribute ascending due to our filter's sort clause
+			expectedOrder := []string{attrBoth, attrErpOnly, attrIdentityOnly, attrSpOnly}
+			sort.Strings(expectedOrder)
+			for i, want := range expectedOrder {
+				ctx.Req.Equal(want, *items[i].RoleAttribute, "at index %d", i)
+			}
+
+			both := usageByAttr(items, attrBoth)
+			ctx.Req.EqualValues(1, *ctx.usageFor(both, "identities").Count)
+			ctx.Req.Nil(ctx.usageFor(both, "identities").Ids, "ids should be null when withIds is unset")
+			ctx.Req.EqualValues(1, *ctx.usageFor(both, "servicePolicies").Count)
+			ctx.Req.EqualValues(1, *ctx.usageFor(both, "edgeRouterPolicies").Count)
+
+			solo := usageByAttr(items, attrIdentityOnly)
+			ctx.Req.EqualValues(1, *ctx.usageFor(solo, "identities").Count)
+			ctx.Req.EqualValues(0, *ctx.usageFor(solo, "servicePolicies").Count)
+			ctx.Req.EqualValues(0, *ctx.usageFor(solo, "edgeRouterPolicies").Count)
+
+			spOnly := usageByAttr(items, attrSpOnly)
+			ctx.Req.EqualValues(0, *ctx.usageFor(spOnly, "identities").Count)
+			ctx.Req.EqualValues(2, *ctx.usageFor(spOnly, "servicePolicies").Count)
+			ctx.Req.EqualValues(0, *ctx.usageFor(spOnly, "edgeRouterPolicies").Count)
+
+			erpOnly := usageByAttr(items, attrErpOnly)
+			ctx.Req.EqualValues(0, *ctx.usageFor(erpOnly, "identities").Count)
+			ctx.Req.EqualValues(0, *ctx.usageFor(erpOnly, "servicePolicies").Count)
+			ctx.Req.EqualValues(1, *ctx.usageFor(erpOnly, "edgeRouterPolicies").Count)
+		})
+
+		t.Run("withIds=true populates entity id arrays", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			resp, err := mgmtClient.API.RoleAttributes.ListIdentityRoleAttributeUsage(&role_attributes.ListIdentityRoleAttributeUsageParams{
+				Filter:  usageFilter(prefix),
+				WithIds: util.Ptr(true),
+			}, nil)
+			ctx.Req.NoError(err)
+
+			items := resp.Payload.Data
+			ctx.Req.Len(items, 4)
+
+			both := usageByAttr(items, attrBoth)
+			ctx.Req.Equal([]string{idBoth.Id}, ctx.usageFor(both, "identities").Ids)
+			ctx.Req.Equal([]string{sp1.id}, ctx.usageFor(both, "servicePolicies").Ids)
+			ctx.Req.Equal([]string{erp.id}, ctx.usageFor(both, "edgeRouterPolicies").Ids)
+
+			solo := usageByAttr(items, attrIdentityOnly)
+			ctx.Req.Equal([]string{idSolo.Id}, ctx.usageFor(solo, "identities").Ids)
+			// When withIds=true, policy sources with count=0 must still emit an
+			// empty (but present) ids array so callers can distinguish
+			// "not requested" (null -> nil) from "requested, no matches" ([]).
+			soloSp := ctx.usageFor(solo, "servicePolicies")
+			ctx.Req.NotNil(soloSp.Ids, "ids should be [] (present) when withIds=true and count=0")
+			ctx.Req.Empty(soloSp.Ids)
+			ctx.Req.EqualValues(0, *soloSp.Count)
+
+			spOnly := usageByAttr(items, attrSpOnly)
+			expectedSp := sortedIds([]string{sp1.id, sp2.id})
+			ctx.Req.Equal(expectedSp, sortedIds(ctx.usageFor(spOnly, "servicePolicies").Ids))
+		})
+
+		t.Run("filter narrows result set", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			filter := fmt.Sprintf(`id contains "%s" and (id contains "both" or id contains "sp-only") sort by id`, prefix)
+			resp, err := mgmtClient.API.RoleAttributes.ListIdentityRoleAttributeUsage(&role_attributes.ListIdentityRoleAttributeUsageParams{
+				Filter: util.Ptr(filter),
+			}, nil)
+			ctx.Req.NoError(err)
+
+			items := resp.Payload.Data
+			ctx.Req.Len(items, 2)
+			ctx.Req.Equal(attrBoth, *items[0].RoleAttribute)
+			ctx.Req.Equal(attrSpOnly, *items[1].RoleAttribute)
+		})
+
+		t.Run("limit and skip apply over the sorted attribute set", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			filter := fmt.Sprintf(`id contains "%s" sort by id skip 1 limit 2`, prefix)
+			resp, err := mgmtClient.API.RoleAttributes.ListIdentityRoleAttributeUsage(&role_attributes.ListIdentityRoleAttributeUsageParams{
+				Filter: util.Ptr(filter),
+			}, nil)
+			ctx.Req.NoError(err)
+
+			items := resp.Payload.Data
+			ctx.Req.Len(items, 2)
+
+			all := []string{attrBoth, attrErpOnly, attrIdentityOnly, attrSpOnly}
+			sort.Strings(all)
+			ctx.Req.Equal(all[1], *items[0].RoleAttribute)
+			ctx.Req.Equal(all[2], *items[1].RoleAttribute)
+		})
+	})
+
+	t.Run("edge router role-attribute usage", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		prefix := "errau-" + eid.New() + "-"
+		attrBoth := prefix + "both"
+		attrRouterOnly := prefix + "er-only"
+		attrErpOnly := prefix + "erp-only"
+		attrSerpOnly := prefix + "serp-only"
+
+		er := ctx.AdminManagementSession.requireNewEdgeRouter(attrBoth)
+		erSolo := ctx.AdminManagementSession.requireNewEdgeRouter(attrRouterOnly)
+
+		erp := ctx.AdminManagementSession.requireNewEdgeRouterPolicy(
+			s("#"+attrBoth, "#"+attrErpOnly),
+			s("#all"),
+		)
+		serp := ctx.AdminManagementSession.requireNewServiceEdgeRouterPolicy(
+			s("#"+attrSerpOnly),
+			s("#all"),
+		)
+
+		resp, err := mgmtClient.API.RoleAttributes.ListEdgeRouterRoleAttributeUsage(&role_attributes.ListEdgeRouterRoleAttributeUsageParams{
+			Filter:  usageFilter(prefix),
+			WithIds: util.Ptr(true),
+		}, nil)
+		ctx.Req.NoError(err)
+
+		items := resp.Payload.Data
+		ctx.Req.Len(items, 4)
+
+		both := usageByAttr(items, attrBoth)
+		ctx.Req.Equal([]string{er.id}, ctx.usageFor(both, "edgeRouters").Ids)
+		ctx.Req.Equal([]string{erp.id}, ctx.usageFor(both, "edgeRouterPolicies").Ids)
+		ctx.Req.EqualValues(0, *ctx.usageFor(both, "serviceEdgeRouterPolicies").Count)
+
+		erOnly := usageByAttr(items, attrRouterOnly)
+		ctx.Req.Equal([]string{erSolo.id}, ctx.usageFor(erOnly, "edgeRouters").Ids)
+		ctx.Req.EqualValues(0, *ctx.usageFor(erOnly, "edgeRouterPolicies").Count)
+		ctx.Req.EqualValues(0, *ctx.usageFor(erOnly, "serviceEdgeRouterPolicies").Count)
+
+		erpOnly := usageByAttr(items, attrErpOnly)
+		ctx.Req.EqualValues(0, *ctx.usageFor(erpOnly, "edgeRouters").Count)
+		ctx.Req.Equal([]string{erp.id}, ctx.usageFor(erpOnly, "edgeRouterPolicies").Ids)
+
+		serpOnly := usageByAttr(items, attrSerpOnly)
+		ctx.Req.Equal([]string{serp.id}, ctx.usageFor(serpOnly, "serviceEdgeRouterPolicies").Ids)
+	})
+
+	t.Run("service role-attribute usage", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		prefix := "srau-" + eid.New() + "-"
+		attrBoth := prefix + "both"
+		attrSvcOnly := prefix + "svc-only"
+		attrSpOnly := prefix + "sp-only"
+		attrSerpOnly := prefix + "serp-only"
+
+		svc := ctx.AdminManagementSession.requireNewService(s(attrBoth), nil)
+		svcSolo := ctx.AdminManagementSession.requireNewService(s(attrSvcOnly), nil)
+
+		sp := ctx.AdminManagementSession.requireNewServicePolicy(
+			"Dial",
+			s("#"+attrBoth, "#"+attrSpOnly),
+			s("#all"),
+			s(),
+		)
+		serp := ctx.AdminManagementSession.requireNewServiceEdgeRouterPolicy(
+			s("#all"),
+			s("#"+attrSerpOnly),
+		)
+
+		resp, err := mgmtClient.API.RoleAttributes.ListServiceRoleAttributeUsage(&role_attributes.ListServiceRoleAttributeUsageParams{
+			Filter:  usageFilter(prefix),
+			WithIds: util.Ptr(true),
+		}, nil)
+		ctx.Req.NoError(err)
+
+		items := resp.Payload.Data
+		ctx.Req.Len(items, 4)
+
+		both := usageByAttr(items, attrBoth)
+		ctx.Req.Equal([]string{svc.Id}, ctx.usageFor(both, "services").Ids)
+		ctx.Req.Equal([]string{sp.id}, ctx.usageFor(both, "servicePolicies").Ids)
+		ctx.Req.EqualValues(0, *ctx.usageFor(both, "serviceEdgeRouterPolicies").Count)
+
+		svcOnly := usageByAttr(items, attrSvcOnly)
+		ctx.Req.Equal([]string{svcSolo.Id}, ctx.usageFor(svcOnly, "services").Ids)
+
+		serpOnly := usageByAttr(items, attrSerpOnly)
+		ctx.Req.Equal([]string{serp.id}, ctx.usageFor(serpOnly, "serviceEdgeRouterPolicies").Ids)
+	})
+
+	t.Run("posture check role-attribute usage", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		prefix := "pcrau-" + eid.New() + "-"
+		attrBoth := prefix + "both"
+		attrPostureOnly := prefix + "pc-only"
+		attrSpOnly := prefix + "sp-only"
+
+		pc := ctx.AdminManagementSession.requireNewPostureCheckDomain(s("example.com"), s(attrBoth))
+		pcSolo := ctx.AdminManagementSession.requireNewPostureCheckDomain(s("example.org"), s(attrPostureOnly))
+
+		sp := ctx.AdminManagementSession.requireNewServicePolicy(
+			"Dial",
+			s("#all"),
+			s("#all"),
+			s("#"+attrBoth, "#"+attrSpOnly),
+		)
+
+		resp, err := mgmtClient.API.RoleAttributes.ListPostureCheckRoleAttributeUsage(&role_attributes.ListPostureCheckRoleAttributeUsageParams{
+			Filter:  usageFilter(prefix),
+			WithIds: util.Ptr(true),
+		}, nil)
+		ctx.Req.NoError(err)
+
+		items := resp.Payload.Data
+		ctx.Req.Len(items, 3)
+
+		both := usageByAttr(items, attrBoth)
+		ctx.Req.Equal([]string{pc.id}, ctx.usageFor(both, "postureChecks").Ids)
+		ctx.Req.Equal([]string{sp.id}, ctx.usageFor(both, "servicePolicies").Ids)
+
+		pcOnly := usageByAttr(items, attrPostureOnly)
+		ctx.Req.Equal([]string{pcSolo.id}, ctx.usageFor(pcOnly, "postureChecks").Ids)
+		ctx.Req.EqualValues(0, *ctx.usageFor(pcOnly, "servicePolicies").Count)
+
+		spOnly := usageByAttr(items, attrSpOnly)
+		ctx.Req.EqualValues(0, *ctx.usageFor(spOnly, "postureChecks").Count)
+		ctx.Req.Equal([]string{sp.id}, ctx.usageFor(spOnly, "servicePolicies").Ids)
+	})
+
+	t.Run("usage endpoints require the same management auth as the sibling list endpoints", func(t *testing.T) {
+		ctx.testContextChanged(t)
+		// withIds returns cross-entity policy ids, which could tempt a future
+		// change toward per-source authorization. The intended behavior is that
+		// usage endpoints carry exactly the same management read permission as
+		// the existing *-role-attributes list endpoints. Lock that by proving an
+		// unauthenticated request is rejected identically on both, including the
+		// withIds variant. If the permission model ever diverges, this fails.
+		// Raw HTTP is deliberate here: status codes for anonymous requests are
+		// the point.
+		pairs := []struct {
+			usage string
+			list  string
+		}{
+			{"identity-role-attribute-usage", "identity-role-attributes"},
+			{"edge-router-role-attribute-usage", "edge-router-role-attributes"},
+			{"service-role-attribute-usage", "service-role-attributes"},
+			{"posture-check-role-attribute-usage", "posture-check-role-attributes"},
+		}
+
+		for _, p := range pairs {
+			listResp, err := ctx.newAnonymousManagementApiRequest().Get(p.list)
+			ctx.Req.NoError(err)
+			ctx.Req.Equal(http.StatusUnauthorized, listResp.StatusCode(),
+				"baseline: unauthenticated %s should be rejected", p.list)
+
+			usageResp, err := ctx.newAnonymousManagementApiRequest().Get(p.usage)
+			ctx.Req.NoError(err)
+			ctx.Req.Equal(listResp.StatusCode(), usageResp.StatusCode(),
+				"%s must require the same auth as %s", p.usage, p.list)
+
+			usageIdsResp, err := ctx.newAnonymousManagementApiRequest().Get(p.usage + "?withIds=true")
+			ctx.Req.NoError(err)
+			ctx.Req.Equal(listResp.StatusCode(), usageIdsResp.StatusCode(),
+				"%s?withIds=true must require the same auth as %s; withIds does not relax authorization", p.usage, p.list)
+		}
+	})
+}


### PR DESCRIPTION
- adds management API endpoints listing role-attribute usage for identities, edge routers, services, and posture checks, reporting per-source counts (and optionally ids via withIds) across home-entity collections and the policies that reference each attribute
- adds RoleAttributeUsage model with QueryRoleAttributeUsage, mapping each RoleAttributeKind to its contributing sources, with all reads in a single transaction so counts stay consistent with the attribute list; returns an empty result (not a panic) for kinds with no attributes
- adds boltz.SetIndexValueTransform and AddSetIndexWithTransform, letting a SetIndex filter and rewrite symbol values without persisting a derived field
- adds derived role-attribute set indexes to the service policy, edge router policy, and service edge router policy stores, built from existing role fields via a role-attribute-only transform that excludes the #all wildcard
- adds v45 migration that backfills the new indexes via each index's own CheckIntegrity(fix=true), scoped to the role-attribute indexes only, with a per-index summary log
- bumps edge-api to v0.31.0 for the new API operations