### PR TITLE
Add router.link.v1 config type. Fixes #3974

### DIFF
--- a/controller/db/config_type_store_test.go
+++ b/controller/db/config_type_store_test.go
@@ -21,8 +21,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openziti/ziti/v2/controller/storage/boltztest"
 	"github.com/openziti/ziti/v2/common/eid"
+	"github.com/openziti/ziti/v2/controller/storage/boltztest"
+	"github.com/xeipuuv/gojsonschema"
 	"go.etcd.io/bbolt"
 )
 
@@ -79,6 +80,146 @@ func (ctx *TestContext) testConfigTypeCrud(*testing.T) {
 
 	boltztest.RequireDelete(ctx, config)
 	boltztest.RequireDelete(ctx, configType)
+}
+
+func Test_RouterLinkV1Builtin(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Cleanup()
+	ctx.Init()
+
+	var stored *ConfigType
+	err := ctx.GetDb().View(func(tx *bbolt.Tx) error {
+		var loadErr error
+		stored, loadErr = ctx.stores.ConfigType.LoadOneByName(tx, RouterLinkV1TypeId)
+		return loadErr
+	})
+	ctx.NoError(err)
+	ctx.NotNil(stored, "router.link.v1 must be registered as a built-in")
+	ctx.Equal(RouterLinkV1TypeId, stored.Id)
+	ctx.Equal(RouterLinkV1TypeId, stored.Name)
+	ctx.Equal(ConfigTypeTargetRouter, stored.Target)
+
+	// Compile the schema. migration_initialize.go writes config types directly via the
+	// store, bypassing the model-level GetCompiledSchema check, so a malformed $ref or
+	// oneOf would only blow up at first config-create. Compile here to catch it eagerly.
+	schema, err := gojsonschema.NewSchemaLoader().Compile(gojsonschema.NewGoLoader(stored.Schema))
+	ctx.NoError(err)
+	ctx.NotNil(schema)
+
+	validate := func(payload map[string]interface{}) *gojsonschema.Result {
+		result, err := schema.Validate(gojsonschema.NewGoLoader(payload))
+		ctx.NoError(err)
+		return result
+	}
+
+	t.Run("valid payload", func(t *testing.T) {
+		ctx.NextTest(t)
+		result := validate(map[string]interface{}{
+			"listeners": []interface{}{
+				map[string]interface{}{
+					"binding":   "transport",
+					"bind":      "tls:0.0.0.0:6262",
+					"advertise": "tls:public.example:6262",
+					"groups":    []interface{}{"default"},
+					"options": map[string]interface{}{
+						"outQueueSize":   16,
+						"connectTimeout": "5s",
+					},
+				},
+			},
+			"dialers": []interface{}{
+				map[string]interface{}{
+					"binding":              "transport",
+					"maxDefaultConnections": 4,
+					"healthyDialBackoff": map[string]interface{}{
+						"retryBackoffFactor": 2,
+						"minRetryInterval":   "1s",
+						"maxRetryInterval":   "1m",
+					},
+				},
+			},
+			"heartbeats": map[string]interface{}{
+				"sendInterval": "10s",
+			},
+			"payloadSenderQueueSize": 256,
+			"ackSenderQueueSize":     128,
+		})
+		ctx.True(result.Valid(), "expected payload to validate, errors: %v", result.Errors())
+	})
+
+	t.Run("binding optional on listener and dialer", func(t *testing.T) {
+		ctx.NextTest(t)
+		result := validate(map[string]interface{}{
+			"listeners": []interface{}{
+				map[string]interface{}{"bind": "tls:0.0.0.0:6262"},
+			},
+			"dialers": []interface{}{
+				map[string]interface{}{},
+			},
+		})
+		ctx.True(result.Valid(), "expected binding-less payload to validate, errors: %v", result.Errors())
+	})
+
+	rejects := []struct {
+		name    string
+		payload map[string]interface{}
+	}{
+		{
+			name:    "extra top-level key",
+			payload: map[string]interface{}{"bogus": true},
+		},
+		{
+			name: "listener missing bind",
+			payload: map[string]interface{}{
+				"listeners": []interface{}{map[string]interface{}{"binding": "transport"}},
+			},
+		},
+		{
+			name: "maxDefaultConnections out of range",
+			payload: map[string]interface{}{
+				"dialers": []interface{}{
+					map[string]interface{}{"maxDefaultConnections": 0},
+				},
+			},
+		},
+		{
+			name: "retryBackoffFactor below minimum",
+			payload: map[string]interface{}{
+				"dialers": []interface{}{
+					map[string]interface{}{
+						"healthyDialBackoff": map[string]interface{}{"retryBackoffFactor": 0.5},
+					},
+				},
+			},
+		},
+		{
+			name: "groups wrong type",
+			payload: map[string]interface{}{
+				"listeners": []interface{}{
+					map[string]interface{}{"bind": "tls:0.0.0.0:6262", "groups": 42},
+				},
+			},
+		},
+		{
+			name: "channelOptions.maxQueuedConnects below minimum",
+			payload: map[string]interface{}{
+				"listeners": []interface{}{
+					map[string]interface{}{
+						"bind":    "tls:0.0.0.0:6262",
+						"options": map[string]interface{}{"maxQueuedConnects": 0},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range rejects {
+		tc := tc
+		t.Run("rejects: "+tc.name, func(t *testing.T) {
+			ctx.NextTest(t)
+			result := validate(tc.payload)
+			ctx.False(result.Valid(), "expected payload to be rejected")
+		})
+	}
 }
 
 func (ctx *TestContext) testConfigTypeTargetImmutability(*testing.T) {

--- a/controller/db/config_type_store_test.go
+++ b/controller/db/config_type_store_test.go
@@ -143,6 +143,7 @@ func Test_RouterLinkV1Builtin(t *testing.T) {
 			},
 			"payloadSenderQueueSize": 256,
 			"ackSenderQueueSize":     128,
+			"gcMode":                 "orphaned",
 		})
 		ctx.True(result.Valid(), "expected payload to validate, errors: %v", result.Errors())
 	})
@@ -158,6 +159,30 @@ func Test_RouterLinkV1Builtin(t *testing.T) {
 			},
 		})
 		ctx.True(result.Valid(), "expected binding-less payload to validate, errors: %v", result.Errors())
