### PR TITLE
Prep for channel v5: bind handler invocation, send priorities

### DIFF
--- a/controller/agent.go
+++ b/controller/agent.go
@@ -45,7 +45,7 @@ func (self *Controller) bindAgentChannel(binding channel.Binding) error {
 	binding.AddReceiveHandlerF(int32(mgmt_pb.ContentType_RaftRestoreFromDb), self.agentOpRestoreFromDb)
 
 	for _, bh := range self.agentBindHandlers {
-		if err := binding.Bind(bh); err != nil {
+		if err := bh.BindChannel(binding); err != nil {
 			return err
 		}
 	}

--- a/controller/handler_ctrl/accept.go
+++ b/controller/handler_ctrl/accept.go
@@ -192,7 +192,7 @@ func (self *CtrlAccepter) Bind(binding channel.Binding) error {
 
 	r.Control = ch.(channel.MultiChannel).GetUnderlayHandler().(ctrlchan.CtrlChannel)
 	r.ConnectTime = time.Now()
-	if err := binding.Bind(newBindHandler(self.heartbeatOptions, r, self.network, self.xctrls)); err != nil {
+	if err = newBindHandler(self.heartbeatOptions, r, self.network, self.xctrls).BindChannel(binding); err != nil {
 		return errors.Wrap(err, "error binding router")
 	}
 

--- a/controller/handler_ctrl/bind.go
+++ b/controller/handler_ctrl/bind.go
@@ -105,7 +105,7 @@ func (self *bindHandler) BindChannel(binding channel.Binding) error {
 
 	xctrlDone := make(chan struct{})
 	for _, x := range self.xctrls {
-		if err := binding.Bind(x); err != nil {
+		if err := x.BindChannel(binding); err != nil {
 			return err
 		}
 		if err := x.Run(binding.GetChannel(), self.network.GetDb(), xctrlDone); err != nil {

--- a/controller/handler_mgmt/bind.go
+++ b/controller/handler_mgmt/bind.go
@@ -108,7 +108,7 @@ func (bindHandler *BindHandler) BindChannel(binding channel.Binding) error {
 
 	xmgmtDone := make(chan struct{})
 	for _, x := range bindHandler.xmgmts.Value() {
-		if err := binding.Bind(x); err != nil {
+		if err := x.BindChannel(binding); err != nil {
 			return err
 		}
 		if err := x.Run(binding.GetChannel(), xmgmtDone); err != nil {

--- a/controller/raft/mesh/mesh.go
+++ b/controller/raft/mesh/mesh.go
@@ -1036,7 +1036,7 @@ func (self *impl) AcceptUnderlay(underlay channel.Underlay) error {
 		if bh == nil {
 			return errors.New("bindHandler not initialized, can't accept controller connection")
 		}
-		if err = binding.Bind(bh); err != nil {
+		if err = bh.BindChannel(binding); err != nil {
 			_ = ch.Close()
 			return errors.Wrapf(err, "error while binding channel from id '%v' or address '%v', closing connection", id, addr)
 		}

--- a/router/agent.go
+++ b/router/agent.go
@@ -58,7 +58,7 @@ func (self *Router) RegisterAgentOp(opId byte, f func(c *bufio.ReadWriter) error
 
 func (self *Router) bindAgentChannel(binding channel.Binding) error {
 	for _, bh := range self.agentBindHandlers {
-		if err := binding.Bind(bh); err != nil {
+		if err := bh.BindChannel(binding); err != nil {
 			return err
 		}
 	}

--- a/router/handler_ctrl/bind.go
+++ b/router/handler_ctrl/bind.go
@@ -133,7 +133,7 @@ func (self *bindHandler) BindChannel(binding channel.Binding) error {
 	}
 
 	for _, x := range self.env.GetXrctrls() {
-		if err := binding.Bind(x); err != nil {
+		if err := x.BindChannel(binding); err != nil {
 			return err
 		}
 	}

--- a/router/xgress_edge/dialer.go
+++ b/router/xgress_edge/dialer.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/michaelquigley/pfxlog"
-	"github.com/openziti/channel/v4"
 	"github.com/openziti/sdk-golang/xgress"
 	edgeSdk "github.com/openziti/sdk-golang/ziti/edge"
 	"github.com/openziti/ziti/v2/common/ctrl_msg"
@@ -179,7 +178,7 @@ func (dialer *dialer) Dial(params xgress_router.DialParams) (xt.PeerData, error)
 		to = timeToDeadline
 	}
 	log.Info("sending dial request to sdk")
-	reply, err := dialRequest.WithPriority(channel.Highest).WithTimeout(to).SendForReply(terminator.GetControlSender())
+	reply, err := dialRequest.WithTimeout(to).SendForReply(terminator.GetControlSender())
 	if err != nil {
 		conn.close(false, err.Error())
 		x.Close()
@@ -282,7 +281,7 @@ func (dialer *dialer) dialSdkXgress(terminator *edgeTerminator, params xgress_ro
 		to = timeToDeadline
 	}
 	log.Info("sending dial request to sdk")
-	reply, err := dialRequest.WithPriority(channel.Highest).WithTimeout(to).SendForReply(terminator.GetControlSender())
+	reply, err := dialRequest.WithTimeout(to).SendForReply(terminator.GetControlSender())
 	if err != nil {
 		edgeForwarder.UnregisterRouting()
 		return nil, err
@@ -357,7 +356,7 @@ func (dialer *dialer) dialLegacy(terminator *edgeTerminator, params xgress_route
 	}
 
 	log.Debug("router not assigning connId for dial")
-	reply, err := dialRequest.WithPriority(channel.Highest).WithTimeout(5 * time.Second).SendForReply(terminator.GetControlSender())
+	reply, err := dialRequest.WithTimeout(5 * time.Second).SendForReply(terminator.GetControlSender())
 	if err != nil {
 		return nil, err
 	}

--- a/router/xgress_edge/listener.go
+++ b/router/xgress_edge/listener.go
@@ -631,7 +631,7 @@ func (self *edgeClientConn) CloseConn(connId uint32, reason string) error {
 	closeMsg := sdkedge.NewStateClosedMsg(connId, reason)
 	closeMsg.PutUint32Header(sdkedge.ConnIdHeader, connId)
 
-	err := closeMsg.WithPriority(channel.High).WithTimeout(5 * time.Second).SendAndWaitForWire(self.ch.GetDefaultSender())
+	err := closeMsg.WithTimeout(5 * time.Second).SendAndWaitForWire(self.ch.GetDefaultSender())
 	if err != nil {
 		log.WithError(err).WithFields(sdkedge.GetLoggerFields(closeMsg)).Error("failed to send state closed message")
 		return err
@@ -1029,7 +1029,7 @@ func (self *edgeClientConn) processBindV2(serviceSessionToken *state.ServiceSess
 	}
 
 	// this needs to go on the data channel to ensure it gets there before data gets there or a state closed msg
-	err = msg.WithPriority(channel.High).WithTimeout(5 * time.Second).SendAndWaitForWire(self.ch.GetDefaultSender())
+	err = msg.WithTimeout(5 * time.Second).SendAndWaitForWire(self.ch.GetDefaultSender())
 	if err != nil {
 		pfxlog.Logger().WithFields(sdkedge.GetLoggerFields(msg)).WithError(err).Error("failed to send bind success response")
 	}
@@ -1314,7 +1314,7 @@ func (self *edgeClientConn) sendConnectedReply(req *channel.Message, response *c
 	}
 
 	// this needs to go on the data channel to ensure it gets there before data gets there or a state closed msg
-	err := msg.WithPriority(channel.High).WithTimeout(5 * time.Second).SendAndWaitForWire(self.ch.GetDefaultSender())
+	err := msg.WithTimeout(5 * time.Second).SendAndWaitForWire(self.ch.GetDefaultSender())
 	if err != nil {
 		pfxlog.Logger().WithFields(sdkedge.GetLoggerFields(msg)).WithError(err).Error("failed to send state response")
 		return
@@ -1336,7 +1336,7 @@ func (self *edgeClientConn) sendStateClosedReply(message string, req *channel.Me
 		}
 	}
 
-	err := msg.WithPriority(channel.High).WithTimeout(5 * time.Second).SendAndWaitForWire(self.ch.GetDefaultSender())
+	err := msg.WithTimeout(5 * time.Second).SendAndWaitForWire(self.ch.GetDefaultSender())
 	if err != nil {
 		pfxlog.Logger().WithFields(sdkedge.GetLoggerFields(msg)).WithError(err).Error("failed to send state response")
 	}
@@ -1758,7 +1758,7 @@ func (self *xgEdgeForwarder) Unrouted() {
 	self.xgCircuits.Remove(self.circuitId)
 
 	msg := sdkedge.NewStateClosedMsg(self.connId, "xgress unrouted")
-	err := msg.WithPriority(channel.High).WithTimeout(5 * time.Second).SendAndWaitForWire(self.ch.GetDefaultSender())
+	err := msg.WithTimeout(5 * time.Second).SendAndWaitForWire(self.ch.GetDefaultSender())
 	if err != nil {
 		pfxlog.Logger().WithField("circuitId", self.circuitId).
 			WithFields(sdkedge.GetLoggerFields(msg)).WithError(err).Error("failed to send state closed")


### PR DESCRIPTION
Fixes #3942

channel v5 removes `Binding.Bind(h)` and the per-message send priority API. Both have replacements already available in v4, so this makes the switch now to shrink the eventual v5 migration:

- bind handlers are invoked via `h.BindChannel(binding)` instead of `binding.Bind(h)`
- `WithPriority` is dropped from edge dial and state message sends; it was already a no-op on grouped channels, and v5 prioritizes by underlay selection rather than queue reordering

No dependency change; this builds and tests on channel v4.3.11.