### PR TITLE
Distribute routers and router-target configs through the RDM. Fixes #3976

### DIFF
--- a/common/pb/edge_ctrl_pb/edge_ctrl.pb.go
+++ b/common/pb/edge_ctrl_pb/edge_ctrl.pb.go
@@ -667,7 +667,7 @@ func (x DataState_PublicKey_Usage) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use DataState_PublicKey_Usage.Descriptor instead.
 func (DataState_PublicKey_Usage) EnumDescriptor() ([]byte, []int) {
-	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 11, 0}
+	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 12, 0}
 }
 
 type DataState_PublicKey_Format int32
@@ -713,7 +713,7 @@ func (x DataState_PublicKey_Format) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use DataState_PublicKey_Format.Descriptor instead.
 func (DataState_PublicKey_Format) EnumDescriptor() ([]byte, []int) {
-	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 11, 1}
+	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 12, 1}
 }
 
 type ServerHello struct {
@@ -4196,6 +4196,82 @@ func (x *DataState_Service) GetConfigs() []string {
 	return nil
 }
 
+type DataState_Router struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Fingerprint   string                 `protobuf:"bytes,3,opt,name=fingerprint,proto3" json:"fingerprint,omitempty"`
+	Configs       []string               `protobuf:"bytes,4,rep,name=configs,proto3" json:"configs,omitempty"`
+	Disabled      bool                   `protobuf:"varint,5,opt,name=disabled,proto3" json:"disabled,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DataState_Router) Reset() {
+	*x = DataState_Router{}
+	mi := &file_edge_ctrl_proto_msgTypes[56]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DataState_Router) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DataState_Router) ProtoMessage() {}
+
+func (x *DataState_Router) ProtoReflect() protoreflect.Message {
+	mi := &file_edge_ctrl_proto_msgTypes[56]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DataState_Router.ProtoReflect.Descriptor instead.
+func (*DataState_Router) Descriptor() ([]byte, []int) {
+	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 6}
+}
+
+func (x *DataState_Router) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *DataState_Router) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *DataState_Router) GetFingerprint() string {
+	if x != nil {
+		return x.Fingerprint
+	}
+	return ""
+}
+
+func (x *DataState_Router) GetConfigs() []string {
+	if x != nil {
+		return x.Configs
+	}
+	return nil
+}
+
+func (x *DataState_Router) GetDisabled() bool {
+	if x != nil {
+		return x.Disabled
+	}
+	return false
+}
+
 type DataState_ServicePolicy struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -4207,7 +4283,7 @@ type DataState_ServicePolicy struct {
 
 func (x *DataState_ServicePolicy) Reset() {
 	*x = DataState_ServicePolicy{}
-	mi := &file_edge_ctrl_proto_msgTypes[56]
+	mi := &file_edge_ctrl_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4219,7 +4295,7 @@ func (x *DataState_ServicePolicy) String() string {
 func (*DataState_ServicePolicy) ProtoMessage() {}
 
 func (x *DataState_ServicePolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_edge_ctrl_proto_msgTypes[56]
+	mi := &file_edge_ctrl_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4232,7 +4308,7 @@ func (x *DataState_ServicePolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DataState_ServicePolicy.ProtoReflect.Descriptor instead.
 func (*DataState_ServicePolicy) Descriptor() ([]byte, []int) {
-	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 6}
+	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 7}
 }
 
 func (x *DataState_ServicePolicy) GetId() string {
@@ -4274,7 +4350,7 @@ type DataState_Revocation struct {
 
 func (x *DataState_Revocation) Reset() {
 	*x = DataState_Revocation{}
-	mi := &file_edge_ctrl_proto_msgTypes[57]
+	mi := &file_edge_ctrl_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4286,7 +4362,7 @@ func (x *DataState_Revocation) String() string {
 func (*DataState_Revocation) ProtoMessage() {}
 
 func (x *DataState_Revocation) ProtoReflect() protoreflect.Message {
-	mi := &file_edge_ctrl_proto_msgTypes[57]
+	mi := &file_edge_ctrl_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4299,7 +4375,7 @@ func (x *DataState_Revocation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DataState_Revocation.ProtoReflect.Descriptor instead.
 func (*DataState_Revocation) Descriptor() ([]byte, []int) {
-	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 7}
+	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 8}
 }
 
 func (x *DataState_Revocation) GetId() string {
@@ -4342,7 +4418,7 @@ type DataState_ServicePolicyChange struct {
 
 func (x *DataState_ServicePolicyChange) Reset() {
 	*x = DataState_ServicePolicyChange{}
-	mi := &file_edge_ctrl_proto_msgTypes[58]
+	mi := &file_edge_ctrl_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4354,7 +4430,7 @@ func (x *DataState_ServicePolicyChange) String() string {
 func (*DataState_ServicePolicyChange) ProtoMessage() {}
 
 func (x *DataState_ServicePolicyChange) ProtoReflect() protoreflect.Message {
-	mi := &file_edge_ctrl_proto_msgTypes[58]
+	mi := &file_edge_ctrl_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4367,7 +4443,7 @@ func (x *DataState_ServicePolicyChange) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DataState_ServicePolicyChange.ProtoReflect.Descriptor instead.
 func (*DataState_ServicePolicyChange) Descriptor() ([]byte, []int) {
-	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 8}
+	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 9}
 }
 
 func (x *DataState_ServicePolicyChange) GetPolicyId() string {
@@ -4411,7 +4487,7 @@ type DataState_ChangeSet struct {
 
 func (x *DataState_ChangeSet) Reset() {
 	*x = DataState_ChangeSet{}
-	mi := &file_edge_ctrl_proto_msgTypes[59]
+	mi := &file_edge_ctrl_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4423,7 +4499,7 @@ func (x *DataState_ChangeSet) String() string {
 func (*DataState_ChangeSet) ProtoMessage() {}
 
 func (x *DataState_ChangeSet) ProtoReflect() protoreflect.Message {
-	mi := &file_edge_ctrl_proto_msgTypes[59]
+	mi := &file_edge_ctrl_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4436,7 +4512,7 @@ func (x *DataState_ChangeSet) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DataState_ChangeSet.ProtoReflect.Descriptor instead.
 func (*DataState_ChangeSet) Descriptor() ([]byte, []int) {
-	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 9}
+	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 10}
 }
 
 func (x *DataState_ChangeSet) GetIndex() uint64 {
@@ -4490,6 +4566,7 @@ type DataState_Event struct {
 	//	*DataState_Event_ServicePolicyChange
 	//	*DataState_Event_ConfigType
 	//	*DataState_Event_Config
+	//	*DataState_Event_Router
 	Model         isDataState_Event_Model `protobuf_oneof:"Model"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -4497,7 +4574,7 @@ type DataState_Event struct {
 
 func (x *DataState_Event) Reset() {
 	*x = DataState_Event{}
-	mi := &file_edge_ctrl_proto_msgTypes[60]
+	mi := &file_edge_ctrl_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4509,7 +4586,7 @@ func (x *DataState_Event) String() string {
 func (*DataState_Event) ProtoMessage() {}
 
 func (x *DataState_Event) ProtoReflect() protoreflect.Message {
-	mi := &file_edge_ctrl_proto_msgTypes[60]
+	mi := &file_edge_ctrl_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4522,7 +4599,7 @@ func (x *DataState_Event) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DataState_Event.ProtoReflect.Descriptor instead.
 func (*DataState_Event) Descriptor() ([]byte, []int) {
-	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 10}
+	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 11}
 }
 
 func (x *DataState_Event) GetAction() DataState_Action {
@@ -4627,6 +4704,15 @@ func (x *DataState_Event) GetConfig() *DataState_Config {
 	return nil
 }
 
+func (x *DataState_Event) GetRouter() *DataState_Router {
+	if x != nil {
+		if x, ok := x.Model.(*DataState_Event_Router); ok {
+			return x.Router
+		}
+	}
+	return nil
+}
+
 type isDataState_Event_Model interface {
 	isDataState_Event_Model()
 }
@@ -4667,6 +4753,10 @@ type DataState_Event_Config struct {
 	Config *DataState_Config `protobuf:"bytes,18,opt,name=config,proto3,oneof"`
 }
 
+type DataState_Event_Router struct {
+	Router *DataState_Router `protobuf:"bytes,19,opt,name=router,proto3,oneof"`
+}
+
 func (*DataState_Event_Identity) isDataState_Event_Model() {}
 
 func (*DataState_Event_Service) isDataState_Event_Model() {}
@@ -4685,6 +4775,8 @@ func (*DataState_Event_ConfigType) isDataState_Event_Model() {}
 
 func (*DataState_Event_Config) isDataState_Event_Model() {}
 
+func (*DataState_Event_Router) isDataState_Event_Model() {}
+
 type DataState_PublicKey struct {
 	state         protoimpl.MessageState      `protogen:"open.v1"`
 	Data          []byte                      `protobuf:"bytes,1,opt,name=data,proto3" json:"data,omitempty"`                                                              //public key
@@ -4697,7 +4789,7 @@ type DataState_PublicKey struct {
 
 func (x *DataState_PublicKey) Reset() {
 	*x = DataState_PublicKey{}
-	mi := &file_edge_ctrl_proto_msgTypes[61]
+	mi := &file_edge_ctrl_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4709,7 +4801,7 @@ func (x *DataState_PublicKey) String() string {
 func (*DataState_PublicKey) ProtoMessage() {}
 
 func (x *DataState_PublicKey) ProtoReflect() protoreflect.Message {
-	mi := &file_edge_ctrl_proto_msgTypes[61]
+	mi := &file_edge_ctrl_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4722,7 +4814,7 @@ func (x *DataState_PublicKey) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DataState_PublicKey.ProtoReflect.Descriptor instead.
 func (*DataState_PublicKey) Descriptor() ([]byte, []int) {
-	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 11}
+	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 12}
 }
 
 func (x *DataState_PublicKey) GetData() []byte {
@@ -4773,7 +4865,7 @@ type DataState_PostureCheck struct {
 
 func (x *DataState_PostureCheck) Reset() {
 	*x = DataState_PostureCheck{}
-	mi := &file_edge_ctrl_proto_msgTypes[62]
+	mi := &file_edge_ctrl_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4785,7 +4877,7 @@ func (x *DataState_PostureCheck) String() string {
 func (*DataState_PostureCheck) ProtoMessage() {}
 
 func (x *DataState_PostureCheck) ProtoReflect() protoreflect.Message {
-	mi := &file_edge_ctrl_proto_msgTypes[62]
+	mi := &file_edge_ctrl_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4798,7 +4890,7 @@ func (x *DataState_PostureCheck) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DataState_PostureCheck.ProtoReflect.Descriptor instead.
 func (*DataState_PostureCheck) Descriptor() ([]byte, []int) {
-	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 12}
+	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 13}
 }
 
 func (x *DataState_PostureCheck) GetId() string {
@@ -4932,7 +5024,7 @@ type DataState_PostureCheck_Mac struct {
 
 func (x *DataState_PostureCheck_Mac) Reset() {
 	*x = DataState_PostureCheck_Mac{}
-	mi := &file_edge_ctrl_proto_msgTypes[67]
+	mi := &file_edge_ctrl_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4944,7 +5036,7 @@ func (x *DataState_PostureCheck_Mac) String() string {
 func (*DataState_PostureCheck_Mac) ProtoMessage() {}
 
 func (x *DataState_PostureCheck_Mac) ProtoReflect() protoreflect.Message {
-	mi := &file_edge_ctrl_proto_msgTypes[67]
+	mi := &file_edge_ctrl_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4957,7 +5049,7 @@ func (x *DataState_PostureCheck_Mac) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DataState_PostureCheck_Mac.ProtoReflect.Descriptor instead.
 func (*DataState_PostureCheck_Mac) Descriptor() ([]byte, []int) {
-	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 12, 0}
+	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 13, 0}
 }
 
 func (x *DataState_PostureCheck_Mac) GetMacAddresses() []string {
@@ -4979,7 +5071,7 @@ type DataState_PostureCheck_Mfa struct {
 
 func (x *DataState_PostureCheck_Mfa) Reset() {
 	*x = DataState_PostureCheck_Mfa{}
-	mi := &file_edge_ctrl_proto_msgTypes[68]
+	mi := &file_edge_ctrl_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4991,7 +5083,7 @@ func (x *DataState_PostureCheck_Mfa) String() string {
 func (*DataState_PostureCheck_Mfa) ProtoMessage() {}
 
 func (x *DataState_PostureCheck_Mfa) ProtoReflect() protoreflect.Message {
-	mi := &file_edge_ctrl_proto_msgTypes[68]
+	mi := &file_edge_ctrl_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5004,7 +5096,7 @@ func (x *DataState_PostureCheck_Mfa) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DataState_PostureCheck_Mfa.ProtoReflect.Descriptor instead.
 func (*DataState_PostureCheck_Mfa) Descriptor() ([]byte, []int) {
-	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 12, 1}
+	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 13, 1}
 }
 
 func (x *DataState_PostureCheck_Mfa) GetTimeoutSeconds() int64 {
@@ -5045,7 +5137,7 @@ type DataState_PostureCheck_Os struct {
 
 func (x *DataState_PostureCheck_Os) Reset() {
 	*x = DataState_PostureCheck_Os{}
-	mi := &file_edge_ctrl_proto_msgTypes[69]
+	mi := &file_edge_ctrl_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5057,7 +5149,7 @@ func (x *DataState_PostureCheck_Os) String() string {
 func (*DataState_PostureCheck_Os) ProtoMessage() {}
 
 func (x *DataState_PostureCheck_Os) ProtoReflect() protoreflect.Message {
-	mi := &file_edge_ctrl_proto_msgTypes[69]
+	mi := &file_edge_ctrl_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5070,7 +5162,7 @@ func (x *DataState_PostureCheck_Os) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DataState_PostureCheck_Os.ProtoReflect.Descriptor instead.
 func (*DataState_PostureCheck_Os) Descriptor() ([]byte, []int) {
-	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 12, 2}
+	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 13, 2}
 }
 
 func (x *DataState_PostureCheck_Os) GetOsType() string {
@@ -5096,7 +5188,7 @@ type DataState_PostureCheck_OsList struct {
 
 func (x *DataState_PostureCheck_OsList) Reset() {
 	*x = DataState_PostureCheck_OsList{}
-	mi := &file_edge_ctrl_proto_msgTypes[70]
+	mi := &file_edge_ctrl_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5108,7 +5200,7 @@ func (x *DataState_PostureCheck_OsList) String() string {
 func (*DataState_PostureCheck_OsList) ProtoMessage() {}
 
 func (x *DataState_PostureCheck_OsList) ProtoReflect() protoreflect.Message {
-	mi := &file_edge_ctrl_proto_msgTypes[70]
+	mi := &file_edge_ctrl_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5121,7 +5213,7 @@ func (x *DataState_PostureCheck_OsList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DataState_PostureCheck_OsList.ProtoReflect.Descriptor instead.
 func (*DataState_PostureCheck_OsList) Descriptor() ([]byte, []int) {
-	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 12, 3}
+	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 13, 3}
 }
 
 func (x *DataState_PostureCheck_OsList) GetOsList() []*DataState_PostureCheck_Os {
@@ -5143,7 +5235,7 @@ type DataState_PostureCheck_Process struct {
 
 func (x *DataState_PostureCheck_Process) Reset() {
 	*x = DataState_PostureCheck_Process{}
-	mi := &file_edge_ctrl_proto_msgTypes[71]
+	mi := &file_edge_ctrl_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5155,7 +5247,7 @@ func (x *DataState_PostureCheck_Process) String() string {
 func (*DataState_PostureCheck_Process) ProtoMessage() {}
 
 func (x *DataState_PostureCheck_Process) ProtoReflect() protoreflect.Message {
-	mi := &file_edge_ctrl_proto_msgTypes[71]
+	mi := &file_edge_ctrl_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5168,7 +5260,7 @@ func (x *DataState_PostureCheck_Process) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DataState_PostureCheck_Process.ProtoReflect.Descriptor instead.
 func (*DataState_PostureCheck_Process) Descriptor() ([]byte, []int) {
-	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 12, 4}
+	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 13, 4}
 }
 
 func (x *DataState_PostureCheck_Process) GetOsType() string {
@@ -5209,7 +5301,7 @@ type DataState_PostureCheck_ProcessMulti struct {
 
 func (x *DataState_PostureCheck_ProcessMulti) Reset() {
 	*x = DataState_PostureCheck_ProcessMulti{}
-	mi := &file_edge_ctrl_proto_msgTypes[72]
+	mi := &file_edge_ctrl_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5221,7 +5313,7 @@ func (x *DataState_PostureCheck_ProcessMulti) String() string {
 func (*DataState_PostureCheck_ProcessMulti) ProtoMessage() {}
 
 func (x *DataState_PostureCheck_ProcessMulti) ProtoReflect() protoreflect.Message {
-	mi := &file_edge_ctrl_proto_msgTypes[72]
+	mi := &file_edge_ctrl_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5234,7 +5326,7 @@ func (x *DataState_PostureCheck_ProcessMulti) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use DataState_PostureCheck_ProcessMulti.ProtoReflect.Descriptor instead.
 func (*DataState_PostureCheck_ProcessMulti) Descriptor() ([]byte, []int) {
-	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 12, 5}
+	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 13, 5}
 }
 
 func (x *DataState_PostureCheck_ProcessMulti) GetSemantic() string {
@@ -5260,7 +5352,7 @@ type DataState_PostureCheck_Domains struct {
 
 func (x *DataState_PostureCheck_Domains) Reset() {
 	*x = DataState_PostureCheck_Domains{}
-	mi := &file_edge_ctrl_proto_msgTypes[73]
+	mi := &file_edge_ctrl_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5272,7 +5364,7 @@ func (x *DataState_PostureCheck_Domains) String() string {
 func (*DataState_PostureCheck_Domains) ProtoMessage() {}
 
 func (x *DataState_PostureCheck_Domains) ProtoReflect() protoreflect.Message {
-	mi := &file_edge_ctrl_proto_msgTypes[73]
+	mi := &file_edge_ctrl_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5285,7 +5377,7 @@ func (x *DataState_PostureCheck_Domains) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DataState_PostureCheck_Domains.ProtoReflect.Descriptor instead.
 func (*DataState_PostureCheck_Domains) Descriptor() ([]byte, []int) {
-	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 12, 6}
+	return file_edge_ctrl_proto_rawDescGZIP(), []int{6, 13, 6}
 }
 
 func (x *DataState_PostureCheck_Domains) GetDomains() []string {
@@ -5306,7 +5398,7 @@ type ConnectEvents_ConnectDetails struct {
 
 func (x *ConnectEvents_ConnectDetails) Reset() {
 	*x = ConnectEvents_ConnectDetails{}
-	mi := &file_edge_ctrl_proto_msgTypes[88]
+	mi := &file_edge_ctrl_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5318,7 +5410,7 @@ func (x *ConnectEvents_ConnectDetails) String() string {
 func (*ConnectEvents_ConnectDetails) ProtoMessage() {}
 
 func (x *ConnectEvents_ConnectDetails) ProtoReflect() protoreflect.Message {
-	mi := &file_edge_ctrl_proto_msgTypes[88]
+	mi := &file_edge_ctrl_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5366,7 +5458,7 @@ type ConnectEvents_IdentityConnectEvents struct {
 
 func (x *ConnectEvents_IdentityConnectEvents) Reset() {
 	*x = ConnectEvents_IdentityConnectEvents{}
-	mi := &file_edge_ctrl_proto_msgTypes[89]
+	mi := &file_edge_ctrl_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5378,7 +5470,7 @@ func (x *ConnectEvents_IdentityConnectEvents) String() string {
 func (*ConnectEvents_IdentityConnectEvents) ProtoMessage() {}
 
 func (x *ConnectEvents_IdentityConnectEvents) ProtoReflect() protoreflect.Message {
-	mi := &file_edge_ctrl_proto_msgTypes[89]
+	mi := &file_edge_ctrl_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5459,7 +5551,7 @@ const file_edge_ctrl_proto_rawDesc = "" +
 	"\x04data\x18\x01 \x03(\v2\".ziti.edge_ctrl.pb.Cache.DataEntryR\x04data\x1a7\n" +
 	"\tDataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\fR\x05value:\x028\x01\"\xcd$\n" +
+	"\x05value\x18\x02 \x01(\fR\x05value:\x028\x01\"\x93&\n" +
 	"\tDataState\x12:\n" +
 	"\x06events\x18\x01 \x03(\v2\".ziti.edge_ctrl.pb.DataState.EventR\x06events\x12\x1a\n" +
 	"\bendIndex\x18\x02 \x01(\x04R\bendIndex\x12\x1e\n" +
@@ -5508,7 +5600,13 @@ const file_edge_ctrl_proto_rawDesc = "" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12.\n" +
 	"\x12encryptionRequired\x18\x03 \x01(\bR\x12encryptionRequired\x12\x18\n" +
-	"\aconfigs\x18\x04 \x03(\tR\aconfigs\x1ar\n" +
+	"\aconfigs\x18\x04 \x03(\tR\aconfigs\x1a\x84\x01\n" +
+	"\x06Router\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12 \n" +
+	"\vfingerprint\x18\x03 \x01(\tR\vfingerprint\x12\x18\n" +
+	"\aconfigs\x18\x04 \x03(\tR\aconfigs\x12\x1a\n" +
+	"\bdisabled\x18\x05 \x01(\bR\bdisabled\x1ar\n" +
 	"\rServicePolicy\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12=\n" +
@@ -5531,7 +5629,7 @@ const file_edge_ctrl_proto_rawDesc = "" +
 	"\visSynthetic\x18\x02 \x01(\bR\visSynthetic\x12<\n" +
 	"\achanges\x18\x03 \x03(\v2\".ziti.edge_ctrl.pb.DataState.EventR\achanges\x12 \n" +
 	"\vtimestampId\x18\x04 \x01(\tR\vtimestampId\x12$\n" +
-	"\rpreviousIndex\x18\x05 \x01(\x04R\rpreviousIndex\x1a\x9e\x06\n" +
+	"\rpreviousIndex\x18\x05 \x01(\x04R\rpreviousIndex\x1a\xdd\x06\n" +
 	"\x05Event\x12;\n" +
 	"\x06action\x18\x01 \x01(\x0e2#.ziti.edge_ctrl.pb.DataState.ActionR\x06action\x12 \n" +
 	"\visSynthetic\x18\x03 \x01(\bR\visSynthetic\x12C\n" +
@@ -5548,7 +5646,8 @@ const file_edge_ctrl_proto_rawDesc = "" +
 	"\n" +
 	"configType\x18\x11 \x01(\v2'.ziti.edge_ctrl.pb.DataState.ConfigTypeH\x00R\n" +
 	"configType\x12=\n" +
-	"\x06config\x18\x12 \x01(\v2#.ziti.edge_ctrl.pb.DataState.ConfigH\x00R\x06configB\a\n" +
+	"\x06config\x18\x12 \x01(\v2#.ziti.edge_ctrl.pb.DataState.ConfigH\x00R\x06config\x12=\n" +
+	"\x06router\x18\x13 \x01(\v2#.ziti.edge_ctrl.pb.DataState.RouterH\x00R\x06routerB\a\n" +
 	"\x05Model\x1a\xa6\x02\n" +
 	"\tPublicKey\x12\x12\n" +
 	"\x04data\x18\x01 \x01(\fR\x04data\x12\x10\n" +
@@ -6010,7 +6109,7 @@ func file_edge_ctrl_proto_rawDescGZIP() []byte {
 }
 
 var file_edge_ctrl_proto_enumTypes = make([]protoimpl.EnumInfo, 11)
-var file_edge_ctrl_proto_msgTypes = make([]protoimpl.MessageInfo, 92)
+var file_edge_ctrl_proto_msgTypes = make([]protoimpl.MessageInfo, 93)
 var file_edge_ctrl_proto_goTypes = []any{
 	(ContentType)(0),                            // 0: ziti.edge_ctrl.pb.ContentType
 	(SessionType)(0),                            // 1: ziti.edge_ctrl.pb.SessionType
@@ -6079,43 +6178,44 @@ var file_edge_ctrl_proto_goTypes = []any{
 	(*DataState_ServiceConfigs)(nil),            // 64: ziti.edge_ctrl.pb.DataState.ServiceConfigs
 	(*DataState_Identity)(nil),                  // 65: ziti.edge_ctrl.pb.DataState.Identity
 	(*DataState_Service)(nil),                   // 66: ziti.edge_ctrl.pb.DataState.Service
-	(*DataState_ServicePolicy)(nil),             // 67: ziti.edge_ctrl.pb.DataState.ServicePolicy
-	(*DataState_Revocation)(nil),                // 68: ziti.edge_ctrl.pb.DataState.Revocation
-	(*DataState_ServicePolicyChange)(nil),       // 69: ziti.edge_ctrl.pb.DataState.ServicePolicyChange
-	(*DataState_ChangeSet)(nil),                 // 70: ziti.edge_ctrl.pb.DataState.ChangeSet
-	(*DataState_Event)(nil),                     // 71: ziti.edge_ctrl.pb.DataState.Event
-	(*DataState_PublicKey)(nil),                 // 72: ziti.edge_ctrl.pb.DataState.PublicKey
-	(*DataState_PostureCheck)(nil),              // 73: ziti.edge_ctrl.pb.DataState.PostureCheck
-	nil,                                         // 74: ziti.edge_ctrl.pb.DataState.ServiceConfigs.ConfigsEntry
-	nil,                                         // 75: ziti.edge_ctrl.pb.DataState.Identity.ServiceHostingPrecedencesEntry
-	nil,                                         // 76: ziti.edge_ctrl.pb.DataState.Identity.ServiceHostingCostsEntry
-	nil,                                         // 77: ziti.edge_ctrl.pb.DataState.Identity.ServiceConfigsEntry
-	(*DataState_PostureCheck_Mac)(nil),          // 78: ziti.edge_ctrl.pb.DataState.PostureCheck.Mac
-	(*DataState_PostureCheck_Mfa)(nil),          // 79: ziti.edge_ctrl.pb.DataState.PostureCheck.Mfa
-	(*DataState_PostureCheck_Os)(nil),           // 80: ziti.edge_ctrl.pb.DataState.PostureCheck.Os
-	(*DataState_PostureCheck_OsList)(nil),       // 81: ziti.edge_ctrl.pb.DataState.PostureCheck.OsList
-	(*DataState_PostureCheck_Process)(nil),      // 82: ziti.edge_ctrl.pb.DataState.PostureCheck.Process
-	(*DataState_PostureCheck_ProcessMulti)(nil), // 83: ziti.edge_ctrl.pb.DataState.PostureCheck.ProcessMulti
-	(*DataState_PostureCheck_Domains)(nil),      // 84: ziti.edge_ctrl.pb.DataState.PostureCheck.Domains
-	nil,                                         // 85: ziti.edge_ctrl.pb.CreateCircuitRequest.PeerDataEntry
-	nil,                                         // 86: ziti.edge_ctrl.pb.CreateCircuitResponse.PeerDataEntry
-	nil,                                         // 87: ziti.edge_ctrl.pb.CreateCircuitResponse.TagsEntry
-	nil,                                         // 88: ziti.edge_ctrl.pb.CreateTerminatorV2Request.PeerDataEntry
-	nil,                                         // 89: ziti.edge_ctrl.pb.CreateApiSessionResponse.ServicePrecedencesEntry
-	nil,                                         // 90: ziti.edge_ctrl.pb.CreateApiSessionResponse.ServiceCostsEntry
-	nil,                                         // 91: ziti.edge_ctrl.pb.CreateCircuitForServiceRequest.PeerDataEntry
-	nil,                                         // 92: ziti.edge_ctrl.pb.CreateCircuitForServiceResponse.PeerDataEntry
-	nil,                                         // 93: ziti.edge_ctrl.pb.CreateCircuitForServiceResponse.TagsEntry
-	nil,                                         // 94: ziti.edge_ctrl.pb.CreateTunnelCircuitV2Request.PeerDataEntry
-	nil,                                         // 95: ziti.edge_ctrl.pb.CreateTunnelCircuitV2Response.PeerDataEntry
-	nil,                                         // 96: ziti.edge_ctrl.pb.CreateTunnelCircuitV2Response.TagsEntry
-	nil,                                         // 97: ziti.edge_ctrl.pb.CreateTunnelTerminatorRequest.PeerDataEntry
-	nil,                                         // 98: ziti.edge_ctrl.pb.CreateTunnelTerminatorRequestV2.PeerDataEntry
-	(*ConnectEvents_ConnectDetails)(nil),        // 99: ziti.edge_ctrl.pb.ConnectEvents.ConnectDetails
-	(*ConnectEvents_IdentityConnectEvents)(nil), // 100: ziti.edge_ctrl.pb.ConnectEvents.IdentityConnectEvents
-	nil,                           // 101: ziti.edge_ctrl.pb.RouterDataModelValidateResponse.OrigEntityCountsEntry
-	nil,                           // 102: ziti.edge_ctrl.pb.RouterDataModelValidateResponse.CopyEntityCountsEntry
-	(*timestamppb.Timestamp)(nil), // 103: google.protobuf.Timestamp
+	(*DataState_Router)(nil),                    // 67: ziti.edge_ctrl.pb.DataState.Router
+	(*DataState_ServicePolicy)(nil),             // 68: ziti.edge_ctrl.pb.DataState.ServicePolicy
+	(*DataState_Revocation)(nil),                // 69: ziti.edge_ctrl.pb.DataState.Revocation
+	(*DataState_ServicePolicyChange)(nil),       // 70: ziti.edge_ctrl.pb.DataState.ServicePolicyChange
+	(*DataState_ChangeSet)(nil),                 // 71: ziti.edge_ctrl.pb.DataState.ChangeSet
+	(*DataState_Event)(nil),                     // 72: ziti.edge_ctrl.pb.DataState.Event
+	(*DataState_PublicKey)(nil),                 // 73: ziti.edge_ctrl.pb.DataState.PublicKey
+	(*DataState_PostureCheck)(nil),              // 74: ziti.edge_ctrl.pb.DataState.PostureCheck
+	nil,                                         // 75: ziti.edge_ctrl.pb.DataState.ServiceConfigs.ConfigsEntry
+	nil,                                         // 76: ziti.edge_ctrl.pb.DataState.Identity.ServiceHostingPrecedencesEntry
+	nil,                                         // 77: ziti.edge_ctrl.pb.DataState.Identity.ServiceHostingCostsEntry
+	nil,                                         // 78: ziti.edge_ctrl.pb.DataState.Identity.ServiceConfigsEntry
+	(*DataState_PostureCheck_Mac)(nil),          // 79: ziti.edge_ctrl.pb.DataState.PostureCheck.Mac
+	(*DataState_PostureCheck_Mfa)(nil),          // 80: ziti.edge_ctrl.pb.DataState.PostureCheck.Mfa
+	(*DataState_PostureCheck_Os)(nil),           // 81: ziti.edge_ctrl.pb.DataState.PostureCheck.Os
+	(*DataState_PostureCheck_OsList)(nil),       // 82: ziti.edge_ctrl.pb.DataState.PostureCheck.OsList
+	(*DataState_PostureCheck_Process)(nil),      // 83: ziti.edge_ctrl.pb.DataState.PostureCheck.Process
+	(*DataState_PostureCheck_ProcessMulti)(nil), // 84: ziti.edge_ctrl.pb.DataState.PostureCheck.ProcessMulti
+	(*DataState_PostureCheck_Domains)(nil),      // 85: ziti.edge_ctrl.pb.DataState.PostureCheck.Domains
+	nil,                                         // 86: ziti.edge_ctrl.pb.CreateCircuitRequest.PeerDataEntry
+	nil,                                         // 87: ziti.edge_ctrl.pb.CreateCircuitResponse.PeerDataEntry
+	nil,                                         // 88: ziti.edge_ctrl.pb.CreateCircuitResponse.TagsEntry
+	nil,                                         // 89: ziti.edge_ctrl.pb.CreateTerminatorV2Request.PeerDataEntry
+	nil,                                         // 90: ziti.edge_ctrl.pb.CreateApiSessionResponse.ServicePrecedencesEntry
+	nil,                                         // 91: ziti.edge_ctrl.pb.CreateApiSessionResponse.ServiceCostsEntry
+	nil,                                         // 92: ziti.edge_ctrl.pb.CreateCircuitForServiceRequest.PeerDataEntry
+	nil,                                         // 93: ziti.edge_ctrl.pb.CreateCircuitForServiceResponse.PeerDataEntry
+	nil,                                         // 94: ziti.edge_ctrl.pb.CreateCircuitForServiceResponse.TagsEntry
+	nil,                                         // 95: ziti.edge_ctrl.pb.CreateTunnelCircuitV2Request.PeerDataEntry
+	nil,                                         // 96: ziti.edge_ctrl.pb.CreateTunnelCircuitV2Response.PeerDataEntry
+	nil,                                         // 97: ziti.edge_ctrl.pb.CreateTunnelCircuitV2Response.TagsEntry
+	nil,                                         // 98: ziti.edge_ctrl.pb.CreateTunnelTerminatorRequest.PeerDataEntry
+	nil,                                         // 99: ziti.edge_ctrl.pb.CreateTunnelTerminatorRequestV2.PeerDataEntry
+	(*ConnectEvents_ConnectDetails)(nil),        // 100: ziti.edge_ctrl.pb.ConnectEvents.ConnectDetails
+	(*ConnectEvents_IdentityConnectEvents)(nil), // 101: ziti.edge_ctrl.pb.ConnectEvents.IdentityConnectEvents
+	nil,                           // 102: ziti.edge_ctrl.pb.RouterDataModelValidateResponse.OrigEntityCountsEntry
+	nil,                           // 103: ziti.edge_ctrl.pb.RouterDataModelValidateResponse.CopyEntityCountsEntry
+	(*timestamppb.Timestamp)(nil), // 104: google.protobuf.Timestamp
 }
 var file_edge_ctrl_proto_depIdxs = []int32{
 	57,  // 0: ziti.edge_ctrl.pb.ServerHello.data:type_name -> ziti.edge_ctrl.pb.ServerHello.DataEntry
@@ -6125,84 +6225,85 @@ var file_edge_ctrl_proto_depIdxs = []int32{
 	59,  // 4: ziti.edge_ctrl.pb.ClientHello.data:type_name -> ziti.edge_ctrl.pb.ClientHello.DataEntry
 	13,  // 5: ziti.edge_ctrl.pb.ClientHello.listeners:type_name -> ziti.edge_ctrl.pb.Listener
 	60,  // 6: ziti.edge_ctrl.pb.Cache.data:type_name -> ziti.edge_ctrl.pb.Cache.DataEntry
-	71,  // 7: ziti.edge_ctrl.pb.DataState.events:type_name -> ziti.edge_ctrl.pb.DataState.Event
+	72,  // 7: ziti.edge_ctrl.pb.DataState.events:type_name -> ziti.edge_ctrl.pb.DataState.Event
 	61,  // 8: ziti.edge_ctrl.pb.DataState.caches:type_name -> ziti.edge_ctrl.pb.DataState.CachesEntry
 	18,  // 9: ziti.edge_ctrl.pb.ApiSessionAdded.apiSessions:type_name -> ziti.edge_ctrl.pb.ApiSession
 	18,  // 10: ziti.edge_ctrl.pb.ApiSessionUpdated.apiSessions:type_name -> ziti.edge_ctrl.pb.ApiSession
-	85,  // 11: ziti.edge_ctrl.pb.CreateCircuitRequest.peerData:type_name -> ziti.edge_ctrl.pb.CreateCircuitRequest.PeerDataEntry
-	86,  // 12: ziti.edge_ctrl.pb.CreateCircuitResponse.peerData:type_name -> ziti.edge_ctrl.pb.CreateCircuitResponse.PeerDataEntry
-	87,  // 13: ziti.edge_ctrl.pb.CreateCircuitResponse.tags:type_name -> ziti.edge_ctrl.pb.CreateCircuitResponse.TagsEntry
-	88,  // 14: ziti.edge_ctrl.pb.CreateTerminatorV2Request.peerData:type_name -> ziti.edge_ctrl.pb.CreateTerminatorV2Request.PeerDataEntry
+	86,  // 11: ziti.edge_ctrl.pb.CreateCircuitRequest.peerData:type_name -> ziti.edge_ctrl.pb.CreateCircuitRequest.PeerDataEntry
+	87,  // 12: ziti.edge_ctrl.pb.CreateCircuitResponse.peerData:type_name -> ziti.edge_ctrl.pb.CreateCircuitResponse.PeerDataEntry
+	88,  // 13: ziti.edge_ctrl.pb.CreateCircuitResponse.tags:type_name -> ziti.edge_ctrl.pb.CreateCircuitResponse.TagsEntry
+	89,  // 14: ziti.edge_ctrl.pb.CreateTerminatorV2Request.peerData:type_name -> ziti.edge_ctrl.pb.CreateTerminatorV2Request.PeerDataEntry
 	6,   // 15: ziti.edge_ctrl.pb.CreateTerminatorV2Request.precedence:type_name -> ziti.edge_ctrl.pb.TerminatorPrecedence
 	7,   // 16: ziti.edge_ctrl.pb.CreateTerminatorV2Response.result:type_name -> ziti.edge_ctrl.pb.CreateTerminatorResult
 	6,   // 17: ziti.edge_ctrl.pb.UpdateTerminatorRequest.precedence:type_name -> ziti.edge_ctrl.pb.TerminatorPrecedence
 	33,  // 18: ziti.edge_ctrl.pb.CreateApiSessionRequest.envInfo:type_name -> ziti.edge_ctrl.pb.EnvInfo
 	34,  // 19: ziti.edge_ctrl.pb.CreateApiSessionRequest.sdkInfo:type_name -> ziti.edge_ctrl.pb.SdkInfo
 	6,   // 20: ziti.edge_ctrl.pb.CreateApiSessionResponse.defaultHostingPrecedence:type_name -> ziti.edge_ctrl.pb.TerminatorPrecedence
-	89,  // 21: ziti.edge_ctrl.pb.CreateApiSessionResponse.servicePrecedences:type_name -> ziti.edge_ctrl.pb.CreateApiSessionResponse.ServicePrecedencesEntry
-	90,  // 22: ziti.edge_ctrl.pb.CreateApiSessionResponse.serviceCosts:type_name -> ziti.edge_ctrl.pb.CreateApiSessionResponse.ServiceCostsEntry
-	91,  // 23: ziti.edge_ctrl.pb.CreateCircuitForServiceRequest.peerData:type_name -> ziti.edge_ctrl.pb.CreateCircuitForServiceRequest.PeerDataEntry
+	90,  // 21: ziti.edge_ctrl.pb.CreateApiSessionResponse.servicePrecedences:type_name -> ziti.edge_ctrl.pb.CreateApiSessionResponse.ServicePrecedencesEntry
+	91,  // 22: ziti.edge_ctrl.pb.CreateApiSessionResponse.serviceCosts:type_name -> ziti.edge_ctrl.pb.CreateApiSessionResponse.ServiceCostsEntry
+	92,  // 23: ziti.edge_ctrl.pb.CreateCircuitForServiceRequest.peerData:type_name -> ziti.edge_ctrl.pb.CreateCircuitForServiceRequest.PeerDataEntry
 	36,  // 24: ziti.edge_ctrl.pb.CreateCircuitForServiceResponse.apiSession:type_name -> ziti.edge_ctrl.pb.CreateApiSessionResponse
 	38,  // 25: ziti.edge_ctrl.pb.CreateCircuitForServiceResponse.session:type_name -> ziti.edge_ctrl.pb.CreateSessionResponse
-	92,  // 26: ziti.edge_ctrl.pb.CreateCircuitForServiceResponse.peerData:type_name -> ziti.edge_ctrl.pb.CreateCircuitForServiceResponse.PeerDataEntry
-	93,  // 27: ziti.edge_ctrl.pb.CreateCircuitForServiceResponse.tags:type_name -> ziti.edge_ctrl.pb.CreateCircuitForServiceResponse.TagsEntry
-	94,  // 28: ziti.edge_ctrl.pb.CreateTunnelCircuitV2Request.peerData:type_name -> ziti.edge_ctrl.pb.CreateTunnelCircuitV2Request.PeerDataEntry
-	95,  // 29: ziti.edge_ctrl.pb.CreateTunnelCircuitV2Response.peerData:type_name -> ziti.edge_ctrl.pb.CreateTunnelCircuitV2Response.PeerDataEntry
-	96,  // 30: ziti.edge_ctrl.pb.CreateTunnelCircuitV2Response.tags:type_name -> ziti.edge_ctrl.pb.CreateTunnelCircuitV2Response.TagsEntry
+	93,  // 26: ziti.edge_ctrl.pb.CreateCircuitForServiceResponse.peerData:type_name -> ziti.edge_ctrl.pb.CreateCircuitForServiceResponse.PeerDataEntry
+	94,  // 27: ziti.edge_ctrl.pb.CreateCircuitForServiceResponse.tags:type_name -> ziti.edge_ctrl.pb.CreateCircuitForServiceResponse.TagsEntry
+	95,  // 28: ziti.edge_ctrl.pb.CreateTunnelCircuitV2Request.peerData:type_name -> ziti.edge_ctrl.pb.CreateTunnelCircuitV2Request.PeerDataEntry
+	96,  // 29: ziti.edge_ctrl.pb.CreateTunnelCircuitV2Response.peerData:type_name -> ziti.edge_ctrl.pb.CreateTunnelCircuitV2Response.PeerDataEntry
+	97,  // 30: ziti.edge_ctrl.pb.CreateTunnelCircuitV2Response.tags:type_name -> ziti.edge_ctrl.pb.CreateTunnelCircuitV2Response.TagsEntry
 	43,  // 31: ziti.edge_ctrl.pb.ServicesList.services:type_name -> ziti.edge_ctrl.pb.TunnelService
-	97,  // 32: ziti.edge_ctrl.pb.CreateTunnelTerminatorRequest.peerData:type_name -> ziti.edge_ctrl.pb.CreateTunnelTerminatorRequest.PeerDataEntry
+	98,  // 32: ziti.edge_ctrl.pb.CreateTunnelTerminatorRequest.peerData:type_name -> ziti.edge_ctrl.pb.CreateTunnelTerminatorRequest.PeerDataEntry
 	6,   // 33: ziti.edge_ctrl.pb.CreateTunnelTerminatorRequest.precedence:type_name -> ziti.edge_ctrl.pb.TerminatorPrecedence
 	36,  // 34: ziti.edge_ctrl.pb.CreateTunnelTerminatorResponse.apiSession:type_name -> ziti.edge_ctrl.pb.CreateApiSessionResponse
 	38,  // 35: ziti.edge_ctrl.pb.CreateTunnelTerminatorResponse.session:type_name -> ziti.edge_ctrl.pb.CreateSessionResponse
-	98,  // 36: ziti.edge_ctrl.pb.CreateTunnelTerminatorRequestV2.peerData:type_name -> ziti.edge_ctrl.pb.CreateTunnelTerminatorRequestV2.PeerDataEntry
+	99,  // 36: ziti.edge_ctrl.pb.CreateTunnelTerminatorRequestV2.peerData:type_name -> ziti.edge_ctrl.pb.CreateTunnelTerminatorRequestV2.PeerDataEntry
 	6,   // 37: ziti.edge_ctrl.pb.CreateTunnelTerminatorRequestV2.precedence:type_name -> ziti.edge_ctrl.pb.TerminatorPrecedence
 	7,   // 38: ziti.edge_ctrl.pb.CreateTunnelTerminatorResponseV2.result:type_name -> ziti.edge_ctrl.pb.CreateTerminatorResult
 	6,   // 39: ziti.edge_ctrl.pb.UpdateTunnelTerminatorRequest.precedence:type_name -> ziti.edge_ctrl.pb.TerminatorPrecedence
-	100, // 40: ziti.edge_ctrl.pb.ConnectEvents.events:type_name -> ziti.edge_ctrl.pb.ConnectEvents.IdentityConnectEvents
+	101, // 40: ziti.edge_ctrl.pb.ConnectEvents.events:type_name -> ziti.edge_ctrl.pb.ConnectEvents.IdentityConnectEvents
 	17,  // 41: ziti.edge_ctrl.pb.RouterDataModelValidateRequest.state:type_name -> ziti.edge_ctrl.pb.DataState
-	101, // 42: ziti.edge_ctrl.pb.RouterDataModelValidateResponse.origEntityCounts:type_name -> ziti.edge_ctrl.pb.RouterDataModelValidateResponse.OrigEntityCountsEntry
-	102, // 43: ziti.edge_ctrl.pb.RouterDataModelValidateResponse.copyEntityCounts:type_name -> ziti.edge_ctrl.pb.RouterDataModelValidateResponse.CopyEntityCountsEntry
+	102, // 42: ziti.edge_ctrl.pb.RouterDataModelValidateResponse.origEntityCounts:type_name -> ziti.edge_ctrl.pb.RouterDataModelValidateResponse.OrigEntityCountsEntry
+	103, // 43: ziti.edge_ctrl.pb.RouterDataModelValidateResponse.copyEntityCounts:type_name -> ziti.edge_ctrl.pb.RouterDataModelValidateResponse.CopyEntityCountsEntry
 	54,  // 44: ziti.edge_ctrl.pb.RouterDataModelValidateResponse.diffs:type_name -> ziti.edge_ctrl.pb.RouterDataModelDiff
 	16,  // 45: ziti.edge_ctrl.pb.DataState.CachesEntry.value:type_name -> ziti.edge_ctrl.pb.Cache
-	74,  // 46: ziti.edge_ctrl.pb.DataState.ServiceConfigs.configs:type_name -> ziti.edge_ctrl.pb.DataState.ServiceConfigs.ConfigsEntry
+	75,  // 46: ziti.edge_ctrl.pb.DataState.ServiceConfigs.configs:type_name -> ziti.edge_ctrl.pb.DataState.ServiceConfigs.ConfigsEntry
 	6,   // 47: ziti.edge_ctrl.pb.DataState.Identity.defaultHostingPrecedence:type_name -> ziti.edge_ctrl.pb.TerminatorPrecedence
-	75,  // 48: ziti.edge_ctrl.pb.DataState.Identity.serviceHostingPrecedences:type_name -> ziti.edge_ctrl.pb.DataState.Identity.ServiceHostingPrecedencesEntry
-	76,  // 49: ziti.edge_ctrl.pb.DataState.Identity.serviceHostingCosts:type_name -> ziti.edge_ctrl.pb.DataState.Identity.ServiceHostingCostsEntry
-	77,  // 50: ziti.edge_ctrl.pb.DataState.Identity.serviceConfigs:type_name -> ziti.edge_ctrl.pb.DataState.Identity.ServiceConfigsEntry
+	76,  // 48: ziti.edge_ctrl.pb.DataState.Identity.serviceHostingPrecedences:type_name -> ziti.edge_ctrl.pb.DataState.Identity.ServiceHostingPrecedencesEntry
+	77,  // 49: ziti.edge_ctrl.pb.DataState.Identity.serviceHostingCosts:type_name -> ziti.edge_ctrl.pb.DataState.Identity.ServiceHostingCostsEntry
+	78,  // 50: ziti.edge_ctrl.pb.DataState.Identity.serviceConfigs:type_name -> ziti.edge_ctrl.pb.DataState.Identity.ServiceConfigsEntry
 	4,   // 51: ziti.edge_ctrl.pb.DataState.ServicePolicy.policyType:type_name -> ziti.edge_ctrl.pb.PolicyType
-	103, // 52: ziti.edge_ctrl.pb.DataState.Revocation.ExpiresAt:type_name -> google.protobuf.Timestamp
-	103, // 53: ziti.edge_ctrl.pb.DataState.Revocation.issuedBefore:type_name -> google.protobuf.Timestamp
+	104, // 52: ziti.edge_ctrl.pb.DataState.Revocation.ExpiresAt:type_name -> google.protobuf.Timestamp
+	104, // 53: ziti.edge_ctrl.pb.DataState.Revocation.issuedBefore:type_name -> google.protobuf.Timestamp
 	5,   // 54: ziti.edge_ctrl.pb.DataState.ServicePolicyChange.relatedEntityType:type_name -> ziti.edge_ctrl.pb.ServicePolicyRelatedEntityType
-	71,  // 55: ziti.edge_ctrl.pb.DataState.ChangeSet.changes:type_name -> ziti.edge_ctrl.pb.DataState.Event
+	72,  // 55: ziti.edge_ctrl.pb.DataState.ChangeSet.changes:type_name -> ziti.edge_ctrl.pb.DataState.Event
 	8,   // 56: ziti.edge_ctrl.pb.DataState.Event.action:type_name -> ziti.edge_ctrl.pb.DataState.Action
 	65,  // 57: ziti.edge_ctrl.pb.DataState.Event.identity:type_name -> ziti.edge_ctrl.pb.DataState.Identity
 	66,  // 58: ziti.edge_ctrl.pb.DataState.Event.service:type_name -> ziti.edge_ctrl.pb.DataState.Service
-	67,  // 59: ziti.edge_ctrl.pb.DataState.Event.servicePolicy:type_name -> ziti.edge_ctrl.pb.DataState.ServicePolicy
-	73,  // 60: ziti.edge_ctrl.pb.DataState.Event.postureCheck:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck
-	72,  // 61: ziti.edge_ctrl.pb.DataState.Event.publicKey:type_name -> ziti.edge_ctrl.pb.DataState.PublicKey
-	68,  // 62: ziti.edge_ctrl.pb.DataState.Event.revocation:type_name -> ziti.edge_ctrl.pb.DataState.Revocation
-	69,  // 63: ziti.edge_ctrl.pb.DataState.Event.servicePolicyChange:type_name -> ziti.edge_ctrl.pb.DataState.ServicePolicyChange
+	68,  // 59: ziti.edge_ctrl.pb.DataState.Event.servicePolicy:type_name -> ziti.edge_ctrl.pb.DataState.ServicePolicy
+	74,  // 60: ziti.edge_ctrl.pb.DataState.Event.postureCheck:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck
+	73,  // 61: ziti.edge_ctrl.pb.DataState.Event.publicKey:type_name -> ziti.edge_ctrl.pb.DataState.PublicKey
+	69,  // 62: ziti.edge_ctrl.pb.DataState.Event.revocation:type_name -> ziti.edge_ctrl.pb.DataState.Revocation
+	70,  // 63: ziti.edge_ctrl.pb.DataState.Event.servicePolicyChange:type_name -> ziti.edge_ctrl.pb.DataState.ServicePolicyChange
 	62,  // 64: ziti.edge_ctrl.pb.DataState.Event.configType:type_name -> ziti.edge_ctrl.pb.DataState.ConfigType
 	63,  // 65: ziti.edge_ctrl.pb.DataState.Event.config:type_name -> ziti.edge_ctrl.pb.DataState.Config
-	9,   // 66: ziti.edge_ctrl.pb.DataState.PublicKey.usages:type_name -> ziti.edge_ctrl.pb.DataState.PublicKey.Usage
-	10,  // 67: ziti.edge_ctrl.pb.DataState.PublicKey.format:type_name -> ziti.edge_ctrl.pb.DataState.PublicKey.Format
-	78,  // 68: ziti.edge_ctrl.pb.DataState.PostureCheck.mac:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck.Mac
-	79,  // 69: ziti.edge_ctrl.pb.DataState.PostureCheck.mfa:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck.Mfa
-	81,  // 70: ziti.edge_ctrl.pb.DataState.PostureCheck.osList:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck.OsList
-	82,  // 71: ziti.edge_ctrl.pb.DataState.PostureCheck.process:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck.Process
-	83,  // 72: ziti.edge_ctrl.pb.DataState.PostureCheck.processMulti:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck.ProcessMulti
-	84,  // 73: ziti.edge_ctrl.pb.DataState.PostureCheck.domains:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck.Domains
-	6,   // 74: ziti.edge_ctrl.pb.DataState.Identity.ServiceHostingPrecedencesEntry.value:type_name -> ziti.edge_ctrl.pb.TerminatorPrecedence
-	64,  // 75: ziti.edge_ctrl.pb.DataState.Identity.ServiceConfigsEntry.value:type_name -> ziti.edge_ctrl.pb.DataState.ServiceConfigs
-	80,  // 76: ziti.edge_ctrl.pb.DataState.PostureCheck.OsList.osList:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck.Os
-	82,  // 77: ziti.edge_ctrl.pb.DataState.PostureCheck.ProcessMulti.processes:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck.Process
-	6,   // 78: ziti.edge_ctrl.pb.CreateApiSessionResponse.ServicePrecedencesEntry.value:type_name -> ziti.edge_ctrl.pb.TerminatorPrecedence
-	99,  // 79: ziti.edge_ctrl.pb.ConnectEvents.IdentityConnectEvents.connectTimes:type_name -> ziti.edge_ctrl.pb.ConnectEvents.ConnectDetails
-	80,  // [80:80] is the sub-list for method output_type
-	80,  // [80:80] is the sub-list for method input_type
-	80,  // [80:80] is the sub-list for extension type_name
-	80,  // [80:80] is the sub-list for extension extendee
-	0,   // [0:80] is the sub-list for field type_name
+	67,  // 66: ziti.edge_ctrl.pb.DataState.Event.router:type_name -> ziti.edge_ctrl.pb.DataState.Router
+	9,   // 67: ziti.edge_ctrl.pb.DataState.PublicKey.usages:type_name -> ziti.edge_ctrl.pb.DataState.PublicKey.Usage
+	10,  // 68: ziti.edge_ctrl.pb.DataState.PublicKey.format:type_name -> ziti.edge_ctrl.pb.DataState.PublicKey.Format
+	79,  // 69: ziti.edge_ctrl.pb.DataState.PostureCheck.mac:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck.Mac
+	80,  // 70: ziti.edge_ctrl.pb.DataState.PostureCheck.mfa:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck.Mfa
+	82,  // 71: ziti.edge_ctrl.pb.DataState.PostureCheck.osList:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck.OsList
+	83,  // 72: ziti.edge_ctrl.pb.DataState.PostureCheck.process:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck.Process
+	84,  // 73: ziti.edge_ctrl.pb.DataState.PostureCheck.processMulti:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck.ProcessMulti
+	85,  // 74: ziti.edge_ctrl.pb.DataState.PostureCheck.domains:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck.Domains
+	6,   // 75: ziti.edge_ctrl.pb.DataState.Identity.ServiceHostingPrecedencesEntry.value:type_name -> ziti.edge_ctrl.pb.TerminatorPrecedence
+	64,  // 76: ziti.edge_ctrl.pb.DataState.Identity.ServiceConfigsEntry.value:type_name -> ziti.edge_ctrl.pb.DataState.ServiceConfigs
+	81,  // 77: ziti.edge_ctrl.pb.DataState.PostureCheck.OsList.osList:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck.Os
+	83,  // 78: ziti.edge_ctrl.pb.DataState.PostureCheck.ProcessMulti.processes:type_name -> ziti.edge_ctrl.pb.DataState.PostureCheck.Process
+	6,   // 79: ziti.edge_ctrl.pb.CreateApiSessionResponse.ServicePrecedencesEntry.value:type_name -> ziti.edge_ctrl.pb.TerminatorPrecedence
+	100, // 80: ziti.edge_ctrl.pb.ConnectEvents.IdentityConnectEvents.connectTimes:type_name -> ziti.edge_ctrl.pb.ConnectEvents.ConnectDetails
+	81,  // [81:81] is the sub-list for method output_type
+	81,  // [81:81] is the sub-list for method input_type
+	81,  // [81:81] is the sub-list for extension type_name
+	81,  // [81:81] is the sub-list for extension extendee
+	0,   // [0:81] is the sub-list for field type_name
 }
 
 func init() { file_edge_ctrl_proto_init() }
@@ -6210,7 +6311,7 @@ func file_edge_ctrl_proto_init() {
 	if File_edge_ctrl_proto != nil {
 		return
 	}
-	file_edge_ctrl_proto_msgTypes[60].OneofWrappers = []any{
+	file_edge_ctrl_proto_msgTypes[61].OneofWrappers = []any{
 		(*DataState_Event_Identity)(nil),
 		(*DataState_Event_Service)(nil),
 		(*DataState_Event_ServicePolicy)(nil),
@@ -6220,8 +6321,9 @@ func file_edge_ctrl_proto_init() {
 		(*DataState_Event_ServicePolicyChange)(nil),
 		(*DataState_Event_ConfigType)(nil),
 		(*DataState_Event_Config)(nil),
+		(*DataState_Event_Router)(nil),
 	}
-	file_edge_ctrl_proto_msgTypes[62].OneofWrappers = []any{
+	file_edge_ctrl_proto_msgTypes[63].OneofWrappers = []any{
 		(*DataState_PostureCheck_Mac_)(nil),
 		(*DataState_PostureCheck_Mfa_)(nil),
 		(*DataState_PostureCheck_OsList_)(nil),
@@ -6235,7 +6337,7 @@ func file_edge_ctrl_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_edge_ctrl_proto_rawDesc), len(file_edge_ctrl_proto_rawDesc)),
 			NumEnums:      11,
-			NumMessages:   92,
+			NumMessages:   93,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/common/pb/edge_ctrl_pb/edge_ctrl.proto
+++ b/common/pb/edge_ctrl_pb/edge_ctrl.proto
@@ -202,6 +202,14 @@ message DataState {
     repeated string configs = 4;
   }
 
+  message Router {
+    string id = 1;
+    string name = 2;
+    string fingerprint = 3;
+    repeated string configs = 4;
+    bool disabled = 5;
+  }
+
   message ServicePolicy {
     string id = 1;
     string name = 2;
@@ -251,6 +259,7 @@ message DataState {
       ServicePolicyChange servicePolicyChange = 16;
       ConfigType configType = 17;
       Config config = 18;
+      Router router = 19;
     }
   }
 

--- a/common/router_data_model.go
+++ b/common/router_data_model.go
@@ -424,9 +424,10 @@ type DataStateConfigType = edge_ctrl_pb.DataState_ConfigType
 // ConfigType represents a configuration type that defines the schema or category for configuration data.
 // Config instances reference a ConfigType to indicate what kind of configuration they contain.
 type ConfigType struct {
-	Id    string
-	Name  string
-	index uint64
+	Id     string
+	Name   string
+	Target string
+	index  uint64
 }
 
 func (self *ConfigType) GetId() string {
@@ -435,13 +436,14 @@ func (self *ConfigType) GetId() string {
 
 func (self *ConfigType) ToProtobuf() *edge_ctrl_pb.DataState_ConfigType {
 	return &edge_ctrl_pb.DataState_ConfigType{
-		Id:   self.Id,
-		Name: self.Name,
+		Id:     self.Id,
+		Name:   self.Name,
+		Target: self.Target,
 	}
 }
 
 func (self *ConfigType) Equals(other *ConfigType) bool {
-	return self.Name == other.Name
+	return self.Name == other.Name && self.Target == other.Target
 }
 
 type DataStateConfig = edge_ctrl_pb.DataState_Config
@@ -587,6 +589,7 @@ type RouterDataModel struct {
 	Configs          cmap.ConcurrentMap[string, *Config]                            `json:"configs"`
 	Identities       cmap.ConcurrentMap[string, *Identity]                          `json:"identities"`
 	Services         cmap.ConcurrentMap[string, *Service]                           `json:"services"`
+	Routers          cmap.ConcurrentMap[string, *edge_ctrl_pb.DataState_Router]     `json:"routers"`
 	ServicePolicies  cmap.ConcurrentMap[string, *ServicePolicy]                     `json:"servicePolicies"`
 	PostureChecks    cmap.ConcurrentMap[string, *PostureCheck]                      `json:"postureChecks"`
 	PublicKeys       cmap.ConcurrentMap[string, *edge_ctrl_pb.DataState_PublicKey]  `json:"publicKeys"`
@@ -612,34 +615,53 @@ type RouterDataModel struct {
 	// underlying datastore
 	timelineId string
 
+	// selfRouterId, when non-empty, is the ID of the local router. Used by
+	// HandleRouterEvent on the receiver side to GC router-target Config orphans
+	// when the local Router entity's Configs list shrinks. Set at construction
+	// time. Empty for non-receiver views (controller-side, validate parsing).
+	selfRouterId string
+
 	lock  sync.Mutex
 	index uint64
 }
 
-// NewBareRouterDataModel creates a new RouterDataModel that is expected to have no buffers, listeners or subscriptions
-func NewBareRouterDataModel() *RouterDataModel {
+// SelfRouterId returns the locally-set router ID, or "" if not set (e.g. on the
+// controller-side RDM).
+func (rdm *RouterDataModel) SelfRouterId() string {
+	return rdm.selfRouterId
+}
+
+// NewBareRouterDataModel creates a new RouterDataModel with no buffers, listeners or subscriptions.
+// Pass the local router ID to enable receiver-side GC of router-target Config orphans on
+// self-Router updates; pass "" for non-receiver views (controller-side construction or
+// validate-snapshot parsing where the local "self" is irrelevant).
+func NewBareRouterDataModel(routerId string) *RouterDataModel {
 	return &RouterDataModel{
 		ConfigTypes:       cmap.New[*ConfigType](),
 		Configs:           cmap.New[*Config](),
 		Identities:        cmap.New[*Identity](),
 		Services:          cmap.New[*Service](),
+		Routers:           cmap.New[*edge_ctrl_pb.DataState_Router](),
 		ServicePolicies:   cmap.New[*ServicePolicy](),
 		PostureChecks:     cmap.New[*PostureCheck](),
 		PublicKeys:        cmap.New[*edge_ctrl_pb.DataState_PublicKey](),
 		Revocations:       cmap.New[*edge_ctrl_pb.DataState_Revocation](),
 		terminatorIdCache: cmap.New[string](),
 		subscriptions:     cmap.New[*IdentitySubscription](),
+		selfRouterId:      routerId,
 	}
 }
 
 // NewReceiverRouterDataModel creates a new RouterDataModel that does not store events. listenerBufferSize affects the
-// buffer size of channels returned to listeners of the data model.
-func NewReceiverRouterDataModel(closeNotify <-chan struct{}) *RouterDataModel {
+// buffer size of channels returned to listeners of the data model. routerId is the local router's ID and enables
+// receiver-side GC of router-target Config orphans on self-Router updates.
+func NewReceiverRouterDataModel(routerId string, closeNotify <-chan struct{}) *RouterDataModel {
 	result := &RouterDataModel{
 		ConfigTypes:              cmap.New[*ConfigType](),
 		Configs:                  cmap.New[*Config](),
 		Identities:               cmap.New[*Identity](),
 		Services:                 cmap.New[*Service](),
+		Routers:                  cmap.New[*edge_ctrl_pb.DataState_Router](),
 		ServicePolicies:          cmap.New[*ServicePolicy](),
 		PostureChecks:            cmap.New[*PostureCheck](),
 		PublicKeys:               cmap.New[*edge_ctrl_pb.DataState_PublicKey](),
@@ -652,19 +674,21 @@ func NewReceiverRouterDataModel(closeNotify <-chan struct{}) *RouterDataModel {
 		closeNotify:              closeNotify,
 		stopNotify:               make(chan struct{}),
 		terminatorIdCache:        cmap.New[string](),
+		selfRouterId:             routerId,
 	}
 	go result.processSubscriberEvents()
 	return result
 }
 
 // NewReceiverRouterDataModelFromDataState creates a new RouterDataModel that does not store events. listenerBufferSize affects the
-// buffer size of channels returned to listeners of the data model.
-func NewReceiverRouterDataModelFromDataState(dataState *edge_ctrl_pb.DataState, closeNotify <-chan struct{}) *RouterDataModel {
+// buffer size of channels returned to listeners of the data model. routerId is the local router's ID.
+func NewReceiverRouterDataModelFromDataState(routerId string, dataState *edge_ctrl_pb.DataState, closeNotify <-chan struct{}) *RouterDataModel {
 	result := &RouterDataModel{
 		ConfigTypes:              cmap.New[*ConfigType](),
 		Configs:                  cmap.New[*Config](),
 		Identities:               cmap.New[*Identity](),
 		Services:                 cmap.New[*Service](),
+		Routers:                  cmap.New[*edge_ctrl_pb.DataState_Router](),
 		ServicePolicies:          cmap.New[*ServicePolicy](),
 		PostureChecks:            cmap.New[*PostureCheck](),
 		PublicKeys:               cmap.New[*edge_ctrl_pb.DataState_PublicKey](),
@@ -678,6 +702,7 @@ func NewReceiverRouterDataModelFromDataState(dataState *edge_ctrl_pb.DataState, 
 		stopNotify:               make(chan struct{}),
 		timelineId:               dataState.TimelineId,
 		terminatorIdCache:        cmap.New[string](),
+		selfRouterId:             routerId,
 	}
 
 	if tIdCache, ok := dataState.Caches[edge_ctrl_pb.CacheType_TerminatorIds.String()]; ok && tIdCache != nil && tIdCache.Data != nil {
@@ -699,13 +724,14 @@ func NewReceiverRouterDataModelFromDataState(dataState *edge_ctrl_pb.DataState, 
 }
 
 // NewReceiverRouterDataModelFromExisting creates a new RouterDataModel that does not store events. listenerBufferSize affects the
-// buffer size of channels returned to listeners of the data model.
-func NewReceiverRouterDataModelFromExisting(existing *RouterDataModel, closeNotify <-chan struct{}) *RouterDataModel {
+// buffer size of channels returned to listeners of the data model. routerId is the local router's ID.
+func NewReceiverRouterDataModelFromExisting(routerId string, existing *RouterDataModel, closeNotify <-chan struct{}) *RouterDataModel {
 	result := &RouterDataModel{
 		ConfigTypes:              existing.ConfigTypes,
 		Configs:                  existing.Configs,
 		Identities:               existing.Identities,
 		Services:                 existing.Services,
+		Routers:                  existing.Routers,
 		ServicePolicies:          existing.ServicePolicies,
 		PostureChecks:            existing.PostureChecks,
 		PublicKeys:               existing.PublicKeys,
@@ -720,6 +746,7 @@ func NewReceiverRouterDataModelFromExisting(existing *RouterDataModel, closeNoti
 		stopNotify:               make(chan struct{}),
 		timelineId:               existing.timelineId,
 		terminatorIdCache:        existing.terminatorIdCache,
+		selfRouterId:             routerId,
 	}
 	currentIndex := existing.CurrentIndex()
 	result.SetCurrentIndex(currentIndex)
@@ -729,7 +756,8 @@ func NewReceiverRouterDataModelFromExisting(existing *RouterDataModel, closeNoti
 
 // NewReceiverRouterDataModelFromFile creates a new RouterDataModel that does not store events and is initialized from
 // a file backup. listenerBufferSize affects the buffer size of channels returned to listeners of the data model.
-func NewReceiverRouterDataModelFromFile(path string, closeNotify <-chan struct{}) (*RouterDataModel, error) {
+// routerId is the local router's ID.
+func NewReceiverRouterDataModelFromFile(routerId string, path string, closeNotify <-chan struct{}) (*RouterDataModel, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, err
@@ -752,7 +780,7 @@ func NewReceiverRouterDataModelFromFile(path string, closeNotify <-chan struct{}
 		return nil, err
 	}
 
-	rdm := NewReceiverRouterDataModelFromDataState(state, closeNotify)
+	rdm := NewReceiverRouterDataModelFromDataState(routerId, state, closeNotify)
 	rdm.lastSaveIndex = &state.EndIndex
 
 	return rdm, nil
@@ -873,24 +901,29 @@ func (rdm *RouterDataModel) Store(event *edge_ctrl_pb.DataState_ChangeSet, onSuc
 		return nil
 	}
 
-	if rdm.index > 0 && rdm.index >= event.Index {
-		return fmt.Errorf("out of order event detected, currentIndex: %d, receivedIndex: %d, type :%T", rdm.index, event.Index, rdm)
+	// All accesses to rdm.index go through atomic ops so that lock-free readers
+	// (CurrentIndex) observe the value written here. The lock still serializes
+	// the read-modify-write so two writers can't both pass the gap check.
+	currentIndex := atomic.LoadUint64(&rdm.index)
+
+	if currentIndex > 0 && currentIndex >= event.Index {
+		return fmt.Errorf("out of order event detected, currentIndex: %d, receivedIndex: %d, type :%T", currentIndex, event.Index, rdm)
 	}
 
 	// Gap detection via previousIndex chain.
 	// PreviousIndex == 0 means: backwards-compatible controller (didn't set it), or first event ever.
-	if event.PreviousIndex > 0 && rdm.index > 0 && event.PreviousIndex != rdm.index {
+	if event.PreviousIndex > 0 && currentIndex > 0 && event.PreviousIndex != currentIndex {
 		return &GapDetectedError{
-			CurrentIndex:  rdm.index,
+			CurrentIndex:  currentIndex,
 			PreviousIndex: event.PreviousIndex,
 			ReceivedIndex: event.Index,
 		}
 	}
 
-	rdm.index = event.Index
+	atomic.StoreUint64(&rdm.index, event.Index)
 
 	if onSuccess != nil {
-		onSuccess(rdm.index, event)
+		onSuccess(event.Index, event)
 	}
 
 	return nil
@@ -916,6 +949,55 @@ func (rdm *RouterDataModel) Handle(index uint64, event *edge_ctrl_pb.DataState_E
 		rdm.HandleRevocationEvent(event, typedModel)
 	case *edge_ctrl_pb.DataState_Event_ServicePolicyChange:
 		rdm.HandleServicePolicyChange(index, typedModel.ServicePolicyChange)
+	case *edge_ctrl_pb.DataState_Event_Router:
+		rdm.HandleRouterEvent(event, typedModel)
+	}
+}
+
+// HandleRouterEvent applies a Router create/update/delete delta to the RDM cache.
+// On the receiver side, when the event is for the local router (selfRouterId)
+// and the action is not Delete, also GC any router-target configs in
+// rdm.Configs whose IDs are no longer referenced by the new Router.Configs
+// list. This keeps the receiver's Configs map aligned with the assignment
+// without requiring the controller to send synthetic remove events.
+//
+// Why diff against the previously-cached Router rather than scanning Configs:
+// the sender (see RouterDataModelSender.FilterEventsForRouter) emits a
+// synthetic Config event for every entry in the new Router.Configs list
+// immediately before the Router event itself. So when this handler runs the
+// configs the new list references are already in rdm.Configs — the only
+// thing to GC is whatever was in the *previous* Configs list but isn't in
+// the new one. That set is the diff against the previously-cached Router,
+// no full Configs walk needed. Every entry in prev.Configs is by definition
+// a router-target config (the controller enforces target=router on Router.
+// Configs), so we don't have to re-check the ConfigType either.
+func (rdm *RouterDataModel) HandleRouterEvent(event *edge_ctrl_pb.DataState_Event, model *edge_ctrl_pb.DataState_Event_Router) {
+	if event.Action == edge_ctrl_pb.DataState_Delete {
+		rdm.Routers.Remove(model.Router.Id)
+		return
+	}
+
+	prev, _ := rdm.Routers.Get(model.Router.Id)
+	rdm.Routers.Set(model.Router.Id, model.Router)
+
+	selfId := rdm.SelfRouterId()
+	if selfId == "" || model.Router.Id != selfId || prev == nil {
+		return
+	}
+
+	keep := make(map[string]struct{}, len(model.Router.Configs))
+	for _, id := range model.Router.Configs {
+		keep[id] = struct{}{}
+	}
+
+	for _, oldId := range prev.Configs {
+		if _, retained := keep[oldId]; retained {
+			continue
+		}
+		if !rdm.Configs.Has(oldId) {
+			continue
+		}
+		rdm.Configs.Remove(oldId)
 	}
 }
 
@@ -1198,9 +1280,10 @@ func (rdm *RouterDataModel) HandleConfigTypeEvent(index uint64, event *edge_ctrl
 		rdm.ConfigTypes.Remove(model.ConfigType.Id)
 	} else {
 		rdm.ConfigTypes.Set(model.ConfigType.Id, &ConfigType{
-			Id:    model.ConfigType.Id,
-			Name:  model.ConfigType.Name,
-			index: index,
+			Id:     model.ConfigType.Id,
+			Name:   model.ConfigType.Name,
+			Target: model.ConfigType.Target,
+			index:  index,
 		})
 
 		rdm.Configs.IterCb(func(configId string, config *Config) {
@@ -1690,6 +1773,16 @@ func (rdm *RouterDataModel) getDataStateAlreadyLocked(index uint64) *edge_ctrl_p
 			Action: edge_ctrl_pb.DataState_Create,
 			Model: &edge_ctrl_pb.DataState_Event_Service{
 				Service: v.ToProtobuf(),
+			},
+		}
+		events = append(events, newEvent)
+	})
+
+	rdm.Routers.IterCb(func(key string, v *edge_ctrl_pb.DataState_Router) {
+		newEvent := &edge_ctrl_pb.DataState_Event{
+			Action: edge_ctrl_pb.DataState_Create,
+			Model: &edge_ctrl_pb.DataState_Event_Router{
+				Router: v,
 			},
 		}
 		events = append(events, newEvent)
@@ -2208,6 +2301,7 @@ func (rdm *RouterDataModel) GetEntityCounts() map[string]uint32 {
 		"configs":            uint32(rdm.Configs.Count()),
 		"identities":         uint32(rdm.Identities.Count()),
 		"Services":           uint32(rdm.Services.Count()),
+		"routers":            uint32(rdm.Routers.Count()),
 		"service-policies":   uint32(rdm.ServicePolicies.Count()),
 		"posture-checks":     uint32(rdm.PostureChecks.Count()),
 		"public-keys":        uint32(rdm.PublicKeys.Count()),
@@ -2341,7 +2435,7 @@ func (rdm *RouterDataModel) NotifyServiceOfConfigChange(serviceId string, index 
 	})
 }
 
-func (rdm *RouterDataModel) NotifyIdentityChange(identityId string, index uint64) {
+func (rdm *RouterDataModel) NotifyIdentityChange(identityId string, _ uint64) {
 	rdm.withIdentity(identityId, func(identity *Identity) {
 		identity.NotifyServiceChange(rdm)
 	})
@@ -2462,6 +2556,7 @@ func (rdm *RouterDataModel) Diff(o *RouterDataModel, sink DiffSink) {
 	diffType("config", rdm.Configs, o.Configs, sink, Config{}, DataStateConfig{})
 	diffType("identity", rdm.Identities, o.Identities, sink, Identity{}, DataStateIdentity{}, serviceAccess{})
 	diffType("service", rdm.Services, o.Services, sink, Service{}, DataStateService{})
+	diffType("router", rdm.Routers, o.Routers, sink, edge_ctrl_pb.DataState_Router{})
 	diffType("service-policy", rdm.ServicePolicies, o.ServicePolicies, sink, ServicePolicy{}, DataStateServicePolicy{})
 	diffType("posture-check", rdm.PostureChecks, o.PostureChecks, sink,
 		PostureCheck{}, DataStatePostureCheck{},
@@ -2680,6 +2775,19 @@ func (rdm *RouterDataModel) ToMap() map[string]interface{} {
 		}
 	})
 	result["services"] = services
+
+	// Export routers
+	routers := make(map[string]interface{})
+	rdm.Routers.IterCb(func(key string, v *edge_ctrl_pb.DataState_Router) {
+		routers[key] = map[string]interface{}{
+			"id":          v.Id,
+			"name":        v.Name,
+			"fingerprint": v.Fingerprint,
+			"configs":     v.Configs,
+			"disabled":    v.Disabled,
+		}
+	})
+	result["routers"] = routers
 
 	// Export service policies
 	servicePolicies := make(map[string]interface{})

--- a/common/router_data_model_sender.go
+++ b/common/router_data_model_sender.go
@@ -24,9 +24,14 @@ import (
 
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/foundation/v2/concurrenz"
+	"github.com/openziti/foundation/v2/stringz"
 	"github.com/openziti/ziti/v2/common/pb/edge_ctrl_pb"
 	cmap "github.com/orcaman/concurrent-map/v2"
 )
+
+// ConfigTypeTargetRouter is the Target value on ConfigType for router-managed configs.
+// Mirrored here to avoid a controller→common import dependency.
+const ConfigTypeTargetRouter = "router"
 
 // RouterDataModelSenderConfig contains the configuration values for a RouterDataModelSender
 type RouterDataModelSenderConfig struct {
@@ -63,6 +68,7 @@ type RouterDataModelSender struct {
 	Configs          cmap.ConcurrentMap[string, *edge_ctrl_pb.DataState_Config]       `json:"configs"`
 	Identities       cmap.ConcurrentMap[string, *SenderIdentity]                      `json:"identities"`
 	Services         cmap.ConcurrentMap[string, *edge_ctrl_pb.DataState_Service]      `json:"services"`
+	Routers          cmap.ConcurrentMap[string, *edge_ctrl_pb.DataState_Router]       `json:"routers"`
 	ServicePolicies  cmap.ConcurrentMap[string, *SenderServicePolicy]                 `json:"servicePolicies"`
 	PostureChecks    cmap.ConcurrentMap[string, *edge_ctrl_pb.DataState_PostureCheck] `json:"postureChecks"`
 	PublicKeys       cmap.ConcurrentMap[string, *edge_ctrl_pb.DataState_PublicKey]    `json:"publicKeys"`
@@ -85,6 +91,7 @@ func NewRouterDataModelSender(timelineSrc TimelineIdSource, logSize uint64, list
 		Configs:            cmap.New[*edge_ctrl_pb.DataState_Config](),
 		Identities:         cmap.New[*SenderIdentity](),
 		Services:           cmap.New[*edge_ctrl_pb.DataState_Service](),
+		Routers:            cmap.New[*edge_ctrl_pb.DataState_Router](),
 		ServicePolicies:    cmap.New[*SenderServicePolicy](),
 		PostureChecks:      cmap.New[*edge_ctrl_pb.DataState_PostureCheck](),
 		PublicKeys:         cmap.New[*edge_ctrl_pb.DataState_PublicKey](),
@@ -172,6 +179,8 @@ func (rdm *RouterDataModelSender) Handle(event *edge_ctrl_pb.DataState_Event) {
 		rdm.HandleRevocationEvent(event, typedModel)
 	case *edge_ctrl_pb.DataState_Event_ServicePolicyChange:
 		rdm.HandleServicePolicyChange(typedModel.ServicePolicyChange)
+	case *edge_ctrl_pb.DataState_Event_Router:
+		rdm.HandleRouterEvent(event, typedModel)
 	}
 }
 
@@ -233,6 +242,16 @@ func (rdm *RouterDataModelSender) HandleConfigEvent(event *edge_ctrl_pb.DataStat
 		rdm.Configs.Remove(model.Config.Id)
 	} else {
 		rdm.Configs.Set(model.Config.Id, model.Config)
+	}
+}
+
+// HandleRouterEvent applies the delta event to the router data model. It is not restricted by index calculations.
+// Generally meant for bulk loading of data during startup.
+func (rdm *RouterDataModelSender) HandleRouterEvent(event *edge_ctrl_pb.DataState_Event, model *edge_ctrl_pb.DataState_Event_Router) {
+	if event.Action == edge_ctrl_pb.DataState_Delete {
+		rdm.Routers.Remove(model.Router.Id)
+	} else {
+		rdm.Routers.Set(model.Router.Id, model.Router)
 	}
 }
 
@@ -406,6 +425,115 @@ func (rdm *RouterDataModelSender) GetDataState() *edge_ctrl_pb.DataState {
 	return result
 }
 
+// GetDataStateForRouter returns a full snapshot scoped to the given router:
+// router-target configs the router isn't associated with are filtered out.
+// All other entity types (services, identities, policies, router-entity events,
+// service-target configs, etc.) flow unchanged. Used by both the rtx full-sync
+// path and the controller-side validation handler.
+func (rdm *RouterDataModelSender) GetDataStateForRouter(routerId string) *edge_ctrl_pb.DataState {
+	state := rdm.GetDataState()
+	if state == nil {
+		return nil
+	}
+	if filtered, changed := rdm.FilterEventsForRouter(routerId, state.Events, false); changed {
+		state.Events = filtered
+	}
+	return state
+}
+
+// FilterEventsForRouter returns the events to deliver to the given router. Config
+// events whose ConfigType targets routers flow only when the router's Configs list
+// contains them; service-target configs and all other event types pass through.
+//
+// When synthesizeMissing is true (delta path) and the routerId's own Router event
+// flows, emit synthetic Config events for every config currently in the router's
+// Configs list. The receiver may not have those Config entities cached yet.
+//
+// For full-sync (synthesizeMissing = false) the snapshot already includes every
+// relevant Config event globally, so synthesis is unnecessary.
+//
+// The returned changed flag is true when the result differs from the input. When
+// false, the caller can reuse the original slice and skip rebuilding the
+// enclosing change set.
+func (rdm *RouterDataModelSender) FilterEventsForRouter(routerId string, events []*edge_ctrl_pb.DataState_Event, synthesizeMissing bool) ([]*edge_ctrl_pb.DataState_Event, bool) {
+	if len(events) == 0 {
+		return events, false
+	}
+
+	var routerConfigs map[string]struct{}
+	var configsCached bool
+	isConfigForRouter := func(configId string) bool {
+		if !configsCached {
+			if cached, ok := rdm.Routers.Get(routerId); ok {
+				routerConfigs = stringz.SliceToSet(cached.Configs)
+			}
+			configsCached = true
+		}
+		_, ok := routerConfigs[configId]
+		return ok
+	}
+
+	// Only configs whose type targets routers are filtered per-router. Service
+	// (and any other non-router-target) configs broadcast unchanged. Defensively
+	// treat a missing config-type lookup as non-router-target.
+	isRouterTargetConfig := func(typeId string) bool {
+		if t, ok := rdm.ConfigTypes.Get(typeId); ok {
+			return t.Target == ConfigTypeTargetRouter
+		}
+		return false
+	}
+
+	// Fast path: scan once to see whether any event needs filtering or synthesis.
+	needsRebuild := false
+	for _, e := range events {
+		switch m := e.Model.(type) {
+		case *edge_ctrl_pb.DataState_Event_Config:
+			if isRouterTargetConfig(m.Config.TypeId) && !isConfigForRouter(m.Config.Id) {
+				needsRebuild = true
+			}
+		case *edge_ctrl_pb.DataState_Event_Router:
+			if synthesizeMissing && m.Router.Id == routerId && e.Action != edge_ctrl_pb.DataState_Delete && len(m.Router.Configs) > 0 {
+				needsRebuild = true
+			}
+		}
+		if needsRebuild {
+			break
+		}
+	}
+
+	if !needsRebuild {
+		return events, false
+	}
+
+	out := make([]*edge_ctrl_pb.DataState_Event, 0, len(events))
+	for _, e := range events {
+		switch m := e.Model.(type) {
+		case *edge_ctrl_pb.DataState_Event_Config:
+			if !isRouterTargetConfig(m.Config.TypeId) || isConfigForRouter(m.Config.Id) {
+				out = append(out, e)
+			}
+		case *edge_ctrl_pb.DataState_Event_Router:
+			if synthesizeMissing && m.Router.Id == routerId && e.Action != edge_ctrl_pb.DataState_Delete {
+				for _, cfgId := range m.Router.Configs {
+					if cfg, ok := rdm.Configs.Get(cfgId); ok {
+						out = append(out, &edge_ctrl_pb.DataState_Event{
+							Action:      edge_ctrl_pb.DataState_Create,
+							IsSynthetic: true,
+							Model: &edge_ctrl_pb.DataState_Event_Config{
+								Config: cfg,
+							},
+						})
+					}
+				}
+			}
+			out = append(out, e)
+		default:
+			out = append(out, e)
+		}
+	}
+	return out, true
+}
+
 func (rdm *RouterDataModelSender) getDataStateAlreadyLocked(index uint64) *edge_ctrl_pb.DataState {
 	var events []*edge_ctrl_pb.DataState_Event
 
@@ -459,6 +587,16 @@ func (rdm *RouterDataModelSender) getDataStateAlreadyLocked(index uint64) *edge_
 			Action: edge_ctrl_pb.DataState_Create,
 			Model: &edge_ctrl_pb.DataState_Event_Service{
 				Service: v,
+			},
+		}
+		events = append(events, newEvent)
+	})
+
+	rdm.Routers.IterCb(func(key string, v *edge_ctrl_pb.DataState_Router) {
+		newEvent := &edge_ctrl_pb.DataState_Event{
+			Action: edge_ctrl_pb.DataState_Create,
+			Model: &edge_ctrl_pb.DataState_Event_Router{
+				Router: v,
 			},
 		}
 		events = append(events, newEvent)
@@ -568,6 +706,7 @@ func (rdm *RouterDataModelSender) GetEntityCounts() map[string]uint32 {
 		"configs":            uint32(rdm.Configs.Count()),
 		"identities":         uint32(rdm.Identities.Count()),
 		"services":           uint32(rdm.Services.Count()),
+		"routers":            uint32(rdm.Routers.Count()),
 		"service-policies":   uint32(rdm.ServicePolicies.Count()),
 		"posture-checks":     uint32(rdm.PostureChecks.Count()),
 		"public-keys":        uint32(rdm.PublicKeys.Count()),

--- a/common/router_data_model_test.go
+++ b/common/router_data_model_test.go
@@ -1,0 +1,201 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+
+	"github.com/openziti/ziti/v2/common/pb/edge_ctrl_pb"
+	"github.com/stretchr/testify/require"
+)
+
+func seedConfigType(rdm *RouterDataModel, id, target string) {
+	rdm.ConfigTypes.Set(id, &ConfigType{
+		Id:     id,
+		Name:   id,
+		Target: target,
+	})
+}
+
+func seedConfig(rdm *RouterDataModel, id, typeId string) {
+	rdm.Configs.Set(id, &Config{
+		Id:     id,
+		Name:   id,
+		TypeId: typeId,
+	})
+}
+
+func Test_HandleRouterEvent_GCsRouterTargetOrphansOnSelf(t *testing.T) {
+	req := require.New(t)
+	rdm := NewBareRouterDataModel("r1")
+
+	seedConfigType(rdm, "router-type", "router")
+	seedConfigType(rdm, "service-type", "service")
+	seedConfig(rdm, "rcfg-A", "router-type")
+	seedConfig(rdm, "rcfg-B", "router-type")
+	seedConfig(rdm, "rcfg-C", "router-type")
+	seedConfig(rdm, "scfg-1", "service-type")
+
+	// Initial association: r1 has rcfg-A and rcfg-B.
+	rdm.Routers.Set("r1", &edge_ctrl_pb.DataState_Router{
+		Id:      "r1",
+		Configs: []string{"rcfg-A", "rcfg-B"},
+	})
+
+	// Update r1 to drop rcfg-B and add rcfg-C.
+	updated := &edge_ctrl_pb.DataState_Router{
+		Id:      "r1",
+		Configs: []string{"rcfg-A", "rcfg-C"},
+	}
+	rdm.HandleRouterEvent(
+		&edge_ctrl_pb.DataState_Event{Action: edge_ctrl_pb.DataState_Update},
+		&edge_ctrl_pb.DataState_Event_Router{Router: updated},
+	)
+
+	req.Equal(1, rdm.Routers.Count())
+	// rcfg-B got GC'd; rcfg-A and rcfg-C remain.
+	req.True(rdm.Configs.Has("rcfg-A"))
+	req.False(rdm.Configs.Has("rcfg-B"), "stale router-target config should be GC'd")
+	req.True(rdm.Configs.Has("rcfg-C"))
+	// service-target config untouched.
+	req.True(rdm.Configs.Has("scfg-1"))
+}
+
+func Test_HandleRouterEvent_NoGCForOtherRouter(t *testing.T) {
+	req := require.New(t)
+	rdm := NewBareRouterDataModel("r1")
+
+	seedConfigType(rdm, "router-type", "router")
+	seedConfig(rdm, "rcfg-A", "router-type")
+	seedConfig(rdm, "rcfg-B", "router-type")
+
+	// r1 still associated with both.
+	rdm.Routers.Set("r1", &edge_ctrl_pb.DataState_Router{
+		Id:      "r1",
+		Configs: []string{"rcfg-A", "rcfg-B"},
+	})
+
+	// A different router updates with no configs. Must NOT GC anything in the
+	// receiver's view.
+	rdm.HandleRouterEvent(
+		&edge_ctrl_pb.DataState_Event{Action: edge_ctrl_pb.DataState_Update},
+		&edge_ctrl_pb.DataState_Event_Router{Router: &edge_ctrl_pb.DataState_Router{
+			Id:      "r2",
+			Configs: nil,
+		}},
+	)
+
+	req.True(rdm.Configs.Has("rcfg-A"))
+	req.True(rdm.Configs.Has("rcfg-B"))
+}
+
+func Test_HandleRouterEvent_NoGCWhenSelfNotSet(t *testing.T) {
+	req := require.New(t)
+	// Receiver-side RDM with no self ID (e.g. controller-side construction
+	// or validate-snapshot parsing). HandleRouterEvent must not GC anything.
+	rdm := NewBareRouterDataModel("")
+
+	seedConfigType(rdm, "router-type", "router")
+	seedConfig(rdm, "rcfg-A", "router-type")
+
+	rdm.HandleRouterEvent(
+		&edge_ctrl_pb.DataState_Event{Action: edge_ctrl_pb.DataState_Update},
+		&edge_ctrl_pb.DataState_Event_Router{Router: &edge_ctrl_pb.DataState_Router{
+			Id:      "r1",
+			Configs: nil,
+		}},
+	)
+
+	req.True(rdm.Configs.Has("rcfg-A"), "should not GC when selfRouterId is unset")
+}
+
+// Test_HandleRouterEvent_FirstSeenNoGC covers the case where this is the
+// first Router event we've seen for the local router. There's no
+// previously-cached Configs list to diff against, so nothing to GC; the
+// sender's synthesized Config events that came with the Router event are
+// what populate the cache.
+func Test_HandleRouterEvent_FirstSeenNoGC(t *testing.T) {
+	req := require.New(t)
+	rdm := NewBareRouterDataModel("r1")
+
+	seedConfigType(rdm, "router-type", "router")
+	seedConfig(rdm, "rcfg-A", "router-type")
+
+	// No prior rdm.Routers entry for r1.
+	rdm.HandleRouterEvent(
+		&edge_ctrl_pb.DataState_Event{Action: edge_ctrl_pb.DataState_Update},
+		&edge_ctrl_pb.DataState_Event_Router{Router: &edge_ctrl_pb.DataState_Router{
+			Id:      "r1",
+			Configs: []string{"rcfg-A"},
+		}},
+	)
+
+	req.True(rdm.Configs.Has("rcfg-A"), "newly-assigned config should remain")
+	req.Equal(1, rdm.Routers.Count())
+}
+
+func Test_HandleRouterEvent_GCEmptyConfigs(t *testing.T) {
+	req := require.New(t)
+	rdm := NewBareRouterDataModel("r1")
+
+	seedConfigType(rdm, "router-type", "router")
+	seedConfigType(rdm, "service-type", "service")
+	seedConfig(rdm, "rcfg-A", "router-type")
+	seedConfig(rdm, "rcfg-B", "router-type")
+	seedConfig(rdm, "scfg-1", "service-type")
+
+	rdm.Routers.Set("r1", &edge_ctrl_pb.DataState_Router{
+		Id:      "r1",
+		Configs: []string{"rcfg-A", "rcfg-B"},
+	})
+
+	// Disassociate everything.
+	rdm.HandleRouterEvent(
+		&edge_ctrl_pb.DataState_Event{Action: edge_ctrl_pb.DataState_Update},
+		&edge_ctrl_pb.DataState_Event_Router{Router: &edge_ctrl_pb.DataState_Router{
+			Id:      "r1",
+			Configs: nil,
+		}},
+	)
+
+	req.False(rdm.Configs.Has("rcfg-A"))
+	req.False(rdm.Configs.Has("rcfg-B"))
+	req.True(rdm.Configs.Has("scfg-1"), "service configs untouched")
+}
+
+func Test_HandleRouterEvent_DeleteSelf(t *testing.T) {
+	req := require.New(t)
+	rdm := NewBareRouterDataModel("r1")
+
+	seedConfigType(rdm, "router-type", "router")
+	seedConfig(rdm, "rcfg-A", "router-type")
+
+	rdm.Routers.Set("r1", &edge_ctrl_pb.DataState_Router{
+		Id:      "r1",
+		Configs: []string{"rcfg-A"},
+	})
+
+	// Delete event for self: only Router entity is removed; configs stay (they
+	// would be cleaned up via subsequent ConfigDelete events).
+	rdm.HandleRouterEvent(
+		&edge_ctrl_pb.DataState_Event{Action: edge_ctrl_pb.DataState_Delete},
+		&edge_ctrl_pb.DataState_Event_Router{Router: &edge_ctrl_pb.DataState_Router{Id: "r1"}},
+	)
+
+	req.False(rdm.Routers.Has("r1"))
+	req.True(rdm.Configs.Has("rcfg-A"))
+}

--- a/common/subscriber_test.go
+++ b/common/subscriber_test.go
@@ -219,7 +219,7 @@ func (self *subscriberTest) initializeRouterDataModel() {
 
 func TestSubscriberCorrectness(t *testing.T) {
 	closeNotify := make(chan struct{})
-	rdm := NewReceiverRouterDataModel(closeNotify)
+	rdm := NewReceiverRouterDataModel("test-router", closeNotify)
 
 	options := agent.Options{
 		AppId:      "subscriber-test",
@@ -314,7 +314,7 @@ func TestSubscriberCorrectness(t *testing.T) {
 
 func TestSubscriberScale(t *testing.T) {
 	closeNotify := make(chan struct{})
-	rdm := NewReceiverRouterDataModel(closeNotify)
+	rdm := NewReceiverRouterDataModel("test-router", closeNotify)
 
 	options := agent.Options{
 		AppId:      "subscriber-test",

--- a/controller/handler_mgmt/validate_router_data_model.go
+++ b/controller/handler_mgmt/validate_router_data_model.go
@@ -132,13 +132,13 @@ func (handler *validateRouterDataModelHandler) ValidateRouterDataModel(req *mgmt
 			}()
 		}
 
-		var dataState *edge_ctrl_pb.DataState
 		for _, router := range result.Entities {
 			connectedRouter := handler.appEnv.GetHostController().GetNetwork().GetConnectedRouter(router.Id)
 			if connectedRouter != nil {
-				if dataState == nil {
-					dataState = handler.appEnv.Broker.GetRouterDataModel().GetDataState()
-				}
+				// Each router gets a per-router-filtered snapshot: router-target
+				// configs not associated with this router are excluded, matching
+				// what the rtx filter delivers in normal operation.
+				dataState := handler.appEnv.Broker.GetRouterDataModel().GetDataStateForRouter(router.Id)
 				sem.Acquire()
 				go func() {
 					defer sem.Release()

--- a/controller/sync_strats/rtx.go
+++ b/controller/sync_strats/rtx.go
@@ -231,8 +231,27 @@ func (rtx *RouterSender) handleModelChange() {
 		}
 
 		for _, curEvent := range events {
+			// Always forward the change set, even when the filter removes every
+			// entry. Sending an empty change set advances the receiver's index
+			// without altering any entities, which keeps the PreviousIndex chain
+			// intact without per-router bookkeeping. The alternative (skipping
+			// filter-empty change sets and rewriting PreviousIndex on the next
+			// non-empty one) is racy under subscription churn and produced gap
+			// detection storms.
+			toSend := curEvent
+			filtered, changed := rtx.filterEventsForRouter(curEvent.Changes, true)
+			if changed {
+				toSend = &edge_ctrl_pb.DataState_ChangeSet{
+					Index:         curEvent.Index,
+					PreviousIndex: curEvent.PreviousIndex,
+					IsSynthetic:   curEvent.IsSynthetic,
+					TimestampId:   curEvent.TimestampId,
+					Changes:       filtered,
+				}
+			}
+
 			var msg *channel.Message
-			if msg, err = rtx.marshal(curEvent); err == nil {
+			if msg, err = rtx.marshal(toSend); err == nil {
 				err = rtx.Router.Control.GetDefaultSender().Send(msg)
 			}
 
@@ -267,8 +286,8 @@ func (rtx *RouterSender) handleModelChange() {
 	}
 
 	if fullSync {
-		//full sync
-		dataState := rtx.routerDataModel.GetDataState()
+		//full sync — already filtered per-router (router-target configs only)
+		dataState := rtx.routerDataModel.GetDataStateForRouter(rtx.Router.Id)
 
 		if dataState == nil {
 			return
@@ -287,6 +306,12 @@ func (rtx *RouterSender) handleModelChange() {
 			logger.Infof("router synced data model to index %d with on timeline: %s", rtx.currentIndex, rtx.timelineId)
 		}
 	}
+}
+
+// filterEventsForRouter delegates to the shared RouterDataModelSender filter.
+// See RouterDataModelSender.FilterEventsForRouter for behavior.
+func (rtx *RouterSender) filterEventsForRouter(events []*edge_ctrl_pb.DataState_Event, synthesizeMissing bool) ([]*edge_ctrl_pb.DataState_Event, bool) {
+	return rtx.routerDataModel.FilterEventsForRouter(rtx.Router.Id, events, synthesizeMissing)
 }
 
 func (rtx *RouterSender) marshal(message protobufs.TypedMessage) (*channel.Message, error) {

--- a/controller/sync_strats/rtx_test.go
+++ b/controller/sync_strats/rtx_test.go
@@ -1,0 +1,339 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package sync_strats
+
+import (
+	"testing"
+
+	"github.com/openziti/ziti/v2/common"
+	"github.com/openziti/ziti/v2/common/pb/edge_ctrl_pb"
+	"github.com/openziti/ziti/v2/controller/model"
+	"github.com/openziti/ziti/v2/controller/models"
+	"github.com/stretchr/testify/require"
+)
+
+type stubTimelineSource string
+
+func (s stubTimelineSource) TimelineId() string { return string(s) }
+
+const (
+	testRouterTargetTypeId  = "router-target.test"
+	testServiceTargetTypeId = "service-target.test"
+)
+
+func newTestRtx(routerId string, routerConfigs []string, rdmConfigs map[string]*edge_ctrl_pb.DataState_Config) *RouterSender {
+	rdm := common.NewRouterDataModelSender(stubTimelineSource("test-timeline"), 16, 1)
+	rdm.ConfigTypes.Set(testRouterTargetTypeId, &edge_ctrl_pb.DataState_ConfigType{
+		Id:     testRouterTargetTypeId,
+		Name:   testRouterTargetTypeId,
+		Target: common.ConfigTypeTargetRouter,
+	})
+	rdm.ConfigTypes.Set(testServiceTargetTypeId, &edge_ctrl_pb.DataState_ConfigType{
+		Id:     testServiceTargetTypeId,
+		Name:   testServiceTargetTypeId,
+		Target: "service",
+	})
+	for id, cfg := range rdmConfigs {
+		// default un-typed test configs to the router-target type, so existing
+		// tests still exercise the filter path
+		if cfg.TypeId == "" {
+			cfg.TypeId = testRouterTargetTypeId
+		}
+		rdm.Configs.Set(id, cfg)
+	}
+	rdm.Routers.Set(routerId, &edge_ctrl_pb.DataState_Router{
+		Id:      routerId,
+		Configs: routerConfigs,
+	})
+	return &RouterSender{
+		Router: &model.Router{
+			BaseEntity: models.BaseEntity{Id: routerId},
+			Configs:    routerConfigs,
+		},
+		routerDataModel: rdm,
+	}
+}
+
+func cfgEvent(id string) *edge_ctrl_pb.DataState_Event {
+	return &edge_ctrl_pb.DataState_Event{
+		Action: edge_ctrl_pb.DataState_Create,
+		Model: &edge_ctrl_pb.DataState_Event_Config{
+			Config: &edge_ctrl_pb.DataState_Config{Id: id, Name: id, TypeId: testRouterTargetTypeId},
+		},
+	}
+}
+
+func serviceCfgEvent(id string) *edge_ctrl_pb.DataState_Event {
+	return &edge_ctrl_pb.DataState_Event{
+		Action: edge_ctrl_pb.DataState_Create,
+		Model: &edge_ctrl_pb.DataState_Event_Config{
+			Config: &edge_ctrl_pb.DataState_Config{Id: id, Name: id, TypeId: testServiceTargetTypeId},
+		},
+	}
+}
+
+func routerEvent(id string, configs []string, action edge_ctrl_pb.DataState_Action) *edge_ctrl_pb.DataState_Event {
+	return &edge_ctrl_pb.DataState_Event{
+		Action: action,
+		Model: &edge_ctrl_pb.DataState_Event_Router{
+			Router: &edge_ctrl_pb.DataState_Router{Id: id, Configs: configs},
+		},
+	}
+}
+
+func serviceEvent(id string) *edge_ctrl_pb.DataState_Event {
+	return &edge_ctrl_pb.DataState_Event{
+		Action: edge_ctrl_pb.DataState_Create,
+		Model: &edge_ctrl_pb.DataState_Event_Service{
+			Service: &edge_ctrl_pb.DataState_Service{Id: id},
+		},
+	}
+}
+
+func Test_filterEventsForRouter_dropsUnrelatedConfigs(t *testing.T) {
+	req := require.New(t)
+	rtx := newTestRtx("r1", []string{"cfg-A"}, map[string]*edge_ctrl_pb.DataState_Config{
+		"cfg-A": {Id: "cfg-A"},
+		"cfg-B": {Id: "cfg-B"},
+	})
+
+	in := []*edge_ctrl_pb.DataState_Event{
+		cfgEvent("cfg-A"),
+		cfgEvent("cfg-B"),
+		serviceEvent("svc-1"),
+	}
+	out, changed := rtx.filterEventsForRouter(in, true)
+
+	req.True(changed)
+	req.Len(out, 2)
+	req.Equal("cfg-A", out[0].Model.(*edge_ctrl_pb.DataState_Event_Config).Config.Id)
+	req.Equal("svc-1", out[1].Model.(*edge_ctrl_pb.DataState_Event_Service).Service.Id)
+}
+
+func Test_filterEventsForRouter_passesNonConfigEvents(t *testing.T) {
+	req := require.New(t)
+	rtx := newTestRtx("r1", nil, nil)
+
+	in := []*edge_ctrl_pb.DataState_Event{
+		serviceEvent("svc-1"),
+		{
+			Action: edge_ctrl_pb.DataState_Create,
+			Model: &edge_ctrl_pb.DataState_Event_Identity{
+				Identity: &edge_ctrl_pb.DataState_Identity{Id: "i1"},
+			},
+		},
+	}
+	out, changed := rtx.filterEventsForRouter(in, true)
+
+	req.False(changed, "expected pass-through to leave events untouched")
+	req.Same(&in[0], &out[0], "expected the same backing slice when no changes")
+	req.Len(out, 2)
+}
+
+func Test_filterEventsForRouter_unchangedWhenAllConfigsBelongToRouter(t *testing.T) {
+	req := require.New(t)
+	rtx := newTestRtx("r1", []string{"cfg-A", "cfg-B"}, map[string]*edge_ctrl_pb.DataState_Config{
+		"cfg-A": {Id: "cfg-A"},
+		"cfg-B": {Id: "cfg-B"},
+	})
+
+	in := []*edge_ctrl_pb.DataState_Event{
+		cfgEvent("cfg-A"),
+		cfgEvent("cfg-B"),
+		serviceEvent("svc-1"),
+	}
+	out, changed := rtx.filterEventsForRouter(in, true)
+
+	req.False(changed)
+	req.Same(&in[0], &out[0])
+	req.Len(out, 3)
+}
+
+func Test_filterEventsForRouter_synthesizesConfigsForSelfRouterUpdate(t *testing.T) {
+	req := require.New(t)
+	rtx := newTestRtx("r1", []string{"cfg-A", "cfg-B"}, map[string]*edge_ctrl_pb.DataState_Config{
+		"cfg-A": {Id: "cfg-A", Name: "A"},
+		"cfg-B": {Id: "cfg-B", Name: "B"},
+	})
+
+	out, changed := rtx.filterEventsForRouter([]*edge_ctrl_pb.DataState_Event{
+		routerEvent("r1", []string{"cfg-A", "cfg-B"}, edge_ctrl_pb.DataState_Update),
+	}, true)
+
+	req.True(changed)
+	// Two synthetic Config Create events, then the original Router event.
+	req.Len(out, 3)
+
+	cfgA, ok := out[0].Model.(*edge_ctrl_pb.DataState_Event_Config)
+	req.True(ok)
+	req.Equal("cfg-A", cfgA.Config.Id)
+	req.True(out[0].IsSynthetic)
+
+	cfgB, ok := out[1].Model.(*edge_ctrl_pb.DataState_Event_Config)
+	req.True(ok)
+	req.Equal("cfg-B", cfgB.Config.Id)
+	req.True(out[1].IsSynthetic)
+
+	_, ok = out[2].Model.(*edge_ctrl_pb.DataState_Event_Router)
+	req.True(ok)
+}
+
+func Test_filterEventsForRouter_otherRouterEventDoesNotSynthesize(t *testing.T) {
+	req := require.New(t)
+	rtx := newTestRtx("r1", []string{"cfg-A"}, map[string]*edge_ctrl_pb.DataState_Config{
+		"cfg-A": {Id: "cfg-A"},
+		"cfg-X": {Id: "cfg-X"},
+	})
+
+	out, changed := rtx.filterEventsForRouter([]*edge_ctrl_pb.DataState_Event{
+		routerEvent("r2", []string{"cfg-X"}, edge_ctrl_pb.DataState_Update),
+	}, true)
+
+	req.False(changed)
+	req.Len(out, 1)
+	_, ok := out[0].Model.(*edge_ctrl_pb.DataState_Event_Router)
+	req.True(ok)
+}
+
+func Test_filterEventsForRouter_fullSyncDoesNotSynthesize(t *testing.T) {
+	req := require.New(t)
+	rtx := newTestRtx("r1", []string{"cfg-A"}, map[string]*edge_ctrl_pb.DataState_Config{
+		"cfg-A": {Id: "cfg-A"},
+	})
+
+	out, changed := rtx.filterEventsForRouter([]*edge_ctrl_pb.DataState_Event{
+		routerEvent("r1", []string{"cfg-A"}, edge_ctrl_pb.DataState_Update),
+	}, false)
+
+	req.False(changed)
+	req.Len(out, 1)
+	_, ok := out[0].Model.(*edge_ctrl_pb.DataState_Event_Router)
+	req.True(ok)
+}
+
+func Test_filterEventsForRouter_selfRouterDeleteDoesNotSynthesize(t *testing.T) {
+	req := require.New(t)
+	rtx := newTestRtx("r1", []string{"cfg-A"}, map[string]*edge_ctrl_pb.DataState_Config{
+		"cfg-A": {Id: "cfg-A"},
+	})
+
+	out, changed := rtx.filterEventsForRouter([]*edge_ctrl_pb.DataState_Event{
+		routerEvent("r1", []string{"cfg-A"}, edge_ctrl_pb.DataState_Delete),
+	}, true)
+
+	req.False(changed)
+	req.Len(out, 1)
+	_, ok := out[0].Model.(*edge_ctrl_pb.DataState_Event_Router)
+	req.True(ok)
+}
+
+func Test_filterEventsForRouter_passesServiceTargetConfigs(t *testing.T) {
+	req := require.New(t)
+	// Router R1 has no router-target configs at all. A service-target config
+	// (any target other than "router") must still flow.
+	rtx := newTestRtx("r1", nil, nil)
+	in := []*edge_ctrl_pb.DataState_Event{
+		serviceCfgEvent("svc-cfg-A"),
+		serviceCfgEvent("svc-cfg-B"),
+	}
+	out, changed := rtx.filterEventsForRouter(in, true)
+
+	req.False(changed, "service-target configs should pass through unchanged")
+	req.Same(&in[0], &out[0])
+	req.Len(out, 2)
+}
+
+func Test_filterEventsForRouter_filtersOnlyRouterTargetConfigs(t *testing.T) {
+	req := require.New(t)
+	// Router R1 has router-target cfg-A. Service-target cfg-S1 always flows;
+	// router-target cfg-B is dropped because it isn't in R1's list.
+	rtx := newTestRtx("r1", []string{"cfg-A"}, map[string]*edge_ctrl_pb.DataState_Config{
+		"cfg-A": {Id: "cfg-A"},
+		"cfg-B": {Id: "cfg-B"},
+	})
+
+	out, changed := rtx.filterEventsForRouter([]*edge_ctrl_pb.DataState_Event{
+		cfgEvent("cfg-A"),
+		cfgEvent("cfg-B"),
+		serviceCfgEvent("svc-cfg-1"),
+	}, true)
+
+	req.True(changed)
+	req.Len(out, 2)
+	req.Equal("cfg-A", out[0].Model.(*edge_ctrl_pb.DataState_Event_Config).Config.Id)
+	req.Equal("svc-cfg-1", out[1].Model.(*edge_ctrl_pb.DataState_Event_Config).Config.Id)
+}
+
+func Test_filterEventsForRouter_unknownTypePassesThrough(t *testing.T) {
+	req := require.New(t)
+	// Defensive: a Config event whose type can't be resolved from the RDM cache
+	// must NOT be silently dropped. It flows through (treated as non-router-target).
+	rtx := newTestRtx("r1", nil, nil)
+	in := []*edge_ctrl_pb.DataState_Event{
+		{
+			Action: edge_ctrl_pb.DataState_Create,
+			Model: &edge_ctrl_pb.DataState_Event_Config{
+				Config: &edge_ctrl_pb.DataState_Config{Id: "cfg-X", TypeId: "unknown-type"},
+			},
+		},
+	}
+	out, changed := rtx.filterEventsForRouter(in, true)
+
+	req.False(changed)
+	req.Len(out, 1)
+}
+
+func Test_filterEventsForRouter_dropsAllConfigsWhenRouterNotInRdmCache(t *testing.T) {
+	req := require.New(t)
+	// Router not yet in RDM cache (e.g. brand-new connect, BuildRouters hasn't run).
+	// All Config events should be filtered out; non-Config events still flow.
+	rtx := newTestRtx("r1", nil, map[string]*edge_ctrl_pb.DataState_Config{
+		"cfg-A": {Id: "cfg-A"},
+	})
+	rtx.routerDataModel.Routers.Remove("r1")
+
+	out, changed := rtx.filterEventsForRouter([]*edge_ctrl_pb.DataState_Event{
+		cfgEvent("cfg-A"),
+		serviceEvent("svc-1"),
+	}, true)
+
+	req.True(changed)
+	req.Len(out, 1)
+	_, ok := out[0].Model.(*edge_ctrl_pb.DataState_Event_Service)
+	req.True(ok)
+}
+
+func Test_filterEventsForRouter_skipsSynthesisForUnknownConfig(t *testing.T) {
+	req := require.New(t)
+	// router R has [cfg-A, cfg-missing], but cfg-missing isn't in the RDM cache yet.
+	rtx := newTestRtx("r1", []string{"cfg-A", "cfg-missing"}, map[string]*edge_ctrl_pb.DataState_Config{
+		"cfg-A": {Id: "cfg-A"},
+	})
+
+	out, changed := rtx.filterEventsForRouter([]*edge_ctrl_pb.DataState_Event{
+		routerEvent("r1", []string{"cfg-A", "cfg-missing"}, edge_ctrl_pb.DataState_Update),
+	}, true)
+
+	req.True(changed)
+	// Only the Config for cfg-A is synthesized; the original Router event still flows.
+	req.Len(out, 2)
+	cfgA, ok := out[0].Model.(*edge_ctrl_pb.DataState_Event_Config)
+	req.True(ok)
+	req.Equal("cfg-A", cfgA.Config.Id)
+	_, ok = out[1].Model.(*edge_ctrl_pb.DataState_Event_Router)
+	req.True(ok)
+}

--- a/controller/sync_strats/sync_instant.go
+++ b/controller/sync_strats/sync_instant.go
@@ -214,6 +214,18 @@ func (strategy *InstantStrategy) Initialize(logSize uint64, bufferSize uint) err
 	}
 	strategy.ae.GetStores().Service.AddEntityConstraint(serviceHandler)
 
+	// router create/delete/update. Subscribed on the base Router store so we catch
+	// changes regardless of whether the operator went through the edge-router,
+	// transit-router, or fabric-router API surface; child stores delegate persistence
+	// to the parent store and trigger its constraints.
+	routerHandler := &constraintToIndexedEvents[*db.Router]{
+		indexProvider: strategy.indexProvider,
+		createHandler: strategy.RouterCreate,
+		updateHandler: strategy.RouterUpdate,
+		deleteHandler: strategy.RouterDelete,
+	}
+	strategy.ae.GetStores().Router.AddEntityConstraint(routerHandler)
+
 	//ca create/delete/update
 	caHandler := &constraintToIndexedEvents[*db.Ca]{
 		indexProvider: strategy.indexProvider,
@@ -1002,6 +1014,10 @@ func (strategy *InstantStrategy) BuildAll(rdm *common.RouterDataModelSender) err
 			return err
 		}
 
+		if err := strategy.BuildRouters(index, tx, rdm); err != nil {
+			return err
+		}
+
 		if err := strategy.BuildServicePolicies(tx, rdm); err != nil {
 			return err
 		}
@@ -1101,6 +1117,22 @@ func (strategy *InstantStrategy) ValidateServices(tx *bbolt.Tx, rdm *common.Rout
 		// TEMPORARY(fabric-edge-collapse): the skip predicate keeps fabric-only services out of RDM
 		// validation; remove with the fabric/edge split.
 	}, func(t *db.Service) bool { return t.IsFabricOnly })
+}
+
+// ValidateRouters compares the controller's Router store against the routers cached in the RDM.
+func (strategy *InstantStrategy) ValidateRouters(tx *bbolt.Tx, rdm *common.RouterDataModelSender) []error {
+	return ValidateType(tx, strategy.ae.GetStores().Router, rdm.Routers, func(t *db.Router, v *edge_ctrl_pb.DataState_Router) []error {
+		var result []error
+		result = diffVals("router", t.Id, "name", t.Name, v.Name, result)
+		fingerprint := ""
+		if t.Fingerprint != nil {
+			fingerprint = *t.Fingerprint
+		}
+		result = diffVals("router", t.Id, "fingerprint", fingerprint, v.Fingerprint, result)
+		result = diffVals("router", t.Id, "disabled", t.Disabled, v.Disabled, result)
+		result = diffJson("router", t.Id, "configs", t.Configs, v.Configs, result)
+		return result
+	})
 }
 
 func (strategy *InstantStrategy) ValidatePostureChecks(tx *bbolt.Tx, rdm *common.RouterDataModelSender) []error {
@@ -1265,7 +1297,7 @@ func diffSets(entityType, id, field string, a, b map[string]struct{}, result []e
 // ValidateType compares each entity in the store against the router data model map m. Entities for
 // which any skip predicate returns true are ignored entirely: they are not validated and not
 // reported as missing, which is how fabric-only services (never sent to routers) are excluded.
-func ValidateType[T boltz.ExtEntity, V any](tx *bbolt.Tx, store db.Store[T], m cmap.ConcurrentMap[string, V], checkF func(T, V) []error, skip ...func(T) bool) []error {
+func ValidateType[T boltz.ExtEntity, V any](tx *bbolt.Tx, store boltz.EntityStore[T], m cmap.ConcurrentMap[string, V], checkF func(T, V) []error, skip ...func(T) bool) []error {
 	var result []error
 	entities := common.CloneMap(m)
 	for cursor := store.IterateIds(tx, ast.BoolNodeTrue); cursor.IsValid(); cursor.Next() {
@@ -1345,6 +1377,27 @@ func (strategy *InstantStrategy) BuildIdentities(index uint64, tx *bbolt.Tx, rdm
 		rdm.HandleIdentityEvent(newEvent, newModel)
 	}
 
+	return nil
+}
+
+// BuildRouters loads every router from the DB and dispatches a Create event for each into the RDM.
+// Called during initial RDM population on controller startup.
+func (strategy *InstantStrategy) BuildRouters(index uint64, tx *bbolt.Tx, rdm *common.RouterDataModelSender) error {
+	for cursor := strategy.ae.GetStores().Router.IterateIds(tx, ast.BoolNodeTrue); cursor.IsValid(); cursor.Next() {
+		currentId := string(cursor.Current())
+
+		router, err := newRouterById(tx, strategy.ae, currentId)
+		if err != nil {
+			return err
+		}
+
+		newModel := &edge_ctrl_pb.DataState_Event_Router{Router: router}
+		newEvent := &edge_ctrl_pb.DataState_Event{
+			Action: edge_ctrl_pb.DataState_Create,
+			Model:  newModel,
+		}
+		rdm.HandleRouterEvent(newEvent, newModel)
+	}
 	return nil
 }
 
@@ -1428,6 +1481,10 @@ func (strategy *InstantStrategy) ValidateAll(rdm *common.RouterDataModelSender) 
 		}
 
 		if errs := strategy.ValidateServicePolicies(tx, rdm); len(errs) != 0 {
+			result = append(result, errs...)
+		}
+
+		if errs := strategy.ValidateRouters(tx, rdm); len(errs) != 0 {
 			result = append(result, errs...)
 		}
 
@@ -1562,6 +1619,30 @@ func newService(storeModel *db.Service) *edge_ctrl_pb.DataState_Service {
 		Name:               storeModel.Name,
 		EncryptionRequired: storeModel.EncryptionRequired,
 		Configs:            storeModel.Configs,
+	}
+}
+
+func newRouterById(tx *bbolt.Tx, ae *env.AppEnv, id string) (*edge_ctrl_pb.DataState_Router, error) {
+	storeModel, err := ae.GetStores().Router.LoadById(tx, id)
+	if err != nil {
+		return nil, err
+	}
+	return newRouter(storeModel), nil
+}
+
+// newRouter projects a db.Router into the protobuf DataState_Router shape that flows through the RDM.
+// Fingerprint is flattened from *string to "" for un-enrolled routers.
+func newRouter(r *db.Router) *edge_ctrl_pb.DataState_Router {
+	fingerprint := ""
+	if r.Fingerprint != nil {
+		fingerprint = *r.Fingerprint
+	}
+	return &edge_ctrl_pb.DataState_Router{
+		Id:          r.Id,
+		Name:        r.Name,
+		Fingerprint: fingerprint,
+		Configs:     r.Configs,
+		Disabled:    r.Disabled,
 	}
 }
 
@@ -1744,6 +1825,21 @@ func (strategy *InstantStrategy) ServiceDelete(index uint64, service *db.Service
 	strategy.handleService(index, edge_ctrl_pb.DataState_Delete, service)
 }
 
+// RouterCreate emits a Create router event into the RDM change set.
+func (strategy *InstantStrategy) RouterCreate(index uint64, router *db.Router) {
+	strategy.handleRouter(index, edge_ctrl_pb.DataState_Create, router)
+}
+
+// RouterUpdate emits an Update router event into the RDM change set.
+func (strategy *InstantStrategy) RouterUpdate(index uint64, router *db.Router) {
+	strategy.handleRouter(index, edge_ctrl_pb.DataState_Update, router)
+}
+
+// RouterDelete emits a Delete router event into the RDM change set.
+func (strategy *InstantStrategy) RouterDelete(index uint64, router *db.Router) {
+	strategy.handleRouter(index, edge_ctrl_pb.DataState_Delete, router)
+}
+
 func (strategy *InstantStrategy) handleConfigType(index uint64, action edge_ctrl_pb.DataState_Action, entity *db.ConfigType) {
 	configType := newConfigType(entity)
 
@@ -1784,6 +1880,15 @@ func (strategy *InstantStrategy) handleService(index uint64, action edge_ctrl_pb
 		Action: action,
 		Model: &edge_ctrl_pb.DataState_Event_Service{
 			Service: svc,
+		},
+	})
+}
+
+func (strategy *InstantStrategy) handleRouter(index uint64, action edge_ctrl_pb.DataState_Action, router *db.Router) {
+	strategy.addToChangeSet(index, &edge_ctrl_pb.DataState_Event{
+		Action: action,
+		Model: &edge_ctrl_pb.DataState_Event_Router{
+			Router: newRouter(router),
 		},
 	})
 }

--- a/doc/design/ctrl-managed-router-config.md
+++ b/doc/design/ctrl-managed-router-config.md
@@ -247,20 +247,24 @@ There are two distinct triggers that cause a `Config` event to flow to a router:
 
 1. **A router's `Configs` list changes.** When an operator associates or disassociates a config:
    - Emit the `Router` event with the new `Configs` IDs.
-   - For any IDs newly added to that router's list, also emit the full `Config` entity to that
-     router (it may not have it yet).
-   - For any IDs newly removed from that router's list, do nothing extra. The receiving router
-     reads its own `Router` entity in the RDM, sees the config is no longer in its list, and stops
-     applying it. The orphaned `Config` entity stays cached on the receiver until the next full
-     sync prunes it. Skipping the explicit-remove event keeps the protocol simpler at the cost of
-     a small amount of dead weight in the receiver's cache, which we consider acceptable.
+   - Whenever that router's own `Router` event flows (on any create or update, not just the initial
+     association), also emit the full `Config` entity for *every* config currently in its `Configs`
+     list. These are sent as synthetic `Config` `Create` events; the receiver caches and dedupes, so
+     re-sending the whole list is simpler than tracking which IDs are newly added and costs nothing
+     the receiver can't absorb. (Full syncs skip this synthesis: the snapshot already carries every
+     relevant `Config` globally.)
+   - For any IDs newly removed from that router's list, do nothing extra on the wire. When the
+     receiving router processes the updated `Router` event for itself, it GCs router-target
+     `Config` entries that are no longer in its `Configs` list. Service-target configs are
+     untouched. This keeps the receiver's view aligned with its assignment without sending
+     synthetic remove events.
 
 2. **A config's data changes.** When an operator PATCHes a config:
    - Emit the `Config` event to every router currently referencing it. The router entity didn't
      change at all here.
 
-Router entities themselves (id, name, fingerprint, cost) are distributed to all routers, so every
-router can validate link peers.
+Router entities themselves (id, name, fingerprint, configs, disabled) are distributed to all
+routers, so every router can validate link peers.
 
 On reconnect, the router sends its current RDM index up. If the controller's event cache can
 replay forward from there, it streams the deltas (with the same per-router config filtering
@@ -269,15 +273,19 @@ the controller fall back to a full filtered snapshot.
 
 The shared event cache contains all events, but each router only sees a subset. The index sequence
 will have gaps from the router's perspective, but this is already the case today: not every raft
-update produces an RDM event, so routers already tolerate index gaps. We may need to move some of
-the gap-handling logic into the `RouterSender` so it can track the previous index per router and
-set it correctly on filtered change sets, rather than relying on the receiver to reconcile.
+update produces an RDM event, so routers already tolerate index gaps. The `RouterSender` keeps the
+`PreviousIndex` chain intact by forwarding every change set, even when per-router filtering removes
+every entry: an empty change set advances the receiver's index without touching any entities, so no
+per-router index bookkeeping is needed. The alternative considered here, having the sender track the
+previous index per router and rewrite it on filtered change sets, proved racy under subscription
+churn and produced gap-detection storms, so it was not adopted.
 
-Orphaned `Config` entities — those that the receiver still has cached after a router-side
-disassociation — get pruned on the (rare) full-sync path. Between full syncs, they sit in the
-RDM cache as dead weight. We've judged that acceptable: the router doesn't apply them (it derives
-its applied set from its own `Router.Configs` list), and they cost a small amount of memory until
-the next full sync.
+Orphan handling: the receiver GCs router-target Configs synchronously when its own `Router`
+event arrives with a shrunk list, so orphans don't accumulate between full syncs. Service-target
+configs broadcast and are kept by every receiver. The earlier "leave orphans cached, prune on
+full sync" framing was simpler on the wire (no synthetic events) but left the receiver's view
+out of sync with assignment in a way that broke validation; the in-place GC retains the
+no-synthetic-events property while keeping the cache aligned.
 
 ## Applying Configuration on the Router
 

--- a/router/state/dataState.go
+++ b/router/state/dataState.go
@@ -78,7 +78,11 @@ func (self *DataStateHandler) HandleReceive(msg *channel.Message, ch channel.Cha
 			WithField("identityToPolicyAssociations", identityToPolicyCount).
 			Info("received full router data model state")
 
-		model := common.NewReceiverRouterDataModelFromDataState(newState, self.state.GetEnv().GetCloseNotify())
+		routerId := ""
+		if id := self.state.GetEnv().GetRouterId(); id != nil {
+			routerId = id.Token
+		}
+		model := common.NewReceiverRouterDataModelFromDataState(routerId, newState, self.state.GetEnv().GetCloseNotify())
 		self.state.SetRouterDataModel(model, false)
 
 		logger.WithField("index", newState.EndIndex).Info("finished processing full router data model state")

--- a/router/state/manager.go
+++ b/router/state/manager.go
@@ -533,6 +533,14 @@ type ManagerImpl struct {
 	connectionTracker ConnectionTracker
 }
 
+// routerId returns the local router's token, or "" if the env doesn't yet know one.
+func (self *ManagerImpl) routerId() string {
+	if id := self.env.GetRouterId(); id != nil {
+		return id.Token
+	}
+	return ""
+}
+
 func (self *ManagerImpl) ParseTotpToken(jwtStr string) (*common.TotpClaims, error) {
 	totpClaims := &common.TotpClaims{}
 	token, err := jwt.ParseWithClaims(jwtStr, totpClaims, self.pubKeyLookup)
@@ -808,7 +816,7 @@ func (self *ManagerImpl) StartRouterModelSave(filePath string, duration time.Dur
 // LoadRouterModel initializes the router data model from a saved file,
 // falling back to an empty model if the file doesn't exist.
 func (self *ManagerImpl) LoadRouterModel(filePath string) {
-	model, err := common.NewReceiverRouterDataModelFromFile(filePath, self.env.GetCloseNotify())
+	model, err := common.NewReceiverRouterDataModelFromFile(self.routerId(), filePath, self.env.GetCloseNotify())
 
 	if err != nil {
 		if !os.IsNotExist(err) {
@@ -816,7 +824,7 @@ func (self *ManagerImpl) LoadRouterModel(filePath string) {
 		} else {
 			pfxlog.Logger().Infof("router data model file does not exist [%s]", filePath)
 		}
-		model = common.NewReceiverRouterDataModel(self.env.GetCloseNotify())
+		model = common.NewReceiverRouterDataModel(self.routerId(), self.env.GetCloseNotify())
 	} else {
 		index := model.CurrentIndex()
 		pfxlog.Logger().WithField("path", filePath).WithField("index", index).Info("loaded router model from file")

--- a/router/state/validate.go
+++ b/router/state/validate.go
@@ -37,7 +37,10 @@ func (self *ValidateDataStateRequestHandler) HandleReceive(msg *channel.Message,
 	}
 
 	newState := request.State
-	model := common.NewBareRouterDataModel()
+	// The "model" here represents the controller's expected state (decoded from
+	// the validate request), not the local receiver's state. selfRouterId is
+	// irrelevant for this view.
+	model := common.NewBareRouterDataModel("")
 	model.WhileLocked(func(u uint64) {
 		for _, event := range newState.Events {
 			model.Handle(newState.EndIndex, event)
@@ -65,7 +68,11 @@ func (self *ValidateDataStateRequestHandler) HandleReceive(msg *channel.Message,
 	current.Validate(model, reportedF)
 
 	if len(response.Diffs) > 0 && request.Fix {
-		model = common.NewReceiverRouterDataModelFromExisting(model, self.state.GetEnv().GetCloseNotify())
+		routerId := ""
+		if id := self.env.GetRouterId(); id != nil {
+			routerId = id.Token
+		}
+		model = common.NewReceiverRouterDataModelFromExisting(routerId, model, self.state.GetEnv().GetCloseNotify())
 		self.state.SetRouterDataModel(model, true)
 	}
 

--- a/tests/router_data_model_test.go
+++ b/tests/router_data_model_test.go
@@ -560,7 +560,7 @@ func Test_RouterDataModel_DataModelReplacement(t *testing.T) {
 
 	fmt.Println("replacing data model")
 	dataState := router.GetRouterDataModel().GetDataState()
-	updatedRouterDataModel := common.NewReceiverRouterDataModelFromDataState(dataState, router.GetCloseNotify())
+	updatedRouterDataModel := common.NewReceiverRouterDataModelFromDataState("", dataState, router.GetCloseNotify())
 	router.GetStateManager().SetRouterDataModel(updatedRouterDataModel, false)
 
 	// time.Sleep(2 * time.Minute)

--- a/zititest/models/router-data-model-test/main.go
+++ b/zititest/models/router-data-model-test/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"embed"
 	_ "embed"
+	"fmt"
 	"os"
 	"path"
 	"time"
@@ -237,6 +238,7 @@ var m = &model.Model{
 				if err := ctrls.Init(run, "#ctrl1"); err != nil {
 					return err
 				}
+				defer ctrls.Close()
 
 				var tasks []parallel.LabeledTask
 				for range 100 {
@@ -251,6 +253,7 @@ var m = &model.Model{
 				if err := ctrls.Init(run, "#ctrl1"); err != nil {
 					return err
 				}
+				defer ctrls.Close()
 
 				var tasks []parallel.LabeledTask
 				for range 100 {
@@ -265,6 +268,7 @@ var m = &model.Model{
 				if err := ctrls.Init(run, "#ctrl1"); err != nil {
 					return err
 				}
+				defer ctrls.Close()
 
 				var tasks []parallel.LabeledTask
 				for range 100 {
@@ -272,6 +276,72 @@ var m = &model.Model{
 					tasks = append(tasks, task)
 				}
 				return parallel.ExecuteLabeled(tasks, 2, nil)
+			}))
+
+			// Router-target config setup: create a router-target config type, a
+			// pool of router configs, and associate two configs with each edge
+			// router. Exercises Phase 1b (Configs field on Router) and Phase 2c
+			// (per-router config filtering in the RouterSender).
+			workflow.AddAction(model.ActionFunc(func(run model.Run) error {
+				ctrls := &models.CtrlClients{}
+				if err := ctrls.Init(run, "#ctrl1"); err != nil {
+					return err
+				}
+				defer ctrls.Close()
+				ctrl := ctrls.GetCtrl("ctrl1")
+
+				// Create several router-target config types so each router can be
+				// associated with multiple configs (the API allows only one config
+				// of a given type per router).
+				const routerConfigTypeCount = 5
+				const routerConfigsPerType = 4
+				const configsPerRouter = 2
+
+				configTypeIds := make([]string, 0, routerConfigTypeCount)
+				for range routerConfigTypeCount {
+					id, err := createRouterTargetConfigType(ctrl)
+					if err != nil {
+						return fmt.Errorf("failed to create router-target config type: %w", err)
+					}
+					configTypeIds = append(configTypeIds, id)
+				}
+
+				var createTasks []parallel.LabeledTask
+				for _, typeId := range configTypeIds {
+					for range routerConfigsPerType {
+						createTasks = append(createTasks, createNewRouterConfig(ctrl, typeId))
+					}
+				}
+				if err := parallel.ExecuteLabeled(createTasks, 4, nil); err != nil {
+					return fmt.Errorf("failed to create router configs: %w", err)
+				}
+
+				buckets := make([]routerConfigBucket, 0, len(configTypeIds))
+				for _, typeId := range configTypeIds {
+					configs, err := models.ListConfigs(ctrl, fmt.Sprintf(`type="%s" limit none`, typeId), 30*time.Second)
+					if err != nil {
+						return fmt.Errorf("failed to list router configs: %w", err)
+					}
+					ids := make([]string, 0, len(configs))
+					for _, c := range configs {
+						ids = append(ids, *c.ID)
+					}
+					buckets = append(buckets, routerConfigBucket{typeId: typeId, configIds: ids})
+				}
+
+				routers, err := models.ListEdgeRouters(ctrl, "limit none", 30*time.Second)
+				if err != nil {
+					return fmt.Errorf("failed to list edge routers: %w", err)
+				}
+
+				var assocTasks []parallel.LabeledTask
+				for _, r := range routers {
+					rId := *r.ID
+					assocTasks = append(assocTasks, parallel.TaskWithLabel("associate.router-configs", "associate router configs", func() error {
+						return associateRouterConfigs(ctrl, rId, buckets, configsPerRouter)
+					}))
+				}
+				return parallel.ExecuteLabeled(assocTasks, 4, nil)
 			}))
 
 			workflow.AddAction(semaphore.Sleep(2 * time.Second))

--- a/zititest/models/router-data-model-test/validation.go
+++ b/zititest/models/router-data-model-test/validation.go
@@ -53,6 +53,7 @@ func sowChaos(run model.Run) error {
 	if err := ctrls.Init(run, ".ctrl"); err != nil {
 		return err
 	}
+	defer ctrls.Close()
 
 	var err error
 
@@ -206,6 +207,12 @@ type taskGenerationContext struct {
 	configs     []*rest_model.ConfigDetail
 	services    []*rest_model.ServiceDetail
 
+	// router-target subset, populated by loadEntities by splitting on configType.Target
+	routerConfigTypes  []*rest_model.ConfigTypeDetail
+	routerConfigs      []*rest_model.ConfigDetail
+	routers            []*rest_model.EdgeRouterDetail
+	routerConfigsDeleted map[string]struct{}
+
 	configTypesDeleted map[string]struct{}
 	configsDeleted     map[string]struct{}
 	servicesDeleted    map[string]struct{}
@@ -219,17 +226,48 @@ type taskGenerationContext struct {
 }
 
 func (self *taskGenerationContext) loadEntities() {
-	self.configTypes, self.err = models.ListConfigTypes(self.ctrls.GetRandomCtrl(), `not (name contains ".v1" or id = "host.v2") limit none`, 15*time.Second)
-	if self.err != nil {
+	allConfigTypes, err := models.ListConfigTypes(self.ctrls.GetRandomCtrl(), `not (name contains ".v1" or id = "host.v2") limit none`, 15*time.Second)
+	if err != nil {
+		self.err = err
 		return
+	}
+	// Split into service-target (the existing chaos pool) and router-target.
+	// Configs picked for service updates must be service-target, so keep the two pools distinct.
+	routerTargetTypes := map[string]struct{}{}
+	for _, ct := range allConfigTypes {
+		if ct.Target != nil && *ct.Target == "router" {
+			self.routerConfigTypes = append(self.routerConfigTypes, ct)
+			routerTargetTypes[*ct.ID] = struct{}{}
+		} else {
+			self.configTypes = append(self.configTypes, ct)
+		}
 	}
 	chaos.Randomize(self.configTypes)
+	chaos.Randomize(self.routerConfigTypes)
 
-	self.configs, self.err = models.ListConfigs(self.ctrls.GetRandomCtrl(), "limit none", 15*time.Second)
-	if self.err != nil {
+	allConfigs, err := models.ListConfigs(self.ctrls.GetRandomCtrl(), "limit none", 15*time.Second)
+	if err != nil {
+		self.err = err
 		return
 	}
+	for _, c := range allConfigs {
+		if c.ConfigTypeID != nil {
+			if _, isRouterTarget := routerTargetTypes[*c.ConfigTypeID]; isRouterTarget {
+				self.routerConfigs = append(self.routerConfigs, c)
+				continue
+			}
+		}
+		self.configs = append(self.configs, c)
+	}
 	chaos.Randomize(self.configs)
+	chaos.Randomize(self.routerConfigs)
+
+	self.routers, err = models.ListEdgeRouters(self.ctrls.GetRandomCtrl(), "limit none", 15*time.Second)
+	if err != nil {
+		self.err = err
+		return
+	}
+	chaos.Randomize(self.routers)
 
 	self.services, self.err = models.ListServices(self.ctrls.GetRandomCtrl(), "limit none", 15*time.Second)
 	if self.err != nil {
@@ -413,6 +451,82 @@ func (self *taskGenerationContext) generateServiceTasks() {
 	}
 }
 
+// generateRouterConfigTasks exercises the dynamic paths of Phase 1b/2c on
+// router-target configs and on router→config associations:
+//   - modify a router-config's data (PATCH) — covers both configs currently
+//     associated with at least one router (delivery via filter) and configs
+//     with no current associations (filtered out for everyone).
+//   - delete a router-config — covers the cleanup loop in
+//     configStore.DeleteById that strips the deleted ID from each referencing
+//     router's Configs slice.
+//   - re-shuffle a router's Configs list — picks a new random subset (which
+//     may be empty), exercising both add (synthesis on the rtx delta path)
+//     and remove (orphan-leave-cached behavior).
+//   - top up the router-config pool so re-shuffle has variety.
+func (self *taskGenerationContext) generateRouterConfigTasks() {
+	if self.err != nil {
+		return
+	}
+	if len(self.routerConfigTypes) == 0 {
+		return
+	}
+
+	// modify a handful of router-configs
+	for i := 0; i < min(5, len(self.routerConfigs)); i++ {
+		entity := self.routerConfigs[i]
+		entityId := *entity.ID
+		self.tasks = append(self.tasks, parallel.TaskWithLabel("modify.router-config", fmt.Sprintf("modify router config %s", entityId), func() error {
+			entity.Data = map[string]interface{}{
+				"k":     uuid.NewString(),
+				"epoch": time.Now().UnixNano(),
+			}
+			return models.UpdateConfigFromDetail(self.ctrls.GetRandomCtrl(), entity, 15*time.Second)
+		}))
+	}
+
+	// delete one router-config every other iteration (only when we have plenty)
+	if scenarioCounter%2 == 0 && len(self.routerConfigs) > 5 {
+		entityId := *self.routerConfigs[len(self.routerConfigs)-1].ID
+		self.routerConfigsDeleted[entityId] = struct{}{}
+		self.lastTasks = append(self.lastTasks, parallel.TaskWithLabel("delete.router-config", fmt.Sprintf("delete router config %s", entityId), func() error {
+			return models.DeleteConfig(self.ctrls.GetRandomCtrl(), entityId, 15*time.Second)
+		}))
+	}
+
+	// keep the pool topped up for re-shuffle variety, rotating across all
+	// router-target config types so re-shuffle has multiple distinct types to
+	// pick from (the API forbids two configs of the same type per router).
+	createCount := 20 - (len(self.routerConfigs) - len(self.routerConfigsDeleted))
+	for i := 0; i < createCount; i++ {
+		typeId := *self.routerConfigTypes[i%len(self.routerConfigTypes)].ID
+		self.tasks = append(self.tasks, createNewRouterConfig(self.ctrls.GetRandomCtrl(), typeId))
+	}
+
+	// group surviving router configs by type so re-shuffle can honor the
+	// one-config-per-type rule.
+	buckets := groupRouterConfigsByType(self.routerConfigs, self.routerConfigsDeleted)
+
+	// re-shuffle each router's Configs. Some routers go to empty (size 0) every
+	// few iterations; otherwise pick 1-3 configs from distinct types.
+	for i, r := range self.routers {
+		routerId := *r.ID
+		// rotate the "empty" assignment through routers across iterations
+		emptyAssignment := (scenarioCounter+i)%4 == 0
+
+		// Use an explicit empty slice (not nil) so JSON marshals as `"configs": []`.
+		// `null` is dropped by the controller's PATCH field parser, producing a
+		// "no fields updated" 500.
+		newConfigs := []string{}
+		if !emptyAssignment {
+			newConfigs = pickRouterConfigsDistinctTypes(buckets, rand.Intn(3)+1)
+		}
+		self.tasks = append(self.tasks, parallel.TaskWithLabel("modify.router-configs", fmt.Sprintf("re-shuffle router %s configs (%d)", routerId, len(newConfigs)), func() error {
+			patch := &rest_model.EdgeRouterPatch{Configs: newConfigs}
+			return models.PatchEdgeRouter(self.ctrls.GetRandomCtrl(), routerId, patch, 15*time.Second)
+		}))
+	}
+}
+
 func (self *taskGenerationContext) getResults() ([]parallel.LabeledTask, []parallel.LabeledTask, error) {
 	if self.err != nil {
 		return nil, nil, self.err
@@ -425,16 +539,18 @@ func (self *taskGenerationContext) getResults() ([]parallel.LabeledTask, []paral
 
 func getServiceAndConfigChaosTasks(_ model.Run, ctrls *models.CtrlClients) ([]parallel.LabeledTask, []parallel.LabeledTask, error) {
 	ctx := &taskGenerationContext{
-		ctrls:              ctrls,
-		configTypesDeleted: map[string]struct{}{},
-		configsDeleted:     map[string]struct{}{},
-		servicesDeleted:    map[string]struct{}{},
+		ctrls:                ctrls,
+		configTypesDeleted:   map[string]struct{}{},
+		configsDeleted:       map[string]struct{}{},
+		servicesDeleted:      map[string]struct{}{},
+		routerConfigsDeleted: map[string]struct{}{},
 	}
 
 	ctx.loadEntities()
 	ctx.generateConfigTypeTasks()
 	ctx.generateConfigTasks()
 	ctx.generateServiceTasks()
+	ctx.generateRouterConfigTasks()
 
 	return ctx.getResults()
 }
@@ -774,6 +890,111 @@ func createNewIdentity(ctrl *zitirest.Clients) parallel.LabeledTask {
 		_, err := models.CreateIdentity(ctrl, svc, 15*time.Second)
 		return err
 	})
+}
+
+// createRouterTargetConfigType creates a single router-target config type
+// with a permissive schema and returns its ID. Distinct from the parallel
+// task helpers because callers need the resulting ID to associate later.
+func createRouterTargetConfigType(ctrl *zitirest.Clients) (string, error) {
+	target := "router"
+	name := newId()
+	entity := &rest_model.ConfigTypeCreate{
+		Name:   name,
+		Target: &target,
+		Schema: map[string]interface{}{
+			"$id":  "https://edge.openziti.org/schemas/router-test.config.json",
+			"type": "object",
+		},
+	}
+	if err := models.CreateConfigType(ctrl, entity, 15*time.Second); err != nil {
+		return "", err
+	}
+	list, err := models.ListConfigTypes(ctrl, fmt.Sprintf(`name="%s"`, *name), 15*time.Second)
+	if err != nil {
+		return "", err
+	}
+	if len(list) == 0 {
+		return "", fmt.Errorf("router-target config type %q not found after create", *name)
+	}
+	return *list[0].ID, nil
+}
+
+func createNewRouterConfig(ctrl *zitirest.Clients, configTypeId string) parallel.LabeledTask {
+	return parallel.TaskWithLabel("create.router-config", "create new router config", func() error {
+		entity := &rest_model.ConfigCreate{
+			Name:         newId(),
+			ConfigTypeID: &configTypeId,
+			Data: map[string]interface{}{
+				"k": uuid.NewString(),
+			},
+		}
+		return models.CreateConfig(ctrl, entity, 15*time.Second)
+	})
+}
+
+// routerConfigBucket groups router configs by their config-type id. The edge
+// router API rejects PATCHes with two configs of the same type, so picking
+// configs for a router has to start from these buckets.
+type routerConfigBucket struct {
+	typeId    string
+	configIds []string
+}
+
+// groupRouterConfigsByType buckets the given router configs by their config
+// type, skipping any IDs in `deleted`. Buckets with no surviving configs are
+// omitted from the result.
+func groupRouterConfigsByType(configs []*rest_model.ConfigDetail, deleted map[string]struct{}) []routerConfigBucket {
+	byType := map[string][]string{}
+	for _, c := range configs {
+		if c.ID == nil || c.ConfigTypeID == nil {
+			continue
+		}
+		if _, gone := deleted[*c.ID]; gone {
+			continue
+		}
+		byType[*c.ConfigTypeID] = append(byType[*c.ConfigTypeID], *c.ID)
+	}
+	buckets := make([]routerConfigBucket, 0, len(byType))
+	for typeId, ids := range byType {
+		buckets = append(buckets, routerConfigBucket{typeId: typeId, configIds: ids})
+	}
+	return buckets
+}
+
+// pickRouterConfigsDistinctTypes returns up to n config IDs drawn from
+// distinct buckets (i.e. distinct config types), each chosen at random within
+// its bucket. Returns a non-nil empty slice when there are no non-empty
+// buckets so callers can pass the result directly into a PATCH body without
+// the JSON marshaling to `null` (which the controller's patch-field parser
+// drops, producing a "no fields updated" error).
+func pickRouterConfigsDistinctTypes(buckets []routerConfigBucket, n int) []string {
+	out := make([]string, 0, n)
+	if n <= 0 || len(buckets) == 0 {
+		return out
+	}
+	perm := rand.Perm(len(buckets))
+	for _, idx := range perm {
+		if len(out) >= n {
+			break
+		}
+		bucket := buckets[idx]
+		if len(bucket.configIds) == 0 {
+			continue
+		}
+		out = append(out, bucket.configIds[rand.Intn(len(bucket.configIds))])
+	}
+	return out
+}
+
+// associateRouterConfigs picks up to `perRouter` router configs (each from a
+// distinct config type, since the API allows only one config per type per
+// router) and PATCHes the given edge router so its Configs field references
+// them.
+func associateRouterConfigs(ctrl *zitirest.Clients, edgeRouterId string, buckets []routerConfigBucket, perRouter int) error {
+	patch := &rest_model.EdgeRouterPatch{
+		Configs: pickRouterConfigsDistinctTypes(buckets, perRouter),
+	}
+	return models.PatchEdgeRouter(ctrl, edgeRouterId, patch, 15*time.Second)
 }
 
 func createNewServicePolicy(ctrl *zitirest.Clients) parallel.LabeledTask {

--- a/zititest/zitilab/models/api.go
+++ b/zititest/zitilab/models/api.go
@@ -566,6 +566,18 @@ func DeleteEdgeRouter(clients *zitirest.Clients, id string, timeout time.Duratio
 	return err
 }
 
+// PatchEdgeRouter applies a partial update to an edge router.
+func PatchEdgeRouter(clients *zitirest.Clients, id string, entity *rest_model.EdgeRouterPatch, timeout time.Duration) error {
+	ctx, cancelF := context.WithTimeout(context.Background(), timeout)
+	defer cancelF()
+	_, err := clients.Edge.EdgeRouter.PatchEdgeRouter(&edge_router.PatchEdgeRouterParams{
+		Context:    ctx,
+		ID:         id,
+		EdgeRouter: entity,
+	}, nil)
+	return err
+}
+
 func ListEdgeRouters(clients *zitirest.Clients, filter string, timeout time.Duration) ([]*rest_model.EdgeRouterDetail, error) {
 	ctx, cancelF := context.WithTimeout(context.Background(), timeout)
 	defer cancelF()

--- a/zititest/zitilab/models/ctrls.go
+++ b/zititest/zitilab/models/ctrls.go
@@ -2,17 +2,36 @@ package models
 
 import (
 	"math/rand/v2"
+	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/fablab/kernel/model"
 	"github.com/openziti/ziti/v2/zitirest"
 	"github.com/openziti/ziti/zititest/zitilab/chaos"
 )
 
+// DefaultReAuthInterval is the fallback re-auth cadence used when the caller
+// does not configure ReAuthInterval before Init. Session timeout in the test
+// configs is 30m, but a chaos-restarted controller drops its in-memory session
+// store immediately — well before any timeout — so the binding constraint here
+// is restart-recovery, not timeout. One minute keeps the test resilient to
+// restarts without spamming the auth endpoint.
+const DefaultReAuthInterval = time.Minute
+
 type CtrlClients struct {
+	// ReAuthInterval, if non-zero, overrides DefaultReAuthInterval. Set this
+	// before calling Init.
+	ReAuthInterval time.Duration
+
 	ctrls       []*zitirest.Clients
 	ctrlMap     map[string]*zitirest.Clients
+	components  []*model.Component
+	run         model.Run
+	reAuthLock  sync.Mutex
+	stop        chan struct{}
+	stopOnce    sync.Once
 	initialized atomic.Bool
 }
 
@@ -21,8 +40,12 @@ func (self *CtrlClients) Init(run model.Run, selector string) error {
 		return nil
 	}
 
+	self.run = run
+	self.stop = make(chan struct{})
 	self.ctrlMap = map[string]*zitirest.Clients{}
 	ctrls := run.GetModel().SelectComponents(selector)
+	self.components = ctrls
+
 	resultC := make(chan struct {
 		err     error
 		id      string
@@ -44,15 +67,76 @@ func (self *CtrlClients) Init(run model.Run, selector string) error {
 		}()
 	}
 
-	for i := 0; i < len(ctrls); i++ {
+	// Preserve component order so reAuth can pair components with clients by
+	// index without depending on the result-channel arrival order.
+	componentIdx := map[string]int{}
+	for i, ctrl := range ctrls {
+		componentIdx[ctrl.Id] = i
+	}
+	self.ctrls = make([]*zitirest.Clients, len(ctrls))
+	for range ctrls {
 		result := <-resultC
 		if result.err != nil {
 			return result.err
 		}
-		self.ctrls = append(self.ctrls, result.clients)
+		self.ctrls[componentIdx[result.id]] = result.clients
 		self.ctrlMap[result.id] = result.clients
 	}
+
+	interval := self.ReAuthInterval
+	if interval <= 0 {
+		interval = DefaultReAuthInterval
+	}
+	go self.reAuthLoop(interval)
 	return nil
+}
+
+// Close stops the background re-auth loop. Safe to call multiple times.
+// Callers should defer this after a successful Init.
+func (self *CtrlClients) Close() {
+	self.stopOnce.Do(func() {
+		if self.stop != nil {
+			close(self.stop)
+		}
+	})
+}
+
+// reAuthLoop periodically refreshes the API session on each controller client.
+// A controller restart drops its in-memory session store, so the test's token
+// becomes invalid; refreshing on a timer keeps the clients usable across chaos
+// restarts without the test having to handle 401s in its retry path.
+func (self *CtrlClients) reAuthLoop(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-self.stop:
+			return
+		case <-ticker.C:
+			self.reAuth()
+		}
+	}
+}
+
+func (self *CtrlClients) reAuth() {
+	self.reAuthLock.Lock()
+	defer self.reAuthLock.Unlock()
+
+	resultC := make(chan error, len(self.components))
+	for i, ctrl := range self.components {
+		username := ctrl.MustStringVariable("credentials.edge.username")
+		password := ctrl.MustStringVariable("credentials.edge.password")
+		clients := self.ctrls[i]
+		go func() {
+			resultC <- clients.Authenticate(username, password)
+		}()
+	}
+
+	for range self.components {
+		if err := <-resultC; err != nil {
+			pfxlog.Logger().WithError(err).Debug("background re-authentication failed for a controller; will retry next tick")
+		}
+	}
 }
 
 func (self *CtrlClients) GetRandomCtrl() *zitirest.Clients {


### PR DESCRIPTION
Stacked on top of #3975.

## Summary

- Adds `DataState.Router` to the RDM event stream; loads routers into the sender at startup; wires entity-change listeners on the router store.
- `RouterSender` filters `Config` events per-router: each router gets the full Router set (for link-peer fingerprint validation) but only its own router-target Configs.
- Receiver side: parses + stores Router entities; GCs router-target Configs whose IDs leave the router's `Configs` list, so the cache stays aligned without synthetic remove events.
- Extends the `router-data-model-test` fablab model with router-config distribution scenarios (assignment, reassignment, controller restart, RDM cache miss).
- Refreshes the design doc with the per-router filtering and change-notification details.

## Notes

The base PR (#3975) defines the `router.link.v1` config type; this PR makes that config actually reach a router. The follow-up PR on top will plug the receiver side into a router-side handler.