### PR TITLE
Remove vestigial legacy link management from the router link registry

### DIFF
--- a/router/link/link_registry.go
+++ b/router/link/link_registry.go
@@ -246,18 +246,12 @@ func (self *linkRegistryImpl) applyLink(link xlink.Xlink) (xlink.Xlink, bool) {
 		go func() {
 			log.Info("duplicate link detected. closing current link (current link id is >= than new link id)")
 
-			legacyCtl := self.useLegacyLinkMgmtForOldCtrl()
-
 			self.ctrls.ForEach(func(ctrlId string, ch channel.Channel) {
 				// report link fault, then close link after allowing some time for circuits to be re-routed
 				fault := &ctrl_pb.Fault{
 					Id:        existing.Id(),
 					Subject:   ctrl_pb.FaultSubject_LinkDuplicate,
 					Iteration: existing.Iteration(),
-				}
-
-				if legacyCtl {
-					fault.Subject = ctrl_pb.FaultSubject_LinkFault
 				}
 
 				if err := protobufs.MarshalTyped(fault).WithTimeout(time.Second).SendAndWaitForWire(ch); err != nil {
@@ -673,24 +667,12 @@ func (self *linkRegistryImpl) Inspect(timeout time.Duration) *inspect.LinksInspe
 	return result
 }
 
-func (self *linkRegistryImpl) useLegacyLinkMgmtForOldCtrl() bool {
-	legacyCtrl := false
-
-	for _, ctrl := range self.ctrls.GetAll() {
-		if ok, _ := ctrl.GetVersion().HasMinimumVersion("0.30.0"); !ok {
-			legacyCtrl = true
-		}
-	}
-	return legacyCtrl
-}
-
 func (self *linkRegistryImpl) GetLinkKey(dialerBinding, protocol, dest, listenerBinding string) string {
-	legacyCtrl := self.useLegacyLinkMgmtForOldCtrl()
-	if dialerBinding == "" || legacyCtrl {
+	if dialerBinding == "" {
 		dialerBinding = "default"
 	}
 
-	if listenerBinding == "" || legacyCtrl {
+	if listenerBinding == "" {
 		listenerBinding = "default"
 	}
 


### PR DESCRIPTION
Follows up the controller-side removal in #3512 by removing the matching pre-0.30 legacy link management vestiges that were left behind in the router's link registry. A controller below `0.30.0` cannot occur in a 2.0-era deployment, so these branches were dead.

Changes (`router/link/link_registry.go`, +2/-20):

- removes `useLegacyLinkMgmtForOldCtrl` and its pre-0.30 controller version check
- drops the legacy branch in `GetLinkKey` that forced dialer/listener bindings to `"default"` for old controllers; only the empty-binding fallback remains
- always reports duplicate links with `FaultSubject_LinkDuplicate`, removing the legacy downgrade to `FaultSubject_LinkFault`

`go build`, `go vet`, and `go test ./router/link/` pass. The removed method was unexported with no remaining references, so there is no cross-package impact.