### PR TITLE
Add link id header to link dials, prefer it on the listener side

### DIFF
--- a/router/handler_link/bind.go
+++ b/router/handler_link/bind.go
@@ -97,6 +97,7 @@ func (self *bindHandler) BindChannel(binding channel.Binding) error {
 
 	log.Info("link destination support heartbeats")
 	cb := &heartbeatCallback{
+		linkId:           self.xlink.Id(),
 		latencyMetric:    latencyMetric,
 		queueTimeMetric:  queueTimeMetric,
 		ch:               binding.GetChannel(),
@@ -146,6 +147,7 @@ func (self *bindHandler) verifyRouter(l xlink.Xlink, ch channel.Channel) error {
 }
 
 type heartbeatCallback struct {
+	linkId           string
 	latencyMetric    metrics.Histogram
 	queueTimeMetric  metrics.Histogram
 	lastResponse     int64
@@ -186,7 +188,7 @@ func (self *heartbeatCallback) CheckHeartBeat() {
 }
 
 func (self *heartbeatCallback) checkQueueTime() {
-	log := pfxlog.Logger().WithField("linkId", self.ch.Id())
+	log := pfxlog.Logger().WithField("linkId", self.linkId)
 	if !self.latencySemaphore.TryAcquire() {
 		log.Warn("unable to check queue time, too many check already running")
 		return

--- a/router/xlink_transport/dialer.go
+++ b/router/xlink_transport/dialer.go
@@ -134,6 +134,7 @@ func (self *dialer) dialSplit(linkId *identity.TokenId, address transport.Addres
 		LinkHeaderRouterVersion: []byte(dial.GetRouterVersion()),
 		LinkHeaderBinding:       []byte(self.GetBinding()),
 		LinkDialedRouterId:      []byte(dial.GetRouterId()),
+		LinkHeaderLinkId:        []byte(linkId.Token),
 	}
 	headers.PutUint32Header(LinkHeaderIteration, dial.GetIteration())
 
@@ -197,6 +198,7 @@ func (self *dialer) dialSingle(linkId *identity.TokenId, address transport.Addre
 		LinkHeaderRouterVersion: []byte(dial.GetRouterVersion()),
 		LinkHeaderBinding:       []byte(self.GetBinding()),
 		LinkDialedRouterId:      []byte(dial.GetRouterId()),
+		LinkHeaderLinkId:        []byte(linkId.Token),
 	}
 	headers.PutUint32Header(LinkHeaderIteration, dial.GetIteration())
 
@@ -245,6 +247,7 @@ func (self *dialer) dialMulti(linkId *identity.TokenId, address transport.Addres
 		LinkHeaderRouterVersion: []byte(dial.GetRouterVersion()),
 		LinkHeaderBinding:       []byte(self.GetBinding()),
 		LinkDialedRouterId:      []byte(dial.GetRouterId()),
+		LinkHeaderLinkId:        []byte(linkId.Token),
 	}
 	headers.PutUint32Header(LinkHeaderIteration, dial.GetIteration())
 

--- a/router/xlink_transport/factory.go
+++ b/router/xlink_transport/factory.go
@@ -30,16 +30,29 @@ import (
 
 type channelType byte
 
+// The link headers are sent in the channel hello message, whose header map is
+// shared with the channel library's own headers (channel.ConnectionIdHeader = 0,
+// channel.TypeHeader = 7, channel.IdHeader = 8, channel.IsGroupedHeader = 9, etc).
+// The grouped underlay dial path overlays channel.TypeHeader and friends onto the
+// dial headers, so new link headers must not reuse the channel library's key range.
+// LinkHeaderLinkId starts at 100 to stay clear of it.
 const (
-	LinkHeaderConnId                    = 0
-	LinkHeaderType                      = 1
-	LinkHeaderRouterId                  = 2
-	LinkHeaderRouterVersion             = 3
-	LinkHeaderBinding                   = 4
-	LinkHeaderIteration                 = 5
-	LinkDialedRouterId                  = 6
-	PayloadChannel          channelType = 1
-	AckChannel              channelType = 2
+	LinkHeaderConnId        = 0
+	LinkHeaderType          = 1
+	LinkHeaderRouterId      = 2
+	LinkHeaderRouterVersion = 3
+	LinkHeaderBinding       = 4
+	LinkHeaderIteration     = 5
+	LinkDialedRouterId      = 6
+
+	// LinkHeaderLinkId carries the link id explicitly. Dialing routers currently
+	// also present the link id as the channel identity token; this header is what
+	// will allow the channel identity to become the dialing router's actual id in
+	// a future release. Readers should prefer it over the channel id when present.
+	LinkHeaderLinkId = 100
+
+	PayloadChannel channelType = 1
+	AckChannel     channelType = 2
 )
 
 func (self channelType) String() string {

--- a/router/xlink_transport/link_id_test.go
+++ b/router/xlink_transport/link_id_test.go
@@ -1,0 +1,241 @@
+/*
+	(c) Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package xlink_transport
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/openziti/channel/v4"
+	"github.com/openziti/identity"
+	"github.com/openziti/transport/v2"
+	transporttls "github.com/openziti/transport/v2/tls"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveLinkId(t *testing.T) {
+	t.Run("prefers header when present", func(t *testing.T) {
+		headers := map[int32][]byte{
+			LinkHeaderLinkId: []byte("the-link-id"),
+		}
+		assert.Equal(t, "the-link-id", resolveLinkId(headers, "fallback-id"))
+	})
+
+	t.Run("falls back to channel id when header absent", func(t *testing.T) {
+		headers := map[int32][]byte{
+			LinkHeaderRouterId: []byte("router-1"),
+		}
+		assert.Equal(t, "fallback-id", resolveLinkId(headers, "fallback-id"))
+	})
+
+	t.Run("falls back to channel id when header empty", func(t *testing.T) {
+		headers := map[int32][]byte{
+			LinkHeaderLinkId: []byte(""),
+		}
+		assert.Equal(t, "fallback-id", resolveLinkId(headers, "fallback-id"))
+	})
+
+	t.Run("falls back to channel id when headers nil", func(t *testing.T) {
+		assert.Equal(t, "fallback-id", resolveLinkId(nil, "fallback-id"))
+	})
+}
+
+// testPki generates an in-memory CA and issues leaf certificates, so the link id
+// tests can run over tls with real certificates in play.
+type testPki struct {
+	caKey  *ecdsa.PrivateKey
+	caCert *x509.Certificate
+	caPem  string
+	serial int64
+}
+
+func newTestPki(t *testing.T) *testPki {
+	req := require.New(t)
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	req.NoError(err)
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "link-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &caKey.PublicKey, caKey)
+	req.NoError(err)
+
+	caCert, err := x509.ParseCertificate(der)
+	req.NoError(err)
+
+	return &testPki{
+		caKey:  caKey,
+		caCert: caCert,
+		caPem:  string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})),
+		serial: 1,
+	}
+}
+
+// newIdentity issues a leaf certificate for the given common name and returns a
+// TokenId for it, with the token defaulted to the common name.
+func (self *testPki) newIdentity(t *testing.T, cn string) *identity.TokenId {
+	req := require.New(t)
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	req.NoError(err)
+
+	self.serial++
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(self.serial),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, self.caCert, &key.PublicKey, self.caKey)
+	req.NoError(err)
+
+	keyDer, err := x509.MarshalECPrivateKey(key)
+	req.NoError(err)
+
+	certPem := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+	keyPem := string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDer}))
+
+	id, err := identity.LoadIdentity(identity.Config{
+		Key:        "pem:" + keyPem,
+		Cert:       "pem:" + certPem,
+		ServerCert: "pem:" + certPem,
+		CA:         "pem:" + self.caPem,
+	})
+	req.NoError(err)
+
+	return identity.NewIdentity(id)
+}
+
+// TestLinkIdHeaderPreferredOverChannelId runs a real hello exchange over tls,
+// mirroring how links dial: the dialer uses its router identity with the token
+// swapped to the link id. It verifies that with certificates in play the channel
+// id still comes from the hello token, not the cert, and that the link id header
+// is preferred over the channel id when the two differ.
+func TestLinkIdHeaderPreferredOverChannelId(t *testing.T) {
+	transport.AddAddressParser(transporttls.AddressParser{})
+	req := require.New(t)
+
+	pki := newTestPki(t)
+	listenerId := pki.newIdentity(t, "listening-router")
+	dialingRouterId := pki.newIdentity(t, "dialing-router")
+
+	// grab a free port for the test listener
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	req.NoError(err)
+	port := l.Addr().(*net.TCPAddr).Port
+	req.NoError(l.Close())
+
+	addr, err := transport.ParseAddress(fmt.Sprintf("tls:127.0.0.1:%d", port))
+	req.NoError(err)
+
+	type acceptResult struct {
+		channelId  string
+		linkId     string
+		peerCertCN string
+	}
+	results := make(chan acceptResult, 1)
+
+	acceptF := func(underlay channel.Underlay) {
+		_, err := channel.NewChannelWithUnderlay("test-listen", underlay, channel.BindHandlerF(func(binding channel.Binding) error {
+			ch := binding.GetChannel()
+			result := acceptResult{
+				channelId: ch.Id(),
+				linkId:    resolveLinkId(ch.Underlay().Headers(), ch.Id()),
+			}
+			if certs := ch.Certificates(); len(certs) > 0 {
+				result.peerCertCN = certs[0].Subject.CommonName
+			}
+			results <- result
+			return nil
+		}), channel.DefaultOptions())
+		assert.NoError(t, err)
+	}
+
+	listenerConfig := channel.ListenerConfig{
+		ConnectOptions: channel.DefaultConnectOptions(),
+	}
+	listener, err := channel.NewClassicListenerF(listenerId, addr, listenerConfig, acceptF)
+	req.NoError(err)
+	defer func() { _ = listener.Close() }()
+
+	// mirror the xlink dialer: the real router identity with the token swapped to
+	// the link id (the current link-id-as-channel-id behavior), and a different
+	// value in the link id header, proving the listener prefers the header
+	dialer := channel.NewClassicDialer(channel.DialerConfig{
+		Identity: dialingRouterId.ShallowCloneWithNewToken("token-link-id"),
+		Endpoint: addr,
+		Headers: map[int32][]byte{
+			LinkHeaderLinkId: []byte("header-link-id"),
+		},
+	})
+
+	// dial the way dialMulti does: the grouped-dial headers get overlaid onto the
+	// link headers in the hello, sharing one header keyspace. This catches link
+	// header keys colliding with the channel library's own header keys (e.g.
+	// channel.TypeHeader overwriting the link id header).
+	firstDialHeaders := channel.Headers{}
+	firstDialHeaders.PutBoolHeader(channel.IsFirstGroupConnection, true)
+	firstDialHeaders.PutBoolHeader(channel.IsGroupedHeader, true)
+	firstDialHeaders.PutStringHeader(channel.TypeHeader, ChannelTypeDefault)
+
+	underlay, err := dialer.CreateWithHeaders(5*time.Second, firstDialHeaders)
+	req.NoError(err)
+
+	ch, err := channel.NewChannelWithUnderlay("test-dial", underlay, channel.BindHandlerF(func(channel.Binding) error {
+		return nil
+	}), channel.DefaultOptions())
+	req.NoError(err)
+	defer func() { _ = ch.Close() }()
+
+	// dial side: the channel id is the listening router's identity
+	req.Equal("listening-router", ch.Id())
+
+	select {
+	case result := <-results:
+		// the client cert was presented, and its common name is the router id,
+		// yet the channel id still comes from the hello token
+		req.Equal("dialing-router", result.peerCertCN)
+		req.Equal("token-link-id", result.channelId)
+		// the link id header wins when it differs from the channel id
+		req.Equal("header-link-id", result.linkId)
+	case <-time.After(5 * time.Second):
+		req.Fail("timed out waiting for link connection")
+	}
+}

--- a/router/xlink_transport/listener.go
+++ b/router/xlink_transport/listener.go
@@ -93,7 +93,7 @@ func (self *listener) GetLocalBinding() string {
 func (self *listener) handleGroupedUnderlay(underlay channel.Underlay, closeCallback func()) (channel.MultiChannel, error) {
 	linkChannel := NewListenerLinkChannel(underlay, self.env.GetLinkPayloadSenderQueueSize(), self.env.GetLinkAckSenderQueueSize())
 	multiConfig := channel.MultiChannelConfig{
-		LogicalName:     "link/" + underlay.Id(),
+		LogicalName:     "link/" + resolveLinkId(underlay.Headers(), underlay.Id()),
 		Options:         self.config.options,
 		UnderlayHandler: linkChannel,
 		BindHandler: channel.BindHandlerF(func(binding channel.Binding) error {
@@ -123,11 +123,13 @@ func (self *listener) handleUngroupedNewUnderlay(underlay channel.Underlay) erro
 }
 
 func (self *listener) BindChannel(binding channel.Binding) error {
+	headers := channel.Headers(binding.GetChannel().Underlay().Headers())
+	linkId := resolveLinkId(headers, binding.GetChannel().Id())
+
 	log := pfxlog.ChannelLogger("link", "linkListener").
 		WithField("linkProtocol", self.GetLinkProtocol()).
-		WithField("linkId", binding.GetChannel().Id())
+		WithField("linkId", linkId)
 
-	headers := channel.Headers(binding.GetChannel().Underlay().Headers())
 	var chanType channelType
 
 	routerId := ""
@@ -158,6 +160,7 @@ func (self *listener) BindChannel(binding channel.Binding) error {
 	log.Info("binding link channel")
 
 	linkMeta := &linkMetadata{
+		linkId:        linkId,
 		routerId:      routerId,
 		routerVersion: routerVersion,
 		dialerBinding: dialerBinding,
@@ -239,7 +242,7 @@ func (self *listener) getOrCreateSplitLink(connId string, linkMeta *linkMetadata
 	} else {
 		pending = &pendingLink{
 			link: &splitImpl{
-				id:            binding.GetChannel().Id(),
+				id:            linkMeta.linkId,
 				key:           self.xlinkRegistery.GetLinkKey(linkMeta.dialerBinding, self.GetLinkProtocol(), linkMeta.routerId, self.config.bindInterface),
 				routerId:      linkMeta.routerId,
 				routerVersion: linkMeta.routerVersion,
@@ -260,7 +263,7 @@ func (self *listener) getOrCreateSplitLink(connId string, linkMeta *linkMetadata
 				link.payloadCh = binding.GetChannel()
 				return nil
 			}
-			return errors.Errorf("got two payload channels for link %v", binding.GetChannel().Id())
+			return errors.Errorf("got two payload channels for link %v", linkMeta.linkId)
 		}); err != nil {
 			return false, nil, err
 		}
@@ -270,7 +273,7 @@ func (self *listener) getOrCreateSplitLink(connId string, linkMeta *linkMetadata
 				link.ackCh = binding.GetChannel()
 				return nil
 			}
-			return errors.Errorf("got two ack channels for link %v", binding.GetChannel().Id())
+			return errors.Errorf("got two ack channels for link %v", linkMeta.linkId)
 		}); err != nil {
 			return false, nil, err
 		}
@@ -283,7 +286,7 @@ func (self *listener) getOrCreateSplitLink(connId string, linkMeta *linkMetadata
 
 func (self *listener) bindNonSplitChannel(binding channel.Binding, linkMeta *linkMetadata, log *logrus.Entry) error {
 	xli := &impl{
-		id:            binding.GetChannel().Id(),
+		id:            linkMeta.linkId,
 		key:           self.xlinkRegistery.GetLinkKey(linkMeta.dialerBinding, self.GetLinkProtocol(), linkMeta.routerId, self.config.bindInterface),
 		routerId:      linkMeta.routerId,
 		routerVersion: linkMeta.routerVersion,
@@ -305,7 +308,7 @@ func (self *listener) bindNonSplitChannel(binding channel.Binding, linkMeta *lin
 
 	bindHandler := self.bindHandlerFactory.NewBindHandler(xli, true, true)
 	if err := bindHandler.BindChannel(binding); err != nil {
-		return errors.Wrapf(err, "error binding channel for link [l/%v]", binding.GetChannel().Id())
+		return errors.Wrapf(err, "error binding channel for link [l/%v]", linkMeta.linkId)
 	}
 
 	log.Info("accepting link")
@@ -358,8 +361,22 @@ type pendingLink struct {
 }
 
 type linkMetadata struct {
+	linkId        string
 	routerId      string
 	routerVersion string
 	dialerBinding string
 	iteration     uint32
+}
+
+// resolveLinkId returns the link id for an incoming link connection. It prefers
+// the LinkHeaderLinkId header, falling back to the given id (the channel identity
+// token) when the header isn't present, as is the case for older routers. Dialing
+// routers currently send the link id as both; reading the header here is what will
+// allow the channel identity to become the dialing router's actual id in a future
+// release.
+func resolveLinkId(headers map[int32][]byte, fallbackId string) string {
+	if linkId, ok := channel.Headers(headers).GetStringHeader(LinkHeaderLinkId); ok && linkId != "" {
+		return linkId
+	}
+	return fallbackId
 }


### PR DESCRIPTION
Fixes #3938

Link channels currently identify themselves by sending the link id as the channel identity token, which makes links inconsistent with other channel consumers, where the channel id is the actual identity of the peer router. This carries the link id explicitly instead:

- adds `LinkHeaderLinkId`, emitted on all three link dial paths, while still presenting the link id as the channel identity token
- the link listener prefers the header when present, falling back to the channel id for older routers

This is a behavioral no-op in a mixed-version fleet: new dialers send the link id in both places, and old dialers still resolve via the token fallback. It removes the listener side's dependency on the token carrying the link id; the future flip of the dialer to presenting the router's real identity as the channel identity token will be tracked separately.