### PR TITLE
Return event-firing error in DeleteById instead of swallowing it

### DIFF
--- a/controller/storage/boltz/store_crud.go
+++ b/controller/storage/boltz/store_crud.go
@@ -445,7 +445,7 @@ func (store *BaseStore[E]) DeleteById(ctx MutateContext, id string) error {
 
 	for _, changeFlow := range changeFlows {
 		if err = changeFlow.fireEvents(); err != nil {
-			return nil
+			return err
 		}
 	}
 


### PR DESCRIPTION
## What

`BaseStore.DeleteById` returned `nil` instead of the error when `changeFlow.fireEvents()` failed, silently discarding the failure.

## Why

`fireEvents()` runs constraint pre-commit processing and registers post-commit handlers. Swallowing its error made a failed delete look successful, so the surrounding bolt transaction committed a delete whose constraint processing never completed. Propagating the error lets the transaction roll back, matching every other error path in the function.

Fixes #3949