### PR TITLE
Revalidate dial circuits and bind terminators on posture changes

### DIFF
--- a/router/state/manager.go
+++ b/router/state/manager.go
@@ -73,13 +73,15 @@ type ConnState struct {
 	PolicyType          edge_ctrl_pb.PolicyType
 }
 
-// DialCircuit is the minimal view of an active dial circuit needed to
-// re-evaluate access (e.g. on a posture change) and revoke it. It is
-// satisfied by both connId mux-sink dial conns and SDK-hosted xgress circuits.
-type DialCircuit interface {
+// EdgeCircuit is the minimal view of an active circuit (dialing or serving)
+// needed to re-evaluate access (e.g. on a posture change) and revoke it. It is
+// satisfied by both connId mux-sink conns and SDK-hosted xgress circuits;
+// IsHostSide distinguishes the dialing side from the hosting (terminator) side.
+type EdgeCircuit interface {
 	GetCircuitId() string
 	GetServiceId() string
-	CloseForDialAccessLoss()
+	IsHostSide() bool
+	CloseForAccessLoss(reason string)
 }
 
 // BindTerminator is the minimal view of an active hosted terminator needed to
@@ -96,9 +98,10 @@ type ConnProvider interface {
 	GetConnIdToSinks() map[uint32]edge.MsgSink[*ConnState]
 	CloseConn(connId uint32, reason string) error
 
-	// IterateDialCircuits invokes f for every active dial circuit on this
-	// connection — both connId mux-sink conns and SDK-hosted xgress circuits.
-	IterateDialCircuits(f func(DialCircuit))
+	// IterateEdgeCircuits invokes f for every active circuit on this connection
+	// (dialing and serving) — both connId mux-sink conns and SDK-hosted xgress
+	// circuits.
+	IterateEdgeCircuits(f func(EdgeCircuit))
 
 	// IterateBindTerminators invokes f for every hosted terminator on this
 	// connection.
@@ -408,10 +411,15 @@ func (self *ManagerImpl) onPostureDataUpdate(data *posture.InstanceData) {
 
 		// Re-evaluate dial access (policy + posture) for every active dial
 		// circuit — both connId mux-sink conns and SDK-hosted xgress circuits.
-		// Collect first, then close: CloseForDialAccessLoss mutates the circuit
+		// Collect first, then close: CloseForAccessLoss mutates the circuit
 		// maps being iterated (mirrors handleDialAccessLost).
-		var dialToClose []DialCircuit
-		edgeConn.IterateDialCircuits(func(c DialCircuit) {
+		var dialToClose []EdgeCircuit
+		edgeConn.IterateEdgeCircuits(func(c EdgeCircuit) {
+			// Serving-side circuits are governed by bind access, handled via the
+			// terminator re-evaluation below; only dial circuits are checked here.
+			if c.IsHostSide() {
+				return
+			}
 			policy, err := posture.HasAccess(rdm, identityId, c.GetServiceId(), data, edge_ctrl_pb.PolicyType_DialPolicy)
 			if err != nil || policy == nil {
 				// every HasAccess error is a definitive denial (entity removed,
@@ -426,7 +434,7 @@ func (self *ManagerImpl) onPostureDataUpdate(data *posture.InstanceData) {
 			}
 		})
 		for _, c := range dialToClose {
-			c.CloseForDialAccessLoss()
+			c.CloseForAccessLoss("dial access lost on posture update")
 		}
 
 		// Re-evaluate bind access (policy + posture) for every hosted terminator

--- a/router/state/manager.go
+++ b/router/state/manager.go
@@ -77,16 +77,16 @@ type ConnState struct {
 // re-evaluate access (e.g. on a posture change) and revoke it. It is
 // satisfied by both connId mux-sink dial conns and SDK-hosted xgress circuits.
 type DialCircuit interface {
+	GetCircuitId() string
 	GetServiceId() string
-	GetApiSessionToken() *ApiSessionToken
 	CloseForDialAccessLoss()
 }
 
 // BindTerminator is the minimal view of an active hosted terminator needed to
 // re-evaluate bind access (e.g. on a posture change) and revoke it.
 type BindTerminator interface {
+	GetTerminatorId() string
 	GetServiceId() string
-	GetApiSessionToken() *ApiSessionToken
 	CloseForBindAccessLoss()
 }
 
@@ -413,11 +413,15 @@ func (self *ManagerImpl) onPostureDataUpdate(data *posture.InstanceData) {
 		var dialToClose []DialCircuit
 		edgeConn.IterateDialCircuits(func(c DialCircuit) {
 			policy, err := posture.HasAccess(rdm, identityId, c.GetServiceId(), data, edge_ctrl_pb.PolicyType_DialPolicy)
-			if err != nil {
-				pfxlog.Logger().WithError(err).WithField("serviceId", c.GetServiceId()).
-					Error("could not determine dial access on posture update; revoking")
-			}
 			if err != nil || policy == nil {
+				// every HasAccess error is a definitive denial (entity removed,
+				// no granting policies, or failed posture checks), so log it as
+				// the revocation reason rather than as a failure
+				pfxlog.Logger().WithError(err).
+					WithField("identityId", identityId).
+					WithField("serviceId", c.GetServiceId()).
+					WithField("circuitId", c.GetCircuitId()).
+					Info("dial access lost on posture update, closing circuit")
 				dialToClose = append(dialToClose, c)
 			}
 		})
@@ -432,11 +436,12 @@ func (self *ManagerImpl) onPostureDataUpdate(data *posture.InstanceData) {
 		var bindToClose []BindTerminator
 		edgeConn.IterateBindTerminators(func(t BindTerminator) {
 			policy, err := posture.HasAccess(rdm, identityId, t.GetServiceId(), data, edge_ctrl_pb.PolicyType_BindPolicy)
-			if err != nil {
-				pfxlog.Logger().WithError(err).WithField("serviceId", t.GetServiceId()).
-					Error("could not determine bind access on posture update; revoking")
-			}
 			if err != nil || policy == nil {
+				pfxlog.Logger().WithError(err).
+					WithField("identityId", identityId).
+					WithField("serviceId", t.GetServiceId()).
+					WithField("terminatorId", t.GetTerminatorId()).
+					Info("bind access lost on posture update, closing terminator")
 				bindToClose = append(bindToClose, t)
 			}
 		})

--- a/router/state/manager.go
+++ b/router/state/manager.go
@@ -73,11 +73,36 @@ type ConnState struct {
 	PolicyType          edge_ctrl_pb.PolicyType
 }
 
+// DialCircuit is the minimal view of an active dial circuit needed to
+// re-evaluate access (e.g. on a posture change) and revoke it. It is
+// satisfied by both connId mux-sink dial conns and SDK-hosted xgress circuits.
+type DialCircuit interface {
+	GetServiceId() string
+	GetApiSessionToken() *ApiSessionToken
+	CloseForDialAccessLoss()
+}
+
+// BindTerminator is the minimal view of an active hosted terminator needed to
+// re-evaluate bind access (e.g. on a posture change) and revoke it.
+type BindTerminator interface {
+	GetServiceId() string
+	GetApiSessionToken() *ApiSessionToken
+	CloseForBindAccessLoss()
+}
+
 // ConnProvider is an interface used to abstract specific conn implementations from lower level packages
 // (such as xgress_edge) to avoid circular dependencies.
 type ConnProvider interface {
 	GetConnIdToSinks() map[uint32]edge.MsgSink[*ConnState]
 	CloseConn(connId uint32, reason string) error
+
+	// IterateDialCircuits invokes f for every active dial circuit on this
+	// connection — both connId mux-sink conns and SDK-hosted xgress circuits.
+	IterateDialCircuits(f func(DialCircuit))
+
+	// IterateBindTerminators invokes f for every hosted terminator on this
+	// connection.
+	IterateBindTerminators(f func(BindTerminator))
 }
 
 // ApiSessionTokenProvider abstracts access to API session tokens, enabling
@@ -363,27 +388,60 @@ func (self *ManagerImpl) onPostureDataUpdate(data *posture.InstanceData) {
 	channels := self.connectionTracker.GetChannelsByIdentityId(data.IdentityId)
 
 	for _, ch := range channels {
-		edgeConn, connIdToSink := GetConnProviderAndSinksFromCh(ch)
+		// Posture data is per-api-session. An identity may have several concurrent
+		// api-sessions (e.g. multiple devices), and GetChannelsByIdentityId returns
+		// all of them — but only the session whose posture changed should be
+		// re-evaluated, since a posture failure on one device must not revoke
+		// another's circuits. Every circuit and terminator on a channel shares the
+		// channel's api-session, so make this check once per channel.
+		apiSessionToken := GetApiSessionTokenFromCh(ch)
+		if apiSessionToken == nil || apiSessionToken.Id != data.ApiSessionId {
+			continue
+		}
 
-		for connId, sink := range connIdToSink {
-			connState := sink.GetData()
+		edgeConn, _ := GetConnProviderAndSinksFromCh(ch)
+		if edgeConn == nil {
+			continue
+		}
 
-			if connState.ApiSessionToken == nil || connState.ApiSessionToken.Id != data.ApiSessionId {
-				continue
-			}
+		identityId := apiSessionToken.IdentityId
 
-			policy, err := posture.HasAccess(rdm, connState.ApiSessionToken.IdentityId, connState.ServiceSessionToken.ServiceId, data, connState.PolicyType)
-
-			var closeErr error
+		// Re-evaluate dial access (policy + posture) for every active dial
+		// circuit — both connId mux-sink conns and SDK-hosted xgress circuits.
+		// Collect first, then close: CloseForDialAccessLoss mutates the circuit
+		// maps being iterated (mirrors handleDialAccessLost).
+		var dialToClose []DialCircuit
+		edgeConn.IterateDialCircuits(func(c DialCircuit) {
+			policy, err := posture.HasAccess(rdm, identityId, c.GetServiceId(), data, edge_ctrl_pb.PolicyType_DialPolicy)
 			if err != nil {
-				closeErr = edgeConn.CloseConn(connId, fmt.Sprintf("could not determine access, encountered error: %s", err))
-			} else if policy == nil {
-				closeErr = edgeConn.CloseConn(connId, "access revoked, not granting policies found")
+				pfxlog.Logger().WithError(err).WithField("serviceId", c.GetServiceId()).
+					Error("could not determine dial access on posture update; revoking")
 			}
+			if err != nil || policy == nil {
+				dialToClose = append(dialToClose, c)
+			}
+		})
+		for _, c := range dialToClose {
+			c.CloseForDialAccessLoss()
+		}
 
-			if closeErr != nil {
-				pfxlog.Logger().WithError(err).Error("error closing connection during access check")
+		// Re-evaluate bind access (policy + posture) for every hosted terminator
+		// on this connection. A posture change that fails a BindPolicy's posture
+		// requirements must revoke the host's terminators, same as a policy
+		// change does via handleBindAccessLost.
+		var bindToClose []BindTerminator
+		edgeConn.IterateBindTerminators(func(t BindTerminator) {
+			policy, err := posture.HasAccess(rdm, identityId, t.GetServiceId(), data, edge_ctrl_pb.PolicyType_BindPolicy)
+			if err != nil {
+				pfxlog.Logger().WithError(err).WithField("serviceId", t.GetServiceId()).
+					Error("could not determine bind access on posture update; revoking")
 			}
+			if err != nil || policy == nil {
+				bindToClose = append(bindToClose, t)
+			}
+		})
+		for _, t := range bindToClose {
+			t.CloseForBindAccessLoss()
 		}
 	}
 }

--- a/router/xgress_edge/connections.go
+++ b/router/xgress_edge/connections.go
@@ -257,7 +257,7 @@ func (self *connectionTracker) scanForCircuitsNeedingPolicyCheck() {
 				WithField("identityId", identityId).
 				WithField("circuitType", reflect.TypeOf(circuit).String())
 			log.WithError(err).Info("unable to verify service access, closing circuit")
-			circuit.CloseForDialAccessLoss()
+			circuit.CloseForAccessLoss("dial access lost")
 		} else {
 			circuit.SetPostCreateAccessCheckDone()
 		}

--- a/router/xgress_edge/fabric.go
+++ b/router/xgress_edge/fabric.go
@@ -67,7 +67,7 @@ type edgeTerminator struct {
 	lastAttempt         time.Time
 	lock                sync.Mutex
 	rateLimitCallback   rate.RateLimitControl
-	failureCount atomic.Uint32
+	failureCount        atomic.Uint32
 }
 
 func (self *edgeTerminator) getIdentityId() string {
@@ -224,6 +224,17 @@ func (self *edgeTerminator) newConnection(connId uint32) (*edgeXgressConn, error
 		seq:        NewMsgQueue(4),
 	}
 
+	// Stamp the host-side conn with its service and api-session so access
+	// re-evaluation can identify it (serving originator + service id) and revoke
+	// it on bind-access loss. Unlike SetData, this does not mark the conn as a
+	// circuit initiator, so post-create dial access checks still skip it. This
+	// must happen before mux.Add makes the conn iterable, so a concurrent access
+	// re-evaluation never sees a host-side conn that looks like a dial circuit.
+	result.setHostSideData(&state.ConnState{
+		ServiceSessionToken: self.serviceSessionToken,
+		ApiSessionToken:     self.edgeClientConn.apiSessionToken,
+	})
+
 	if err := mux.Add(result); err != nil {
 		return nil, err
 	}
@@ -249,6 +260,7 @@ const (
 	FlagClosed                  = 0
 	FlagPostCreateAccessChecked = 1
 	FlagIsCircuitInitiator      = 2
+	FlagIsHostSide              = 3
 
 	FlagPostCreateAccessCheckedMask = 1 << FlagPostCreateAccessChecked
 	FlagIsCircuitInitiatorMask      = 1 << FlagIsCircuitInitiator
@@ -289,12 +301,29 @@ func (self *edgeXgressConn) GetData() *state.ConnState {
 	return self.data.Load()
 }
 
-func (self *edgeXgressConn) CloseForDialAccessLoss() {
-	self.close(true, "dial access lost")
+func (self *edgeXgressConn) CloseForAccessLoss(reason string) {
+	self.close(true, reason)
+}
+
+// IsHostSide reports whether this conn is the hosting (terminator) side of a
+// circuit, as opposed to the dialing (initiator) side. It is flag-based rather
+// than derived from the xgress so it's valid as soon as the conn is iterable
+// via the mux, before the xgress is attached.
+func (self *edgeXgressConn) IsHostSide() bool {
+	return self.flags.IsSet(FlagIsHostSide)
 }
 
 func (self *edgeXgressConn) SetData(data *state.ConnState) {
 	self.flags.Set(FlagIsCircuitInitiator, true)
+	self.data.Store(data)
+}
+
+// setHostSideData marks the conn as host-side and stores the serving-side
+// ConnState (service and api-session) without marking the conn as a circuit
+// initiator, so post-create dial access checks correctly skip it while access
+// re-evaluation can still resolve its service id.
+func (self *edgeXgressConn) setHostSideData(data *state.ConnState) {
+	self.flags.Set(FlagIsHostSide, true)
 	self.data.Store(data)
 }
 
@@ -341,7 +370,7 @@ func (self *edgeXgressConn) HandleControlMsg(controlType xgress.ControlType, hea
 		hop, _ := headers.GetUint32Header(xgress.ControlHopCount)
 		if hop == 1 {
 			// TODO: find a way to get terminator id for hopId
-			xgress.RespondToTraceRequest(channel.Headers(headers), "xgress/edge", "", responder)
+			xgress.RespondToTraceRequest(headers, "xgress/edge", "", responder)
 			return nil
 		}
 

--- a/router/xgress_edge/hosted.go
+++ b/router/xgress_edge/hosted.go
@@ -1007,6 +1007,19 @@ func (self *hostedServiceRegistry) getTerminatorsForService(serviceId string) []
 	return result
 }
 
+// getTerminatorsForConn returns a snapshot of the terminators hosted on the
+// given connection. Used to scope a posture re-evaluation to one identity's
+// API session rather than to every host of a service.
+func (self *hostedServiceRegistry) getTerminatorsForConn(conn *edgeClientConn) []*edgeTerminator {
+	var result []*edgeTerminator
+	self.terminators.IterCb(func(key string, v *edgeTerminator) {
+		if v.edgeClientConn == conn {
+			result = append(result, v)
+		}
+	})
+	return result
+}
+
 type inspectTerminatorsEvent struct {
 	result atomic.Pointer[[]*inspect.SdkTerminatorInspectDetail]
 	done   chan struct{}

--- a/router/xgress_edge/listener.go
+++ b/router/xgress_edge/listener.go
@@ -428,6 +428,46 @@ func (self *edgeClientConn) NotifyIdentityEvent(state *common.IdentityState, eve
 		if err := self.ch.GetChannel().Close(); err != nil {
 			log.WithError(err).Error("failed to close channel")
 		}
+	} else if eventType == common.IdentityPostureChecksUpdatedEvent {
+		// The identity's posture requirements changed (a posture check added to or
+		// removed from a service policy, or a check definition edited). The
+		// service-membership diff does not surface this, so re-evaluate this
+		// connection's active circuits and terminators against current posture.
+		self.revalidatePostureAccess()
+	}
+}
+
+// revalidatePostureAccess re-evaluates dial and bind access for this
+// connection's active circuits and hosted terminators against the identity's
+// current posture, closing any that no longer have access. It runs on the
+// identity-subscription worker, which dedups (via the data model's dirty-set
+// marker) and retries (via the scan fallback), so it inherits that resilience.
+func (self *edgeClientConn) revalidatePostureAccess() {
+	stateManager := self.listener.factory.stateManager
+	apiSession := self.apiSessionToken
+	if apiSession == nil {
+		return
+	}
+
+	// Dial circuits — both connId mux-sink conns and SDK-hosted xgress circuits.
+	// Collect first, then close: CloseForDialAccessLoss mutates the maps
+	// IterateCircuits walks (mirrors handleDialAccessLost).
+	var dialToClose []edgeCircuit
+	self.IterateCircuits(func(c edgeCircuit) {
+		if policy, err := stateManager.HasAccess(apiSession.IdentityId, apiSession.Id, c.GetServiceId(), edge_ctrl_pb.PolicyType_DialPolicy); err != nil || policy == nil {
+			dialToClose = append(dialToClose, c)
+		}
+	})
+	for _, c := range dialToClose {
+		c.CloseForDialAccessLoss()
+	}
+
+	// Hosted bind terminators on this connection (getTerminatorsForConn returns a
+	// snapshot, so closing while ranging it is safe).
+	for _, terminator := range self.GetHostedServicesRegistry().getTerminatorsForConn(self) {
+		if policy, err := stateManager.HasAccess(apiSession.IdentityId, apiSession.Id, terminator.GetServiceId(), edge_ctrl_pb.PolicyType_BindPolicy); err != nil || policy == nil {
+			terminator.CloseForBindAccessLoss()
+		}
 	}
 }
 
@@ -460,15 +500,8 @@ func (self *edgeClientConn) handleBindAccessLost(service *common.IdentityService
 	terminators := self.GetHostedServicesRegistry().getTerminatorsForService(service.GetId())
 	for _, terminator := range terminators {
 		log.WithField("terminatorId", terminator.terminatorId).
-			Info("bind access to service, closing terminator")
-		edgeErr := &EdgeError{
-			Message:   "bind access lost",
-			Code:      sdkedge.ErrorCodeAccessDenied,
-			RetryHint: sdkedge.RetryStartOver, // switch back to start over once timing issues are resolved
-		}
-		reason := "bind access lost"
-		self.GetHostedServicesRegistry().ensureSdkCloseSent(terminator, reason, edgeErr)
-		terminator.close(self.GetHostedServicesRegistry(), true, reason)
+			Info("bind access to service lost, closing terminator")
+		terminator.CloseForBindAccessLoss()
 	}
 }
 
@@ -511,6 +544,53 @@ func (self *edgeClientConn) IterateCircuits(f func(c edgeCircuit)) {
 	self.xgCircuits.IterCb(func(_ string, v *xgEdgeForwarder) {
 		f(v)
 	})
+}
+
+// IterateDialCircuits implements state.ConnProvider, exposing every active dial
+// circuit (mux-sink conns and SDK-hosted xgress circuits) to the posture
+// re-evaluation path. edgeCircuit's method set is a superset of
+// state.DialCircuit, so each circuit satisfies it directly.
+func (self *edgeClientConn) IterateDialCircuits(f func(state.DialCircuit)) {
+	self.IterateCircuits(func(c edgeCircuit) {
+		f(c)
+	})
+}
+
+// IterateBindTerminators implements state.ConnProvider, exposing the hosted
+// terminators owned by this connection to the posture re-evaluation path.
+func (self *edgeClientConn) IterateBindTerminators(f func(state.BindTerminator)) {
+	for _, t := range self.GetHostedServicesRegistry().getTerminatorsForConn(self) {
+		f(t)
+	}
+}
+
+func (self *edgeTerminator) GetServiceId() string {
+	if self.serviceSessionToken == nil {
+		return ""
+	}
+	return self.serviceSessionToken.ServiceId
+}
+
+func (self *edgeTerminator) GetApiSessionToken() *state.ApiSessionToken {
+	if self.edgeClientConn == nil {
+		return nil
+	}
+	return self.edgeClientConn.apiSessionToken
+}
+
+// CloseForBindAccessLoss revokes a hosted terminator whose bind access was lost
+// (policy or posture): it notifies the SDK with an access-denied error and
+// tears the terminator down.
+func (self *edgeTerminator) CloseForBindAccessLoss() {
+	registry := self.edgeClientConn.GetHostedServicesRegistry()
+	edgeErr := &EdgeError{
+		Message:   "bind access lost",
+		Code:      sdkedge.ErrorCodeAccessDenied,
+		RetryHint: sdkedge.RetryStartOver, // switch back to start over once timing issues are resolved
+	}
+	reason := "bind access lost"
+	registry.ensureSdkCloseSent(self, reason, edgeErr)
+	self.close(registry, true, reason)
 }
 
 // getIdentityId safely retrieves the identity ID from the associated API session.

--- a/router/xgress_edge/listener.go
+++ b/router/xgress_edge/listener.go
@@ -445,15 +445,24 @@ func (self *edgeClientConn) NotifyIdentityEvent(state *common.IdentityState, eve
 func (self *edgeClientConn) revalidatePostureAccess() {
 	stateManager := self.listener.factory.stateManager
 	apiSession := self.apiSessionToken
-	if apiSession == nil || apiSession.IsOidc() {
+	// Only OIDC sessions are enforced router-side against the RDM. Legacy
+	// sessions have their posture evaluated at the controller, which invalidates
+	// the session and pushes the removal to the router, so they need no
+	// router-side revalidation here.
+	if apiSession == nil || !apiSession.IsOidc() {
 		return
 	}
 
 	// Dial circuits — both connId mux-sink conns and SDK-hosted xgress circuits.
-	// Collect first, then close: CloseForDialAccessLoss mutates the maps
+	// Collect first, then close: CloseForAccessLoss mutates the maps
 	// IterateCircuits walks (mirrors handleDialAccessLost).
 	var dialToClose []edgeCircuit
 	self.IterateCircuits(func(c edgeCircuit) {
+		// Host-side circuits are governed by bind access, handled via the
+		// terminator re-evaluation below; only dial circuits are checked here.
+		if c.IsHostSide() {
+			return
+		}
 		if policy, err := stateManager.HasAccess(apiSession.IdentityId, apiSession.Id, c.GetServiceId(), edge_ctrl_pb.PolicyType_DialPolicy); err != nil || policy == nil {
 			// every HasAccess error is a definitive denial (entity removed,
 			// no granting policies, or failed posture checks), so log it as
@@ -467,7 +476,7 @@ func (self *edgeClientConn) revalidatePostureAccess() {
 		}
 	})
 	for _, c := range dialToClose {
-		c.CloseForDialAccessLoss()
+		c.CloseForAccessLoss("dial access lost on posture update")
 	}
 
 	// Hosted bind terminators on this connection (getTerminatorsForConn returns a
@@ -525,14 +534,16 @@ func (self *edgeClientConn) handleDialAccessLost(service *common.IdentityService
 
 	var toClose []edgeCircuit
 	self.IterateCircuits(func(c edgeCircuit) {
-		if c.GetServiceId() == service.GetId() {
+		// Only dial circuits are governed by dial access; serving circuits for the
+		// same service are handled by handleBindAccessLost.
+		if !c.IsHostSide() && c.GetServiceId() == service.GetId() {
 			toClose = append(toClose, c)
 		}
 	})
 
 	for _, c := range toClose {
 		log.WithField("circuitId", c.GetCircuitId()).Info("closing circuit, dial access lost")
-		c.CloseForDialAccessLoss()
+		c.CloseForAccessLoss("dial access lost")
 	}
 }
 
@@ -540,7 +551,8 @@ type edgeCircuit interface {
 	GetCircuitId() string
 	GetServiceId() string
 	GetApiSessionToken() *state.ApiSessionToken
-	CloseForDialAccessLoss()
+	IsHostSide() bool
+	CloseForAccessLoss(reason string)
 	IsPostCreateAccessCheckNeeded() bool
 	SetPostCreateAccessCheckDone()
 }
@@ -559,11 +571,11 @@ func (self *edgeClientConn) IterateCircuits(f func(c edgeCircuit)) {
 	})
 }
 
-// IterateDialCircuits implements state.ConnProvider, exposing every active dial
-// circuit (mux-sink conns and SDK-hosted xgress circuits) to the posture
-// re-evaluation path. edgeCircuit's method set is a superset of
-// state.DialCircuit, so each circuit satisfies it directly.
-func (self *edgeClientConn) IterateDialCircuits(f func(state.DialCircuit)) {
+// IterateEdgeCircuits implements state.ConnProvider, exposing every active
+// circuit (dialing and serving; mux-sink conns and SDK-hosted xgress circuits)
+// to the posture re-evaluation path. edgeCircuit's method set is a superset of
+// state.EdgeCircuit, so each circuit satisfies it directly.
+func (self *edgeClientConn) IterateEdgeCircuits(f func(state.EdgeCircuit)) {
 	self.IterateCircuits(func(c edgeCircuit) {
 		f(c)
 	})
@@ -597,8 +609,10 @@ func (self *edgeTerminator) GetApiSessionToken() *state.ApiSessionToken {
 }
 
 // CloseForBindAccessLoss revokes a hosted terminator whose bind access was lost
-// (policy or posture): it notifies the SDK with an access-denied error and
-// tears the terminator down.
+// (policy or posture): it notifies the SDK with an access-denied error, tears the
+// terminator down, and closes the active circuits served through it. An identity
+// that should no longer be hosting must not keep serving, so its established
+// circuits are dropped promptly rather than left to drain.
 func (self *edgeTerminator) CloseForBindAccessLoss() {
 	registry := self.edgeClientConn.GetHostedServicesRegistry()
 	edgeErr := &EdgeError{
@@ -609,6 +623,22 @@ func (self *edgeTerminator) CloseForBindAccessLoss() {
 	reason := "bind access lost"
 	registry.ensureSdkCloseSent(self, reason, edgeErr)
 	self.close(registry, true, reason)
+
+	// Tear down the active circuits served through this terminator so they drop
+	// promptly rather than draining. They are found by iterating the conn's
+	// circuits for serving-side ones on this service (rather than tracked per
+	// terminator), which covers both mux-sink and SDK-xgress serving conns;
+	// closing each faults its circuit so the dialing side drops too.
+	serviceId := self.GetServiceId()
+	var toClose []edgeCircuit
+	self.edgeClientConn.IterateCircuits(func(c edgeCircuit) {
+		if c.IsHostSide() && c.GetServiceId() == serviceId {
+			toClose = append(toClose, c)
+		}
+	})
+	for _, c := range toClose {
+		c.CloseForAccessLoss(reason)
+	}
 }
 
 // getIdentityId safely retrieves the identity ID from the associated API session.
@@ -1716,8 +1746,14 @@ func (self *xgEdgeForwarder) GetApiSessionId() string {
 	return self.edgeClientConn.GetApiSessionToken().Id
 }
 
-func (self *xgEdgeForwarder) CloseForDialAccessLoss() {
+func (self *xgEdgeForwarder) CloseForAccessLoss(string) {
 	self.cleanupXgressCircuit(self)
+}
+
+// IsHostSide reports whether this forwarder is the hosting (terminator) side of
+// a circuit, as opposed to the dialing (initiator) side.
+func (self *xgEdgeForwarder) IsHostSide() bool {
+	return self.originator == xgress.Terminator
 }
 
 func (self *xgEdgeForwarder) IsPostCreateAccessCheckNeeded() bool {

--- a/router/xgress_edge/listener.go
+++ b/router/xgress_edge/listener.go
@@ -445,7 +445,7 @@ func (self *edgeClientConn) NotifyIdentityEvent(state *common.IdentityState, eve
 func (self *edgeClientConn) revalidatePostureAccess() {
 	stateManager := self.listener.factory.stateManager
 	apiSession := self.apiSessionToken
-	if apiSession == nil {
+	if apiSession == nil || apiSession.IsOidc() {
 		return
 	}
 
@@ -455,6 +455,14 @@ func (self *edgeClientConn) revalidatePostureAccess() {
 	var dialToClose []edgeCircuit
 	self.IterateCircuits(func(c edgeCircuit) {
 		if policy, err := stateManager.HasAccess(apiSession.IdentityId, apiSession.Id, c.GetServiceId(), edge_ctrl_pb.PolicyType_DialPolicy); err != nil || policy == nil {
+			// every HasAccess error is a definitive denial (entity removed,
+			// no granting policies, or failed posture checks), so log it as
+			// the revocation reason rather than as a failure
+			pfxlog.Logger().WithError(err).
+				WithField("identityId", apiSession.IdentityId).
+				WithField("serviceId", c.GetServiceId()).
+				WithField("circuitId", c.GetCircuitId()).
+				Info("dial access lost on posture update, closing circuit")
 			dialToClose = append(dialToClose, c)
 		}
 	})
@@ -466,6 +474,11 @@ func (self *edgeClientConn) revalidatePostureAccess() {
 	// snapshot, so closing while ranging it is safe).
 	for _, terminator := range self.GetHostedServicesRegistry().getTerminatorsForConn(self) {
 		if policy, err := stateManager.HasAccess(apiSession.IdentityId, apiSession.Id, terminator.GetServiceId(), edge_ctrl_pb.PolicyType_BindPolicy); err != nil || policy == nil {
+			pfxlog.Logger().WithError(err).
+				WithField("identityId", apiSession.IdentityId).
+				WithField("serviceId", terminator.GetServiceId()).
+				WithField("terminatorId", terminator.GetTerminatorId()).
+				Info("bind access lost on posture update, closing terminator")
 			terminator.CloseForBindAccessLoss()
 		}
 	}
@@ -569,6 +582,11 @@ func (self *edgeTerminator) GetServiceId() string {
 		return ""
 	}
 	return self.serviceSessionToken.ServiceId
+}
+
+// GetTerminatorId returns the terminator's id, implementing state.BindTerminator.
+func (self *edgeTerminator) GetTerminatorId() string {
+	return self.terminatorId
 }
 
 func (self *edgeTerminator) GetApiSessionToken() *state.ApiSessionToken {

--- a/tests/posture_revalidation_oidc_test.go
+++ b/tests/posture_revalidation_oidc_test.go
@@ -1,0 +1,459 @@
+//go:build apitests
+
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openziti/edge-api/rest_model"
+	"github.com/openziti/sdk-golang/ziti"
+	"github.com/openziti/sdk-golang/ziti/edge/posture"
+	"github.com/openziti/ziti/v2/common/eid"
+	"github.com/openziti/ziti/v2/controller/xt_smartrouting"
+)
+
+// echoPostureTestServer is the hosted-service handler used by the posture
+// revalidation tests: it echoes "hello, <name>" for each name it reads.
+func echoPostureTestServer(conn *testServerConn) error {
+	for {
+		name, eof := conn.ReadString(1024, 1*time.Minute)
+		if eof {
+			return conn.server.close()
+		}
+		if name == "quit" {
+			conn.WriteString("ok", time.Second)
+			return conn.server.close()
+		}
+		conn.WriteString("hello, "+name, time.Second)
+	}
+}
+
+// requireConnClosed polls until conn reports closed, failing the test if it
+// stays open past the timeout. Posture revalidation is asynchronous (the router
+// re-evaluates and tears the circuit out of band), so a poll is required.
+func requireConnClosed(ctx *TestContext, conn *TestConn) {
+	// A read is what surfaces the close on these conns (a bare IsClosed poll
+	// never advances the conn state). Loop with a short read deadline so we detect
+	// the close promptly yet bound the total wait, failing fast on a regression
+	// instead of blocking until the test timeout.
+	deadline := time.Now().Add(10 * time.Second)
+	buf := make([]byte, 1)
+	for time.Now().Before(deadline) {
+		if conn.IsClosed() {
+			return
+		}
+		_ = conn.SetReadDeadline(time.Now().Add(250 * time.Millisecond))
+		if _, err := conn.Read(buf); err != nil && conn.IsClosed() {
+			return
+		}
+	}
+	ctx.Req.True(conn.IsClosed(), "expected connection to be closed by posture revalidation")
+}
+
+// requireConnUsable asserts a connection survives a posture change: revocation,
+// if it were going to happen, fires within ~100ms of the posture update, so this
+// waits well past that and then confirms the connection is still open and still
+// carries data end to end.
+func requireConnUsable(ctx *TestContext, conn *TestConn) {
+	time.Sleep(1 * time.Second)
+	ctx.Req.False(conn.IsClosed(), "connection should remain open after a still-compliant posture change")
+	name := eid.New()
+	conn.WriteString(name, time.Second)
+	conn.ReadExpected("hello, "+name, time.Second)
+}
+
+// Test_PostureRevalidation_HostTerminator_OnPostureData_OIDC covers the gap where
+// a posture-data change revoked only dial conns and missed hosted bind
+// terminators. The host's OS posture goes invalid while a client circuit is
+// active; the router must revalidate the host's bind access and revoke its
+// terminator, tearing down the active circuit.
+func Test_PostureRevalidation_HostTerminator_OnPostureData_OIDC(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+	ctx.RequireAdminManagementApiLogin()
+
+	dialIdentityRole := eid.New()
+	hostIdentityRole := eid.New()
+	serviceRole := eid.New()
+	postureCheckRoleAttr := eid.New()
+
+	adminManagementApi := ctx.NewEdgeManagementApi(nil)
+	_, err := adminManagementApi.Authenticate(ctx.NewAdminCredentials(), nil)
+	ctx.Req.NoError(err)
+
+	targetOs := &rest_model.OperatingSystem{
+		Type:     ToPtr(rest_model.OsTypeWindows),
+		Versions: []string{"1.0.0"},
+	}
+	validOsInfo := posture.OsInfo{Type: string(*targetOs.Type), Version: targetOs.Versions[0]}
+	invalidOsInfo := posture.OsInfo{Type: string(*targetOs.Type), Version: "2.0.0"}
+
+	_, err = adminManagementApi.CreatePostureCheckOs([]*rest_model.OperatingSystem{targetOs}, []string{postureCheckRoleAttr})
+	ctx.Req.NoError(err)
+
+	ctx.AdminManagementSession.requireNewEdgeRouterPolicy(s("#all"), s("#all"))
+	ctx.AdminManagementSession.requireNewServiceEdgeRouterPolicy(s("#all"), s("#all"))
+
+	service := ctx.AdminManagementSession.testContext.newService(s(serviceRole), nil)
+	service.terminatorStrategy = xt_smartrouting.Name
+	ctx.AdminManagementSession.requireCreateEntity(service)
+
+	// Bind requires the OS posture check (host must satisfy it); Dial has none, so
+	// the client's access never changes and any revocation is driven by the host.
+	ctx.AdminManagementSession.requireNewServicePolicyWithSemantic("Dial", "AllOf", s("#"+serviceRole), s("#"+dialIdentityRole), nil)
+	ctx.AdminManagementSession.requireNewServicePolicyWithSemantic("Bind", "AllOf", s("#"+serviceRole), s("#"+hostIdentityRole), s("#"+postureCheckRoleAttr))
+
+	ctx.CreateEnrollAndStartEdgeRouter()
+
+	// Host (OIDC) reports valid posture and hosts the service.
+	_, hostZtx := ctx.AdminManagementSession.RequireCreateSdkContext(hostIdentityRole)
+	hostContext := hostZtx.(*ziti.ContextImpl)
+	hostContext.CtrlClt.SetAllowOidcDynamicallyEnabled(true)
+	defer hostContext.Close()
+	ctx.Req.NoError(hostContext.Authenticate())
+
+	currentHostOsInfo := validOsInfo
+	hostContext.CtrlClt.PostureCache.SetOsProviderFunc(func() posture.OsInfo {
+		return currentHostOsInfo
+	})
+
+	listener, err := hostContext.Listen(service.Name)
+	ctx.Req.NoError(err)
+	defer func() { _ = listener.Close() }()
+
+	testServer := newTestServer(listener, echoPostureTestServer)
+	testServer.start()
+
+	// Client (OIDC) dials successfully while the host's posture is valid.
+	_, clientZtx := ctx.AdminManagementSession.RequireCreateSdkContext(dialIdentityRole)
+	clientContext := clientZtx.(*ziti.ContextImpl)
+	clientContext.CtrlClt.SetAllowOidcDynamicallyEnabled(true)
+	defer clientContext.Close()
+	ctx.Req.NoError(clientContext.Authenticate())
+
+	clientConn := ctx.WrapConn(clientContext.Dial(service.Name))
+	defer func() { _ = clientConn.Close() }()
+
+	name := eid.New()
+	clientConn.WriteString(name, time.Second)
+	clientConn.ReadExpected("hello, "+name, time.Second)
+
+	t.Run("host posture data goes invalid", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		currentHostOsInfo = invalidOsInfo
+		hostContext.CtrlClt.PostureCache.Evaluate()
+
+		t.Run("revokes the host terminator, tearing down the active circuit", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			requireConnClosed(ctx, clientConn)
+		})
+
+		t.Run("a new dial fails with the terminator revoked", func(t *testing.T) {
+			ctx.testContextChanged(t)
+
+			var dialErr error
+			for i := 0; i < 50; i++ {
+				newConn, err := clientContext.Dial(service.Name)
+				if err != nil {
+					dialErr = err
+					break
+				}
+				_ = newConn.Close()
+				time.Sleep(100 * time.Millisecond)
+			}
+			ctx.Req.Error(dialErr)
+		})
+	})
+}
+
+// Test_PostureRevalidation_DialCircuit_OnRequirementChange_OIDC covers the gap
+// where tightening a service policy's posture requirements (here, adding a
+// posture check to the dial policy) did not re-evaluate active circuits. After
+// the client establishes a circuit, the dial policy gains an OS posture check the
+// client cannot satisfy; the router must revalidate and revoke the active circuit
+// without waiting for a fresh posture-data report or dial.
+func Test_PostureRevalidation_DialCircuit_OnRequirementChange_OIDC(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+	ctx.RequireAdminManagementApiLogin()
+
+	dialIdentityRole := eid.New()
+	hostIdentityRole := eid.New()
+	serviceRole := eid.New()
+	postureCheckRoleAttr := eid.New()
+
+	adminManagementApi := ctx.NewEdgeManagementApi(nil)
+	_, err := adminManagementApi.Authenticate(ctx.NewAdminCredentials(), nil)
+	ctx.Req.NoError(err)
+
+	// An OS posture check the client will not satisfy; not attached to any policy
+	// yet, so the initial dial succeeds.
+	targetOs := &rest_model.OperatingSystem{
+		Type:     ToPtr(rest_model.OsTypeWindows),
+		Versions: []string{"1.0.0"},
+	}
+	clientOsInfo := posture.OsInfo{Type: string(*targetOs.Type), Version: "2.0.0"}
+
+	_, err = adminManagementApi.CreatePostureCheckOs([]*rest_model.OperatingSystem{targetOs}, []string{postureCheckRoleAttr})
+	ctx.Req.NoError(err)
+
+	ctx.AdminManagementSession.requireNewEdgeRouterPolicy(s("#all"), s("#all"))
+	ctx.AdminManagementSession.requireNewServiceEdgeRouterPolicy(s("#all"), s("#all"))
+
+	service := ctx.AdminManagementSession.testContext.newService(s(serviceRole), nil)
+	service.terminatorStrategy = xt_smartrouting.Name
+	ctx.AdminManagementSession.requireCreateEntity(service)
+
+	// Dial policy starts with no posture requirement; the host has none.
+	dialPolicy := ctx.AdminManagementSession.requireNewServicePolicyWithSemantic("Dial", "AllOf", s("#"+serviceRole), s("#"+dialIdentityRole), nil)
+	ctx.AdminManagementSession.requireNewServicePolicyWithSemantic("Bind", "AllOf", s("#"+serviceRole), s("#"+hostIdentityRole), nil)
+
+	ctx.CreateEnrollAndStartEdgeRouter()
+
+	// Host (OIDC) hosts the service; it has no posture requirement.
+	_, hostZtx := ctx.AdminManagementSession.RequireCreateSdkContext(hostIdentityRole)
+	hostContext := hostZtx.(*ziti.ContextImpl)
+	hostContext.CtrlClt.SetAllowOidcDynamicallyEnabled(true)
+	defer hostContext.Close()
+	ctx.Req.NoError(hostContext.Authenticate())
+
+	listener, err := hostContext.Listen(service.Name)
+	ctx.Req.NoError(err)
+	defer func() { _ = listener.Close() }()
+
+	testServer := newTestServer(listener, echoPostureTestServer)
+	testServer.start()
+
+	// Client (OIDC) reports an OS that won't satisfy the (not-yet-attached) check,
+	// then dials successfully since the dial policy currently has no posture.
+	_, clientZtx := ctx.AdminManagementSession.RequireCreateSdkContext(dialIdentityRole)
+	clientContext := clientZtx.(*ziti.ContextImpl)
+	clientContext.CtrlClt.SetAllowOidcDynamicallyEnabled(true)
+	defer clientContext.Close()
+	ctx.Req.NoError(clientContext.Authenticate())
+
+	clientContext.CtrlClt.PostureCache.SetOsProviderFunc(func() posture.OsInfo {
+		return clientOsInfo
+	})
+
+	clientConn := ctx.WrapConn(clientContext.Dial(service.Name))
+	defer func() { _ = clientConn.Close() }()
+
+	name := eid.New()
+	clientConn.WriteString(name, time.Second)
+	clientConn.ReadExpected("hello, "+name, time.Second)
+
+	t.Run("adding a posture check to the dial policy", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		dialPolicy.postureCheckRoles = s("#" + postureCheckRoleAttr)
+		ctx.AdminManagementSession.requireUpdateEntity(dialPolicy)
+
+		t.Run("revalidates and revokes the active circuit", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			requireConnClosed(ctx, clientConn)
+		})
+	})
+}
+
+// Test_PostureRevalidation_NoRevocation_HostPostureStaysCompliant_OIDC is the
+// negative control for the hosted-terminator path: when the host's posture data
+// changes but still satisfies the bind policy's posture check, revalidation must
+// run but retain the terminator and the active circuit.
+func Test_PostureRevalidation_NoRevocation_HostPostureStaysCompliant_OIDC(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+	ctx.RequireAdminManagementApiLogin()
+
+	dialIdentityRole := eid.New()
+	hostIdentityRole := eid.New()
+	serviceRole := eid.New()
+	postureCheckRoleAttr := eid.New()
+
+	adminManagementApi := ctx.NewEdgeManagementApi(nil)
+	_, err := adminManagementApi.Authenticate(ctx.NewAdminCredentials(), nil)
+	ctx.Req.NoError(err)
+
+	// The OS check accepts two versions; the host moves between them, staying
+	// compliant throughout.
+	targetOs := &rest_model.OperatingSystem{
+		Type:     ToPtr(rest_model.OsTypeWindows),
+		Versions: []string{"1.0.0", "2.0.0"},
+	}
+	firstOsInfo := posture.OsInfo{Type: string(*targetOs.Type), Version: "1.0.0"}
+	secondOsInfo := posture.OsInfo{Type: string(*targetOs.Type), Version: "2.0.0"}
+
+	_, err = adminManagementApi.CreatePostureCheckOs([]*rest_model.OperatingSystem{targetOs}, []string{postureCheckRoleAttr})
+	ctx.Req.NoError(err)
+
+	ctx.AdminManagementSession.requireNewEdgeRouterPolicy(s("#all"), s("#all"))
+	ctx.AdminManagementSession.requireNewServiceEdgeRouterPolicy(s("#all"), s("#all"))
+
+	service := ctx.AdminManagementSession.testContext.newService(s(serviceRole), nil)
+	service.terminatorStrategy = xt_smartrouting.Name
+	ctx.AdminManagementSession.requireCreateEntity(service)
+
+	ctx.AdminManagementSession.requireNewServicePolicyWithSemantic("Dial", "AllOf", s("#"+serviceRole), s("#"+dialIdentityRole), nil)
+	ctx.AdminManagementSession.requireNewServicePolicyWithSemantic("Bind", "AllOf", s("#"+serviceRole), s("#"+hostIdentityRole), s("#"+postureCheckRoleAttr))
+
+	ctx.CreateEnrollAndStartEdgeRouter()
+
+	_, hostZtx := ctx.AdminManagementSession.RequireCreateSdkContext(hostIdentityRole)
+	hostContext := hostZtx.(*ziti.ContextImpl)
+	hostContext.CtrlClt.SetAllowOidcDynamicallyEnabled(true)
+	defer hostContext.Close()
+	ctx.Req.NoError(hostContext.Authenticate())
+
+	currentHostOsInfo := firstOsInfo
+	hostContext.CtrlClt.PostureCache.SetOsProviderFunc(func() posture.OsInfo {
+		return currentHostOsInfo
+	})
+
+	listener, err := hostContext.Listen(service.Name)
+	ctx.Req.NoError(err)
+	defer func() { _ = listener.Close() }()
+
+	testServer := newTestServer(listener, echoPostureTestServer)
+	testServer.start()
+
+	_, clientZtx := ctx.AdminManagementSession.RequireCreateSdkContext(dialIdentityRole)
+	clientContext := clientZtx.(*ziti.ContextImpl)
+	clientContext.CtrlClt.SetAllowOidcDynamicallyEnabled(true)
+	defer clientContext.Close()
+	ctx.Req.NoError(clientContext.Authenticate())
+
+	clientConn := ctx.WrapConn(clientContext.Dial(service.Name))
+	defer func() { _ = clientConn.Close() }()
+
+	name := eid.New()
+	clientConn.WriteString(name, time.Second)
+	clientConn.ReadExpected("hello, "+name, time.Second)
+
+	t.Run("host posture data changes but stays compliant", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		currentHostOsInfo = secondOsInfo
+		hostContext.CtrlClt.PostureCache.Evaluate()
+
+		t.Run("retains the terminator and the active circuit", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			requireConnUsable(ctx, clientConn)
+		})
+
+		t.Run("still accepts new dials", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			newConn := ctx.WrapConn(clientContext.Dial(service.Name))
+			defer func() { _ = newConn.Close() }()
+			newName := eid.New()
+			newConn.WriteString(newName, time.Second)
+			newConn.ReadExpected("hello, "+newName, time.Second)
+		})
+	})
+}
+
+// Test_PostureRevalidation_NoRevocation_DialPostureStaysCompliant_OIDC is the
+// negative control for the dial path: when the client's posture data changes but
+// still satisfies the dial policy's posture check, revalidation must run but
+// retain the active circuit.
+func Test_PostureRevalidation_NoRevocation_DialPostureStaysCompliant_OIDC(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+	ctx.RequireAdminManagementApiLogin()
+
+	dialIdentityRole := eid.New()
+	hostIdentityRole := eid.New()
+	serviceRole := eid.New()
+	postureCheckRoleAttr := eid.New()
+
+	adminManagementApi := ctx.NewEdgeManagementApi(nil)
+	_, err := adminManagementApi.Authenticate(ctx.NewAdminCredentials(), nil)
+	ctx.Req.NoError(err)
+
+	targetOs := &rest_model.OperatingSystem{
+		Type:     ToPtr(rest_model.OsTypeWindows),
+		Versions: []string{"1.0.0", "2.0.0"},
+	}
+	firstOsInfo := posture.OsInfo{Type: string(*targetOs.Type), Version: "1.0.0"}
+	secondOsInfo := posture.OsInfo{Type: string(*targetOs.Type), Version: "2.0.0"}
+
+	_, err = adminManagementApi.CreatePostureCheckOs([]*rest_model.OperatingSystem{targetOs}, []string{postureCheckRoleAttr})
+	ctx.Req.NoError(err)
+
+	ctx.AdminManagementSession.requireNewEdgeRouterPolicy(s("#all"), s("#all"))
+	ctx.AdminManagementSession.requireNewServiceEdgeRouterPolicy(s("#all"), s("#all"))
+
+	service := ctx.AdminManagementSession.testContext.newService(s(serviceRole), nil)
+	service.terminatorStrategy = xt_smartrouting.Name
+	ctx.AdminManagementSession.requireCreateEntity(service)
+
+	// Dial requires the OS posture check (client must satisfy it); Bind has none.
+	ctx.AdminManagementSession.requireNewServicePolicyWithSemantic("Dial", "AllOf", s("#"+serviceRole), s("#"+dialIdentityRole), s("#"+postureCheckRoleAttr))
+	ctx.AdminManagementSession.requireNewServicePolicyWithSemantic("Bind", "AllOf", s("#"+serviceRole), s("#"+hostIdentityRole), nil)
+
+	ctx.CreateEnrollAndStartEdgeRouter()
+
+	_, hostZtx := ctx.AdminManagementSession.RequireCreateSdkContext(hostIdentityRole)
+	hostContext := hostZtx.(*ziti.ContextImpl)
+	hostContext.CtrlClt.SetAllowOidcDynamicallyEnabled(true)
+	defer hostContext.Close()
+	ctx.Req.NoError(hostContext.Authenticate())
+
+	listener, err := hostContext.Listen(service.Name)
+	ctx.Req.NoError(err)
+	defer func() { _ = listener.Close() }()
+
+	testServer := newTestServer(listener, echoPostureTestServer)
+	testServer.start()
+
+	_, clientZtx := ctx.AdminManagementSession.RequireCreateSdkContext(dialIdentityRole)
+	clientContext := clientZtx.(*ziti.ContextImpl)
+	clientContext.CtrlClt.SetAllowOidcDynamicallyEnabled(true)
+	defer clientContext.Close()
+	ctx.Req.NoError(clientContext.Authenticate())
+
+	currentClientOsInfo := firstOsInfo
+	clientContext.CtrlClt.PostureCache.SetOsProviderFunc(func() posture.OsInfo {
+		return currentClientOsInfo
+	})
+
+	clientConn := ctx.WrapConn(clientContext.Dial(service.Name))
+	defer func() { _ = clientConn.Close() }()
+
+	name := eid.New()
+	clientConn.WriteString(name, time.Second)
+	clientConn.ReadExpected("hello, "+name, time.Second)
+
+	t.Run("client posture data changes but stays compliant", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		currentClientOsInfo = secondOsInfo
+		clientContext.CtrlClt.PostureCache.Evaluate()
+
+		t.Run("retains the active circuit", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			requireConnUsable(ctx, clientConn)
+		})
+	})
+}


### PR DESCRIPTION
## Summary

Router-side posture revalidation was incomplete: when access should be revoked due to posture, several active connections were left open.

1. **Posture-data changes covered only mux-sink dial conns.** `onPostureDataUpdate` iterated only the connId-keyed mux sinks (reading `ServiceSessionToken.ServiceId`), so it missed **SDK-hosted xgress dial circuits** (`xgCircuits`) and **hosted bind terminators**. A device that fell out of posture compliance kept those circuits/terminators alive.
2. **Posture-requirement changes weren't reacted to at all.** Tightening a service policy's posture requirements — adding/removing a posture check, or editing a check definition — updated the model but never re-evaluated active circuits, since the service-membership diff doesn't surface posture changes (`IdentityService` carries no posture info). They lingered until the next posture-data report, a fresh dial, or token expiry.

## Changes

- `onPostureDataUpdate` now re-evaluates **both** dial circuits (including SDK-hosted xgress in `xgCircuits`) **and** hosted bind terminators, keyed on `GetServiceId` (which also fixes a latent nil `ServiceSessionToken` deref), closing denied access via `CloseForDialAccessLoss` / `CloseForBindAccessLoss`.
- `edgeClientConn` now handles `IdentityPostureChecksUpdatedEvent`, re-evaluating its circuits and terminators when the identity's posture requirements change. This rides the existing identity-subscription marker/scan pipeline, so it dedups and retries if the work queue is full.
- Adds the supporting seams: `state.DialCircuit` / `state.BindTerminator` views and `ConnProvider.IterateDialCircuits` / `IterateBindTerminators`, `getTerminatorsForConn`, and `edgeTerminator.CloseForBindAccessLoss`; refactors `handleBindAccessLost` onto the shared close path.

## Backport

This is the main-line fix and closes #3908. The targeted backport to `release-v2.0.x` is tracked separately by #3928 (both gaps are pre-existing — verified at `v2.0.0`).

