### PR TITLE
fixes #3952 reject invalid externalIdClaim and stop enrollment panic

### DIFF
--- a/controller/model/ca_model.go
+++ b/controller/model/ca_model.go
@@ -22,13 +22,13 @@ import (
 	"net/url"
 
 	"github.com/openziti/foundation/v2/errorz"
-	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/openziti/x509-claims/x509claims"
 	"github.com/openziti/ziti/v2/common/cert"
 	"github.com/openziti/ziti/v2/common/eid"
 	"github.com/openziti/ziti/v2/controller/apierror"
 	"github.com/openziti/ziti/v2/controller/db"
 	"github.com/openziti/ziti/v2/controller/models"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/pkg/errors"
 	"go.etcd.io/bbolt"
 )
@@ -90,10 +90,8 @@ func (entity *Ca) toBoltEntityForCreate(tx *bbolt.Tx, env Env) (*db.Ca, error) {
 		entity.IdentityNameFormat = DefaultCaIdentityNameFormat
 	}
 
-	if entity.ExternalIdClaim != nil {
-		if entity.ExternalIdClaim.Matcher == db.ExternalIdClaimMatcherScheme && entity.ExternalIdClaim.Location != db.ExternalIdClaimLocSanUri {
-			return nil, apierror.NewBadRequestFieldError(*errorz.NewFieldError("scheme matcher can only be used with URI locations", "matcher", entity.ExternalIdClaim.Matcher))
-		}
+	if err := validateExternalIdClaim(entity.ExternalIdClaim); err != nil {
+		return nil, err
 	}
 
 	var fp string
@@ -175,6 +173,10 @@ func (entity *Ca) toBoltEntityForUpdate(*bbolt.Tx, Env, boltz.FieldChecker) (*db
 		entity.IdentityNameFormat = DefaultCaIdentityNameFormat
 	}
 
+	if err := validateExternalIdClaim(entity.ExternalIdClaim); err != nil {
+		return nil, err
+	}
+
 	boltEntity := &db.Ca{
 		BaseExtEntity:             *boltz.NewExtEntity(entity.Id, entity.Tags),
 		Name:                      entity.Name,
@@ -200,6 +202,36 @@ func (entity *Ca) toBoltEntityForUpdate(*bbolt.Tx, Env, boltz.FieldChecker) (*db
 	return boltEntity, nil
 }
 
+// validateExternalIdClaim rejects unsupported or incomplete externalIdClaim configurations
+// with a bad request error so they cannot be stored and later fail enrollment/authentication.
+// It exercises the same location/matcher/parser rules used to extract the claim, so any
+// configuration that would error at extraction time is rejected up front at CA create/update.
+func validateExternalIdClaim(claim *ExternalIdClaim) error {
+	if claim == nil {
+		return nil
+	}
+
+	if claim.Index < 0 {
+		return apierror.NewBadRequestFieldError(*errorz.NewFieldError("index must be greater than or equal to zero", "externalIdClaim.index", claim.Index))
+	}
+
+	var err error
+	switch claim.Location {
+	case db.ExternalIdClaimLocCommonName, db.ExternalIdClaimLocSanEmail:
+		_, err = getStringDefinition(claim)
+	case db.ExternalIdClaimLocSanUri:
+		_, err = getUriDefinition(claim)
+	default:
+		return apierror.NewBadRequestFieldError(*errorz.NewFieldError(fmt.Sprintf("unsupported location [%s]", claim.Location), "externalIdClaim.location", claim.Location))
+	}
+
+	if err != nil {
+		return apierror.NewBadRequestFieldError(*errorz.NewFieldError(err.Error(), "externalIdClaim", claim))
+	}
+
+	return nil
+}
+
 // GetExternalId will attempt to retrieve a string claim from a x509 Certificate based on
 // location, matching, and parsing of various x509 Certificate fields.
 func (entity *Ca) GetExternalId(cert *x509.Certificate) (string, error) {
@@ -214,38 +246,46 @@ func (entity *Ca) GetExternalId(cert *x509.Certificate) (string, error) {
 	switch entity.ExternalIdClaim.Location {
 	case db.ExternalIdClaimLocCommonName:
 		definition, err := getStringDefinition(entity.ExternalIdClaim)
-		definition.Locator = &x509claims.LocatorCommonName{}
 		if err != nil {
 			return "", err
 		}
+		definition.Locator = &x509claims.LocatorCommonName{}
 
 		provider.Definitions = append(provider.Definitions, definition)
 
 	case db.ExternalIdClaimLocSanUri:
 		definition, err := getUriDefinition(entity.ExternalIdClaim)
-		definition.Locator = &x509claims.LocatorSanUri{}
 		if err != nil {
 			return "", err
 		}
+		definition.Locator = &x509claims.LocatorSanUri{}
 
 		provider.Definitions = append(provider.Definitions, definition)
 	case db.ExternalIdClaimLocSanEmail:
 		definition, err := getStringDefinition(entity.ExternalIdClaim)
-		definition.Locator = &x509claims.LocatorSanEmail{}
 		if err != nil {
 			return "", err
 		}
+		definition.Locator = &x509claims.LocatorSanEmail{}
 
 		provider.Definitions = append(provider.Definitions, definition)
+	default:
+		return "", fmt.Errorf("unsupported location [%s]", entity.ExternalIdClaim.Location)
 	}
 
 	claims := provider.Claims(cert)
 
-	if int64(len(claims)) > entity.ExternalIdClaim.Index {
-		return claims[entity.ExternalIdClaim.Index], nil
+	if entity.ExternalIdClaim.Index < 0 || entity.ExternalIdClaim.Index >= int64(len(claims)) {
+		return "", errors.New("no claim found")
 	}
 
-	return "", errors.New("no claim found")
+	externalId := claims[entity.ExternalIdClaim.Index]
+
+	if externalId == "" {
+		return "", errors.New("claim resolved to an empty value")
+	}
+
+	return externalId, nil
 }
 
 // getUriDefinition returns an x509Claims.DefinitionLMP that will locate, match, and parse url.URL properties.

--- a/controller/model/ca_model.go
+++ b/controller/model/ca_model.go
@@ -168,12 +168,17 @@ func (entity *Ca) toBoltEntityForCreate(tx *bbolt.Tx, env Env) (*db.Ca, error) {
 	return boltEntity, nil
 }
 
-func (entity *Ca) toBoltEntityForUpdate(*bbolt.Tx, Env, boltz.FieldChecker) (*db.Ca, error) {
+func (entity *Ca) toBoltEntityForUpdate(tx *bbolt.Tx, env Env, checker boltz.FieldChecker) (*db.Ca, error) {
 	if entity.IdentityNameFormat == "" {
 		entity.IdentityNameFormat = DefaultCaIdentityNameFormat
 	}
 
-	if err := validateExternalIdClaim(entity.ExternalIdClaim); err != nil {
+	claim, err := entity.effectiveExternalIdClaim(tx, env, checker)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := validateExternalIdClaim(claim); err != nil {
 		return nil, err
 	}
 
@@ -202,6 +207,81 @@ func (entity *Ca) toBoltEntityForUpdate(*bbolt.Tx, Env, boltz.FieldChecker) (*db
 	return boltEntity, nil
 }
 
+// caExternalIdClaimFields are the persisted externalIdClaim subfields, used to detect which
+// subfields a partial update touches.
+var caExternalIdClaimFields = []string{
+	db.FieldCaExternalIdClaimLocation,
+	db.FieldCaExternalIdClaimMatcher,
+	db.FieldCaExternalIdClaimMatcherCriteria,
+	db.FieldCaExternalIdClaimParser,
+	db.FieldCaExternalIdClaimParserCriteria,
+	db.FieldCaExternalIdClaimIndex,
+}
+
+// effectiveExternalIdClaim returns the externalIdClaim to validate for an update so validation
+// matches what will be stored. A nil checker is a full replace, so the request claim stands as-is.
+// For a patch only the subfields named in the checker change: if none touch the claim it is left
+// unchanged (nil, validation skipped), otherwise the supplied subfields are overlaid onto the stored
+// claim and the merged result is validated. Subfield gating mirrors PersistEntity exactly.
+func (entity *Ca) effectiveExternalIdClaim(tx *bbolt.Tx, env Env, checker boltz.FieldChecker) (*ExternalIdClaim, error) {
+	// No claim supplied: the update either clears the claim or leaves it untouched. Nothing to validate.
+	if entity.ExternalIdClaim == nil {
+		return nil, nil
+	}
+
+	// Full replace (nil checker): validate the supplied claim as-is.
+	if checker == nil {
+		return entity.ExternalIdClaim, nil
+	}
+
+	// Partial update: if no claim subfield is being set, the stored claim is unchanged (the empty {}
+	// object older CLIs send on every update). Skip validation rather than treating it as incomplete.
+	touched := false
+	for _, field := range caExternalIdClaimFields {
+		if checker.IsUpdated(field) {
+			touched = true
+			break
+		}
+	}
+	if !touched {
+		return nil, nil
+	}
+
+	// Overlay the supplied subfields onto the stored claim so the merged result is what gets validated.
+	merged := &ExternalIdClaim{}
+	if existing, err := env.GetStores().Ca.LoadById(tx, entity.Id); err != nil {
+		return nil, err
+	} else if existing != nil && existing.ExternalIdClaim != nil {
+		merged.Location = existing.ExternalIdClaim.Location
+		merged.Matcher = existing.ExternalIdClaim.Matcher
+		merged.MatcherCriteria = existing.ExternalIdClaim.MatcherCriteria
+		merged.Parser = existing.ExternalIdClaim.Parser
+		merged.ParserCriteria = existing.ExternalIdClaim.ParserCriteria
+		merged.Index = existing.ExternalIdClaim.Index
+	}
+
+	if checker.IsUpdated(db.FieldCaExternalIdClaimLocation) {
+		merged.Location = entity.ExternalIdClaim.Location
+	}
+	if checker.IsUpdated(db.FieldCaExternalIdClaimMatcher) {
+		merged.Matcher = entity.ExternalIdClaim.Matcher
+	}
+	if checker.IsUpdated(db.FieldCaExternalIdClaimMatcherCriteria) {
+		merged.MatcherCriteria = entity.ExternalIdClaim.MatcherCriteria
+	}
+	if checker.IsUpdated(db.FieldCaExternalIdClaimParser) {
+		merged.Parser = entity.ExternalIdClaim.Parser
+	}
+	if checker.IsUpdated(db.FieldCaExternalIdClaimParserCriteria) {
+		merged.ParserCriteria = entity.ExternalIdClaim.ParserCriteria
+	}
+	if checker.IsUpdated(db.FieldCaExternalIdClaimIndex) {
+		merged.Index = entity.ExternalIdClaim.Index
+	}
+
+	return merged, nil
+}
+
 // validateExternalIdClaim rejects unsupported or incomplete externalIdClaim configurations
 // with a bad request error so they cannot be stored and later fail enrollment/authentication.
 // It exercises the same location/matcher/parser rules used to extract the claim, so any
@@ -226,7 +306,8 @@ func validateExternalIdClaim(claim *ExternalIdClaim) error {
 	}
 
 	if err != nil {
-		return apierror.NewBadRequestFieldError(*errorz.NewFieldError(err.Error(), "externalIdClaim", claim))
+		value := fmt.Sprintf("location=%s matcher=%s parser=%s", claim.Location, claim.Matcher, claim.Parser)
+		return apierror.NewBadRequestFieldError(*errorz.NewFieldError(err.Error(), "externalIdClaim", value))
 	}
 
 	return nil
@@ -235,7 +316,9 @@ func validateExternalIdClaim(claim *ExternalIdClaim) error {
 // GetExternalId will attempt to retrieve a string claim from a x509 Certificate based on
 // location, matching, and parsing of various x509 Certificate fields.
 func (entity *Ca) GetExternalId(cert *x509.Certificate) (string, error) {
-	if entity.ExternalIdClaim == nil {
+	// A claim with no location is unconfigured (e.g. the empty bucket an older CLI's empty {} patch
+	// leaves behind). Treat it as no claim so enrollment falls back to a certificate fingerprint.
+	if entity.ExternalIdClaim == nil || entity.ExternalIdClaim.Location == "" {
 		return "", nil
 	}
 

--- a/controller/model/ca_test.go
+++ b/controller/model/ca_test.go
@@ -1,11 +1,157 @@
 package model
 
 import (
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"fmt"
+	"net/url"
 	"testing"
 
+	"github.com/openziti/ziti/v2/controller/db"
 	"github.com/stretchr/testify/require"
 )
+
+// mustParseUri parses a raw URI for SAN URI test certificates.
+func mustParseUri(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	require.New(t).NoError(err)
+	return u
+}
+
+// getExternalIdNoPanic invokes Ca.GetExternalId, recovering any panic so a single
+// crashing configuration cannot abort sibling subtests. It reports whether the call
+// panicked in addition to its normal return values.
+func getExternalIdNoPanic(ca *Ca, cert *x509.Certificate) (result string, err error, panicked bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			panicked = true
+		}
+	}()
+	result, err = ca.GetExternalId(cert)
+	return result, err, panicked
+}
+
+// Test_Ca_GetExternalId encodes the expected behavior from the issue matrix:
+//   - An unsupported or incomplete externalIdClaim never panics; it returns an error.
+//   - A claim that matches but resolves to an empty string returns an error rather than
+//     a silently-accepted empty externalId.
+//   - A valid configuration returns the extracted value.
+func Test_Ca_GetExternalId(t *testing.T) {
+	const sanUri = "acme:tenant:042"
+	const spiffeId = "spiffe://acme/tenant/042"
+	const commonName = "acme:tenant:042"
+	const email = "tenant042@acme.example"
+
+	newCert := func(t *testing.T) *x509.Certificate {
+		return &x509.Certificate{
+			Subject:        pkix.Name{CommonName: commonName},
+			URIs:           []*url.URL{mustParseUri(t, sanUri), mustParseUri(t, spiffeId)},
+			EmailAddresses: []string{email},
+		}
+	}
+
+	caWith := func(claim *ExternalIdClaim) *Ca {
+		return &Ca{ExternalIdClaim: claim}
+	}
+
+	t.Run("does not panic and errors on unsupported matcher for SAN URI", func(t *testing.T) {
+		req := require.New(t)
+		for _, matcher := range []string{db.ExternalIdClaimMatcherPrefix, db.ExternalIdClaimMatcherSuffix} {
+			ca := caWith(&ExternalIdClaim{
+				Location:        db.ExternalIdClaimLocSanUri,
+				Matcher:         matcher,
+				MatcherCriteria: "acme:tenant:",
+				Parser:          db.ExternalIdClaimParserNone,
+			})
+			_, err, panicked := getExternalIdNoPanic(ca, newCert(t))
+			req.False(panicked, "matcher %s on SAN URI should not panic", matcher)
+			req.Error(err, "matcher %s on SAN URI should return an error", matcher)
+		}
+	})
+
+	t.Run("does not panic and errors on missing matcher criteria", func(t *testing.T) {
+		req := require.New(t)
+		cases := []*ExternalIdClaim{
+			{Location: db.ExternalIdClaimLocSanUri, Matcher: db.ExternalIdClaimMatcherScheme, MatcherCriteria: "", Parser: db.ExternalIdClaimParserNone},
+			{Location: db.ExternalIdClaimLocCommonName, Matcher: db.ExternalIdClaimMatcherPrefix, MatcherCriteria: "", Parser: db.ExternalIdClaimParserNone},
+			{Location: db.ExternalIdClaimLocSanEmail, Matcher: db.ExternalIdClaimMatcherSuffix, MatcherCriteria: "", Parser: db.ExternalIdClaimParserNone},
+		}
+		for _, claim := range cases {
+			_, err, panicked := getExternalIdNoPanic(caWith(claim), newCert(t))
+			req.False(panicked, "claim %+v should not panic", claim)
+			req.Error(err, "claim %+v should return an error", claim)
+		}
+	})
+
+	t.Run("does not panic and errors on missing parser criteria for split", func(t *testing.T) {
+		req := require.New(t)
+		ca := caWith(&ExternalIdClaim{
+			Location:       db.ExternalIdClaimLocCommonName,
+			Matcher:        db.ExternalIdClaimMatcherAll,
+			Parser:         db.ExternalIdClaimParserSplit,
+			ParserCriteria: "",
+		})
+		_, err, panicked := getExternalIdNoPanic(ca, newCert(t))
+		req.False(panicked, "split parser with empty criteria should not panic")
+		req.Error(err, "split parser with empty criteria should return an error")
+	})
+
+	t.Run("does not panic and errors on negative index", func(t *testing.T) {
+		req := require.New(t)
+		ca := caWith(&ExternalIdClaim{
+			Location: db.ExternalIdClaimLocCommonName,
+			Matcher:  db.ExternalIdClaimMatcherAll,
+			Parser:   db.ExternalIdClaimParserNone,
+			Index:    -1,
+		})
+		_, err, panicked := getExternalIdNoPanic(ca, newCert(t))
+		req.False(panicked, "negative index should not panic")
+		req.Error(err, "negative index should return an error")
+	})
+
+	t.Run("errors when a matched claim resolves to empty", func(t *testing.T) {
+		req := require.New(t)
+		// PREFIX trims the entire common name, leaving an empty claim.
+		ca := caWith(&ExternalIdClaim{
+			Location:        db.ExternalIdClaimLocCommonName,
+			Matcher:         db.ExternalIdClaimMatcherPrefix,
+			MatcherCriteria: commonName,
+			Parser:          db.ExternalIdClaimParserNone,
+		})
+		result, err, panicked := getExternalIdNoPanic(ca, newCert(t))
+		req.False(panicked)
+		req.Error(err, "a matched-but-empty claim must not be accepted as an empty externalId")
+		req.Empty(result)
+	})
+
+	t.Run("returns the value for a valid SAN URI scheme claim", func(t *testing.T) {
+		req := require.New(t)
+		ca := caWith(&ExternalIdClaim{
+			Location:        db.ExternalIdClaimLocSanUri,
+			Matcher:         db.ExternalIdClaimMatcherScheme,
+			MatcherCriteria: "spiffe",
+			Parser:          db.ExternalIdClaimParserNone,
+		})
+		result, err, panicked := getExternalIdNoPanic(ca, newCert(t))
+		req.False(panicked)
+		req.NoError(err)
+		req.Equal(spiffeId, result)
+	})
+
+	t.Run("returns the value for a valid common name all claim", func(t *testing.T) {
+		req := require.New(t)
+		ca := caWith(&ExternalIdClaim{
+			Location: db.ExternalIdClaimLocCommonName,
+			Matcher:  db.ExternalIdClaimMatcherAll,
+			Parser:   db.ExternalIdClaimParserNone,
+		})
+		result, err, panicked := getExternalIdNoPanic(ca, newCert(t))
+		req.False(panicked)
+		req.NoError(err)
+		req.Equal(commonName, result)
+	})
+}
 
 func Test_IdentityNameFormatter(t *testing.T) {
 	const (

--- a/controller/model/ca_test.go
+++ b/controller/model/ca_test.go
@@ -151,6 +151,18 @@ func Test_Ca_GetExternalId(t *testing.T) {
 		req.NoError(err)
 		req.Equal(commonName, result)
 	})
+
+	t.Run("treats a claim with an empty location as no claim", func(t *testing.T) {
+		req := require.New(t)
+		// An externalIdClaim with no location is unconfigured (e.g. the empty bucket left by an
+		// older CLI's empty {} patch). It must read as "no claim" -> fall back to fingerprint,
+		// not error, so existing CAs keep enrolling after upgrade.
+		ca := caWith(&ExternalIdClaim{})
+		result, err, panicked := getExternalIdNoPanic(ca, newCert(t))
+		req.False(panicked)
+		req.NoError(err)
+		req.Empty(result)
+	})
 }
 
 func Test_IdentityNameFormatter(t *testing.T) {

--- a/tests/ca_test.go
+++ b/tests/ca_test.go
@@ -751,3 +751,145 @@ func Test_CA(t *testing.T) {
 		})
 	})
 }
+
+// Test_CA_ExternalIdClaim_Validation asserts that unsupported or incomplete externalIdClaim
+// configurations are rejected with HTTP 400 at CA create and update time, rather than being
+// stored and later crashing enrollment/authentication with an HTTP 500 (see issue matrix).
+func Test_CA_ExternalIdClaim_Validation(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+	ctx.RequireAdminManagementApiLogin()
+
+	invalidClaims := []struct {
+		name  string
+		claim *rest_model.ExternalIDClaim
+	}{
+		{
+			name: "san uri with prefix matcher",
+			claim: &rest_model.ExternalIDClaim{
+				Index:           ToPtr[int64](0),
+				Location:        ToPtr(rest_model.ExternalIDClaimLocationSANURI),
+				Matcher:         ToPtr(rest_model.ExternalIDClaimMatcherPREFIX),
+				MatcherCriteria: ToPtr("acme:tenant:"),
+				Parser:          ToPtr(rest_model.ExternalIDClaimParserNONE),
+				ParserCriteria:  ToPtr(""),
+			},
+		},
+		{
+			name: "san uri with suffix matcher",
+			claim: &rest_model.ExternalIDClaim{
+				Index:           ToPtr[int64](0),
+				Location:        ToPtr(rest_model.ExternalIDClaimLocationSANURI),
+				Matcher:         ToPtr(rest_model.ExternalIDClaimMatcherSUFFIX),
+				MatcherCriteria: ToPtr(":042"),
+				Parser:          ToPtr(rest_model.ExternalIDClaimParserNONE),
+				ParserCriteria:  ToPtr(""),
+			},
+		},
+		{
+			name: "scheme matcher with empty criteria",
+			claim: &rest_model.ExternalIDClaim{
+				Index:           ToPtr[int64](0),
+				Location:        ToPtr(rest_model.ExternalIDClaimLocationSANURI),
+				Matcher:         ToPtr(rest_model.ExternalIDClaimMatcherSCHEME),
+				MatcherCriteria: ToPtr(""),
+				Parser:          ToPtr(rest_model.ExternalIDClaimParserNONE),
+				ParserCriteria:  ToPtr(""),
+			},
+		},
+		{
+			name: "prefix matcher with empty criteria",
+			claim: &rest_model.ExternalIDClaim{
+				Index:           ToPtr[int64](0),
+				Location:        ToPtr(rest_model.ExternalIDClaimLocationCOMMONNAME),
+				Matcher:         ToPtr(rest_model.ExternalIDClaimMatcherPREFIX),
+				MatcherCriteria: ToPtr(""),
+				Parser:          ToPtr(rest_model.ExternalIDClaimParserNONE),
+				ParserCriteria:  ToPtr(""),
+			},
+		},
+		{
+			name: "split parser with empty criteria",
+			claim: &rest_model.ExternalIDClaim{
+				Index:           ToPtr[int64](0),
+				Location:        ToPtr(rest_model.ExternalIDClaimLocationCOMMONNAME),
+				Matcher:         ToPtr(rest_model.ExternalIDClaimMatcherALL),
+				MatcherCriteria: ToPtr(""),
+				Parser:          ToPtr(rest_model.ExternalIDClaimParserSPLIT),
+				ParserCriteria:  ToPtr(""),
+			},
+		},
+		{
+			name: "negative index",
+			claim: &rest_model.ExternalIDClaim{
+				Index:           ToPtr[int64](-1),
+				Location:        ToPtr(rest_model.ExternalIDClaimLocationCOMMONNAME),
+				Matcher:         ToPtr(rest_model.ExternalIDClaimMatcherALL),
+				MatcherCriteria: ToPtr(""),
+				Parser:          ToPtr(rest_model.ExternalIDClaimParserNONE),
+				ParserCriteria:  ToPtr(""),
+			},
+		},
+	}
+
+	for _, tc := range invalidClaims {
+		t.Run("can not create a CA with "+tc.name, func(t *testing.T) {
+			ctx.testContextChanged(t)
+
+			_, _, caPEM := newTestCaCert()
+
+			caCreate := &rest_model.CaCreate{
+				CertPem:                   ToPtr(caPEM.String()),
+				ExternalIDClaim:           tc.claim,
+				IdentityRoles:             []string{},
+				IsAuthEnabled:             ToPtr(true),
+				IsAutoCaEnrollmentEnabled: ToPtr(true),
+				IsOttCaEnrollmentEnabled:  ToPtr(true),
+				Name:                      ToPtr(eid.New()),
+			}
+
+			resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(caCreate).Post("/cas")
+			ctx.NoError(err)
+			ctx.Equal(http.StatusBadRequest, resp.StatusCode(), string(resp.Body()))
+		})
+	}
+
+	for _, tc := range invalidClaims {
+		t.Run("can not patch a CA to "+tc.name, func(t *testing.T) {
+			ctx.testContextChanged(t)
+
+			_, _, caPEM := newTestCaCert()
+
+			caCreate := &rest_model.CaCreate{
+				CertPem:                   ToPtr(caPEM.String()),
+				IdentityRoles:             []string{},
+				IsAuthEnabled:             ToPtr(true),
+				IsAutoCaEnrollmentEnabled: ToPtr(true),
+				IsOttCaEnrollmentEnabled:  ToPtr(true),
+				Name:                      ToPtr(eid.New()),
+			}
+
+			caCreateResult := &rest_model.CreateEnvelope{}
+
+			resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(caCreate).SetResult(caCreateResult).Post("/cas")
+			ctx.NoError(err)
+			ctx.Equal(http.StatusCreated, resp.StatusCode(), string(resp.Body()))
+
+			caPatch := &rest_model.CaPatch{
+				ExternalIDClaim: &rest_model.ExternalIDClaimPatch{
+					Index:           tc.claim.Index,
+					Location:        tc.claim.Location,
+					Matcher:         tc.claim.Matcher,
+					MatcherCriteria: tc.claim.MatcherCriteria,
+					Parser:          tc.claim.Parser,
+					ParserCriteria:  tc.claim.ParserCriteria,
+				},
+			}
+
+			resp, err = ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(caPatch).Patch("/cas/" + caCreateResult.Data.ID)
+			ctx.NoError(err)
+			ctx.Equal(http.StatusBadRequest, resp.StatusCode(), string(resp.Body()))
+		})
+	}
+}

--- a/tests/ca_test.go
+++ b/tests/ca_test.go
@@ -893,3 +893,134 @@ func Test_CA_ExternalIdClaim_Validation(t *testing.T) {
 		})
 	}
 }
+
+// createTestCaWithClaim creates a CA carrying the given externalIdClaim (nil for none) and returns its id.
+func createTestCaWithClaim(ctx *TestContext, claim *rest_model.ExternalIDClaim) string {
+	_, _, caPEM := newTestCaCert()
+	caCreate := &rest_model.CaCreate{
+		CertPem:                   ToPtr(caPEM.String()),
+		ExternalIDClaim:           claim,
+		IdentityRoles:             []string{},
+		IsAuthEnabled:             ToPtr(true),
+		IsAutoCaEnrollmentEnabled: ToPtr(true),
+		IsOttCaEnrollmentEnabled:  ToPtr(true),
+		Name:                      ToPtr(eid.New()),
+	}
+	result := &rest_model.CreateEnvelope{}
+	resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(caCreate).SetResult(result).Post("/cas")
+	ctx.Req.NoError(err)
+	ctx.Req.Equal(http.StatusCreated, resp.StatusCode(), string(resp.Body()))
+	return result.Data.ID
+}
+
+// getTestCaClaim returns the stored externalIdClaim for a CA, or nil if it has none.
+func getTestCaClaim(ctx *TestContext, id string) *rest_model.ExternalIDClaim {
+	result := &rest_model.DetailCaEnvelope{}
+	resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetResult(result).Get("/cas/" + id)
+	ctx.Req.NoError(err)
+	ctx.Req.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body()))
+	return result.Data.ExternalIDClaim
+}
+
+// Test_CA_ExternalIdClaim_PatchMerge covers PATCH merge semantics for externalIdClaim. A PATCH
+// carries only the subfields it names and the server merges them onto the stored claim. The nuance
+// this guards: the empty {} object older CLIs send on every update (even a rename) must be a no-op,
+// not a validation 400; a supplied subfield must merge with stored values; only the resulting merged
+// claim is validated; and omitting the claim clears it.
+func Test_CA_ExternalIdClaim_PatchMerge(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+	ctx.RequireAdminManagementApiLogin()
+
+	// A valid stored starting point: extract the common name prefixed with "acme:".
+	baseClaim := func() *rest_model.ExternalIDClaim {
+		return &rest_model.ExternalIDClaim{
+			Index:           ToPtr[int64](0),
+			Location:        ToPtr(rest_model.ExternalIDClaimLocationCOMMONNAME),
+			Matcher:         ToPtr(rest_model.ExternalIDClaimMatcherPREFIX),
+			MatcherCriteria: ToPtr("acme:"),
+			Parser:          ToPtr(rest_model.ExternalIDClaimParserNONE),
+			ParserCriteria:  ToPtr(""),
+		}
+	}
+
+	t.Run("empty claim object is a no-op (old CLI rename path)", func(t *testing.T) {
+		ctx.testContextChanged(t)
+		// Old CLIs always send "externalIdClaim": {} even for a rename. It must preserve the
+		// stored claim, not be validated as an incomplete (location-less) claim.
+		id := createTestCaWithClaim(ctx, baseClaim())
+
+		caPatch := &rest_model.CaPatch{
+			Name:            ToPtr(eid.New()),
+			ExternalIDClaim: &rest_model.ExternalIDClaimPatch{},
+		}
+		resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(caPatch).Patch("/cas/" + id)
+		ctx.NoError(err)
+		ctx.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body()))
+
+		claim := getTestCaClaim(ctx, id)
+		ctx.Req.NotNil(claim)
+		ctx.Equal("acme:", *claim.MatcherCriteria, "stored claim should be unchanged")
+	})
+
+	t.Run("a supplied subfield merges with stored values", func(t *testing.T) {
+		ctx.testContextChanged(t)
+		// Patching only matcherCriteria leaves location/matcher/parser as stored.
+		id := createTestCaWithClaim(ctx, baseClaim())
+
+		caPatch := &rest_model.CaPatch{
+			ExternalIDClaim: &rest_model.ExternalIDClaimPatch{MatcherCriteria: ToPtr("widget:")},
+		}
+		resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(caPatch).Patch("/cas/" + id)
+		ctx.NoError(err)
+		ctx.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body()))
+
+		claim := getTestCaClaim(ctx, id)
+		ctx.Req.NotNil(claim)
+		ctx.Equal("widget:", *claim.MatcherCriteria)
+		ctx.Equal(rest_model.ExternalIDClaimLocationCOMMONNAME, *claim.Location, "location should be retained")
+		ctx.Equal(rest_model.ExternalIDClaimMatcherPREFIX, *claim.Matcher, "matcher should be retained")
+	})
+
+	t.Run("a subfield patch producing an invalid merged claim is rejected", func(t *testing.T) {
+		ctx.testContextChanged(t)
+		// SCHEME is invalid for COMMON_NAME; the merged result must be validated and rejected.
+		id := createTestCaWithClaim(ctx, baseClaim())
+
+		caPatch := &rest_model.CaPatch{
+			ExternalIDClaim: &rest_model.ExternalIDClaimPatch{Matcher: ToPtr(rest_model.ExternalIDClaimMatcherSCHEME)},
+		}
+		resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(caPatch).Patch("/cas/" + id)
+		ctx.NoError(err)
+		ctx.Equal(http.StatusBadRequest, resp.StatusCode(), string(resp.Body()))
+	})
+
+	t.Run("empty claim object on a CA with no claim is a no-op", func(t *testing.T) {
+		ctx.testContextChanged(t)
+		// Same old-CLI path against a CA that never had a claim: must not 400.
+		id := createTestCaWithClaim(ctx, nil)
+
+		caPatch := &rest_model.CaPatch{
+			Name:            ToPtr(eid.New()),
+			ExternalIDClaim: &rest_model.ExternalIDClaimPatch{},
+		}
+		resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(caPatch).Patch("/cas/" + id)
+		ctx.NoError(err)
+		ctx.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body()))
+	})
+
+	t.Run("omitting the claim clears it", func(t *testing.T) {
+		ctx.testContextChanged(t)
+		// A patch with no externalIdClaim key removes the stored claim (delete-on-nil). This is the
+		// signal the new --clear-external-id-claim CLI flag sends.
+		id := createTestCaWithClaim(ctx, baseClaim())
+
+		caPatch := &rest_model.CaPatch{Name: ToPtr(eid.New())}
+		resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(caPatch).Patch("/cas/" + id)
+		ctx.NoError(err)
+		ctx.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body()))
+
+		ctx.Req.Nil(getTestCaClaim(ctx, id), "claim should be cleared")
+	})
+}