+	})
+
+	durationPayload := func(d interface{}) map[string]interface{} {
+		return map[string]interface{}{
+			"listeners": []interface{}{
+				map[string]interface{}{
+					"bind":    "tls:0.0.0.0:6262",
+					"options": map[string]interface{}{"connectTimeout": d},
+				},
+			},
+		}
+	}
+
+	t.Run("duration formats", func(t *testing.T) {
+		ctx.NextTest(t)
+		// these mirror what time.ParseDuration accepts
+		for _, d := range []string{"1h", "1h30m", "1.5h", "300ms", "500us", "10s", "1m", "200ns"} {
+			result := validate(durationPayload(d))
+			ctx.True(result.Valid(), "expected duration %q to validate, errors: %v", d, result.Errors())
+		}
+		for _, d := range []string{"", "1", "30", "1h30", "1 m", "1x", "h", "1hh"} {
+			result := validate(durationPayload(d))
+			ctx.False(result.Valid(), "expected duration %q to be rejected", d)
+		}
 	})
 
 	rejects := []struct {
@@ -211,9 +236,12 @@ func Test_RouterLinkV1Builtin(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:    "gcMode not in enum",
+			payload: map[string]interface{}{"gcMode": "aggressive"},
+		},
 	}
 	for _, tc := range rejects {
-		tc := tc
 		t.Run("rejects: "+tc.name, func(t *testing.T) {
 			ctx.NextTest(t)
 			result := validate(tc.payload)

--- a/controller/db/migration_initialize.go
+++ b/controller/db/migration_initialize.go
@@ -712,7 +712,7 @@ var routerLinkV1ConfigType = &ConfigType{
 		"definitions": map[string]interface{}{
 			"duration": map[string]interface{}{
 				"type":    "string",
-				"pattern": "^[0-9]+(h|m|s|ms)$",
+				"pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
 			},
 			"groups": map[string]interface{}{
 				"oneOf": []interface{}{
@@ -870,6 +870,12 @@ var routerLinkV1ConfigType = &ConfigType{
 			"ackSenderQueueSize": map[string]interface{}{
 				"type":    "integer",
 				"minimum": 1,
+			},
+			"gcMode": map[string]interface{}{
+				"type":        "string",
+				"enum":        []interface{}{"preserve", "orphaned", "changed"},
+				"default":     "preserve",
+				"description": "Auto-GC policy for stale links. 'preserve' (default) never acts; 'orphaned' closes links whose supporting listener/dialer is entirely gone; 'changed' closes links whose listener/dialer details have changed (binding, advertise, groups).",
 			},
 		},
 	},

--- a/controller/db/migration_initialize.go
+++ b/controller/db/migration_initialize.go
@@ -45,6 +45,7 @@ func (m *Migrations) initialize(step *boltz.MigrationStep) int {
 	m.addSystemAuthPolicies(step)
 	m.createConfigType(step, interfacesConfigTypeV1)
 	m.createConfigType(step, proxyConfigTypeV1)
+	m.createConfigType(step, routerLinkV1ConfigType)
 
 	return CurrentDbVersion
 }
@@ -689,6 +690,186 @@ var proxyConfigTypeV1 = &ConfigType{
 			},
 			"binding": map[string]interface{}{
 				"type": "string",
+			},
+		},
+	},
+}
+
+var RouterLinkV1TypeId = "router.link.v1"
+
+// routerLinkV1ConfigType is the built-in config type that describes a router's
+// link subsystem (listeners, dialers, heartbeats, queue sizes). Targets routers.
+var routerLinkV1ConfigType = &ConfigType{
+	BaseExtEntity: boltz.BaseExtEntity{
+		Id: RouterLinkV1TypeId,
+	},
+	Name:   RouterLinkV1TypeId,
+	Target: ConfigTypeTargetRouter,
+	Schema: map[string]interface{}{
+		"$id":                  "https://netfoundry.io/schemas/router.link.v1.config.json",
+		"type":                 "object",
+		"additionalProperties": false,
+		"definitions": map[string]interface{}{
+			"duration": map[string]interface{}{
+				"type":    "string",
+				"pattern": "^[0-9]+(h|m|s|ms)$",
+			},
+			"groups": map[string]interface{}{
+				"oneOf": []interface{}{
+					map[string]interface{}{"type": "string"},
+					map[string]interface{}{
+						"type":  "array",
+						"items": map[string]interface{}{"type": "string"},
+					},
+				},
+			},
+			"channelOptions": map[string]interface{}{
+				"type":                 "object",
+				"additionalProperties": false,
+				"properties": map[string]interface{}{
+					"outQueueSize": map[string]interface{}{
+						"type":    "integer",
+						"minimum": 1,
+					},
+					"maxQueuedConnects": map[string]interface{}{
+						"type":    "integer",
+						"minimum": 1,
+						"maximum": 5000,
+					},
+					"maxOutstandingConnects": map[string]interface{}{
+						"type":    "integer",
+						"minimum": 1,
+						"maximum": 1000,
+					},
+					"connectTimeout": map[string]interface{}{
+						"$ref": "#/definitions/duration",
+					},
+					"writeTimeout": map[string]interface{}{
+						"$ref": "#/definitions/duration",
+					},
+				},
+			},
+			"backoff": map[string]interface{}{
+				"type":                 "object",
+				"additionalProperties": false,
+				"properties": map[string]interface{}{
+					"retryBackoffFactor": map[string]interface{}{
+						"type":    "number",
+						"minimum": 1,
+						"maximum": 100,
+					},
+					"minRetryInterval": map[string]interface{}{
+						"$ref": "#/definitions/duration",
+					},
+					"maxRetryInterval": map[string]interface{}{
+						"$ref": "#/definitions/duration",
+					},
+				},
+			},
+			"listener": map[string]interface{}{
+				"type":                 "object",
+				"additionalProperties": false,
+				"required":             []interface{}{"bind"},
+				"properties": map[string]interface{}{
+					"binding": map[string]interface{}{
+						"type":      "string",
+						"minLength": 1,
+						"default":   "transport",
+					},
+					"bind": map[string]interface{}{
+						"type":        "string",
+						"minLength":   1,
+						"description": "transport address e.g. tls:0.0.0.0:6262",
+					},
+					"advertise": map[string]interface{}{
+						"type": "string",
+					},
+					"bindInterface": map[string]interface{}{
+						"type": "string",
+					},
+					"groups": map[string]interface{}{
+						"$ref": "#/definitions/groups",
+					},
+					"options": map[string]interface{}{
+						"$ref": "#/definitions/channelOptions",
+					},
+				},
+			},
+			"dialer": map[string]interface{}{
+				"type":                 "object",
+				"additionalProperties": false,
+				"properties": map[string]interface{}{
+					"binding": map[string]interface{}{
+						"type":      "string",
+						"minLength": 1,
+						"default":   "transport",
+					},
+					"maxDefaultConnections": map[string]interface{}{
+						"type":    "integer",
+						"minimum": 1,
+						"maximum": 100,
+					},
+					"maxAckConnections": map[string]interface{}{
+						"type":    "integer",
+						"minimum": 0,
+						"maximum": 100,
+					},
+					"startupDelay": map[string]interface{}{
+						"$ref": "#/definitions/duration",
+					},
+					"bindInterface": map[string]interface{}{
+						"type":        "string",
+						"description": "interface name (matches listener.bindInterface)",
+					},
+					"groups": map[string]interface{}{
+						"$ref": "#/definitions/groups",
+					},
+					"healthyDialBackoff": map[string]interface{}{
+						"$ref": "#/definitions/backoff",
+					},
+					"unhealthyDialBackoff": map[string]interface{}{
+						"$ref": "#/definitions/backoff",
+					},
+					"options": map[string]interface{}{
+						"$ref": "#/definitions/channelOptions",
+					},
+				},
+			},
+			"heartbeats": map[string]interface{}{
+				"type":                 "object",
+				"additionalProperties": false,
+				"properties": map[string]interface{}{
+					"sendInterval": map[string]interface{}{
+						"$ref": "#/definitions/duration",
+					},
+					"checkInterval": map[string]interface{}{
+						"$ref": "#/definitions/duration",
+					},
+					"closeUnresponsiveTimeout": map[string]interface{}{
+						"$ref": "#/definitions/duration",
+					},
+				},
+			},
+		},
+		"properties": map[string]interface{}{
+			"listeners": map[string]interface{}{
+				"type":  "array",
+				"items": map[string]interface{}{"$ref": "#/definitions/listener"},
+			},
+			"dialers": map[string]interface{}{
+				"type":  "array",
+				"items": map[string]interface{}{"$ref": "#/definitions/dialer"},
+			},
+			"heartbeats": map[string]interface{}{
+				"$ref": "#/definitions/heartbeats",
+			},
+			"payloadSenderQueueSize": map[string]interface{}{
+				"type":    "integer",
+				"minimum": 1,
+			},
+			"ackSenderQueueSize": map[string]interface{}{
+				"type":    "integer",
+				"minimum": 1,
 			},
 		},
 	},

--- a/controller/db/migrations.go
+++ b/controller/db/migrations.go
@@ -215,6 +215,10 @@ func (m *Migrations) migrate(step *boltz.MigrationStep) int {
 		m.collapseEdgeServices(step)               // migration 47
 	}
 
+	if step.CurrentVersion < 47 {
+		m.createOrUpdateConfigType(step, routerLinkV1ConfigType)
+	}
+
 	// current version
 	if step.CurrentVersion <= CurrentDbVersion {
 		return CurrentDbVersion

--- a/controller/db/migrations.go
+++ b/controller/db/migrations.go
@@ -213,9 +213,6 @@ func (m *Migrations) migrate(step *boltz.MigrationStep) int {
 		m.setConfigTypeTargets(step)               // migration 45
 		m.backfillPolicyRoleAttributeIndexes(step) // migration 46
 		m.collapseEdgeServices(step)               // migration 47
-	}
-
-	if step.CurrentVersion < 47 {
 		m.createOrUpdateConfigType(step, routerLinkV1ConfigType)
 	}
 

--- a/doc/design/ctrl-managed-router-config.md
+++ b/doc/design/ctrl-managed-router-config.md
@@ -103,16 +103,30 @@ config before it ever reaches a router.
 ### Associating Configs with Routers
 
 Today, services have a `Configs []string` field that holds config IDs. We'd add the same thing to the router
-model:
+model. The field lives on the base `Router` rather than only on `EdgeRouter`, so fabric, edge, and transit
+routers all share the same association mechanism:
 
 ```go
-type EdgeRouter struct {
+type Router struct {
     // ... existing fields
     Configs []string `json:"configs"` // Router config IDs
 }
 ```
 
-Like services, a router can have at most one config per config type. This is enforced at the store level.
+Like services, a router can have at most one config per config type. This is enforced at the model layer
+on create and update.
+
+Validation for router configs is stricter than for service configs: each referenced config must resolve to
+an existing config type, and that type's `Target` must be `"router"`. The edge-service path tolerates a
+config whose config type can't be loaded; for routers we reject the association so an orphaned reference
+can't slip through. The validator also short-circuits when the `configs` field isn't part of the update
+field set, so unrelated updates (e.g. router-initiated control-channel listener updates) don't pay the
+cost of re-loading every config and config type.
+
+When a config is deleted, the config store walks every router that references it, rewrites the router's
+`Configs` slice, and re-`Update`s the router. This mirrors the existing service-cleanup loop and ensures
+any entity-update listeners see the change rather than relying solely on the boltz link collection
+auto-clearing the bucket.
 
 ### Handling Arbitrary Xgress Types
 
@@ -199,8 +213,14 @@ All routers get the same identities, services, policies, etc. For router configs
 a router's config may contain binding addresses, credentials, or tuning parameters that are only
 relevant to that specific router.
 
-It would be interesting if we could distribute router configs only to the routers they apply to. There
-are a few ways to approach this:
+The motivation for filtering is **blast radius, not memory**. A back-of-envelope estimate for a
+network with 1000 routers, ~10k identities, ~1k services, ~5k configs, and ~2k policies puts the
+in-memory RDM at roughly 100-200 MB per router after Go map/string/pointer overhead. That's not a
+concern on any modern host, and even an order of magnitude more entities still fits comfortably in
+single-digit GB. So we don't need disk-backed or tiered caching for the RDM. We do, however, want
+to avoid leaking per-router secrets to every other router.
+
+There are a few ways to approach the filtering:
 
 **Option A: Per-router filtering at send time.** The `RouterSender` (which wraps each router's connection
 to the shared RDM) could filter events before sending. When building a full `DataState` snapshot or
@@ -216,28 +236,48 @@ simpler but loses the replay/gap-detection guarantees of the RDM event cache.
 containing just its own router entity and configs. The overlay would have its own event index and replay
 cache. This is the most complex option but gives clean separation.
 
-Option A is probably the right starting point. The filtering is straightforward: when building the
-`DataState` or replaying events, include `Router` events for all routers (everyone needs fingerprints for
-link validation), but include `Config` events only when the config is associated with the receiving router.
-The `RouterSender` already has access to the router's ID, so the filter is just a membership check on the
-config's associated router set.
+Option A is the right starting point. We filter `Config` events per-router and broadcast everything
+else (identities, services, policies, router entities, etc.) as today. Filtering identities or
+services would buy us some memory but cost a lot more bookkeeping per RouterSender, and we just
+established memory isn't the bottleneck.
 
 ### Change Notification Flow
 
-1. Operator creates/updates/deletes a config associated with a router.
-2. Controller generates a `DataState.Event` with the config change at the next index.
-3. When broadcasting to connected routers, the `RouterSender` checks whether each config event is
-   relevant to its router. If so, it includes it. If not, it skips it.
-4. For full syncs on connect, the `RouterSender` builds a filtered `DataState` snapshot that includes
-   only configs associated with that router.
-5. Router entities themselves (id, name, fingerprint, cost) are distributed to all routers, so every
-   router can validate link peers.
+There are two distinct triggers that cause a `Config` event to flow to a router:
 
-This means the shared event cache contains all events, but each router only sees a subset. The index
-sequence will have gaps from the router's perspective, but this is already the case today: not every
-raft update produces an RDM event, so routers already tolerate index gaps. We may need to move some
-of the gap-handling logic into the `RouterSender` so it can track the previous index per router and
+1. **A router's `Configs` list changes.** When an operator associates or disassociates a config:
+   - Emit the `Router` event with the new `Configs` IDs.
+   - For any IDs newly added to that router's list, also emit the full `Config` entity to that
+     router (it may not have it yet).
+   - For any IDs newly removed from that router's list, do nothing extra. The receiving router
+     reads its own `Router` entity in the RDM, sees the config is no longer in its list, and stops
+     applying it. The orphaned `Config` entity stays cached on the receiver until the next full
+     sync prunes it. Skipping the explicit-remove event keeps the protocol simpler at the cost of
+     a small amount of dead weight in the receiver's cache, which we consider acceptable.
+
+2. **A config's data changes.** When an operator PATCHes a config:
+   - Emit the `Config` event to every router currently referencing it. The router entity didn't
+     change at all here.
+
+Router entities themselves (id, name, fingerprint, cost) are distributed to all routers, so every
+router can validate link peers.
+
+On reconnect, the router sends its current RDM index up. If the controller's event cache can
+replay forward from there, it streams the deltas (with the same per-router config filtering
+applied). Only if the router is far enough behind that the event cache can't cover the gap does
+the controller fall back to a full filtered snapshot.
+
+The shared event cache contains all events, but each router only sees a subset. The index sequence
+will have gaps from the router's perspective, but this is already the case today: not every raft
+update produces an RDM event, so routers already tolerate index gaps. We may need to move some of
+the gap-handling logic into the `RouterSender` so it can track the previous index per router and
 set it correctly on filtered change sets, rather than relying on the receiver to reconcile.
+
+Orphaned `Config` entities — those that the receiver still has cached after a router-side
+disassociation — get pruned on the (rare) full-sync path. Between full syncs, they sit in the
+RDM cache as dead weight. We've judged that acceptable: the router doesn't apply them (it derives
+its applied set from its own `Router.Configs` list), and they cost a small amount of memory until
+the next full sync.
 
 ## Applying Configuration on the Router
 
@@ -539,10 +579,13 @@ Files: `controller/db/config_type_store.go`, `controller/model/config_type_model
 **1b. Add `configs` field to Router.**
 
 Add a `Configs []string` field to the base Router db entity and model. Add the same one-config-
-per-type validation that services have. Expose it through the REST API on router create/update.
+per-type validation that services have, plus a stricter requirement that each config's config
+type exists and has `Target = "router"`. Expose it through the REST API on router create/update.
+Add a router-cleanup loop to `configStoreImpl.DeleteById` mirroring the existing service loop.
 
-Files: `controller/db/router_store.go`, `controller/model/router_model.go`,
-`controller/model/router_manager.go`, REST route/model files, db migration.
+Files: `controller/db/router_store.go`, `controller/db/config_store.go`,
+`controller/model/router_model.go`, `controller/model/router_manager.go`, REST route/model
+files.
 
 **1c. Define the `router.link.v1` config type and schema.**
 


### PR DESCRIPTION
## Summary

- Defines the built-in `router.link.v1` config type (target=router) with a JSON schema for listeners, dialers, heartbeats, payload/ack queue sizes, and a top-level `gcMode`.
- Registered for fresh databases via `initialize` and for existing databases via a migration step that bumps the schema version from 46 to 47.
- This is the first concrete router-targeted config type for the controller-managed router configuration work (see `doc/design/ctrl-managed-router-config.md`). The RDM integration that actually distributes it follows in a separate PR.

