### PR TITLE
Issue 3980 posture check changes

### DIFF
--- a/controller/handler_edge_ctrl/errors.go
+++ b/controller/handler_edge_ctrl/errors.go
@@ -19,8 +19,10 @@ package handler_edge_ctrl
 import (
 	"errors"
 
+	"github.com/openziti/foundation/v2/errorz"
 	"github.com/openziti/sdk-golang/ziti/edge"
 	"github.com/openziti/ziti/v2/common/pb/edge_ctrl_pb"
+	"github.com/openziti/ziti/v2/controller/apierror"
 )
 
 type controllerError interface {
@@ -46,7 +48,23 @@ func internalError(err error) controllerError {
 	if errors.As(err, &ctrlErr) {
 		return ctrlErr
 	}
+	// A "cluster has no leader" condition is transient: it happens when a model update is
+	// attempted before raft leadership is established (notably during controller startup, when
+	// a router tries to create its tunnel terminator before the controller wins the election).
+	// Classify it as busy (RetryTooBusy -> FailedBusy) so callers like terminator establishment
+	// back off and retry instead of giving up, which would otherwise strand the service.
+	if isClusterNoLeaderErr(err) {
+		return busyError(err)
+	}
 	return internalErrorWrapper{error: err}
+}
+
+func isClusterNoLeaderErr(err error) bool {
+	var apiErr *errorz.ApiError
+	if errors.As(err, &apiErr) {
+		return apiErr.AppCode == apierror.ClusterHasNoLeaderCode
+	}
+	return false
 }
 
 func nonRetriableError(err error) controllerError {

--- a/controller/handler_edge_ctrl/errors_test.go
+++ b/controller/handler_edge_ctrl/errors_test.go
@@ -17,8 +17,12 @@
 package handler_edge_ctrl
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/openziti/sdk-golang/ziti/edge"
+	"github.com/openziti/ziti/v2/common/pb/edge_ctrl_pb"
+	"github.com/openziti/ziti/v2/controller/apierror"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -27,4 +31,48 @@ func Test_ErrorsIs(t *testing.T) {
 	err := error(InvalidSessionError{})
 	req := require.New(t)
 	req.True(errors.Is(err, InvalidSessionError{}))
+}
+
+// These three tests come from a real failure. On a cold HA start, a router tried to create its
+// tunnel terminator before the controller had elected a raft leader. The controller returned
+// CLUSTER_NO_LEADER, internalError classified it as FailedOther (not retryable), and the router
+// gave up. The terminator was never created, so every dial to that service failed with "service
+// has no terminators" - permanently, even after a leader was elected seconds later. The fix is to
+// treat CLUSTER_NO_LEADER as retryable (FailedBusy) so the router backs off and tries again. These
+// tests lock in that classification: the no-leader case retries, a wrapped no-leader case still
+// retries, and an unrelated error does not.
+
+// A "cluster has no leader" condition is transient and should be retryable.
+// internalError must map it to FailedBusy so routers retry instead of giving up.
+func Test_internalError_clusterNoLeaderIsRetryable(t *testing.T) {
+	req := require.New(t)
+
+	ctrlErr := internalError(apierror.NewClusterHasNoLeaderError())
+
+	req.Equal(edge.RetryTooBusy, ctrlErr.GetRetryHint())
+	req.Equal(edge_ctrl_pb.CreateTerminatorResult_FailedBusy, retryHintToResult(ctrlErr.GetRetryHint()))
+}
+
+// internalError uses errors.As to find the no-leader error, which means it keeps working even
+// when that error is wrapped (e.g. fmt.Errorf("...: %w", err)). Today's terminator path passes
+// the error unwrapped, but a caller could wrap it, so this test pins the wrapped case to
+// FailedBusy too. If someone changes internalError to a direct type check, this test fails.
+func Test_internalError_wrappedClusterNoLeaderIsRetryable(t *testing.T) {
+	req := require.New(t)
+
+	wrapped := fmt.Errorf("could not create terminator: %w", apierror.NewClusterHasNoLeaderError())
+	ctrlErr := internalError(wrapped)
+
+	req.Equal(edge_ctrl_pb.CreateTerminatorResult_FailedBusy, retryHintToResult(ctrlErr.GetRetryHint()))
+}
+
+// Only the no-leader error should be retryable. A generic error must map to FailedOther so the
+// router gives up instead of retrying forever. If someone makes internalError treat all errors
+// as retryable, this test catches it.
+func Test_internalError_genericErrorIsNotBusy(t *testing.T) {
+	req := require.New(t)
+
+	ctrlErr := internalError(errors.New("some unexpected failure"))
+
+	req.Equal(edge_ctrl_pb.CreateTerminatorResult_FailedOther, retryHintToResult(ctrlErr.GetRetryHint()))
 }

--- a/controller/handler_edge_ctrl/posture_responses_forward.go
+++ b/controller/handler_edge_ctrl/posture_responses_forward.go
@@ -19,12 +19,162 @@ package handler_edge_ctrl
 import (
 	"time"
 
+	"github.com/michaelquigley/pfxlog"
+	"github.com/openziti/channel/v4"
 	sdkedge_pb "github.com/openziti/sdk-golang/pb/edge_client_pb"
+	"github.com/openziti/ziti/v2/controller/env"
 	"github.com/openziti/ziti/v2/controller/model"
+	"google.golang.org/protobuf/proto"
 )
 
-// postureResponsesToModel is unimplemented: the HA posture-forwarding feature is delivered by the
-// code patch. The signature exists so the tests compile and fail on assertions until then.
+// contentTypePostureResponsesForward must match the constant in router/xgress_edge/listener.go.
+const contentTypePostureResponsesForward = int32(20507)
+const hdrPostureIdentityId = int32(2001)
+const hdrPostureApiSessionId = int32(2002)
+
+type postureResponsesForwardHandler struct {
+	appEnv *env.AppEnv
+}
+
+func NewPostureResponsesForwardHandler(appEnv *env.AppEnv) channel.TypedReceiveHandler {
+	return &postureResponsesForwardHandler{appEnv: appEnv}
+}
+
+func (self *postureResponsesForwardHandler) ContentType() int32 {
+	return contentTypePostureResponsesForward
+}
+
+func (self *postureResponsesForwardHandler) Label() string {
+	return "posture.responses.forward"
+}
+
+func (self *postureResponsesForwardHandler) HandleReceive(msg *channel.Message, _ channel.Channel) {
+	identityId := string(msg.Headers[hdrPostureIdentityId])
+	apiSessionId := string(msg.Headers[hdrPostureApiSessionId])
+
+	if identityId == "" || apiSessionId == "" {
+		pfxlog.Logger().Warn("forwarded posture responses missing identity or apiSession header, dropping")
+		return
+	}
+
+	postureResponses := &sdkedge_pb.PostureResponses{}
+	if err := proto.Unmarshal(msg.Body, postureResponses); err != nil {
+		pfxlog.Logger().WithError(err).Warn("failed to unmarshal forwarded posture responses")
+		return
+	}
+
+	// only the path->check-ID mapping touches the store, so build it only when a process is present.
+	var singleProcessChecksByPath map[string][]string
+	for _, resp := range postureResponses.Responses {
+		if resp.GetProcessList() != nil {
+			singleProcessChecksByPath = self.buildSingleProcessCheckPathMap()
+			break
+		}
+	}
+
+	modelResponses := postureResponsesToModel(postureResponses, time.Now().UTC(), singleProcessChecksByPath)
+
+	if len(modelResponses) > 0 {
+		self.appEnv.Managers.PostureResponse.Create(identityId, modelResponses)
+	}
+}
+
+// postureResponsesToModel converts forwarded SDK posture responses into controller model objects.
+// Process checks evaluate two ways: PROCESS_MULTI by path, legacy PROCESS by check ID.
+// singleProcessChecksByPath supplies the real IDs for matching paths.
 func postureResponsesToModel(postureResponses *sdkedge_pb.PostureResponses, now time.Time, singleProcessChecksByPath map[string][]string) []*model.PostureResponse {
-	return nil
+	var modelResponses []*model.PostureResponse
+
+	for _, resp := range postureResponses.Responses {
+		if os := resp.GetOs(); os != nil {
+			pr := &model.PostureResponse{
+				PostureCheckId: "ha-forwarded-os",
+				TypeId:         model.PostureCheckTypeOs,
+				TimedOut:       false,
+				LastUpdatedAt:  now,
+			}
+			pr.SubType = &model.PostureResponseOs{
+				PostureResponse: pr,
+				Type:            os.Type,
+				Version:         os.Version,
+				Build:           os.Build,
+			}
+			modelResponses = append(modelResponses, pr)
+
+		} else if macs := resp.GetMacs(); macs != nil {
+			pr := &model.PostureResponse{
+				PostureCheckId: "ha-forwarded-mac",
+				TypeId:         model.PostureCheckTypeMAC,
+				TimedOut:       false,
+				LastUpdatedAt:  now,
+			}
+			pr.SubType = &model.PostureResponseMac{
+				PostureResponse: pr,
+				Addresses:       macs.Addresses,
+			}
+			modelResponses = append(modelResponses, pr)
+
+		} else if domain := resp.GetDomain(); domain != nil {
+			pr := &model.PostureResponse{
+				PostureCheckId: "ha-forwarded-domain",
+				TypeId:         model.PostureCheckTypeDomain,
+				TimedOut:       false,
+				LastUpdatedAt:  now,
+			}
+			pr.SubType = &model.PostureResponseDomain{
+				PostureResponse: pr,
+				Name:            domain.Name,
+			}
+			modelResponses = append(modelResponses, pr)
+
+		} else if procList := resp.GetProcessList(); procList != nil {
+			for _, proc := range procList.Processes {
+				// One entry per claiming check ID (legacy PROCESS), or a synthetic ID when none.
+				// Either way Path is set, which is what PROCESS_MULTI matches on.
+				checkIds := singleProcessChecksByPath[proc.Path]
+				if len(checkIds) == 0 {
+					checkIds = []string{"ha-forwarded-process:" + proc.Path}
+				}
+
+				for _, checkId := range checkIds {
+					pr := &model.PostureResponse{
+						PostureCheckId: checkId,
+						TypeId:         model.PostureCheckTypeProcess,
+						TimedOut:       false,
+						LastUpdatedAt:  now,
+					}
+					pr.SubType = &model.PostureResponseProcess{
+						PostureResponse:    pr,
+						Path:               proc.Path,
+						IsRunning:          proc.IsRunning,
+						BinaryHash:         proc.Hash,
+						SignerFingerprints: proc.SignerFingerprints,
+					}
+					modelResponses = append(modelResponses, pr)
+				}
+			}
+		}
+	}
+
+	return modelResponses
+}
+
+// path -> IDs of legacy single-PROCESS checks watching it. PROCESS_MULTI is matched by path, not
+// ID, so it is excluded.
+func (self *postureResponsesForwardHandler) buildSingleProcessCheckPathMap() map[string][]string {
+	result := map[string][]string{}
+
+	checks, err := self.appEnv.Managers.PostureCheck.Query("limit none")
+	if err != nil {
+		pfxlog.Logger().WithError(err).Warn("could not query posture checks for process path mapping")
+		return result
+	}
+
+	for _, check := range checks.PostureChecks {
+		if proc, ok := check.SubType.(*model.PostureCheckProcess); ok && proc.Path != "" {
+			result[proc.Path] = append(result[proc.Path], check.Id)
+		}
+	}
+
+	return result
 }

--- a/controller/handler_edge_ctrl/posture_responses_forward.go
+++ b/controller/handler_edge_ctrl/posture_responses_forward.go
@@ -1,0 +1,30 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package handler_edge_ctrl
+
+import (
+	"time"
+
+	sdkedge_pb "github.com/openziti/sdk-golang/pb/edge_client_pb"
+	"github.com/openziti/ziti/v2/controller/model"
+)
+
+// postureResponsesToModel is unimplemented: the HA posture-forwarding feature is delivered by the
+// code patch. The signature exists so the tests compile and fail on assertions until then.
+func postureResponsesToModel(postureResponses *sdkedge_pb.PostureResponses, now time.Time, singleProcessChecksByPath map[string][]string) []*model.PostureResponse {
+	return nil
+}

--- a/controller/handler_edge_ctrl/posture_responses_forward_test.go
+++ b/controller/handler_edge_ctrl/posture_responses_forward_test.go
@@ -1,0 +1,234 @@
+package handler_edge_ctrl
+
+import (
+	"testing"
+	"time"
+
+	sdkedge_pb "github.com/openziti/sdk-golang/pb/edge_client_pb"
+	"github.com/openziti/ziti/v2/controller/model"
+)
+
+// These tests cover postureResponsesToModel, which turns posture data forwarded from a router (in
+// SDK protobuf form) into the controller's internal model objects so the controller can evaluate
+// posture and report isPassing. Process checks are the tricky part and the reason most of these
+// tests exist. There are two flavors that the controller evaluates differently:
+//
+//   PROCESS_MULTI checks are matched by the process PATH.
+//   legacy single PROCESS checks are matched by the posture-check ID.
+//
+// The forwarded data only tells us the process path, not which check it belongs to. So the
+// conversion stores every process by path (so PROCESS_MULTI works) and, when we know a single
+// PROCESS check watches that path, also emits a copy tagged with that check's real ID (so legacy
+// PROCESS works). OS, MAC, and Domain are simpler (a plain type-and-field mapping) and are covered
+// to catch a field accidentally getting mapped to the wrong place.
+
+func processListResponse(procs ...*sdkedge_pb.PostureResponse_Process) *sdkedge_pb.PostureResponses {
+	return &sdkedge_pb.PostureResponses{
+		Responses: []*sdkedge_pb.PostureResponse{
+			{
+				Type: &sdkedge_pb.PostureResponse_ProcessList_{
+					ProcessList: &sdkedge_pb.PostureResponse_ProcessList{Processes: procs},
+				},
+			},
+		},
+	}
+}
+
+// applyAll stores the given responses into a PostureData the same way the controller does at
+// runtime, so a test can then inspect what landed where. It only sets up the process fields, so
+// pass it process responses. The OS/MAC/Domain test checks the converted responses directly
+// instead, because storing those needs a fully built PostureData that this helper does not create.
+func applyAll(responses []*model.PostureResponse) *model.PostureData {
+	pd := &model.PostureData{
+		Processes:      []*model.PostureResponseProcess{},
+		ProcessPathMap: map[string]*model.PostureResponseProcess{},
+	}
+	for _, r := range responses {
+		r.Apply(pd)
+	}
+	return pd
+}
+
+// A process we have no specific check ID for (the PROCESS_MULTI case) must still be stored, keyed
+// by its path, because that is how PROCESS_MULTI evaluation finds it. Also checks that the reported
+// binary hash gets normalized (non-hex stripped, lowercased) as it is stored.
+func TestPostureResponsesToModel_ProcessMulti_StoredByPath(t *testing.T) {
+	const path = "C:\\Windows\\System32\\notepad.exe"
+
+	responses := postureResponsesToModel(
+		processListResponse(&sdkedge_pb.PostureResponse_Process{
+			Path:               path,
+			IsRunning:          true,
+			Hash:               "AB:C1:23", // intentionally NOT hex-clean: Apply must normalize to "abc123"
+			SignerFingerprints: []string{"FP1"},
+		}),
+		time.Now().UTC(),
+		nil, // no single-PROCESS checks claim this path
+	)
+
+	if len(responses) != 1 {
+		t.Fatalf("expected 1 model response, got %d", len(responses))
+	}
+	if got := responses[0].PostureCheckId; got != "ha-forwarded-process:"+path {
+		t.Fatalf("expected synthetic check id for unclaimed path, got %q", got)
+	}
+
+	pd := applyAll(responses)
+	stored, ok := pd.ProcessPathMap[path]
+	if !ok {
+		t.Fatalf("expected ProcessPathMap to contain path %q for PROCESS_MULTI evaluation", path)
+	}
+	if !stored.IsRunning {
+		t.Fatalf("expected stored process IsRunning=true")
+	}
+	// Using an already-clean value would not prove anything. "AB:C1:23" must be hex-cleaned
+	// (non-hex stripped, lowercased) to "abc123" as it is stored.
+	if stored.BinaryHash != "abc123" {
+		t.Fatalf("expected BinaryHash normalized to abc123, got %q", stored.BinaryHash)
+	}
+}
+
+// A legacy single PROCESS check is matched by check ID, so when we know which checks watch this
+// path, the conversion must emit a response tagged with each real check ID, not just the generic
+// path-only entry. Two checks on the same path get two responses.
+func TestPostureResponsesToModel_SingleProcess_UsesRealCheckIds(t *testing.T) {
+	const path = "/usr/bin/myapp"
+	pathMap := map[string][]string{
+		path: {"check-A", "check-B"},
+	}
+
+	responses := postureResponsesToModel(
+		processListResponse(&sdkedge_pb.PostureResponse_Process{Path: path, IsRunning: true}),
+		time.Now().UTC(),
+		pathMap,
+	)
+
+	if len(responses) != 2 {
+		t.Fatalf("expected 2 model responses (one per claiming check), got %d", len(responses))
+	}
+
+	ids := map[string]bool{}
+	for _, r := range responses {
+		ids[r.PostureCheckId] = true
+		if r.TypeId != model.PostureCheckTypeProcess {
+			t.Fatalf("expected TypeId PROCESS, got %q", r.TypeId)
+		}
+	}
+	if !ids["check-A"] || !ids["check-B"] {
+		t.Fatalf("expected responses for check-A and check-B, got %v", ids)
+	}
+
+	// Both checks evaluate by PostureCheckId against pd.Processes.
+	pd := applyAll(responses)
+	for _, want := range []string{"check-A", "check-B"} {
+		found := false
+		for _, p := range pd.Processes {
+			if p.PostureCheckId == want && p.IsRunning {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected a running process response for %q in pd.Processes", want)
+		}
+	}
+}
+
+// A path watched by a single PROCESS check must ALSO be stored by path, so that a PROCESS_MULTI
+// check on the same path keeps working too. One reported process has to satisfy both check styles
+// at once.
+func TestPostureResponsesToModel_ClaimedPath_AlsoInPathMap(t *testing.T) {
+	const path = "/usr/bin/myapp"
+	pathMap := map[string][]string{path: {"check-A"}}
+
+	responses := postureResponsesToModel(
+		processListResponse(&sdkedge_pb.PostureResponse_Process{Path: path, IsRunning: true}),
+		time.Now().UTC(),
+		pathMap,
+	)
+
+	pd := applyAll(responses)
+	if _, ok := pd.ProcessPathMap[path]; !ok {
+		t.Fatalf("expected claimed path %q to also be present in ProcessPathMap", path)
+	}
+}
+
+// OS, MAC, and Domain responses must convert to the matching model type with their fields copied
+// across correctly. The process tests do not exercise these branches, so they are covered here.
+// Empty input must produce no responses.
+func TestPostureResponsesToModel_OsMacDomain_MapFields(t *testing.T) {
+	now := time.Now().UTC()
+
+	t.Run("os", func(t *testing.T) {
+		out := postureResponsesToModel(&sdkedge_pb.PostureResponses{Responses: []*sdkedge_pb.PostureResponse{
+			{Type: &sdkedge_pb.PostureResponse_Os{Os: &sdkedge_pb.PostureResponse_OperatingSystem{
+				Type: "Windows", Version: "10.0.26200", Build: "build-1",
+			}}},
+		}}, now, nil)
+
+		if len(out) != 1 {
+			t.Fatalf("expected 1 response, got %d", len(out))
+		}
+		if out[0].TypeId != model.PostureCheckTypeOs {
+			t.Fatalf("expected TypeId OS, got %q", out[0].TypeId)
+		}
+		os, ok := out[0].SubType.(*model.PostureResponseOs)
+		if !ok {
+			t.Fatalf("expected *PostureResponseOs subtype, got %T", out[0].SubType)
+		}
+		if os.Type != "Windows" || os.Version != "10.0.26200" || os.Build != "build-1" {
+			t.Fatalf("OS fields mismatched: type=%q version=%q build=%q", os.Type, os.Version, os.Build)
+		}
+	})
+
+	t.Run("mac", func(t *testing.T) {
+		out := postureResponsesToModel(&sdkedge_pb.PostureResponses{Responses: []*sdkedge_pb.PostureResponse{
+			{Type: &sdkedge_pb.PostureResponse_Macs_{Macs: &sdkedge_pb.PostureResponse_Macs{
+				Addresses: []string{"aa:bb:cc:dd:ee:ff"},
+			}}},
+		}}, now, nil)
+
+		if len(out) != 1 {
+			t.Fatalf("expected 1 MAC response, got %d", len(out))
+		}
+		if out[0].TypeId != model.PostureCheckTypeMAC {
+			t.Fatalf("expected TypeId MAC, got %q", out[0].TypeId)
+		}
+		mac, ok := out[0].SubType.(*model.PostureResponseMac)
+		if !ok {
+			t.Fatalf("expected *PostureResponseMac subtype, got %T", out[0].SubType)
+		}
+		if len(mac.Addresses) != 1 || mac.Addresses[0] != "aa:bb:cc:dd:ee:ff" {
+			t.Fatalf("MAC addresses mismatched: %v", mac.Addresses)
+		}
+	})
+
+	t.Run("domain", func(t *testing.T) {
+		out := postureResponsesToModel(&sdkedge_pb.PostureResponses{Responses: []*sdkedge_pb.PostureResponse{
+			{Type: &sdkedge_pb.PostureResponse_Domain_{Domain: &sdkedge_pb.PostureResponse_Domain{
+				Name: "CORP",
+			}}},
+		}}, now, nil)
+
+		if len(out) != 1 {
+			t.Fatalf("expected 1 DOMAIN response, got %d", len(out))
+		}
+		if out[0].TypeId != model.PostureCheckTypeDomain {
+			t.Fatalf("expected TypeId DOMAIN, got %q", out[0].TypeId)
+		}
+		dom, ok := out[0].SubType.(*model.PostureResponseDomain)
+		if !ok {
+			t.Fatalf("expected *PostureResponseDomain subtype, got %T", out[0].SubType)
+		}
+		if dom.Name != "CORP" {
+			t.Fatalf("domain name mismatched: %q", dom.Name)
+		}
+	})
+
+	t.Run("empty input yields no responses", func(t *testing.T) {
+		out := postureResponsesToModel(&sdkedge_pb.PostureResponses{}, now, nil)
+		if len(out) != 0 {
+			t.Fatalf("expected no responses for empty input, got %d", len(out))
+		}
+	})
+}

--- a/controller/server/controller.go
+++ b/controller/server/controller.go
@@ -125,6 +125,7 @@ func (c *Controller) GetCtrlHandlers(binding channel.Binding) []channel.TypedRec
 		handler_edge_ctrl.NewUpdateTunnelTerminatorHandler(c.AppEnv, ch),
 		handler_edge_ctrl.NewRemoveTunnelTerminatorHandler(c.AppEnv, ch),
 		handler_edge_ctrl.NewListTunnelServicesHandler(c.AppEnv, ch, tunnelState),
+		handler_edge_ctrl.NewPostureResponsesForwardHandler(c.AppEnv),
 		handler_edge_ctrl.NewTunnelHealthEventHandler(c.AppEnv, ch),
 		handler_edge_ctrl.NewExtendEnrollmentHandler(c.AppEnv),
 		handler_edge_ctrl.NewExtendEnrollmentVerifyHandler(c.AppEnv),

--- a/router/posture/os.go
+++ b/router/posture/os.go
@@ -43,6 +43,11 @@ func (m *OsCheck) Evaluate(data *InstanceData) *CheckError {
 		}
 	}
 
+	// type matched, no version constraint: any version passes (matches the controller's check).
+	if len(foundOs.OsVersions) == 0 {
+		return nil
+	}
+
 	dataVer, err := semver.Make(data.Os.Os.GetVersion())
 
 	if err != nil {

--- a/router/posture/os_test.go
+++ b/router/posture/os_test.go
@@ -1,0 +1,96 @@
+package posture
+
+import (
+	"testing"
+
+	"github.com/openziti/sdk-golang/pb/edge_client_pb"
+	"github.com/openziti/ziti/v2/common/pb/edge_ctrl_pb"
+)
+
+const testOsType = "Windows"
+const testOsVersion = "10.0.26200"
+
+// newOsCheck builds an OsCheck whose single OS entry matches testOsType. osVersions are the
+// version range constraints; pass nil/empty to model a check with no version constraint.
+func newOsCheck(osVersions []string) *OsCheck {
+	return &OsCheck{
+		DataState_PostureCheck: &edge_ctrl_pb.DataState_PostureCheck{
+			Id:   "test-os-id",
+			Name: "my-os-check",
+		},
+		DataState_PostureCheck_OsList: &edge_ctrl_pb.DataState_PostureCheck_OsList{
+			OsList: []*edge_ctrl_pb.DataState_PostureCheck_Os{
+				{
+					OsType:     testOsType,
+					OsVersions: osVersions,
+				},
+			},
+		},
+	}
+}
+
+func osData(osType, version string) *InstanceData {
+	return &InstanceData{
+		Os: &edge_client_pb.PostureResponse_Os{
+			Os: &edge_client_pb.PostureResponse_OperatingSystem{
+				Type:    osType,
+				Version: version,
+			},
+		},
+	}
+}
+
+// Regression: an OS check whose OS type matches but that has NO version constraint must pass
+// for any reported version. Previously the empty-OsVersions loop fell through to a failure with
+// "none of the given values were in the valid values, given: [<version>], valid: []".
+func TestOsCheck_MatchingTypeNoVersionConstraint_Passes(t *testing.T) {
+	check := newOsCheck(nil)
+
+	if err := check.Evaluate(osData(testOsType, testOsVersion)); err != nil {
+		t.Fatalf("expected nil (pass) for matching OS type with no version constraint, got: %v", err)
+	}
+}
+
+// An OS check with no version constraint must pass even when the reported version is not valid
+// semver. This guards the empty-OsVersions early return staying ahead of semver.Make: if that
+// guard ever moves below the parse, a client reporting e.g. "unknown" regresses to a failure.
+func TestOsCheck_NoVersionConstraintNonSemverVersion_Passes(t *testing.T) {
+	check := newOsCheck(nil)
+
+	if err := check.Evaluate(osData(testOsType, "unknown")); err != nil {
+		t.Fatalf("expected nil (pass) for no version constraint with non-semver version, got: %v", err)
+	}
+}
+
+func TestOsCheck_MatchingTypeAndVersionInRange_Passes(t *testing.T) {
+	check := newOsCheck([]string{">=10.0.0 <=11.0.0"})
+
+	if err := check.Evaluate(osData(testOsType, testOsVersion)); err != nil {
+		t.Fatalf("expected nil (pass) for version in range, got: %v", err)
+	}
+}
+
+func TestOsCheck_MatchingTypeVersionOutOfRange_Fails(t *testing.T) {
+	check := newOsCheck([]string{">=11.0.0"})
+
+	if err := check.Evaluate(osData(testOsType, testOsVersion)); err == nil {
+		t.Fatalf("expected a CheckError for version below the required range, got nil")
+	}
+}
+
+func TestOsCheck_TypeMismatch_Fails(t *testing.T) {
+	check := newOsCheck(nil)
+
+	if err := check.Evaluate(osData("Linux", "5.15.0")); err == nil {
+		t.Fatalf("expected a CheckError for non-matching OS type, got nil")
+	}
+}
+
+// No OS posture reported at all must fail cleanly, not panic.
+func TestOsCheck_NilOsData_DoesNotPanic(t *testing.T) {
+	check := newOsCheck(nil)
+
+	if err := check.Evaluate(&InstanceData{}); err == nil {
+		t.Fatalf("expected a CheckError when no OS posture data is present, got nil")
+	}
+}

--- a/router/posture/process.go
+++ b/router/posture/process.go
@@ -174,18 +174,30 @@ func (p *ProcessCheck) compareProcesses(osType string, given *edge_client_pb.Pos
 		return result
 	}
 
-	if len(valid.Hashes) > 0 && !stringz.Contains(valid.Hashes, given.Hash) {
-		result.Reason = fmt.Errorf("hash is not valid, given %s, expected one of: %v", given.Hash, valid.Hashes)
+	// an empty hash is not a real constraint (a check with no hash arrives as []string{""}),
+	// so only the non-empty entries count.
+	validHashes := make([]string, 0, len(valid.Hashes))
+	for _, h := range valid.Hashes {
+		if h != "" {
+			validHashes = append(validHashes, h)
+		}
+	}
+
+	if len(validHashes) > 0 && !stringz.Contains(validHashes, given.Hash) {
+		result.Reason = fmt.Errorf("hash is not valid, given %s, expected one of: %v", given.Hash, validHashes)
 		return result
 	}
 
-	if len(valid.Fingerprints) > 0 {
-		validPrints := map[string]struct{}{}
-
-		for _, validPrint := range valid.Fingerprints {
+	// an empty fingerprint is not a real constraint (a single PROCESS check with no signer
+	// arrives as []string{""}), so only the non-empty entries count.
+	validPrints := map[string]struct{}{}
+	for _, validPrint := range valid.Fingerprints {
+		if validPrint != "" {
 			validPrints[validPrint] = struct{}{}
 		}
+	}
 
+	if len(validPrints) > 0 {
 		validPrintFound := false
 		for _, givenPrint := range given.SignerFingerprints {
 			if _, ok := validPrints[givenPrint]; ok {
@@ -195,7 +207,7 @@ func (p *ProcessCheck) compareProcesses(osType string, given *edge_client_pb.Pos
 		}
 
 		if !validPrintFound {
-			result.Reason = fmt.Errorf("valid signer not found, given: %v, expected one of: %v", given.SignerFingerprints, valid.Hashes)
+			result.Reason = fmt.Errorf("valid signer not found, given: %v, expected one of: %v", given.SignerFingerprints, valid.Fingerprints)
 			return result
 		}
 	}

--- a/router/posture/process_test.go
+++ b/router/posture/process_test.go
@@ -73,6 +73,137 @@ func TestProcessCheck_NoPostureData_DoesNotPanic(t *testing.T) {
 	}
 }
 
+// A single PROCESS check with no signer requirement arrives with Fingerprints []string{""} (the
+// controller packs the empty signer into a one-element slice). That empty entry is not a real
+// constraint, so a running process reporting no signers must pass.
+func TestProcessCheck_EmptyStringFingerprint_TreatedAsNoConstraint(t *testing.T) {
+	for _, semantic := range []string{db.SemanticAnyOf, db.SemanticAllOf} {
+		t.Run(semantic, func(t *testing.T) {
+			check := newProcessCheck(semantic)
+			check.Processes[0].Fingerprints = []string{""}
+
+			data := &InstanceData{
+				Os: &edge_client_pb.PostureResponse_Os{
+					Os: &edge_client_pb.PostureResponse_OperatingSystem{Type: "Windows"},
+				},
+				ProcessList: &edge_client_pb.PostureResponse_ProcessList{
+					Processes: []*edge_client_pb.PostureResponse_Process{
+						{Path: testProcPath, IsRunning: true}, // running, reports no signer fingerprints
+					},
+				},
+			}
+
+			if result := check.Evaluate(data); result != nil {
+				t.Fatalf("semantic %s: expected pass when the only signer fingerprint is empty, got: %v", semantic, result.Cause)
+			}
+		})
+	}
+}
+
+// Same empty-signer case for a multi-process (PROCESS_MULTI) check: every configured process has
+// an empty signer entry, and every reported process is running with no signers. Must pass under
+// both semantics.
+func TestProcessCheck_Multi_EmptyStringFingerprints_TreatedAsNoConstraint(t *testing.T) {
+	const otherPath = "C:\\Windows\\System32\\calc.exe"
+
+	for _, semantic := range []string{db.SemanticAnyOf, db.SemanticAllOf} {
+		t.Run(semantic, func(t *testing.T) {
+			check := &ProcessCheck{
+				DataState_PostureCheck: &edge_ctrl_pb.DataState_PostureCheck{Id: "test-id", Name: "my-proc-multi"},
+				DataState_PostureCheck_ProcessMulti: &edge_ctrl_pb.DataState_PostureCheck_ProcessMulti{
+					Semantic: semantic,
+					Processes: []*edge_ctrl_pb.DataState_PostureCheck_Process{
+						{OsType: "Windows", Path: testProcPath, Fingerprints: []string{""}},
+						{OsType: "Windows", Path: otherPath, Fingerprints: []string{""}},
+					},
+				},
+			}
+
+			data := &InstanceData{
+				Os: &edge_client_pb.PostureResponse_Os{
+					Os: &edge_client_pb.PostureResponse_OperatingSystem{Type: "Windows"},
+				},
+				ProcessList: &edge_client_pb.PostureResponse_ProcessList{
+					Processes: []*edge_client_pb.PostureResponse_Process{
+						{Path: testProcPath, IsRunning: true},
+						{Path: otherPath, IsRunning: true},
+					},
+				},
+			}
+
+			if result := check.Evaluate(data); result != nil {
+				t.Fatalf("semantic %s: expected pass when signer fingerprints are empty, got: %v", semantic, result.Cause)
+			}
+		})
+	}
+}
+
+// Same empty-constraint case for hashes: a check with no hash requirement arrives as
+// Hashes []string{""}, which is not a real constraint, so a running process passes regardless of
+// the hash it reports.
+func TestProcessCheck_EmptyStringHash_TreatedAsNoConstraint(t *testing.T) {
+	for _, semantic := range []string{db.SemanticAnyOf, db.SemanticAllOf} {
+		t.Run(semantic, func(t *testing.T) {
+			check := newProcessCheck(semantic)
+			check.Processes[0].Hashes = []string{""}
+
+			data := &InstanceData{
+				Os: &edge_client_pb.PostureResponse_Os{
+					Os: &edge_client_pb.PostureResponse_OperatingSystem{Type: "Windows"},
+				},
+				ProcessList: &edge_client_pb.PostureResponse_ProcessList{
+					Processes: []*edge_client_pb.PostureResponse_Process{
+						{Path: testProcPath, IsRunning: true, Hash: "feedface"},
+					},
+				},
+			}
+
+			if result := check.Evaluate(data); result != nil {
+				t.Fatalf("semantic %s: expected pass when the only hash constraint is empty, got: %v", semantic, result.Cause)
+			}
+		})
+	}
+}
+
+// With one process passing and one failing, the semantic decides the outcome: AnyOf passes
+// (at least one good), AllOf fails (not all good).
+func TestProcessCheck_MultiSemantics_OnePassOneFail(t *testing.T) {
+	const failPath = "C:\\Windows\\System32\\calc.exe"
+
+	newCheck := func(semantic string) *ProcessCheck {
+		return &ProcessCheck{
+			DataState_PostureCheck: &edge_ctrl_pb.DataState_PostureCheck{Id: "test-id", Name: "my-proc-multi"},
+			DataState_PostureCheck_ProcessMulti: &edge_ctrl_pb.DataState_PostureCheck_ProcessMulti{
+				Semantic: semantic,
+				Processes: []*edge_ctrl_pb.DataState_PostureCheck_Process{
+					{OsType: "Windows", Path: testProcPath},                              // no constraint -> passes
+					{OsType: "Windows", Path: failPath, Hashes: []string{"deadbeef"}},   // hash required
+				},
+			},
+		}
+	}
+
+	// reported: both running, but the second reports a hash that does not match "deadbeef"
+	data := &InstanceData{
+		Os: &edge_client_pb.PostureResponse_Os{
+			Os: &edge_client_pb.PostureResponse_OperatingSystem{Type: "Windows"},
+		},
+		ProcessList: &edge_client_pb.PostureResponse_ProcessList{
+			Processes: []*edge_client_pb.PostureResponse_Process{
+				{Path: testProcPath, IsRunning: true},
+				{Path: failPath, IsRunning: true, Hash: "feedface"},
+			},
+		},
+	}
+
+	if result := newCheck(db.SemanticAnyOf).Evaluate(data); result != nil {
+		t.Fatalf("AnyOf: expected pass (one process matches), got: %v", result.Cause)
+	}
+	if result := newCheck(db.SemanticAllOf).Evaluate(data); result == nil {
+		t.Fatalf("AllOf: expected failure (one process does not match), got pass")
+	}
+}
+
 // Nil InstanceData must fail with NilStateError, not panic.
 func TestProcessCheck_NilInstanceData(t *testing.T) {
 	for _, semantic := range []string{db.SemanticAnyOf, db.SemanticAllOf} {

--- a/router/xgress_edge/listener.go
+++ b/router/xgress_edge/listener.go
@@ -1470,16 +1470,36 @@ func (self *edgeClientConn) sendStateClosedReply(message string, req *channel.Me
 	}
 }
 
+// router→controller message carrying raw PostureResponses so the controller can update its
+// posture state. Not in the proto enum, both sides use these constants directly.
+const contentTypePostureResponsesForward = int32(20507)
+const hdrPostureIdentityId = int32(2001)
+const hdrPostureApiSessionId = int32(2002)
+
 func (self *edgeClientConn) processPostureResponse(msg *channel.Message, ch channel.Channel) {
 	if msg.ContentType == int32(edge_client_pb.ContentType_PostureResponseType) {
 		postureResponses := &edge_client_pb.PostureResponses{}
 
 		if err := proto.Unmarshal(msg.Body, postureResponses); err != nil {
 			pfxlog.Logger().WithError(err).Error("failed to unmarshal posture responses")
+			return
 		}
 
 		go self.listener.factory.stateManager.ProcessPostureResponses(ch, postureResponses)
 
+		// in HA the posture only reaches the router, so forward it on or the controller reports
+		// isPassing=false forever.
+		apiSessionToken := state.GetApiSessionTokenFromCh(ch)
+		if apiSessionToken != nil && apiSessionToken.IdentityId != "" {
+			forwardMsg := channel.NewMessage(contentTypePostureResponsesForward, msg.Body)
+			forwardMsg.Headers[hdrPostureIdentityId] = []byte(apiSessionToken.IdentityId)
+			forwardMsg.Headers[hdrPostureApiSessionId] = []byte(apiSessionToken.Id)
+			if ctrlCh := self.listener.factory.env.GetNetworkControllers().AnyValidCtrlChannel(); ctrlCh != nil {
+				if err := ctrlCh.Send(forwardMsg); err != nil {
+					pfxlog.Logger().WithError(err).Error("failed to forward posture responses to controller")
+				}
+			}
+		}
 	}
 }
 

--- a/ziti/cmd/edge/list.go
+++ b/ziti/cmd/edge/list.go
@@ -1296,6 +1296,21 @@ func outputPostureChecks(options *api.Options, children []*gabs.Container, pagin
 				for _, os := range osDetails.OperatingSystems {
 					osType := string(*os.Type)
 
+					if len(os.Versions) == 0 {
+						// an OS with no version constraint still needs a row, otherwise the whole
+						// check renders nothing and looks like it is missing from the list.
+						outTable.AppendRow(table.Row{
+							id,
+							name,
+							typeStr,
+							roleAttributes,
+							osType,
+							"",
+							"",
+						}, rowConfigAutoMerge)
+						continue
+					}
+
 					for _, version := range os.Versions {
 						outTable.AppendRow(table.Row{
 							id,


### PR DESCRIPTION
fixes #3980 

**NOTE** please review change to `internalError` wrt 'busy|retry' vs 'error'

* forwards process checks to the controller to properly clear posture checks
* adds tests to verify bad/fixed functionality (red|green tested)
* verified using ziti-edge-tunnel 1.7 sdk live in ZDEW + process posture check + os posture check
* fixes ziti list posture check issue where incomplete listing would occur