### PR TITLE
Increase certificate serial number namespace to 159 bits. Fixes #3945

### DIFF
--- a/common/cert/cert.go
+++ b/common/cert/cert.go
@@ -79,17 +79,33 @@ func (so *SigningOpts) Apply(c *x509.Certificate) {
 	}
 }
 
+// SerialGenerator produces certificate serial numbers. Implementations must return a
+// positive integer that DER-encodes within RFC 5280's 20-octet serialNumber limit.
 type SerialGenerator interface {
-	Generate() *big.Int
+	Generate() (*big.Int, error)
 }
+
+// serialMax is 2^159 - 1, the largest positive integer that DER-encodes within the
+// 20-octet (160-bit, signed two's-complement) serialNumber limit of RFC 5280 §4.1.2.2.
+// The leading sign bit must stay 0 to remain positive, so 159 magnitude bits is the
+// ceiling that never needs a leading 0x00 pad octet.
+var serialMax = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 159), big.NewInt(1))
 
 type DefaultSerialGenerator struct{}
 
-func (DefaultSerialGenerator) Generate() *big.Int {
-	//@todo this need to be better, this does not include negative numbers for 20bit values, nor is this managed
-	r, _ := rand.Int(rand.Reader, big.NewInt(524287))
+// Generate returns a cryptographically random certificate serial number in the range
+// [1, 2^159 - 1]. The 159-bit width gives a vanishingly small collision probability and
+// provides entropy as defense-in-depth against chosen-prefix signature-hash collisions,
+// while staying within RFC 5280's 20-octet limit.
+func (DefaultSerialGenerator) Generate() (*big.Int, error) {
+	// rand.Int draws from [0, serialMax) = [0, 2^159 - 2]; shift to [1, 2^159 - 1] so
+	// the serial is strictly positive without ever exceeding the 20-octet ceiling.
+	n, err := rand.Int(rand.Reader, serialMax)
+	if err != nil {
+		return nil, fmt.Errorf("could not generate certificate serial number: %w", err)
+	}
 
-	return r
+	return n.Add(n, big.NewInt(1)), nil
 }
 
 var _ Signer = &ServerSigner{}
@@ -125,13 +141,18 @@ func (s *ServerSigner) SignCsr(csr *x509.CertificateRequest, opts *SigningOpts) 
 		return nil, fmt.Errorf("CSR signature validation failed: %s", err)
 	}
 
+	serialNumber, err := s.SerialGenerator.Generate()
+	if err != nil {
+		return nil, err
+	}
+
 	// create client certificate template
 	certTemplate := x509.Certificate{
 		Signature:          csr.Signature,
 		PublicKeyAlgorithm: csr.PublicKeyAlgorithm,
 		PublicKey:          csr.PublicKey,
 
-		SerialNumber: s.SerialGenerator.Generate(),
+		SerialNumber: serialNumber,
 		Issuer:       s.caCert.Subject,
 		Subject:      csr.Subject,
 		NotBefore:    time.Now().Add(-time.Minute),
@@ -187,6 +208,11 @@ func (s *ClientSigner) SignCsr(csr *x509.CertificateRequest, opts *SigningOpts) 
 		return nil, fmt.Errorf("CSR signature validation failed: %s", err)
 	}
 
+	serialNumber, err := s.SerialGenerator.Generate()
+	if err != nil {
+		return nil, err
+	}
+
 	// create client certificate template
 	certTemplate := x509.Certificate{
 		Signature: csr.Signature,
@@ -194,7 +220,7 @@ func (s *ClientSigner) SignCsr(csr *x509.CertificateRequest, opts *SigningOpts) 
 		PublicKeyAlgorithm: csr.PublicKeyAlgorithm,
 		PublicKey:          csr.PublicKey,
 
-		SerialNumber: s.SerialGenerator.Generate(),
+		SerialNumber: serialNumber,
 		Issuer:       s.caCert.Subject,
 		Subject:      csr.Subject,
 		NotBefore:    time.Now().Add(-time.Minute),

--- a/common/cert/serial_test.go
+++ b/common/cert/serial_test.go
@@ -1,0 +1,60 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package cert
+
+import (
+	"math/big"
+	"testing"
+)
+
+func TestDefaultSerialGenerator(t *testing.T) {
+	gen := DefaultSerialGenerator{}
+
+	// 2^159 - 1 is the inclusive maximum (20-octet, positive ceiling per RFC 5280).
+	max := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 159), big.NewInt(1))
+	one := big.NewInt(1)
+
+	for range 10000 {
+		serial, err := gen.Generate()
+		if err != nil {
+			t.Fatalf("unexpected error generating serial: %v", err)
+		}
+
+		// must be strictly positive
+		if serial.Sign() <= 0 {
+			t.Fatalf("serial must be > 0, got %s", serial)
+		}
+
+		// must not exceed the positive 20-octet ceiling
+		if serial.Cmp(max) > 0 {
+			t.Fatalf("serial %s exceeds 2^159 - 1", serial)
+		}
+
+		// at least 1, at most 1: confirm strictly positive lower bound holds
+		if serial.Cmp(one) < 0 {
+			t.Fatalf("serial %s below 1", serial)
+		}
+
+		// the DER encoding (signed two's-complement, minimal) must be <= 20 octets
+		if octets := len(serial.Bytes()); octets > 20 {
+			// big.Int.Bytes() is unsigned big-endian magnitude; for a value <= 2^159-1
+			// the top magnitude bit is 0, so no sign-pad octet is added by DER and the
+			// magnitude length equals the DER content length.
+			t.Fatalf("serial %s encodes to %d octets, exceeds 20", serial, octets)
+		}
+	}
+}


### PR DESCRIPTION
Widens the certificate serial number namespace from ~2^19 to 159 bits, the largest value that fits RFC 5280's 20-octet serial limit. Serials are now drawn from a CSPRNG, are guaranteed positive, and RNG errors are surfaced rather than swallowed.

The `SerialGenerator` interface gains an error return; both `SignCsr` implementations propagate it. Adds a test asserting positivity and the 20-octet bound.