--- a/tests/enrollment_ca_auto_specific_test.go
+++ b/tests/enrollment_ca_auto_specific_test.go
@@ -30,6 +30,67 @@ import (
 	"github.com/openziti/ziti/v2/common/eid"
 )
 
+// Test_EnrollmentCaAuto_EmptyExternalIdClaim verifies that a validly-configured externalIdClaim
+// that resolves to an empty string for a given certificate fails enrollment cleanly rather than
+// silently enrolling the identity via a certificate fingerprint with no externalId.
+func Test_EnrollmentCaAuto_EmptyExternalIdClaim(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+	ctx.RequireAdminManagementApiLogin()
+
+	ctx.testContextChanged(t)
+
+	commonName := "empty-claim-" + eid.New()
+
+	testCa := newTestCa()
+	// PREFIX trimming the entire common name leaves an empty claim. The configuration is valid
+	// (COMMON_NAME supports PREFIX), but the extracted externalId is empty for this certificate.
+	testCa.externalIdClaim = &externalIdClaim{
+		location:        rest_model.ExternalIDClaimLocationCOMMONNAME,
+		matcher:         rest_model.ExternalIDClaimMatcherPREFIX,
+		matcherCriteria: commonName,
+		parser:          rest_model.ExternalIDClaimParserNONE,
+		parserCriteria:  "",
+		index:           0,
+	}
+	testCa.identityNameFormat = "[requestedName]"
+
+	testCaId := ctx.AdminManagementSession.requireCreateEntity(testCa)
+	ctx.Req.NotEmpty(testCaId)
+
+	caContainer := ctx.AdminManagementSession.requireQuery("cas/" + testCaId)
+	token := caContainer.Path("data.verificationToken").Data().(string)
+	ctx.Req.NotEmpty(token)
+
+	verifyCert, _, err := generateCaSignedClientCert(testCa.publicCert, testCa.privateKey, token)
+	ctx.Req.NoError(err)
+
+	verifyPem := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: verifyCert.Raw})
+
+	resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetHeader("content-type", "text/plain").SetBody(verifyPem).Post("cas/" + testCaId + "/verify")
+	ctx.Req.NoError(err)
+	standardJsonResponseTests(resp, http.StatusOK, t)
+
+	clientCert, clientKey, err := generateCaSignedClientCert(testCa.publicCert, testCa.privateKey, commonName)
+	ctx.Req.NoError(err)
+
+	restClient, _, transport := ctx.NewClientComponents(EdgeClientApiPath)
+	transport.TLSClientConfig.Certificates = []tls.Certificate{
+		{
+			Certificate: [][]byte{clientCert.Raw},
+			PrivateKey:  clientKey,
+		},
+	}
+
+	enrollResp, err := restClient.R().
+		SetHeader("content-type", "application/json").
+		Post("enroll?method=ca")
+	ctx.Req.NoError(err)
+
+	ctx.Req.Equal(http.StatusBadRequest, enrollResp.StatusCode(), string(enrollResp.Body()))
+}
+
 // Test_EnrollmetnCaAutoSpecific uses the ca specific enrollment endpoint rather than the generic enroll endpoint.
 func Test_EnrollmetnCaAutoSpecific(t *testing.T) {
 	ctx := NewTestContext(t)

--- a/ziti/cmd/edge/update_ca.go
+++ b/ziti/cmd/edge/update_ca.go
@@ -43,7 +43,8 @@ type updateCaOptions struct {
 	identityAttributes []string
 	identityNameFormat string
 
-	externalIDClaim rest_model.ExternalIDClaimPatch
+	externalIDClaim      rest_model.ExternalIDClaimPatch
+	clearExternalIDClaim bool
 }
 
 // newUpdateAuthenticatorCmd creates the 'edge controller update authenticator' command
@@ -117,6 +118,7 @@ func newUpdateCaCmd(out io.Writer, errOut io.Writer) *cobra.Command {
 	cmd.Flags().StringVarP(options.externalIDClaim.MatcherCriteria, "matcher-criteria", "x", "", "criteria used with the given matcher")
 	cmd.Flags().StringVarP(options.externalIDClaim.Parser, "parser", "p", "", "the parser to use on found external ids")
 	cmd.Flags().StringVarP(options.externalIDClaim.ParserCriteria, "parser-criteria", "z", "", "criteria used with the given parser")
+	cmd.Flags().BoolVar(&options.clearExternalIDClaim, "clear-external-id-claim", false, "remove the externalIdClaim configuration from the CA")
 
 	options.AddCommonFlags(cmd)
 	return cmd
@@ -172,35 +174,45 @@ func runUpdateCa(options updateCaOptions) error {
 		changed = true
 	}
 
-	ca.ExternalIDClaim = &rest_model.ExternalIDClaimPatch{}
-	if options.Cmd.Flag("location").Changed {
-		ca.ExternalIDClaim.Location = options.externalIDClaim.Location
-		changed = true
-	}
+	claimChanged := options.Cmd.Flag("location").Changed ||
+		options.Cmd.Flag("index").Changed ||
+		options.Cmd.Flag("matcher").Changed ||
+		options.Cmd.Flag("matcher-criteria").Changed ||
+		options.Cmd.Flag("parser").Changed ||
+		options.Cmd.Flag("parser-criteria").Changed
 
-	if options.Cmd.Flag("index").Changed {
-		ca.ExternalIDClaim.Index = options.externalIDClaim.Index
+	if options.clearExternalIDClaim {
+		if claimChanged {
+			return errors.New("--clear-external-id-claim cannot be combined with externalIdClaim field flags")
+		}
+		// Omit externalIdClaim entirely so the server removes the stored claim (delete-on-nil).
+		ca.ExternalIDClaim = nil
 		changed = true
-	}
-
-	if options.Cmd.Flag("matcher").Changed {
-		ca.ExternalIDClaim.Matcher = options.externalIDClaim.Matcher
-		changed = true
-	}
-
-	if options.Cmd.Flag("matcher-criteria").Changed {
-		ca.ExternalIDClaim.MatcherCriteria = options.externalIDClaim.MatcherCriteria
-		changed = true
-	}
-
-	if options.Cmd.Flag("parser").Changed {
-		ca.ExternalIDClaim.Parser = options.externalIDClaim.Parser
-		changed = true
-	}
-
-	if options.Cmd.Flag("parser-criteria").Changed {
-		ca.ExternalIDClaim.ParserCriteria = options.externalIDClaim.ParserCriteria
-		changed = true
+	} else {
+		// Always send an (empty) object so an unrelated update preserves the stored claim rather
+		// than clearing it; supplied subfields are merged server-side.
+		ca.ExternalIDClaim = &rest_model.ExternalIDClaimPatch{}
+		if options.Cmd.Flag("location").Changed {
+			ca.ExternalIDClaim.Location = options.externalIDClaim.Location
+		}
+		if options.Cmd.Flag("index").Changed {
+			ca.ExternalIDClaim.Index = options.externalIDClaim.Index
+		}
+		if options.Cmd.Flag("matcher").Changed {
+			ca.ExternalIDClaim.Matcher = options.externalIDClaim.Matcher
+		}
+		if options.Cmd.Flag("matcher-criteria").Changed {
+			ca.ExternalIDClaim.MatcherCriteria = options.externalIDClaim.MatcherCriteria
+		}
+		if options.Cmd.Flag("parser").Changed {
+			ca.ExternalIDClaim.Parser = options.externalIDClaim.Parser
+		}
+		if options.Cmd.Flag("parser-criteria").Changed {
+			ca.ExternalIDClaim.ParserCriteria = options.externalIDClaim.ParserCriteria
+		}
+		if claimChanged {
+			changed = true
+		}
 	}
 
 	if options.TagsProvided() {


### PR DESCRIPTION
- moves the error check before the locator assignment in Ca.GetExternalId so an unsupported matcher/parser no longer nil-derefs and returns HTTP 500
- guards the claim index against negative and out-of-range values and errors when a matched claim resolves to an empty string, so an empty externalId is never silently accepted nor mapped to an identity
- adds validateExternalIdClaim, rejecting unsupported locations, unsupported matcher/parser combos, missing matcher/parser criteria, and negative indexes with HTTP 400 at CA create and update time
- applies the validation to both CA create and update, which previously had no externalIdClaim validation on the update path
- tests GetExternalId across the matcher/parser matrix for no-panic and correct error/value behavior
- tests CA create and update reject invalid externalIdClaim configurations
- tests that an externalIdClaim resolving to empty fails enrollment cleanly