### PR TITLE
Feature/resolver multi interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [Config Type Target Field](#config-type-target-field) - Config types now have a target field indicating whether they apply to services, routers or other entities
 * [Wildcard OIDC Issuers](#wildcard-oidc-issuers) - Controllers with a wildcard server-certificate SAN can serve OIDC for explicitly allow-listed hostnames
 * [Router Configs](#router-configs) - Allow routers to have a list of associated configs
+* [Multiple Resolver Addresses for tproxy](#multiple-resolver-addresses-for-tproxy) - `resolver` now accepts a single address or a list of addresses
 
 ## Cluster Quorum Recovery
 
@@ -140,6 +141,29 @@ The CLI has been updated to support the new field:
 * `ziti fabric create router` accepts `--config <id>` (repeatable)
 * `ziti fabric update router` accepts `--config <id>` to replace the router's config list
 
+## Multiple Resolver Addresses for tproxy
+
+The `resolver` option in `xgress_edge_tunnel` tproxy configs now accepts either a
+single string (as before) or a YAML list of `udp://` addresses. A single shared
+resolver instance handles all listeners so hostname→IP mappings remain consistent
+across interfaces. Existing single-address configs are unchanged.
+
+```yaml
+# single address (unchanged)
+- binding: tunnel
+  options:
+    mode: tproxy
+    resolver: udp://172.18.102.70:53
+
+# multiple addresses
+- binding: tunnel
+  options:
+    mode: tproxy
+    resolver:
+      - udp://172.18.102.70:53
+      - udp://192.168.10.1:53
+```
+
 ## Component Updates and Bug Fixes
 
 * github.com/openziti/foundation/v2: [v2.0.91 -> v2.0.92](https://github.com/openziti/foundation/compare/v2.0.91...v2.0.92)
@@ -163,5 +187,6 @@ The CLI has been updated to support the new field:
     * [Issue #3744](https://github.com/openziti/ziti/issues/3744) - Add a target field to config type
     * [Issue #3684](https://github.com/openziti/ziti/issues/3684) - Keep controller mesh fully connected, as much as possible
     * [Issue #3849](https://github.com/openziti/ziti/issues/3849) - Add a recover mechanism for when a controller cluster can't form a quorum
+    * [Issue #3988](https://github.com/openziti/ziti/issues/3988) - Support multiple resolver addresses for tproxy mode
 
 

--- a/router/xgress_edge_tunnel/factory.go
+++ b/router/xgress_edge_tunnel/factory.go
@@ -161,7 +161,7 @@ type Options struct {
 	*xgress.Options
 	mode             string
 	svcPollRate      time.Duration
-	resolver         string
+	resolver         []string
 	dnsSvcIpRange    string
 	dnsUpstreams     []string
 	dnsUnanswerable  string
@@ -174,7 +174,7 @@ type Options struct {
 func (options *Options) load(data xgress.OptionsData) error {
 	options.mode = DefaultMode
 	options.svcPollRate = DefaultServicePollRate
-	options.resolver = DefaultDnsResolver
+	options.resolver = []string{DefaultDnsResolver}
 	options.dnsSvcIpRange = DefaultDnsServiceIpRange
 	options.dnsUnanswerable = DefaultDnsUnanswerable
 
@@ -200,10 +200,19 @@ func (options *Options) load(data xgress.OptionsData) error {
 		}
 
 		if value, found := data["resolver"]; found {
-			if strVal, ok := value.(string); ok {
-				options.resolver = strVal
-			} else {
-				return errors.Errorf("invalid value '%v' for resolver, must be string value", value)
+			switch v := value.(type) {
+			case string:
+				options.resolver = []string{v}
+			case []interface{}:
+				for _, item := range v {
+					strVal, ok := item.(string)
+					if !ok {
+						return errors.Errorf("invalid value '%v' for resolver, must be a string or list of strings", item)
+					}
+					options.resolver = append(options.resolver, strVal)
+				}
+			default:
+				return errors.Errorf("invalid value '%v' for resolver, must be a string or list of strings", value)
 			}
 		}
 

--- a/router/xgress_edge_tunnel/tunneler.go
+++ b/router/xgress_edge_tunnel/tunneler.go
@@ -104,10 +104,10 @@ func (self *tunneler) Start() error {
 			return errors.Wrap(err, "failed to initialize tproxy interceptor")
 		}
 	} else if self.listenOptions.mode == "host" {
-		self.listenOptions.resolver = ""
+		self.listenOptions.resolver = nil
 		self.interceptor = host.New()
 	} else if self.listenOptions.mode == "proxy" {
-		self.listenOptions.resolver = ""
+		self.listenOptions.resolver = nil
 		if self.interceptor, err = proxy.New(self.env.GetAlerter(), net.IPv4zero, self.listenOptions.services); err != nil {
 			return errors.Wrap(err, "failed to initialize proxy interceptor")
 		}

--- a/tunnel/dns/dns.go
+++ b/tunnel/dns/dns.go
@@ -20,7 +20,7 @@ package dns
 
 // these functions are only implemented when OS=linux
 
-func NewDnsServer(addr string, upstreams []string, unanswered unansweredDisposition) (Resolver, error) {
+func NewDnsServer(addrs []string, upstreams []string, unanswered unansweredDisposition) (Resolver, error) {
 	return nil, nil
 }
 

--- a/tunnel/dns/dns_linux.go
+++ b/tunnel/dns/dns_linux.go
@@ -70,33 +70,33 @@ func NewDnsServer(addrs []string, upstreams []string, unanswered unansweredDispo
 		log.Infof("configured upstream DNS server: %s over %s", upstreamURL.Host, upstreamURL.Scheme)
 	}
 
+	startedCh := make(chan struct{}, len(addrs))
 	errChan := make(chan error, len(addrs))
+
 	for _, addr := range addrs {
 		s := &dns.Server{
 			Addr:    addr,
 			Net:     "udp",
 			Handler: r,
+			NotifyStartedFunc: func() {
+				log.Infof("dns server running at %s", addr)
+				startedCh <- struct{}{}
+			},
 		}
 		r.servers = append(r.servers, s)
 		go func() {
-			errChan <- s.ListenAndServe()
+			if err := s.ListenAndServe(); err != nil {
+				errChan <- err
+			}
 		}()
 	}
 
-	deadline := time.After(2 * time.Second)
-	started := 0
-	for started < len(addrs) {
+	for range addrs {
 		select {
+		case <-startedCh:
+			// server confirmed ready
 		case err := <-errChan:
-			if err != nil {
-				return nil, fmt.Errorf("dns server failed to start: %w", err)
-			}
-			return nil, fmt.Errorf("dns server stopped prematurely")
-		case <-deadline:
-			for _, s := range r.servers {
-				log.Infof("dns server running at %s", s.Addr)
-			}
-			started = len(addrs) // all assumed running after timeout
+			return nil, fmt.Errorf("dns server failed to start: %w", err)
 		}
 	}
 

--- a/tunnel/dns/dns_linux.go
+++ b/tunnel/dns/dns_linux.go
@@ -30,22 +30,17 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// NewDnsServer starts a local DNS server on addr and configures zero or more
-// upstream DNS servers for recursive forwarding. Each upstream is a URL of
-// the form udp://host:port or tcp://host:port. When multiple upstreams are
-// provided, queries are fanned out in parallel; see resolver.queryUpstreams
-// for winner-selection semantics.
-func NewDnsServer(addr string, upstreams []string, unanswered unansweredDisposition) (Resolver, error) {
+// NewDnsServer starts one local DNS server per address in addrs and configures
+// zero or more upstream DNS servers for recursive forwarding. All listeners
+// share a single resolver instance so hostname mappings are consistent across
+// addresses. Each upstream is a URL of the form udp://host:port or
+// tcp://host:port. When multiple upstreams are provided, queries are fanned
+// out in parallel; see resolver.queryUpstreams for winner-selection semantics.
+func NewDnsServer(addrs []string, upstreams []string, unanswered unansweredDisposition) (Resolver, error) {
 	log.Infof("starting dns server...")
-	s := &dns.Server{
-		Addr: addr,
-		Net:  "udp",
-	}
 
-	names := make(map[string]net.IP)
 	r := &resolver{
-		server:     s,
-		names:      names,
+		names:      make(map[string]net.IP),
 		ips:        make(map[string]string),
 		namesMtx:   sync.Mutex{},
 		domains:    make(map[string]*domainEntry),
@@ -74,22 +69,35 @@ func NewDnsServer(addr string, upstreams []string, unanswered unansweredDisposit
 		})
 		log.Infof("configured upstream DNS server: %s over %s", upstreamURL.Host, upstreamURL.Scheme)
 	}
-	s.Handler = r
 
-	errChan := make(chan error)
-	go func() {
-		errChan <- s.ListenAndServe()
-	}()
-
-	select {
-	case err := <-errChan:
-		if err != nil {
-			return nil, fmt.Errorf("dns server failed to start: %w", err)
-		} else {
-			return nil, fmt.Errorf("dns server stopped prematurely")
+	errChan := make(chan error, len(addrs))
+	for _, addr := range addrs {
+		s := &dns.Server{
+			Addr:    addr,
+			Net:     "udp",
+			Handler: r,
 		}
-	case <-time.After(2 * time.Second):
-		log.Infof("dns server running at %s", s.Addr)
+		r.servers = append(r.servers, s)
+		go func() {
+			errChan <- s.ListenAndServe()
+		}()
+	}
+
+	deadline := time.After(2 * time.Second)
+	started := 0
+	for started < len(addrs) {
+		select {
+		case err := <-errChan:
+			if err != nil {
+				return nil, fmt.Errorf("dns server failed to start: %w", err)
+			}
+			return nil, fmt.Errorf("dns server stopped prematurely")
+		case <-deadline:
+			for _, s := range r.servers {
+				log.Infof("dns server running at %s", s.Addr)
+			}
+			started = len(addrs) // all assumed running after timeout
+		}
 	}
 
 	const resolverConfigHelp = "ziti-tunnel runs an internal DNS server which must be first in the host's\n" +
@@ -98,9 +106,8 @@ func NewDnsServer(addr string, upstreams []string, unanswered unansweredDisposit
 		"\n" +
 		"    prepend domain-name-servers %s;\n\n"
 
-	err := r.testSystemResolver()
-	if err != nil {
-		log.Errorf("system resolver test failed: %s\n\n"+resolverConfigHelp, err, addr)
+	if err := r.testSystemResolver(); err != nil {
+		log.Errorf("system resolver test failed: %s\n\n"+resolverConfigHelp, err, addrs[0])
 	}
 
 	return r, nil

--- a/tunnel/dns/server.go
+++ b/tunnel/dns/server.go
@@ -51,7 +51,7 @@ type upstream struct {
 }
 
 type resolver struct {
-	server     *dns.Server
+	servers    []*dns.Server
 	names      map[string]net.IP
 	ips        map[string]string
 	namesMtx   sync.Mutex
@@ -77,15 +77,16 @@ func parseUnansweredDisposition(raw string) (unansweredDisposition, error) {
 // and an unanswered-query disposition. An empty upstreams slice disables upstream
 // forwarding. When multiple upstreams are provided, queries are fanned out in
 // parallel and the first NOERROR response wins (see queryUpstreams).
-func NewResolver(config string, upstreams []string, unansweredConfig string) (Resolver, error) {
+func NewResolver(configs []string, upstreams []string, unansweredConfig string) (Resolver, error) {
 	flushDnsCaches()
-	if config == "" {
+	if len(configs) == 0 || (len(configs) == 1 && configs[0] == "") {
 		return nil, nil
 	}
 
-	resolverURL, err := url.Parse(config)
+	// Parse unanswered disposition and scheme from the first entry.
+	firstURL, err := url.Parse(configs[0])
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse resolver configuration '%s': %w", config, err)
+		return nil, fmt.Errorf("failed to parse resolver configuration '%s': %w", configs[0], err)
 	}
 
 	unanswered := unansweredRefused
@@ -94,8 +95,8 @@ func NewResolver(config string, upstreams []string, unansweredConfig string) (Re
 		if err != nil {
 			return nil, err
 		}
-	} else if resolverURL.RawQuery != "" {
-		values := resolverURL.Query()
+	} else if firstURL.RawQuery != "" {
+		values := firstURL.Query()
 		if raw := strings.TrimSpace(values.Get("response")); raw != "" {
 			unanswered, err = parseUnansweredDisposition(raw)
 			if err != nil {
@@ -116,18 +117,32 @@ func NewResolver(config string, upstreams []string, unansweredConfig string) (Re
 		}
 	}
 
-	switch resolverURL.Scheme {
+	switch firstURL.Scheme {
 	case "", "file":
-		return NewRefCountingResolver(NewHostFile(resolverURL.Path)), nil
+		if len(configs) > 1 {
+			return nil, fmt.Errorf("file:// resolver does not support multiple addresses")
+		}
+		return NewRefCountingResolver(NewHostFile(firstURL.Path)), nil
 	case "udp":
-		dnsResolver, err := NewDnsServer(resolverURL.Host, upstreams, unanswered)
+		addrs := make([]string, 0, len(configs))
+		for _, c := range configs {
+			u, err := url.Parse(c)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse resolver configuration '%s': %w", c, err)
+			}
+			if u.Scheme != "udp" {
+				return nil, fmt.Errorf("all resolver addresses must use the same scheme; '%s' differs from 'udp'", c)
+			}
+			addrs = append(addrs, u.Host)
+		}
+		dnsResolver, err := NewDnsServer(addrs, upstreams, unanswered)
 		if err != nil {
 			return nil, err
 		}
 		return NewRefCountingResolver(dnsResolver), nil
 	}
 
-	return nil, fmt.Errorf("invalid resolver configuration '%s'. must be 'file://' or 'udp://' URL", config)
+	return nil, fmt.Errorf("invalid resolver configuration '%s'. must be 'file://' or 'udp://' URL", configs[0])
 }
 
 func (r *resolver) testSystemResolver() error {
@@ -447,5 +462,11 @@ func (r *resolver) RemoveHostname(hostname string) net.IP {
 
 func (r *resolver) Cleanup() error {
 	log.Debug("shutting down")
-	return r.server.Shutdown()
+	var lastErr error
+	for _, s := range r.servers {
+		if err := s.Shutdown(); err != nil {
+			lastErr = err
+		}
+	}
+	return lastErr
 }

--- a/ziti/tunnel/root.go
+++ b/ziti/tunnel/root.go
@@ -152,7 +152,7 @@ func rootPostRun(cmd *cobra.Command, _ []string) {
 	resolverConfig := cmd.Flag(resolverCfgFlag).Value.String()
 	upstreams, _ := cmd.Flags().GetStringSlice(dnsUpstreamFlag)
 	unansweredDisposition, _ := cmd.Flags().GetString(dnsUnanswerableFlag)
-	resolver, err := dns.NewResolver(resolverConfig, upstreams, unansweredDisposition)
+	resolver, err := dns.NewResolver([]string{resolverConfig}, upstreams, unansweredDisposition)
 	if err != nil {
 		log.WithError(err).Fatal("failed to start DNS resolver")
 	}


### PR DESCRIPTION
https://github.com/openziti/ziti/issues/3988 

  resolver previously accepted only a single udp:// address. This change makes it accept either a bare
  string (backwards-compatible) or a YAML list of addresses. A single shared resolver instance handles
  all listeners so hostname mappings remain consistent across interfaces.