### PR TITLE
Enforce api-session and identity revocations on the router

### DIFF
--- a/common/oidc_tokens.go
+++ b/common/oidc_tokens.go
@@ -64,6 +64,20 @@ const (
 	ServiceSessionTypeDial = "Dial"
 )
 
+// MaxTokenDuration returns the longest of the refresh, access, and id token
+// durations. It is the cutoff a revocation must outlive to be sure no token it
+// targets can still be valid.
+func MaxTokenDuration(refreshToken, accessToken, idToken time.Duration) time.Duration {
+	maxDuration := refreshToken
+	if accessToken > maxDuration {
+		maxDuration = accessToken
+	}
+	if idToken > maxDuration {
+		maxDuration = idToken
+	}
+	return maxDuration
+}
+
 type CustomClaims struct {
 	ApiSessionId            string              `json:"z_asid,omitempty"`
 	ExternalId              string              `json:"z_eid,omitempty"`

--- a/common/pb/edge_cmd_pb/edge_cmd.pb.go
+++ b/common/pb/edge_cmd_pb/edge_cmd.pb.go
@@ -2801,6 +2801,7 @@ type Revocation struct {
 	ExpiresAt     *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=expiresAt,proto3" json:"expiresAt,omitempty"`
 	Tags          map[string]*TagValue   `protobuf:"bytes,3,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Type          string                 `protobuf:"bytes,4,opt,name=type,proto3" json:"type,omitempty"`
+	IssuedBefore  *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=issuedBefore,proto3" json:"issuedBefore,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2861,6 +2862,13 @@ func (x *Revocation) GetType() string {
 		return x.Type
 	}
 	return ""
+}
+
+func (x *Revocation) GetIssuedBefore() *timestamppb.Timestamp {
+	if x != nil {
+		return x.IssuedBefore
+	}
+	return nil
 }
 
 type DeleteRevocationsBatchCommand struct {
@@ -5193,13 +5201,14 @@ const file_edge_cmd_proto_rawDesc = "" +
 	"\tTagsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.ziti.edge_cmd.pb.TagValueR\x05value:\x028\x01B\t\n" +
-	"\asubtype\"\xfb\x01\n" +
+	"\asubtype\"\xbb\x02\n" +
 	"\n" +
 	"Revocation\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x128\n" +
 	"\texpiresAt\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\texpiresAt\x12:\n" +
 	"\x04tags\x18\x03 \x03(\v2&.ziti.edge_cmd.pb.Revocation.TagsEntryR\x04tags\x12\x12\n" +
-	"\x04type\x18\x04 \x01(\tR\x04type\x1aS\n" +
+	"\x04type\x18\x04 \x01(\tR\x04type\x12>\n" +
+	"\fissuedBefore\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\fissuedBefore\x1aS\n" +
 	"\tTagsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.ziti.edge_cmd.pb.TagValueR\x05value:\x028\x01\"p\n" +
@@ -5460,52 +5469,53 @@ var file_edge_cmd_proto_depIdxs = []int32{
 	73,  // 58: ziti.edge_cmd.pb.PostureCheck.domains:type_name -> ziti.edge_cmd.pb.PostureCheck.Domains
 	82,  // 59: ziti.edge_cmd.pb.Revocation.expiresAt:type_name -> google.protobuf.Timestamp
 	75,  // 60: ziti.edge_cmd.pb.Revocation.tags:type_name -> ziti.edge_cmd.pb.Revocation.TagsEntry
-	1,   // 61: ziti.edge_cmd.pb.DeleteRevocationsBatchCommand.ctx:type_name -> ziti.edge_cmd.pb.ChangeContext
-	29,  // 62: ziti.edge_cmd.pb.CreateRevocationsBatchCommand.revocations:type_name -> ziti.edge_cmd.pb.Revocation
-	1,   // 63: ziti.edge_cmd.pb.CreateRevocationsBatchCommand.ctx:type_name -> ziti.edge_cmd.pb.ChangeContext
-	76,  // 64: ziti.edge_cmd.pb.Service.tags:type_name -> ziti.edge_cmd.pb.Service.TagsEntry
-	77,  // 65: ziti.edge_cmd.pb.ServiceEdgeRouterPolicy.tags:type_name -> ziti.edge_cmd.pb.ServiceEdgeRouterPolicy.TagsEntry
-	78,  // 66: ziti.edge_cmd.pb.ServicePolicy.tags:type_name -> ziti.edge_cmd.pb.ServicePolicy.TagsEntry
-	79,  // 67: ziti.edge_cmd.pb.TransitRouter.tags:type_name -> ziti.edge_cmd.pb.TransitRouter.TagsEntry
-	80,  // 68: ziti.edge_cmd.pb.TransitRouter.ctrlChanListeners:type_name -> ziti.edge_cmd.pb.TransitRouter.CtrlChanListenersEntry
-	35,  // 69: ziti.edge_cmd.pb.CreateTransitRouterCmd.router:type_name -> ziti.edge_cmd.pb.TransitRouter
-	21,  // 70: ziti.edge_cmd.pb.CreateTransitRouterCmd.enrollment:type_name -> ziti.edge_cmd.pb.Enrollment
-	1,   // 71: ziti.edge_cmd.pb.CreateTransitRouterCmd.ctx:type_name -> ziti.edge_cmd.pb.ChangeContext
-	81,  // 72: ziti.edge_cmd.pb.UpdateServiceConfigsCmd.serviceConfigs:type_name -> ziti.edge_cmd.pb.UpdateServiceConfigsCmd.ServiceConfig
-	1,   // 73: ziti.edge_cmd.pb.UpdateServiceConfigsCmd.ctx:type_name -> ziti.edge_cmd.pb.ChangeContext
-	6,   // 74: ziti.edge_cmd.pb.JsonMap.ValueEntry.value:type_name -> ziti.edge_cmd.pb.JsonValue
-	82,  // 75: ziti.edge_cmd.pb.Authenticator.Cert.extendRequestedAt:type_name -> google.protobuf.Timestamp
-	3,   // 76: ziti.edge_cmd.pb.Authenticator.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
-	46,  // 77: ziti.edge_cmd.pb.AuthPolicy.Primary.cert:type_name -> ziti.edge_cmd.pb.AuthPolicy.Primary.Cert
-	47,  // 78: ziti.edge_cmd.pb.AuthPolicy.Primary.updb:type_name -> ziti.edge_cmd.pb.AuthPolicy.Primary.Updb
-	48,  // 79: ziti.edge_cmd.pb.AuthPolicy.Primary.extJwt:type_name -> ziti.edge_cmd.pb.AuthPolicy.Primary.ExtJwt
-	3,   // 80: ziti.edge_cmd.pb.AuthPolicy.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
-	3,   // 81: ziti.edge_cmd.pb.Ca.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
-	3,   // 82: ziti.edge_cmd.pb.Config.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
-	3,   // 83: ziti.edge_cmd.pb.ConfigType.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
-	3,   // 84: ziti.edge_cmd.pb.Controller.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
-	13,  // 85: ziti.edge_cmd.pb.Controller.ApiAddressesEntry.value:type_name -> ziti.edge_cmd.pb.ApiAddressList
-	3,   // 86: ziti.edge_cmd.pb.EdgeRouter.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
-	16,  // 87: ziti.edge_cmd.pb.EdgeRouter.CtrlChanListenersEntry.value:type_name -> ziti.edge_cmd.pb.CtrlChanListenerDetail
-	3,   // 88: ziti.edge_cmd.pb.EdgeRouterPolicy.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
-	3,   // 89: ziti.edge_cmd.pb.Enrollment.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
-	3,   // 90: ziti.edge_cmd.pb.ExternalJwtSigner.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
-	3,   // 91: ziti.edge_cmd.pb.Identity.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
-	3,   // 92: ziti.edge_cmd.pb.Mfa.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
-	69,  // 93: ziti.edge_cmd.pb.PostureCheck.OsList.osList:type_name -> ziti.edge_cmd.pb.PostureCheck.Os
-	71,  // 94: ziti.edge_cmd.pb.PostureCheck.ProcessMulti.processes:type_name -> ziti.edge_cmd.pb.PostureCheck.Process
-	3,   // 95: ziti.edge_cmd.pb.PostureCheck.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
-	3,   // 96: ziti.edge_cmd.pb.Revocation.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
-	3,   // 97: ziti.edge_cmd.pb.Service.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
-	3,   // 98: ziti.edge_cmd.pb.ServiceEdgeRouterPolicy.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
-	3,   // 99: ziti.edge_cmd.pb.ServicePolicy.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
-	3,   // 100: ziti.edge_cmd.pb.TransitRouter.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
-	16,  // 101: ziti.edge_cmd.pb.TransitRouter.CtrlChanListenersEntry.value:type_name -> ziti.edge_cmd.pb.CtrlChanListenerDetail
-	102, // [102:102] is the sub-list for method output_type
-	102, // [102:102] is the sub-list for method input_type
-	102, // [102:102] is the sub-list for extension type_name
-	102, // [102:102] is the sub-list for extension extendee
-	0,   // [0:102] is the sub-list for field type_name
+	82,  // 61: ziti.edge_cmd.pb.Revocation.issuedBefore:type_name -> google.protobuf.Timestamp
+	1,   // 62: ziti.edge_cmd.pb.DeleteRevocationsBatchCommand.ctx:type_name -> ziti.edge_cmd.pb.ChangeContext
+	29,  // 63: ziti.edge_cmd.pb.CreateRevocationsBatchCommand.revocations:type_name -> ziti.edge_cmd.pb.Revocation
+	1,   // 64: ziti.edge_cmd.pb.CreateRevocationsBatchCommand.ctx:type_name -> ziti.edge_cmd.pb.ChangeContext
+	76,  // 65: ziti.edge_cmd.pb.Service.tags:type_name -> ziti.edge_cmd.pb.Service.TagsEntry
+	77,  // 66: ziti.edge_cmd.pb.ServiceEdgeRouterPolicy.tags:type_name -> ziti.edge_cmd.pb.ServiceEdgeRouterPolicy.TagsEntry
+	78,  // 67: ziti.edge_cmd.pb.ServicePolicy.tags:type_name -> ziti.edge_cmd.pb.ServicePolicy.TagsEntry
+	79,  // 68: ziti.edge_cmd.pb.TransitRouter.tags:type_name -> ziti.edge_cmd.pb.TransitRouter.TagsEntry
+	80,  // 69: ziti.edge_cmd.pb.TransitRouter.ctrlChanListeners:type_name -> ziti.edge_cmd.pb.TransitRouter.CtrlChanListenersEntry
+	35,  // 70: ziti.edge_cmd.pb.CreateTransitRouterCmd.router:type_name -> ziti.edge_cmd.pb.TransitRouter
+	21,  // 71: ziti.edge_cmd.pb.CreateTransitRouterCmd.enrollment:type_name -> ziti.edge_cmd.pb.Enrollment
+	1,   // 72: ziti.edge_cmd.pb.CreateTransitRouterCmd.ctx:type_name -> ziti.edge_cmd.pb.ChangeContext
+	81,  // 73: ziti.edge_cmd.pb.UpdateServiceConfigsCmd.serviceConfigs:type_name -> ziti.edge_cmd.pb.UpdateServiceConfigsCmd.ServiceConfig
+	1,   // 74: ziti.edge_cmd.pb.UpdateServiceConfigsCmd.ctx:type_name -> ziti.edge_cmd.pb.ChangeContext
+	6,   // 75: ziti.edge_cmd.pb.JsonMap.ValueEntry.value:type_name -> ziti.edge_cmd.pb.JsonValue
+	82,  // 76: ziti.edge_cmd.pb.Authenticator.Cert.extendRequestedAt:type_name -> google.protobuf.Timestamp
+	3,   // 77: ziti.edge_cmd.pb.Authenticator.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
+	46,  // 78: ziti.edge_cmd.pb.AuthPolicy.Primary.cert:type_name -> ziti.edge_cmd.pb.AuthPolicy.Primary.Cert
+	47,  // 79: ziti.edge_cmd.pb.AuthPolicy.Primary.updb:type_name -> ziti.edge_cmd.pb.AuthPolicy.Primary.Updb
+	48,  // 80: ziti.edge_cmd.pb.AuthPolicy.Primary.extJwt:type_name -> ziti.edge_cmd.pb.AuthPolicy.Primary.ExtJwt
+	3,   // 81: ziti.edge_cmd.pb.AuthPolicy.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
+	3,   // 82: ziti.edge_cmd.pb.Ca.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
+	3,   // 83: ziti.edge_cmd.pb.Config.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
+	3,   // 84: ziti.edge_cmd.pb.ConfigType.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
+	3,   // 85: ziti.edge_cmd.pb.Controller.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
+	13,  // 86: ziti.edge_cmd.pb.Controller.ApiAddressesEntry.value:type_name -> ziti.edge_cmd.pb.ApiAddressList
+	3,   // 87: ziti.edge_cmd.pb.EdgeRouter.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
+	16,  // 88: ziti.edge_cmd.pb.EdgeRouter.CtrlChanListenersEntry.value:type_name -> ziti.edge_cmd.pb.CtrlChanListenerDetail
+	3,   // 89: ziti.edge_cmd.pb.EdgeRouterPolicy.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
+	3,   // 90: ziti.edge_cmd.pb.Enrollment.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
+	3,   // 91: ziti.edge_cmd.pb.ExternalJwtSigner.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
+	3,   // 92: ziti.edge_cmd.pb.Identity.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
+	3,   // 93: ziti.edge_cmd.pb.Mfa.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
+	69,  // 94: ziti.edge_cmd.pb.PostureCheck.OsList.osList:type_name -> ziti.edge_cmd.pb.PostureCheck.Os
+	71,  // 95: ziti.edge_cmd.pb.PostureCheck.ProcessMulti.processes:type_name -> ziti.edge_cmd.pb.PostureCheck.Process
+	3,   // 96: ziti.edge_cmd.pb.PostureCheck.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
+	3,   // 97: ziti.edge_cmd.pb.Revocation.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
+	3,   // 98: ziti.edge_cmd.pb.Service.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
+	3,   // 99: ziti.edge_cmd.pb.ServiceEdgeRouterPolicy.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
+	3,   // 100: ziti.edge_cmd.pb.ServicePolicy.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
+	3,   // 101: ziti.edge_cmd.pb.TransitRouter.TagsEntry.value:type_name -> ziti.edge_cmd.pb.TagValue
+	16,  // 102: ziti.edge_cmd.pb.TransitRouter.CtrlChanListenersEntry.value:type_name -> ziti.edge_cmd.pb.CtrlChanListenerDetail
+	103, // [103:103] is the sub-list for method output_type
+	103, // [103:103] is the sub-list for method input_type
+	103, // [103:103] is the sub-list for extension type_name
+	103, // [103:103] is the sub-list for extension extendee
+	0,   // [0:103] is the sub-list for field type_name
 }
 
 func init() { file_edge_cmd_proto_init() }

--- a/common/pb/edge_cmd_pb/edge_cmd.proto
+++ b/common/pb/edge_cmd_pb/edge_cmd.proto
@@ -443,6 +443,7 @@ message Revocation {
   google.protobuf.Timestamp expiresAt = 2;
   map<string, TagValue> tags = 3;
   string type = 4;
+  google.protobuf.Timestamp issuedBefore = 5;
 }
 
 message DeleteRevocationsBatchCommand {

--- a/common/pb/edge_ctrl_pb/edge_ctrl.pb.go
+++ b/common/pb/edge_ctrl_pb/edge_ctrl.pb.go
@@ -4257,9 +4257,17 @@ func (x *DataState_ServicePolicy) GetPolicyType() PolicyType {
 }
 
 type DataState_Revocation struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	ExpiresAt     *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=ExpiresAt,proto3" json:"ExpiresAt,omitempty"`
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	Id        string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	ExpiresAt *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=ExpiresAt,proto3" json:"ExpiresAt,omitempty"`
+	// type distinguishes what id identifies, using rest_model.RevocationTypeEnum
+	// values: an api-session ("API_SESSION"), an identity ("IDENTITY"), or a
+	// token/jti ("JTI"). Empty for legacy revocations.
+	Type string `protobuf:"bytes,3,opt,name=type,proto3" json:"type,omitempty"`
+	// issuedBefore is the cutoff for IDENTITY revocations: only sessions issued
+	// (iat) before this time are revoked, so a session re-authenticated after
+	// the cutoff survives the still-lingering revocation. Ignored for other types.
+	IssuedBefore  *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=issuedBefore,proto3" json:"issuedBefore,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4304,6 +4312,20 @@ func (x *DataState_Revocation) GetId() string {
 func (x *DataState_Revocation) GetExpiresAt() *timestamppb.Timestamp {
 	if x != nil {
 		return x.ExpiresAt
+	}
+	return nil
+}
+
+func (x *DataState_Revocation) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+func (x *DataState_Revocation) GetIssuedBefore() *timestamppb.Timestamp {
+	if x != nil {
+		return x.IssuedBefore
 	}
 	return nil
 }
@@ -5437,7 +5459,7 @@ const file_edge_ctrl_proto_rawDesc = "" +
 	"\x04data\x18\x01 \x03(\v2\".ziti.edge_ctrl.pb.Cache.DataEntryR\x04data\x1a7\n" +
 	"\tDataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\fR\x05value:\x028\x01\"\xf8#\n" +
+	"\x05value\x18\x02 \x01(\fR\x05value:\x028\x01\"\xcd$\n" +
 	"\tDataState\x12:\n" +
 	"\x06events\x18\x01 \x03(\v2\".ziti.edge_ctrl.pb.DataState.EventR\x06events\x12\x1a\n" +
 	"\bendIndex\x18\x02 \x01(\x04R\bendIndex\x12\x1e\n" +
@@ -5492,11 +5514,13 @@ const file_edge_ctrl_proto_rawDesc = "" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12=\n" +
 	"\n" +
 	"policyType\x18\x03 \x01(\x0e2\x1d.ziti.edge_ctrl.pb.PolicyTypeR\n" +
-	"policyType\x1aV\n" +
+	"policyType\x1a\xaa\x01\n" +
 	"\n" +
 	"Revocation\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x128\n" +
-	"\tExpiresAt\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\tExpiresAt\x1a\xd0\x01\n" +
+	"\tExpiresAt\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\tExpiresAt\x12\x12\n" +
+	"\x04type\x18\x03 \x01(\tR\x04type\x12>\n" +
+	"\fissuedBefore\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\fissuedBefore\x1a\xd0\x01\n" +
 	"\x13ServicePolicyChange\x12\x1a\n" +
 	"\bpolicyId\x18\x01 \x01(\tR\bpolicyId\x12*\n" +
 	"\x10relatedEntityIds\x18\x02 \x03(\tR\x10relatedEntityIds\x12_\n" +
@@ -6147,37 +6171,38 @@ var file_edge_ctrl_proto_depIdxs = []int32{
 	77,  // 50: ziti.edge_ctrl.pb.DataState.Identity.serviceConfigs:type_name -> ziti.edge_ctrl.pb.DataState.Identity.ServiceConfigsEntry
 	4,   // 51: ziti.edge_ctrl.pb.DataState.ServicePolicy.policyType:type_name -> ziti.edge_ctrl.pb.PolicyType
 	103, // 52: ziti.edge_ctrl.pb.DataState.Revocation.ExpiresAt:type_name -> google.protobuf.Timestamp
-	5,   // 53: ziti.edge_ctrl.pb.DataState.ServicePolicyChange.relatedEntityType:type_name -> ziti.edge_ctrl.pb.ServicePolicyRelatedEntityType
-	71,  // 54: ziti.edge_ctrl.pb.DataState.ChangeSet.changes:type_name -> ziti.edge_ctrl.pb.DataState.Event
-	8,   // 55: ziti.edge_ctrl.pb.DataState.Event.action:type_name -> ziti.edge_ctrl.pb.DataState.Action
-	65,  // 56: ziti.edge_ctrl.pb.DataState.Event.identity:type_name -> ziti.edge_ctrl.pb.DataState.Identity
-	66,  // 57: ziti.edge_ctrl.pb.DataState.Event.service:type_name -> ziti.edge_ctrl.pb.DataState.Service
-	67,  // 58: ziti.edge_ctrl.pb.DataState.Event.servicePolicy:type_name -> ziti.edge_ctrl.pb.DataState.ServicePolicy
-	73,  // 59: ziti.edge_ctrl.pb.DataState.Event.postureCheck:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck
-	72,  // 60: ziti.edge_ctrl.pb.DataState.Event.publicKey:type_name -> ziti.edge_ctrl.pb.DataState.PublicKey
-	68,  // 61: ziti.edge_ctrl.pb.DataState.Event.revocation:type_name -> ziti.edge_ctrl.pb.DataState.Revocation
-	69,  // 62: ziti.edge_ctrl.pb.DataState.Event.servicePolicyChange:type_name -> ziti.edge_ctrl.pb.DataState.ServicePolicyChange
-	62,  // 63: ziti.edge_ctrl.pb.DataState.Event.configType:type_name -> ziti.edge_ctrl.pb.DataState.ConfigType
-	63,  // 64: ziti.edge_ctrl.pb.DataState.Event.config:type_name -> ziti.edge_ctrl.pb.DataState.Config
-	9,   // 65: ziti.edge_ctrl.pb.DataState.PublicKey.usages:type_name -> ziti.edge_ctrl.pb.DataState.PublicKey.Usage
-	10,  // 66: ziti.edge_ctrl.pb.DataState.PublicKey.format:type_name -> ziti.edge_ctrl.pb.DataState.PublicKey.Format
-	78,  // 67: ziti.edge_ctrl.pb.DataState.PostureCheck.mac:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck.Mac
-	79,  // 68: ziti.edge_ctrl.pb.DataState.PostureCheck.mfa:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck.Mfa
-	81,  // 69: ziti.edge_ctrl.pb.DataState.PostureCheck.osList:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck.OsList
-	82,  // 70: ziti.edge_ctrl.pb.DataState.PostureCheck.process:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck.Process
-	83,  // 71: ziti.edge_ctrl.pb.DataState.PostureCheck.processMulti:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck.ProcessMulti
-	84,  // 72: ziti.edge_ctrl.pb.DataState.PostureCheck.domains:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck.Domains
-	6,   // 73: ziti.edge_ctrl.pb.DataState.Identity.ServiceHostingPrecedencesEntry.value:type_name -> ziti.edge_ctrl.pb.TerminatorPrecedence
-	64,  // 74: ziti.edge_ctrl.pb.DataState.Identity.ServiceConfigsEntry.value:type_name -> ziti.edge_ctrl.pb.DataState.ServiceConfigs
-	80,  // 75: ziti.edge_ctrl.pb.DataState.PostureCheck.OsList.osList:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck.Os
-	82,  // 76: ziti.edge_ctrl.pb.DataState.PostureCheck.ProcessMulti.processes:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck.Process
-	6,   // 77: ziti.edge_ctrl.pb.CreateApiSessionResponse.ServicePrecedencesEntry.value:type_name -> ziti.edge_ctrl.pb.TerminatorPrecedence
-	99,  // 78: ziti.edge_ctrl.pb.ConnectEvents.IdentityConnectEvents.connectTimes:type_name -> ziti.edge_ctrl.pb.ConnectEvents.ConnectDetails
-	79,  // [79:79] is the sub-list for method output_type
-	79,  // [79:79] is the sub-list for method input_type
-	79,  // [79:79] is the sub-list for extension type_name
-	79,  // [79:79] is the sub-list for extension extendee
-	0,   // [0:79] is the sub-list for field type_name
+	103, // 53: ziti.edge_ctrl.pb.DataState.Revocation.issuedBefore:type_name -> google.protobuf.Timestamp
+	5,   // 54: ziti.edge_ctrl.pb.DataState.ServicePolicyChange.relatedEntityType:type_name -> ziti.edge_ctrl.pb.ServicePolicyRelatedEntityType
+	71,  // 55: ziti.edge_ctrl.pb.DataState.ChangeSet.changes:type_name -> ziti.edge_ctrl.pb.DataState.Event
+	8,   // 56: ziti.edge_ctrl.pb.DataState.Event.action:type_name -> ziti.edge_ctrl.pb.DataState.Action
+	65,  // 57: ziti.edge_ctrl.pb.DataState.Event.identity:type_name -> ziti.edge_ctrl.pb.DataState.Identity
+	66,  // 58: ziti.edge_ctrl.pb.DataState.Event.service:type_name -> ziti.edge_ctrl.pb.DataState.Service
+	67,  // 59: ziti.edge_ctrl.pb.DataState.Event.servicePolicy:type_name -> ziti.edge_ctrl.pb.DataState.ServicePolicy
+	73,  // 60: ziti.edge_ctrl.pb.DataState.Event.postureCheck:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck
+	72,  // 61: ziti.edge_ctrl.pb.DataState.Event.publicKey:type_name -> ziti.edge_ctrl.pb.DataState.PublicKey
+	68,  // 62: ziti.edge_ctrl.pb.DataState.Event.revocation:type_name -> ziti.edge_ctrl.pb.DataState.Revocation
+	69,  // 63: ziti.edge_ctrl.pb.DataState.Event.servicePolicyChange:type_name -> ziti.edge_ctrl.pb.DataState.ServicePolicyChange
+	62,  // 64: ziti.edge_ctrl.pb.DataState.Event.configType:type_name -> ziti.edge_ctrl.pb.DataState.ConfigType
+	63,  // 65: ziti.edge_ctrl.pb.DataState.Event.config:type_name -> ziti.edge_ctrl.pb.DataState.Config
+	9,   // 66: ziti.edge_ctrl.pb.DataState.PublicKey.usages:type_name -> ziti.edge_ctrl.pb.DataState.PublicKey.Usage
+	10,  // 67: ziti.edge_ctrl.pb.DataState.PublicKey.format:type_name -> ziti.edge_ctrl.pb.DataState.PublicKey.Format
+	78,  // 68: ziti.edge_ctrl.pb.DataState.PostureCheck.mac:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck.Mac
+	79,  // 69: ziti.edge_ctrl.pb.DataState.PostureCheck.mfa:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck.Mfa
+	81,  // 70: ziti.edge_ctrl.pb.DataState.PostureCheck.osList:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck.OsList
+	82,  // 71: ziti.edge_ctrl.pb.DataState.PostureCheck.process:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck.Process
+	83,  // 72: ziti.edge_ctrl.pb.DataState.PostureCheck.processMulti:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck.ProcessMulti
+	84,  // 73: ziti.edge_ctrl.pb.DataState.PostureCheck.domains:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck.Domains
+	6,   // 74: ziti.edge_ctrl.pb.DataState.Identity.ServiceHostingPrecedencesEntry.value:type_name -> ziti.edge_ctrl.pb.TerminatorPrecedence
+	64,  // 75: ziti.edge_ctrl.pb.DataState.Identity.ServiceConfigsEntry.value:type_name -> ziti.edge_ctrl.pb.DataState.ServiceConfigs
+	80,  // 76: ziti.edge_ctrl.pb.DataState.PostureCheck.OsList.osList:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck.Os
+	82,  // 77: ziti.edge_ctrl.pb.DataState.PostureCheck.ProcessMulti.processes:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck.Process
+	6,   // 78: ziti.edge_ctrl.pb.CreateApiSessionResponse.ServicePrecedencesEntry.value:type_name -> ziti.edge_ctrl.pb.TerminatorPrecedence
+	99,  // 79: ziti.edge_ctrl.pb.ConnectEvents.IdentityConnectEvents.connectTimes:type_name -> ziti.edge_ctrl.pb.ConnectEvents.ConnectDetails
+	80,  // [80:80] is the sub-list for method output_type
+	80,  // [80:80] is the sub-list for method input_type
+	80,  // [80:80] is the sub-list for extension type_name
+	80,  // [80:80] is the sub-list for extension extendee
+	0,   // [0:80] is the sub-list for field type_name
 }
 
 func init() { file_edge_ctrl_proto_init() }

--- a/common/pb/edge_ctrl_pb/edge_ctrl.proto
+++ b/common/pb/edge_ctrl_pb/edge_ctrl.proto
@@ -211,6 +211,14 @@ message DataState {
   message Revocation {
     string id = 1;
     google.protobuf.Timestamp ExpiresAt = 2;
+    // type distinguishes what id identifies, using rest_model.RevocationTypeEnum
+    // values: an api-session ("API_SESSION"), an identity ("IDENTITY"), or a
+    // token/jti ("JTI"). Empty for legacy revocations.
+    string type = 3;
+    // issuedBefore is the cutoff for IDENTITY revocations: only sessions issued
+    // (iat) before this time are revoked, so a session re-authenticated after
+    // the cutoff survives the still-lingering revocation. Ignored for other types.
+    google.protobuf.Timestamp issuedBefore = 4;
   }
 
   message ServicePolicyChange {

--- a/common/router_data_model.go
+++ b/common/router_data_model.go
@@ -33,6 +33,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/michaelquigley/pfxlog"
+	"github.com/openziti/edge-api/rest_model"
 	"github.com/openziti/foundation/v2/concurrenz"
 	"github.com/openziti/ziti/v2/common/pb/edge_ctrl_pb"
 	cmap "github.com/orcaman/concurrent-map/v2"
@@ -44,6 +45,18 @@ const (
 	IdentityAdded   byte = 1
 	IdentityUpdated byte = 2
 	IdentityDeleted byte = 4
+)
+
+// Revocation type values for DataState_Revocation.Type, distinguishing what the
+// revocation's Id identifies so the router can match it against the right token
+// attribute. They mirror rest_model.RevocationTypeEnum — the canonical taxonomy
+// used by the management revocation API and persisted on model.Revocation — so
+// router-side matching and every producer share one vocabulary. An empty type
+// is a legacy revocation with no router-side enforcement.
+const (
+	RevocationTypeApiSession = string(rest_model.RevocationTypeEnumAPISESSION) // "API_SESSION"; Id is an api-session id (z_asid)
+	RevocationTypeIdentity   = string(rest_model.RevocationTypeEnumIDENTITY)   // "IDENTITY"; Id is an identity id
+	RevocationTypeToken      = string(rest_model.RevocationTypeEnumJTI)        // "JTI"; Id is a token id (jti)
 )
 
 // RouterDataModelConfig contains the configuration values for a RouterDataModel
@@ -1406,6 +1419,33 @@ func (rdm *RouterDataModel) HandleRevocationEvent(event *edge_ctrl_pb.DataState_
 	} else {
 		rdm.Revocations.Set(model.Revocation.Id, model.Revocation)
 	}
+}
+
+// IsApiSessionRevoked reports whether the api-session with the given id has been
+// revoked (e.g. by OIDC end-session). The api-session id is a unique value, so
+// an api-session-typed revocation keyed by it unambiguously targets that
+// session.
+func (rdm *RouterDataModel) IsApiSessionRevoked(apiSessionId string) bool {
+	if revocation, found := rdm.Revocations.Get(apiSessionId); found {
+		return revocation.Type == RevocationTypeApiSession
+	}
+	return false
+}
+
+// IsIdentityRevoked reports whether a session for the given identity, issued at
+// issuedAt, has been revoked (e.g. by disabling/deleting the identity or an
+// identity-scoped revocation). The revocation carries an IssuedBefore cutoff so
+// only sessions that predate it are revoked; a session re-authenticated after
+// the cutoff survives the still-lingering revocation. A revocation with no
+// cutoff is treated as revoking all of the identity's sessions.
+func (rdm *RouterDataModel) IsIdentityRevoked(identityId string, issuedAt time.Time) bool {
+	if revocation, found := rdm.Revocations.Get(identityId); found && revocation.Type == RevocationTypeIdentity {
+		if revocation.IssuedBefore == nil {
+			return true
+		}
+		return issuedAt.Before(revocation.IssuedBefore.AsTime())
+	}
+	return false
 }
 
 func (rdm *RouterDataModel) HandleServicePolicyChange(index uint64, model *edge_ctrl_pb.DataState_ServicePolicyChange) {

--- a/controller/config/config_edge.go
+++ b/controller/config/config_edge.go
@@ -34,6 +34,7 @@ import (
 	"github.com/michaelquigley/pfxlog"
 	nfpem "github.com/openziti/foundation/v2/pem"
 	"github.com/openziti/identity"
+	"github.com/openziti/ziti/v2/common"
 	"github.com/openziti/ziti/v2/controller/command"
 	"github.com/pkg/errors"
 )
@@ -126,6 +127,13 @@ type Oidc struct {
 	// RevocationEnforcerFrequency is how often the controller purges expired
 	// revocation records from the database.
 	RevocationEnforcerFrequency time.Duration
+}
+
+// MaxTokenDuration returns the longest of the configured refresh, access, and id
+// token durations. Revocations are set to expire after this so they outlive any
+// token they target.
+func (o *Oidc) MaxTokenDuration() time.Duration {
+	return common.MaxTokenDuration(o.RefreshTokenDuration, o.AccessTokenDuration, o.IdTokenDuration)
 }
 
 type EdgeConfig struct {

--- a/controller/db/identity_revocation_constraint.go
+++ b/controller/db/identity_revocation_constraint.go
@@ -1,0 +1,95 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package db
+
+import (
+	"time"
+
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
+)
+
+// IdentityRevocationConstraint creates an identity-scoped revocation in the same
+// transaction as the identity change that warrants it: deleting an identity, or
+// disabling one. Self-contained OIDC JWTs are not stored, so without a revocation
+// the router would keep serving a deleted/disabled identity's live sessions until
+// their tokens expired. Running as a store pre-commit constraint makes the
+// revocation atomic with the change and impossible to skip from any code path.
+//
+// The revocation type and lifetime are injected (the db layer has no view of the
+// OIDC config or the rest_model revocation taxonomy), so the constraint stays
+// free of those dependencies and the wiring layer supplies them.
+type IdentityRevocationConstraint struct {
+	revocationStore RevocationStore
+	revocationType  string
+	revocationTtl   func() time.Duration
+}
+
+// NewIdentityRevocationConstraint builds an IdentityRevocationConstraint that
+// writes revocations of the given type into revocationStore, with an expiry of
+// now plus revocationTtl() (the longest a token could remain valid).
+func NewIdentityRevocationConstraint(revocationStore RevocationStore, revocationType string, revocationTtl func() time.Duration) *IdentityRevocationConstraint {
+	return &IdentityRevocationConstraint{
+		revocationStore: revocationStore,
+		revocationType:  revocationType,
+		revocationTtl:   revocationTtl,
+	}
+}
+
+// ProcessPreCommit creates the revocation, within the change's transaction, when
+// an identity is deleted or transitions into the disabled state.
+func (self *IdentityRevocationConstraint) ProcessPreCommit(state *boltz.EntityChangeState[*Identity]) error {
+	switch state.ChangeType {
+	case boltz.EntityDeleted:
+		if state.InitialState != nil {
+			return self.revoke(state, state.InitialState.Id)
+		}
+	case boltz.EntityUpdated:
+		// Only the transition into the disabled state warrants a revocation;
+		// other updates, including changes made while already disabled, leave any
+		// existing revocation untouched.
+		if state.InitialState != nil && state.FinalState != nil &&
+			state.InitialState.DisabledAt == nil && state.FinalState.DisabledAt != nil {
+			return self.revoke(state, state.FinalState.Id)
+		}
+	}
+	return nil
+}
+
+// ProcessPostCommit is a no-op; the revocation is persisted in ProcessPreCommit
+// and the revocation store's own handler pushes it to the routers on commit.
+func (self *IdentityRevocationConstraint) ProcessPostCommit(*boltz.EntityChangeState[*Identity]) {}
+
+// revoke creates, replacing any prior entry, an identity-scoped revocation within
+// the change's transaction. The cutoff is now, so a session re-authenticated
+// after a re-enable survives the still-lingering revocation.
+func (self *IdentityRevocationConstraint) revoke(state *boltz.EntityChangeState[*Identity], identityId string) error {
+	now := time.Now()
+	revocation := &Revocation{
+		BaseExtEntity: *boltz.NewExtEntity(identityId, nil),
+		ExpiresAt:     now.Add(self.revocationTtl()),
+		Type:          self.revocationType,
+		IssuedBefore:  now,
+	}
+
+	ctx := state.GetCtx()
+	if self.revocationStore.IsEntityPresent(ctx.Tx(), identityId) {
+		if err := self.revocationStore.DeleteById(ctx, identityId); err != nil {
+			return err
+		}
+	}
+	return self.revocationStore.Create(ctx, revocation)
+}

--- a/controller/db/revocation_store.go
+++ b/controller/db/revocation_store.go
@@ -24,14 +24,16 @@ import (
 )
 
 const (
-	FieldRevocationExpiresAt = "expiresAt"
-	FieldRevocationType      = "type"
+	FieldRevocationExpiresAt    = "expiresAt"
+	FieldRevocationType         = "type"
+	FieldRevocationIssuedBefore = "issuedBefore"
 )
 
 type Revocation struct {
 	boltz.BaseExtEntity
-	ExpiresAt time.Time `json:"expiresAt"`
-	Type      string    `json:"type"`
+	ExpiresAt    time.Time `json:"expiresAt"`
+	Type         string    `json:"type"`
+	IssuedBefore time.Time `json:"issuedBefore"`
 }
 
 func (r Revocation) GetEntityType() string {
@@ -59,6 +61,7 @@ func (store *revocationStoreImpl) initializeLocal() {
 	store.AddExtEntitySymbols()
 	store.AddSymbol(FieldRevocationExpiresAt, ast.NodeTypeDatetime)
 	store.AddSymbol(FieldRevocationType, ast.NodeTypeString)
+	store.AddSymbol(FieldRevocationIssuedBefore, ast.NodeTypeDatetime)
 }
 
 func (store *revocationStoreImpl) initializeLinked() {}
@@ -71,10 +74,12 @@ func (store *revocationStoreImpl) FillEntity(entity *Revocation, bucket *boltz.T
 	entity.LoadBaseValues(bucket)
 	entity.ExpiresAt = bucket.GetTimeOrError(FieldRevocationExpiresAt)
 	entity.Type = bucket.GetStringWithDefault(FieldRevocationType, "")
+	entity.IssuedBefore = bucket.GetTimeOrDefault(FieldRevocationIssuedBefore, time.Time{})
 }
 
 func (store *revocationStoreImpl) PersistEntity(entity *Revocation, ctx *boltz.PersistContext) {
 	entity.SetBaseValues(ctx)
 	ctx.SetTimeP(FieldRevocationExpiresAt, &entity.ExpiresAt)
 	ctx.SetString(FieldRevocationType, entity.Type)
+	ctx.SetTimeP(FieldRevocationIssuedBefore, &entity.IssuedBefore)
 }

--- a/controller/internal/routes/revocation_router.go
+++ b/controller/internal/routes/revocation_router.go
@@ -25,12 +25,12 @@ import (
 	"github.com/openziti/edge-api/rest_management_api_server/operations/revocation"
 	"github.com/openziti/edge-api/rest_model"
 	"github.com/openziti/foundation/v2/errorz"
-	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/openziti/ziti/v2/controller/env"
 	"github.com/openziti/ziti/v2/controller/model"
 	"github.com/openziti/ziti/v2/controller/models"
 	"github.com/openziti/ziti/v2/controller/permissions"
 	"github.com/openziti/ziti/v2/controller/response"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
 )
 
 func init() {
@@ -76,7 +76,7 @@ func (r *RevocationRouter) Detail(ae *env.AppEnv, rc *response.RequestContext) {
 }
 
 // Create handles POST /revocations. It validates the submitted id against the
-// revocation type, computes the expiry from the configured refresh token duration,
+// revocation type, computes the expiry from the maximum configured token duration,
 // and persists the revocation entry.
 func (r *RevocationRouter) Create(ae *env.AppEnv, rc *response.RequestContext, params revocation.CreateRevocationParams) {
 	Create(rc, rc, RevocationLinkFactory, func() (string, error) {
@@ -84,7 +84,7 @@ func (r *RevocationRouter) Create(ae *env.AppEnv, rc *response.RequestContext, p
 		if err != nil {
 			return "", err
 		}
-		if err = ae.Managers.Revocation.Create(entity, rc.NewChangeContext()); err != nil {
+		if err = ae.Managers.Revocation.CreateOrReplace(entity, rc.NewChangeContext()); err != nil {
 			return "", err
 		}
 		return entity.Id, nil
@@ -122,7 +122,8 @@ func mapCreateRevocationToModel(ae *env.AppEnv, r *http.Request, create *rest_mo
 		}
 	}
 
-	expiresAt := time.Now().Add(ae.GetConfig().Edge.Oidc.RefreshTokenDuration)
+	now := time.Now()
+	expiresAt := now.Add(ae.GetConfig().Edge.Oidc.MaxTokenDuration())
 
 	return &model.Revocation{
 		BaseEntity: models.BaseEntity{
@@ -131,5 +132,8 @@ func mapCreateRevocationToModel(ae *env.AppEnv, r *http.Request, create *rest_mo
 		},
 		ExpiresAt: expiresAt,
 		Type:      string(revocationType),
+		// IssuedBefore is the cutoff for IDENTITY revocations: sessions issued
+		// before now are revoked, while a later re-authentication survives.
+		IssuedBefore: now,
 	}, nil
 }

--- a/controller/model/identity_manager.go
+++ b/controller/model/identity_manager.go
@@ -27,7 +27,7 @@ import (
 	"github.com/openziti/foundation/v2/errorz"
 	"github.com/openziti/metrics"
 	"github.com/openziti/sdk-golang/ziti"
-	"github.com/openziti/ziti/v2/controller/storage/boltz"
+	"github.com/openziti/ziti/v2/common"
 	"github.com/openziti/ziti/v2/common/ctrlchan"
 	"github.com/openziti/ziti/v2/common/eid"
 	"github.com/openziti/ziti/v2/common/inspect"
@@ -42,6 +42,7 @@ import (
 	"github.com/openziti/ziti/v2/controller/fields"
 	"github.com/openziti/ziti/v2/controller/models"
 	"github.com/openziti/ziti/v2/controller/permissions"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	cmap "github.com/orcaman/concurrent-map/v2"
 	"go.etcd.io/bbolt"
 	"google.golang.org/protobuf/proto"
@@ -80,6 +81,16 @@ func NewIdentityManager(env Env) *IdentityManager {
 	RegisterCommand(env, &CreateIdentityWithEnrollmentsCmd{}, &edge_cmd_pb.CreateIdentityWithEnrollmentsCmd{})
 	RegisterCommand(env, &CreateIdentityWithAuthenticatorsCmd{}, &edge_cmd_pb.CreateIdentityWithAuthenticatorsCmd{})
 	RegisterCommand(env, &UpdateServiceConfigsCmd{}, &edge_cmd_pb.UpdateServiceConfigsCmd{})
+
+	// Revoke a deleted or disabled identity's live OIDC sessions atomically with
+	// the identity change itself, so the revocation cannot be skipped. The db-level
+	// constraint is config-agnostic, so the revocation type and lifetime are
+	// supplied here.
+	env.GetStores().Identity.AddEntityConstraint(db.NewIdentityRevocationConstraint(
+		env.GetStores().Revocation,
+		common.RevocationTypeIdentity,
+		func() time.Duration { return env.GetConfig().Edge.Oidc.RefreshTokenDuration },
+	))
 
 	return manager
 }
@@ -607,6 +618,8 @@ func (self *IdentityManager) Disable(identityId string, duration time.Duration, 
 		return err
 	}
 
+	// Disabling sets DisabledAt, which the IdentityRevocationConstraint observes
+	// to revoke the identity's live OIDC sessions in the same transaction.
 	return self.GetEnv().GetManagers().ApiSession.DeleteByIdentityId(identityId, ctx)
 }
 

--- a/controller/model/identity_manager_test.go
+++ b/controller/model/identity_manager_test.go
@@ -132,7 +132,10 @@ func (ctx *TestContext) testIdentityConfigOverridesIdentityDelete(t *testing.T) 
 	ctx.NoError(err)
 
 	boltztest.ValidateDeleted(ctx, service.Id)
-	boltztest.ValidateDeleted(ctx, identity.Id)
+	// Deleting an identity creates an identity-scoped revocation keyed by the
+	// identity id (to revoke its live OIDC sessions), which legitimately remains
+	// under the revocations bucket, so exclude that path from the scan.
+	boltztest.ValidateDeleted(ctx, identity.Id, "/"+db.RootBucket+"/"+db.EntityTypeRevocations)
 	boltztest.ValidateDeleted(ctx, cfg1.Id)
 	boltztest.ValidateDeleted(ctx, cfg2.Id)
 }

--- a/controller/model/revocation_manager.go
+++ b/controller/model/revocation_manager.go
@@ -21,13 +21,13 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/openziti/ziti/v2/common/pb/cmd_pb"
 	"github.com/openziti/ziti/v2/common/pb/edge_cmd_pb"
 	"github.com/openziti/ziti/v2/controller/change"
 	"github.com/openziti/ziti/v2/controller/command"
 	"github.com/openziti/ziti/v2/controller/db"
 	"github.com/openziti/ziti/v2/controller/models"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -54,6 +54,20 @@ func (self *RevocationManager) ApplyUpdate(_ *command.UpdateEntityCommand[*Revoc
 
 func (self *RevocationManager) Create(entity *Revocation, ctx *change.Context) error {
 	return DispatchCreate[*Revocation](self, entity, ctx)
+}
+
+// CreateOrReplace creates the revocation, first removing any existing revocation
+// with the same id. Identity- and api-session-scoped revocations are keyed by
+// the identity/session id, so a repeat (e.g. re-disabling an identity, or a
+// second logout) would otherwise collide with the lingering prior entry;
+// replacing it refreshes the ExpiresAt and IssuedBefore cutoff.
+func (self *RevocationManager) CreateOrReplace(entity *Revocation, ctx *change.Context) error {
+	if existing, _ := self.Read(entity.Id); existing != nil {
+		if err := self.Delete(entity.Id, ctx); err != nil {
+			return err
+		}
+	}
+	return self.Create(entity, ctx)
 }
 
 func (self *RevocationManager) ApplyCreate(cmd *command.CreateEntityCommand[*Revocation], ctx boltz.MutateContext) error {
@@ -120,6 +134,9 @@ func (self *RevocationManager) Marshall(entity *Revocation) ([]byte, error) {
 		Tags:      tags,
 		Type:      entity.Type,
 	}
+	if !entity.IssuedBefore.IsZero() {
+		msg.IssuedBefore = timePtrToPb(&entity.IssuedBefore)
+	}
 
 	return proto.Marshal(msg)
 }
@@ -134,14 +151,18 @@ func (self *RevocationManager) Unmarshall(bytes []byte) (*Revocation, error) {
 		return nil, fmt.Errorf("revocation msg for id '%v' has nil ExpiresAt", msg.Id)
 	}
 
-	return &Revocation{
+	revocation := &Revocation{
 		BaseEntity: models.BaseEntity{
 			Id:   msg.Id,
 			Tags: edge_cmd_pb.DecodeTags(msg.Tags),
 		},
 		ExpiresAt: *pbTimeToTimePtr(msg.ExpiresAt),
 		Type:      msg.Type,
-	}, nil
+	}
+	if msg.IssuedBefore != nil {
+		revocation.IssuedBefore = msg.IssuedBefore.AsTime()
+	}
+	return revocation, nil
 }
 
 // DeleteBatch dispatches a batched delete of revocation IDs through raft as a
@@ -252,11 +273,16 @@ func (self *CreateRevocationsBatchCommand) Encode() ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		pbRevocations = append(pbRevocations, &edge_cmd_pb.Revocation{
+		pbRev := &edge_cmd_pb.Revocation{
 			Id:        rev.Id,
 			ExpiresAt: timePtrToPb(&rev.ExpiresAt),
 			Tags:      tags,
-		})
+			Type:      rev.Type,
+		}
+		if !rev.IssuedBefore.IsZero() {
+			pbRev.IssuedBefore = timePtrToPb(&rev.IssuedBefore)
+		}
+		pbRevocations = append(pbRevocations, pbRev)
 	}
 	return cmd_pb.EncodeProtobuf(&edge_cmd_pb.CreateRevocationsBatchCommand{
 		Revocations: pbRevocations,
@@ -277,6 +303,10 @@ func (self *CreateRevocationsBatchCommand) Decode(env Env, msg *edge_cmd_pb.Crea
 				Tags: edge_cmd_pb.DecodeTags(pbRev.Tags),
 			},
 			ExpiresAt: *pbTimeToTimePtr(pbRev.ExpiresAt),
+			Type:      pbRev.Type,
+		}
+		if pbRev.IssuedBefore != nil {
+			rev.IssuedBefore = pbRev.IssuedBefore.AsTime()
 		}
 		self.Revocations = append(self.Revocations, rev)
 	}

--- a/controller/model/revocation_model.go
+++ b/controller/model/revocation_model.go
@@ -19,16 +19,17 @@ package model
 import (
 	"time"
 
-	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/openziti/ziti/v2/controller/db"
 	"github.com/openziti/ziti/v2/controller/models"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"go.etcd.io/bbolt"
 )
 
 type Revocation struct {
 	models.BaseEntity
-	ExpiresAt time.Time
-	Type      string
+	ExpiresAt    time.Time
+	Type         string
+	IssuedBefore time.Time
 }
 
 func (entity *Revocation) toBoltEntityForUpdate(tx *bbolt.Tx, env Env, _ boltz.FieldChecker) (*db.Revocation, error) {
@@ -39,6 +40,7 @@ func (entity *Revocation) fillFrom(_ Env, _ *bbolt.Tx, boltRevocation *db.Revoca
 	entity.FillCommon(boltRevocation)
 	entity.ExpiresAt = boltRevocation.ExpiresAt
 	entity.Type = boltRevocation.Type
+	entity.IssuedBefore = boltRevocation.IssuedBefore
 
 	return nil
 }
@@ -48,6 +50,7 @@ func (entity *Revocation) toBoltEntityForCreate(*bbolt.Tx, Env) (*db.Revocation,
 		BaseExtEntity: *boltz.NewExtEntity(entity.Id, entity.Tags),
 		ExpiresAt:     entity.ExpiresAt,
 		Type:          entity.Type,
+		IssuedBefore:  entity.IssuedBefore,
 	}
 
 	return boltEntity, nil

--- a/controller/oidc_auth/config.go
+++ b/controller/oidc_auth/config.go
@@ -63,14 +63,7 @@ func NewConfig(issuers []Issuer, cert *x509.Certificate, key crypto.PrivateKey) 
 // MaxTokenDuration returns the maximum token lifetime currently configured
 func (c *Config) MaxTokenDuration() time.Duration {
 	if c.maxTokenDuration == nil {
-		curMaxDur := c.RefreshTokenDuration
-
-		for _, duration := range []time.Duration{c.AccessTokenDuration, c.IdTokenDuration} {
-			if duration > curMaxDur {
-				curMaxDur = duration
-			}
-		}
-
+		curMaxDur := common.MaxTokenDuration(c.RefreshTokenDuration, c.AccessTokenDuration, c.IdTokenDuration)
 		c.maxTokenDuration = &curMaxDur
 	}
 

--- a/controller/oidc_auth/storage.go
+++ b/controller/oidc_auth/storage.go
@@ -898,7 +898,44 @@ func (s *HybridStorage) TokenRequestByRefreshToken(_ context.Context, refreshTok
 // TerminateSession implements the op.Storage interface
 func (s *HybridStorage) TerminateSession(_ context.Context, identityId string, clientID string) error {
 	now := time.Now()
-	return s.saveRevocation(NewRevocation(identityId, now.Add(s.config.MaxTokenDuration())))
+	revocation := NewRevocation(identityId, now.Add(s.config.MaxTokenDuration()))
+	revocation.Type = common.RevocationTypeIdentity
+	revocation.IssuedBefore = now
+	return s.saveOrReplaceRevocation(revocation)
+}
+
+var _ op.CanTerminateSessionFromRequest = (*HybridStorage)(nil)
+
+// TerminateSessionFromRequest implements op.CanTerminateSessionFromRequest. The
+// op framework prefers it over TerminateSession when present. It revokes the
+// specific api-session being terminated, identified by the z_asid claim in the
+// end-session request's id_token_hint, so revocation is precise to this session
+// (a re-authentication gets a fresh z_asid and is unaffected). When the hint
+// carries no api-session id, it falls back to the identity-scoped revocation.
+func (s *HybridStorage) TerminateSessionFromRequest(_ context.Context, endSessionRequest *op.EndSessionRequest) (string, error) {
+	now := time.Now()
+	expiresAt := now.Add(s.config.MaxTokenDuration())
+
+	if claims := endSessionRequest.IDTokenHintClaims; claims != nil {
+		if apiSessionId, ok := claims.Claims[common.CustomClaimApiSessionId].(string); ok && apiSessionId != "" {
+			revocation := NewRevocation(apiSessionId, expiresAt)
+			revocation.Type = common.RevocationTypeApiSession
+			if err := s.saveOrReplaceRevocation(revocation); err != nil {
+				return "", oidc.ErrServerError()
+			}
+			return endSessionRequest.RedirectURI, nil
+		}
+	}
+
+	if endSessionRequest.UserID != "" {
+		revocation := NewRevocation(endSessionRequest.UserID, expiresAt)
+		revocation.Type = common.RevocationTypeIdentity
+		revocation.IssuedBefore = now
+		if err := s.saveOrReplaceRevocation(revocation); err != nil {
+			return "", oidc.ErrServerError()
+		}
+	}
+	return endSessionRequest.RedirectURI, nil
 }
 
 // GetRefreshTokenInfo implements the op.Storage interface
@@ -920,6 +957,7 @@ func (s *HybridStorage) RevokeToken(_ context.Context, tokenIDOrToken string, _ 
 			return nil //not a valid token ignore
 		}
 		revocation := NewRevocation(claims.JWTID, claims.Expiration.AsTime())
+		revocation.Type = common.RevocationTypeToken
 		if err := s.saveRevocation(revocation); err != nil {
 			return oidc.ErrServerError()
 		}
@@ -928,6 +966,7 @@ func (s *HybridStorage) RevokeToken(_ context.Context, tokenIDOrToken string, _ 
 	}
 
 	revocation := NewRevocation(tokenIDOrToken, time.Now().Add(s.config.MaxTokenDuration()))
+	revocation.Type = common.RevocationTypeToken
 	if err := s.saveRevocation(revocation); err != nil {
 		return oidc.ErrServerError()
 	}
@@ -1137,6 +1176,14 @@ func (s *HybridStorage) saveRevocation(revocation *model.Revocation) error {
 	return s.env.GetManagers().Revocation.Create(revocation, change.New())
 }
 
+// saveOrReplaceRevocation persists a revocation that is keyed by a reusable id
+// (an identity or api-session id, as opposed to a unique token jti), replacing
+// any lingering prior entry so a repeat logout/termination refreshes its cutoff
+// rather than colliding.
+func (s *HybridStorage) saveOrReplaceRevocation(revocation *model.Revocation) error {
+	return s.env.GetManagers().Revocation.CreateOrReplace(revocation, change.New())
+}
+
 func (s *HybridStorage) renewRefreshToken(currentRefreshToken string, accessClaims *common.AccessClaims) (string, *common.RefreshClaims, error) {
 	_, refreshClaims, err := s.parseRefreshToken(currentRefreshToken)
 
@@ -1148,7 +1195,9 @@ func (s *HybridStorage) renewRefreshToken(currentRefreshToken string, accessClai
 	// about to expire anyway; otherwise queue it for batched creation.
 	expiresAt := refreshClaims.Expiration.AsTime()
 	if s.config.RevocationMinTokenLifetime == 0 || time.Until(expiresAt) > s.config.RevocationMinTokenLifetime {
-		s.batcher.Add(NewRevocation(refreshClaims.JWTID, expiresAt))
+		revocation := NewRevocation(refreshClaims.JWTID, expiresAt)
+		revocation.Type = common.RevocationTypeToken
+		s.batcher.Add(revocation)
 	}
 
 	// Use the access claims' CustomClaims so that any updates from CSR signing

--- a/controller/storage/boltz/paths.go
+++ b/controller/storage/boltz/paths.go
@@ -149,6 +149,11 @@ type deletedIdScanner struct {
 }
 
 func (visitor *deletedIdScanner) VisitBucket(path string, key []byte, _ *bbolt.Bucket) bool {
+	for _, ignorePath := range visitor.ignorePaths {
+		if strings.HasPrefix(path, ignorePath) {
+			return true
+		}
+	}
 	if bytes.Equal(visitor.key, key) {
 		visitor.err = errors.Errorf("found id %v as key under path %v", string(visitor.key), path)
 		return false

--- a/controller/sync_strats/sync_instant.go
+++ b/controller/sync_strats/sync_instant.go
@@ -35,8 +35,6 @@ import (
 	nfPem "github.com/openziti/foundation/v2/pem"
 	"github.com/openziti/foundation/v2/stringz"
 	"github.com/openziti/identity"
-	"github.com/openziti/ziti/v2/controller/storage/ast"
-	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/openziti/ziti/v2/common"
 	"github.com/openziti/ziti/v2/common/build"
 	"github.com/openziti/ziti/v2/common/pb/edge_ctrl_pb"
@@ -45,6 +43,8 @@ import (
 	"github.com/openziti/ziti/v2/controller/env"
 	"github.com/openziti/ziti/v2/controller/handler_edge_ctrl"
 	"github.com/openziti/ziti/v2/controller/model"
+	"github.com/openziti/ziti/v2/controller/storage/ast"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	cmap "github.com/orcaman/concurrent-map/v2"
 	"github.com/pkg/errors"
 	"go.etcd.io/bbolt"
@@ -1865,12 +1865,18 @@ func (strategy *InstantStrategy) sendDataStateChangeSet(rtx *RouterSender, state
 }
 
 func (strategy *InstantStrategy) handleRevocation(index uint64, action edge_ctrl_pb.DataState_Action, revocation *db.Revocation) {
+	var issuedBefore *timestamppb.Timestamp
+	if !revocation.IssuedBefore.IsZero() {
+		issuedBefore = timestamppb.New(revocation.IssuedBefore)
+	}
 	strategy.addToChangeSet(index, &edge_ctrl_pb.DataState_Event{
 		Action: action,
 		Model: &edge_ctrl_pb.DataState_Event_Revocation{
 			Revocation: &edge_ctrl_pb.DataState_Revocation{
-				Id:        revocation.Id,
-				ExpiresAt: timestamppb.New(revocation.ExpiresAt),
+				Id:           revocation.Id,
+				ExpiresAt:    timestamppb.New(revocation.ExpiresAt),
+				Type:         revocation.Type,
+				IssuedBefore: issuedBefore,
 			},
 		},
 	})

--- a/router/state/manager.go
+++ b/router/state/manager.go
@@ -1642,6 +1642,7 @@ func (sm *ManagerImpl) startConnectionVerification(resolution time.Duration) {
 // This only inspections connections backed by JWTs. It will end connections that have no inspectable API Session.
 func (sm *ManagerImpl) CheckConnections() {
 	connections := sm.connectionTracker.GetChannels()
+	rdm := sm.routerDataModel.Load()
 
 	now := time.Now()
 	for _, channels := range connections {
@@ -1661,6 +1662,12 @@ func (sm *ManagerImpl) CheckConnections() {
 					continue
 				}
 
+				// Revoked api-session (e.g. OIDC end-session): close the channel.
+				if rdm != nil && rdm.IsApiSessionRevoked(apiSession.Id) {
+					_ = ch.Close()
+					continue
+				}
+
 				if apiSession.Type == ApiSessionTokenJwt {
 					if apiSession.Claims == nil {
 						_ = ch.Close()
@@ -1670,6 +1677,14 @@ func (sm *ManagerImpl) CheckConnections() {
 					exp := apiSession.Claims.Expiration
 
 					if exp.AsTime().Before(now) {
+						_ = ch.Close()
+						continue
+					}
+
+					// Revoked identity (e.g. disabled/deleted identity, or an
+					// identity-scoped revocation): close sessions issued before
+					// the revocation's cutoff.
+					if rdm != nil && rdm.IsIdentityRevoked(apiSession.IdentityId, apiSession.Claims.IssuedAt.AsTime()) {
 						_ = ch.Close()
 						continue
 					}

--- a/tests/revocation_enforcement_oidc_test.go
+++ b/tests/revocation_enforcement_oidc_test.go
@@ -1,0 +1,272 @@
+//go:build apitests
+
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package tests
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/openziti/edge-api/rest_model"
+	"github.com/openziti/sdk-golang/ziti"
+	"github.com/openziti/ziti/v2/common/eid"
+	"github.com/openziti/ziti/v2/controller/xt_smartrouting"
+)
+
+// Revocation enforcement is driven by the router's CheckConnections reaper, which
+// runs on a 5s interval, so closure is not immediate. These helpers bound the
+// wait generously (several reaper ticks) to detect the close yet still fail fast
+// on a regression rather than hanging until the test timeout.
+
+// requireConnClosedByReaper waits for the reaper to close a revoked connection. A
+// read surfaces the close (a bare IsClosed poll never advances the conn state).
+func requireConnClosedByReaper(ctx *TestContext, conn *TestConn) {
+	deadline := time.Now().Add(20 * time.Second)
+	buf := make([]byte, 1)
+	for time.Now().Before(deadline) {
+		if conn.IsClosed() {
+			return
+		}
+		_ = conn.SetReadDeadline(time.Now().Add(250 * time.Millisecond))
+		if _, err := conn.Read(buf); err != nil && conn.IsClosed() {
+			return
+		}
+	}
+	ctx.Req.True(conn.IsClosed(), "expected connection to be closed by revocation enforcement")
+}
+
+// requireConnSurvivesReaper confirms a connection is NOT revoked: it waits past a
+// reaper tick (so an erroneous revocation would have closed it) and then verifies
+// the connection is still open and carries data.
+func requireConnSurvivesReaper(ctx *TestContext, conn *TestConn) {
+	time.Sleep(7 * time.Second)
+	ctx.Req.False(conn.IsClosed(), "connection should not be revoked")
+	name := eid.New()
+	conn.WriteString(name, time.Second)
+	conn.ReadExpected("hello, "+name, time.Second)
+}
+
+func requireSetIdentityDisabled(ctx *TestContext, identityId string, path string) {
+	body := &rest_model.DisableParams{DurationMinutes: ToPtr(int64(0))}
+	resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(body).Post("identities/" + identityId + "/" + path)
+	ctx.Req.NoError(err)
+	ctx.Req.Equal(http.StatusOK, resp.StatusCode())
+}
+
+// setupRevocationEnv creates an edge router and an SDK-hosted service, and returns
+// the admin management client, the service, the dialing identity, and a
+// freshly-authenticated OIDC client context for it. Cleanup of the SDK contexts
+// is registered on t.
+func setupRevocationEnv(t *testing.T, ctx *TestContext) (*ManagementHelperClient, *service, *identity, *ziti.ContextImpl) {
+	ctx.RequireAdminManagementApiLogin()
+
+	dialIdentityRole := eid.New()
+	hostIdentityRole := eid.New()
+	serviceRole := eid.New()
+
+	adminApi := ctx.NewEdgeManagementApi(nil)
+	_, err := adminApi.Authenticate(ctx.NewAdminCredentials(), nil)
+	ctx.Req.NoError(err)
+
+	ctx.AdminManagementSession.requireNewEdgeRouterPolicy(s("#all"), s("#all"))
+	ctx.AdminManagementSession.requireNewServiceEdgeRouterPolicy(s("#all"), s("#all"))
+
+	svc := ctx.AdminManagementSession.testContext.newService(s(serviceRole), nil)
+	svc.terminatorStrategy = xt_smartrouting.Name
+	ctx.AdminManagementSession.requireCreateEntity(svc)
+
+	ctx.AdminManagementSession.requireNewServicePolicyWithSemantic("Dial", "AllOf", s("#"+serviceRole), s("#"+dialIdentityRole), nil)
+	ctx.AdminManagementSession.requireNewServicePolicyWithSemantic("Bind", "AllOf", s("#"+serviceRole), s("#"+hostIdentityRole), nil)
+
+	ctx.CreateEnrollAndStartEdgeRouter()
+
+	// Host (OIDC) hosting the service.
+	_, hostZtx := ctx.AdminManagementSession.RequireCreateSdkContext(hostIdentityRole)
+	hostContext := hostZtx.(*ziti.ContextImpl)
+	hostContext.CtrlClt.SetAllowOidcDynamicallyEnabled(true)
+	ctx.Req.NoError(hostContext.Authenticate())
+	t.Cleanup(hostContext.Close)
+
+	listener, err := hostContext.Listen(svc.Name)
+	ctx.Req.NoError(err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	testServer := newTestServer(listener, echoServerHandler)
+	testServer.start()
+
+	// Dialing client (OIDC).
+	dialIdentity, clientZtx := ctx.AdminManagementSession.RequireCreateSdkContext(dialIdentityRole)
+	clientContext := clientZtx.(*ziti.ContextImpl)
+	clientContext.CtrlClt.SetAllowOidcDynamicallyEnabled(true)
+	ctx.Req.NoError(clientContext.Authenticate())
+	t.Cleanup(clientContext.Close)
+
+	return adminApi, svc, dialIdentity, clientContext
+}
+
+func requireDataFlows(ctx *TestContext, conn *TestConn) {
+	name := eid.New()
+	conn.WriteString(name, time.Second)
+	conn.ReadExpected("hello, "+name, time.Second)
+}
+
+// echoServerHandler echoes "hello, <name>" for each name read, closing only the
+// individual connection when it ends rather than the whole listener. This keeps
+// the host serving across connection closes, which the revocation tests require:
+// a revocation closes one connection and the test then re-dials a fresh one.
+func echoServerHandler(conn *testServerConn) error {
+	for {
+		name, eof := conn.ReadString(1024, time.Minute)
+		if eof || name == "quit" {
+			return nil
+		}
+		conn.WriteString("hello, "+name, time.Second)
+	}
+}
+
+// freshAuthedContext creates and authenticates a new OIDC SDK context for an
+// existing identity, yielding a brand-new api-session (a fresh z_asid and issue
+// time). Authenticate on an already-authenticated context is a no-op, so a new
+// context is required to exercise re-authentication.
+func freshAuthedContext(t *testing.T, ctx *TestContext, id *identity) *ziti.ContextImpl {
+	ztx, err := ziti.NewContext(id.config)
+	ctx.Req.NoError(err)
+	clientContext, ok := ztx.(*ziti.ContextImpl)
+	ctx.Req.True(ok)
+	clientContext.CtrlClt.SetAllowOidcDynamicallyEnabled(true)
+	t.Cleanup(clientContext.Close)
+	ctx.Req.NoError(clientContext.Authenticate())
+	return clientContext
+}
+
+// Test_Revocation_ApiSession_OIDC covers api-session revocation enforcement: when
+// the specific api-session (z_asid) backing a live connection is revoked, the
+// router closes that connection; a re-authenticated session (a fresh z_asid) is
+// unaffected.
+func Test_Revocation_ApiSession_OIDC(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+
+	adminApi, svc, dialIdentity, clientContext := setupRevocationEnv(t, ctx)
+
+	clientConn := ctx.WrapConn(clientContext.Dial(svc.Name))
+	requireDataFlows(ctx, clientConn)
+
+	apiSessionId := clientContext.CtrlClt.GetCurrentApiSession().GetId()
+	ctx.Req.NotEmpty(apiSessionId)
+
+	t.Run("revoking the api-session closes its connection", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		_, err := adminApi.CreateRevocation(apiSessionId, rest_model.RevocationTypeEnumAPISESSION)
+		ctx.Req.NoError(err)
+
+		requireConnClosedByReaper(ctx, clientConn)
+	})
+
+	t.Run("a fresh session for the same identity is unaffected", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		freshContext := freshAuthedContext(t, ctx, dialIdentity)
+		newApiSessionId := freshContext.CtrlClt.GetCurrentApiSession().GetId()
+		ctx.Req.NotEqual(apiSessionId, newApiSessionId, "a fresh authentication should produce a new api-session id")
+
+		newConn := ctx.WrapConn(freshContext.Dial(svc.Name))
+		requireConnSurvivesReaper(ctx, newConn)
+	})
+}
+
+// Test_Revocation_IdentityDisable_OIDC covers identity revocation on disable:
+// disabling an identity produces an identity-scoped revocation, and the router
+// closes that identity's live connections.
+func Test_Revocation_IdentityDisable_OIDC(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+
+	_, svc, dialIdentity, clientContext := setupRevocationEnv(t, ctx)
+
+	clientConn := ctx.WrapConn(clientContext.Dial(svc.Name))
+	requireDataFlows(ctx, clientConn)
+
+	t.Run("disabling the identity closes its connection", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		requireSetIdentityDisabled(ctx, dialIdentity.Id, "disable")
+
+		requireConnClosedByReaper(ctx, clientConn)
+	})
+}
+
+// Test_Revocation_IdentityDelete_OIDC covers identity revocation on delete:
+// deleting an identity produces an identity-scoped revocation (its self-contained
+// OIDC JWTs aren't otherwise reachable), and the router closes its live
+// connections.
+func Test_Revocation_IdentityDelete_OIDC(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+
+	_, svc, dialIdentity, clientContext := setupRevocationEnv(t, ctx)
+
+	clientConn := ctx.WrapConn(clientContext.Dial(svc.Name))
+	requireDataFlows(ctx, clientConn)
+
+	t.Run("deleting the identity closes its connection", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		ctx.AdminManagementSession.requireDeleteEntity(dialIdentity)
+
+		requireConnClosedByReaper(ctx, clientConn)
+	})
+}
+
+// Test_Revocation_IdentityCutoff_PostCutoffSessionSurvives_OIDC covers the
+// IssuedBefore cutoff: an identity revocation invalidates only sessions issued
+// before it, so a session re-authenticated after a re-enable survives even though
+// the revocation still lingers.
+func Test_Revocation_IdentityCutoff_PostCutoffSessionSurvives_OIDC(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+
+	adminApi, svc, dialIdentity, clientContext := setupRevocationEnv(t, ctx)
+
+	clientConn := ctx.WrapConn(clientContext.Dial(svc.Name))
+	requireDataFlows(ctx, clientConn)
+
+	// An identity revocation's cutoff is set to its creation time, which is after
+	// this session was issued, so this pre-cutoff session is revoked. (Created via
+	// the management API rather than a disable so the identity stays enabled and
+	// can still authenticate a new session below.)
+	_, err := adminApi.CreateRevocation(dialIdentity.Id, rest_model.RevocationTypeEnumIDENTITY)
+	ctx.Req.NoError(err)
+	requireConnClosedByReaper(ctx, clientConn)
+
+	t.Run("a session authenticated after the cutoff survives", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		// A fresh session is issued after the cutoff, so it must not be revoked
+		// even though the identity revocation still lingers.
+		freshContext := freshAuthedContext(t, ctx, dialIdentity)
+		newConn := ctx.WrapConn(freshContext.Dial(svc.Name))
+		requireConnSurvivesReaper(ctx, newConn)
+	})
+}


### PR DESCRIPTION
## Summary

`ManagerImpl.CheckConnections()` (the ~5s router reaper) enforced only JWT *expiry*, so a revoked OIDC api-session, or a disabled/deleted identity, kept its live circuits and hosted terminators until the access token expired. This makes the router enforce the RouterDataModel `Revocations` directly, tightening access-loss propagation to the `CheckConnections` interval.

## Changes

**Revocation `Type` taxonomy.** Adds a `Type` field to `DataState_Revocation` (and the raft `Revocation` command proto), mirroring `rest_model.RevocationTypeEnum` (`API_SESSION` / `IDENTITY` / `JTI`) so the management API, OIDC producers, sync, and router enforcement share one vocabulary. `common.RevocationType*` constants are compile-time bound to the REST enum to prevent drift.

**Api-session revocation (e.g. OIDC end-session).**
- `TerminateSessionFromRequest` revokes the specific api-session named by the `z_asid` claim in the end-session request, so revocation is precise to that session (a re-authentication gets a fresh `z_asid` and is unaffected); falls back to an identity-scoped revocation when the hint carries none.
- `RouterDataModel.IsApiSessionRevoked`, enforced in `CheckConnections`.

**Identity revocation (disable / delete / identity-scoped).**
- Adds an `IssuedBefore` cutoff to the revocation (proto + db + model + raft marshalling): an `IDENTITY` revocation invalidates only sessions issued before the cutoff, so a session re-authenticated after a re-enable survives the still-lingering revocation.
- `RouterDataModel.IsIdentityRevoked(identityId, issuedAt)`, enforced in `CheckConnections`.
- Disabling or deleting an identity now produces an identity revocation via an `EntityConstraint` on the identity store, so the revocation is written **in the same transaction** as the identity change and can't be skipped from any code path. Self-contained OIDC JWTs aren't stored, so the existing cascade-delete of legacy api-sessions doesn't reach them.
- The management revocation API and OIDC identity fallback set the cutoff; `RevocationManager.CreateOrReplace` lets a repeat logout/termination refresh the cutoff rather than collide on the reused id.

Also carries the previously-dropped `Type` through the batched raft revocation marshalling.

## Stacking / dependency

Based on `posture-revalidation` (#3922) — please merge that first; this PR's diff will reduce to its own two commits once it does.

Fixes #3927. Backport to `release-v2.0.x` tracked by #3929.