### PR TITLE
  fixes #3992 stop controller panic when a web server listener fails

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/openziti/secretstream v0.1.51
 	github.com/openziti/transport/v2 v2.0.216
 	github.com/openziti/x509-claims v1.0.3
-	github.com/openziti/xweb/v3 v3.0.4
+	github.com/openziti/xweb/v3 v3.0.5-0.20260618140905-54cc19903f1c
 	github.com/orcaman/concurrent-map/v2 v2.0.1
 	github.com/pkg/errors v0.9.1
 	github.com/rabbitmq/amqp091-go v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -562,6 +562,8 @@ github.com/openziti/x509-claims v1.0.3 h1:HNdQ8Nf1agB3lBs1gahcO6zfkeS4S5xoQ2/PkY
 github.com/openziti/x509-claims v1.0.3/go.mod h1:Z0WIpBm6c4ecrpRKrou6Gk2wrLWxJO/+tuUwKh8VewE=
 github.com/openziti/xweb/v3 v3.0.4 h1:sKQJOJDQiWcTkuc37L7oc0Z0jQ5Poh2zaa5raiP0GLc=
 github.com/openziti/xweb/v3 v3.0.4/go.mod h1:xb9m4ySnKilHM4wbUC2MnGfilDu/kKw97DWL13ZTvqk=
+github.com/openziti/xweb/v3 v3.0.5-0.20260618140905-54cc19903f1c h1:ItIhxwbkKVrDrqJlPrb0RMwEYircOSyDkQWo/KcVjx4=
+github.com/openziti/xweb/v3 v3.0.5-0.20260618140905-54cc19903f1c/go.mod h1:xb9m4ySnKilHM4wbUC2MnGfilDu/kKw97DWL13ZTvqk=
 github.com/orcaman/concurrent-map/v2 v2.0.1 h1:jOJ5Pg2w1oeB6PeDurIYf6k9PQ+aTITr/6lP/L/zp6c=
 github.com/orcaman/concurrent-map/v2 v2.0.1/go.mod h1:9Eq3TG2oBe5FirmYWQfYO5iH1q0Jv47PLaNK++uCdOM=
 github.com/parallaxsecond/parsec-client-go v0.0.0-20221025095442-f0a77d263cf9 h1:mOvehYivJ4Aqu2CPe3D3lv8jhqOI9/1o0THxJHBE0qw=

--- a/tests/configsets.go
+++ b/tests/configsets.go
@@ -53,6 +53,15 @@ var DualOidcServers = ConfigSet{
 	CtrlConfig: "testdata/configs/dual-oidc-servers/ctrl.yml",
 }
 
+// OidcListenerBindFailure is a controller-only config set with a second web server whose bind
+// point interface is an unbindable address, so its listener fails at startup. Used to verify that
+// a web server whose listener cannot bind causes the controller to log the error and keep the
+// other servers running, rather than panicking on a nil listener.
+var OidcListenerBindFailure = ConfigSet{
+	Name:       "oidc-listener-bind-failure",
+	CtrlConfig: "testdata/configs/oidc-listener-bind-failure/ctrl.yml",
+}
+
 // WildcardOidcServer is a controller-only config set that supplies a wildcard (*.wildcard.test) server
 // certificate via alt_server_certs alongside an ordinary primary server cert, modeling a controller fronted
 // by a wildcard (e.g. LetsEncrypt) certificate. Used to verify that the OIDC discovery document served to a

--- a/tests/oidc_listener_bind_failure_test.go
+++ b/tests/oidc_listener_bind_failure_test.go
@@ -1,0 +1,33 @@
+package tests
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// Test_OidcListener_BindFailure_DoesNotPanic verifies that when a configured web server's
+// listener cannot bind (here, an edge-oidc server whose bind point interface is unbindable),
+// the controller logs the error and the remaining web servers keep serving, rather than
+// panicking on a nil listener during startup.
+func Test_OidcListener_BindFailure_DoesNotPanic(t *testing.T) {
+	ctx := NewTestContextWithConfigSet(t, OidcListenerBindFailure)
+	defer ctx.Teardown()
+
+	// StartServer waits for the REST API port to come up; if the failing server panicked
+	// during startup, the controller process would abort before this returns.
+	ctx.StartServer()
+
+	t.Run("primary server stays up and serves OIDC discovery", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		discoveryUrl := "https://" + ctx.ApiHost + "/oidc/.well-known/openid-configuration"
+		resp, err := ctx.newAnonymousClientApiRequest().Get(discoveryUrl)
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusOK, resp.StatusCode())
+
+		var discovery map[string]interface{}
+		ctx.Req.NoError(json.Unmarshal(resp.Body(), &discovery))
+		ctx.Req.Contains(discovery, "issuer")
+	})
+}

--- a/tests/testdata/configs/oidc-listener-bind-failure/ctrl.yml
+++ b/tests/testdata/configs/oidc-listener-bind-failure/ctrl.yml
@@ -1,0 +1,69 @@
+v: 3
+
+db: ${ZITI_TEST_DB}
+
+identity:
+  cert: testdata/ca/intermediate/certs/ctrl-client.cert.pem
+  server_cert: testdata/ca/intermediate/certs/ctrl-server.cert.pem
+  key: testdata/ca/intermediate/private/ctrl.key.pem
+  ca: testdata/ca/intermediate/certs/ca-chain.cert.pem
+
+trustDomain: at-test
+
+ctrl:
+  listener: tls:127.0.0.1:6262
+
+mgmt:
+  listener: tls:127.0.0.1:10000
+
+terminator:
+  validators:
+    edge: edge
+
+edge:
+  api:
+    sessionTimeout: 30m
+    address: 127.0.0.1:1281
+  enrollment:
+    signingCert:
+      cert: testdata/ca/intermediate/certs/intermediate.cert.pem
+      key: testdata/ca/intermediate/private/intermediate.key.decrypted.pem
+      ca: testdata/ca/intermediate/certs/ca-chain.cert.pem
+    edgeIdentity:
+      duration: 20m
+    edgeRouter:
+      duration: 60m
+
+
+web:
+  - name: primary-server
+    bindPoints:
+      - interface: 127.0.0.1:1281
+        address: 127.0.0.1:1281
+    options: {}
+    apis:
+      - binding: health-checks
+      - binding: fabric
+      - binding: edge-management
+      - binding: edge-client
+      - binding: edge-oidc
+        options:
+          redirectURIs:
+            - "http://localhost:*/auth/callback"
+            - "http://127.0.0.1:*/auth/callback"
+
+  # This server's bind point interface is an unbindable address (TEST-NET-1, not
+  # assigned to any local interface), so its Listener fails at startup. This models
+  # the failing edge-oidc listener: the controller must log the error and keep the
+  # primary server running, not panic.
+  - name: failing-oidc-server
+    bindPoints:
+      - interface: 192.0.2.1:1282
+        address: 127.0.0.1:1282
+    options: {}
+    apis:
+      - binding: edge-oidc
+        options:
+          redirectURIs:
+            - "http://localhost:*/auth/callback"
+            - "http://127.0.0.1:*/auth/callback"


### PR DESCRIPTION
  - updates openziti/xweb/v3 for actual fix
  - adds Test_OidcListener_BindFailure_DoesNotPanic and the oidc-listener-bind-failure config set, asserting the controller keeps the other web servers running when an edge-oidc listener cannot bind

Requires: https://github.com/openziti/xweb/pull/35