### PR TITLE
Prevent enrollment-based privilege escalation to admin identities. Fixes #4010

### DIFF
--- a/controller/internal/routes/enrollment_router.go
+++ b/controller/internal/routes/enrollment_router.go
@@ -17,16 +17,20 @@
 package routes
 
 import (
+	"errors"
 	"time"
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/openziti/edge-api/rest_management_api_server/operations/enrollment"
 	"github.com/openziti/edge-api/rest_model"
 	"github.com/openziti/foundation/v2/errorz"
+	"github.com/openziti/foundation/v2/stringz"
 	"github.com/openziti/ziti/v2/controller/env"
 	"github.com/openziti/ziti/v2/controller/model"
+	"github.com/openziti/ziti/v2/controller/models"
 	"github.com/openziti/ziti/v2/controller/permissions"
 	"github.com/openziti/ziti/v2/controller/response"
+	"github.com/openziti/ziti/v2/controller/storage/ast"
 )
 
 func init() {
@@ -76,18 +80,40 @@ func (r *EnrollmentRouter) Register(ae *env.AppEnv) {
 }
 
 func (r *EnrollmentRouter) List(ae *env.AppEnv, rc *response.RequestContext) {
-	ListWithHandler[*model.Enrollment](ae, rc, ae.Managers.Enrollment, MapEnrollmentToRestEntity)
+	lister := ae.Managers.Enrollment
+	ListWithQueryF[*model.Enrollment](ae, rc, lister, MapEnrollmentToRestEntity, func(query ast.Query) (*models.EntityListResult[*model.Enrollment], error) {
+		// Enrollments expose the one-time-token used to enroll as their target identity, so a
+		// non-admin must not be able to see enrollments belonging to admin identities.
+		if !rc.HasPermission(permissions.AdminPermission) {
+			scopeQuery, err := ast.Parse(lister.GetSymbolTypes(), "not (identity.isAdmin = true)")
+			if err != nil {
+				return nil, err
+			}
+			query.SetPredicate(ast.NewAndExprNode(query.GetPredicate(), scopeQuery.GetPredicate()))
+		}
+		return lister.BasePreparedList(query)
+	})
 }
 
 func (r *EnrollmentRouter) Detail(ae *env.AppEnv, rc *response.RequestContext) {
+	if !r.allowNonAdminAccessToEnrollment(ae, rc) {
+		return
+	}
 	DetailWithHandler[*model.Enrollment](ae, rc, ae.Managers.Enrollment, MapEnrollmentToRestEntity)
 }
 
 func (r *EnrollmentRouter) Delete(ae *env.AppEnv, rc *response.RequestContext) {
+	if !r.allowNonAdminAccessToEnrollment(ae, rc) {
+		return
+	}
 	DeleteWithHandler(rc, ae.Managers.Enrollment)
 }
 
 func (r *EnrollmentRouter) Refresh(ae *env.AppEnv, rc *response.RequestContext, params enrollment.RefreshEnrollmentParams) {
+	if !r.allowNonAdminAccessToEnrollment(ae, rc) {
+		return
+	}
+
 	id, err := rc.GetEntityId()
 
 	if err != nil {
@@ -113,10 +139,58 @@ func (r *EnrollmentRouter) Refresh(ae *env.AppEnv, rc *response.RequestContext, 
 }
 
 func (r *EnrollmentRouter) Create(ae *env.AppEnv, rc *response.RequestContext, params enrollment.CreateEnrollmentParams) {
+	if !r.allowNonAdminEnrollmentForIdentity(ae, rc, stringz.OrEmpty(params.Enrollment.IdentityID)) {
+		return
+	}
+
 	Create(rc, rc, EnrollmentLinkFactory, func() (string, error) {
 		return MapCreate(ae.Managers.Enrollment.Create, MapCreateEnrollmentToModel(params.Enrollment), rc)
 	})
 
+}
+
+// allowNonAdminEnrollmentForIdentity ensures that a non-admin caller is not creating an enrollment
+// that targets an admin identity. An enrollment mints the one-time-token used to enroll as its
+// target identity, so allowing this would let a non-admin escalate to admin. It responds with an
+// unauthorized error and returns false when the operation should be denied.
+func (r *EnrollmentRouter) allowNonAdminEnrollmentForIdentity(ae *env.AppEnv, rc *response.RequestContext, identityId string) bool {
+	if rc.HasPermission(permissions.AdminPermission) {
+		return true
+	}
+
+	if identityId != "" {
+		if identity, _ := ae.Managers.Identity.Read(identityId); identity != nil && identity.IsAdmin {
+			rc.RespondWithError(nonAdminNotAllowedError(errors.New("non-admins may not manage enrollments for admin identities")))
+			return false
+		}
+	}
+
+	return true
+}
+
+// allowNonAdminAccessToEnrollment ensures that a non-admin caller is not reading, refreshing, or
+// deleting an enrollment that belongs to an admin identity. The enrollment carries the live token
+// and JWT used to enroll as its target identity, so exposing or refreshing an admin identity's
+// enrollment would permit privilege escalation. It responds with an unauthorized error and returns
+// false when the operation should be denied. When the enrollment cannot be loaded, it allows the
+// request to proceed so the downstream handler can produce the appropriate not-found response.
+func (r *EnrollmentRouter) allowNonAdminAccessToEnrollment(ae *env.AppEnv, rc *response.RequestContext) bool {
+	if rc.HasPermission(permissions.AdminPermission) {
+		return true
+	}
+
+	id, err := rc.GetEntityId()
+	if err != nil {
+		rc.RespondWithError(err)
+		return false
+	}
+
+	enrollmentEntity, err := ae.Managers.Enrollment.Read(id)
+	if err != nil || enrollmentEntity == nil || enrollmentEntity.IdentityId == nil {
+		return true
+	}
+
+	return r.allowNonAdminEnrollmentForIdentity(ae, rc, *enrollmentEntity.IdentityId)
 }
 
 func MapCreateEnrollmentToModel(create *rest_model.EnrollmentCreate) *model.Enrollment {

--- a/controller/internal/routes/enrollment_router.go
+++ b/controller/internal/routes/enrollment_router.go
@@ -96,101 +96,111 @@ func (r *EnrollmentRouter) List(ae *env.AppEnv, rc *response.RequestContext) {
 }
 
 func (r *EnrollmentRouter) Detail(ae *env.AppEnv, rc *response.RequestContext) {
-	if !r.allowNonAdminAccessToEnrollment(ae, rc) {
-		return
-	}
-	DetailWithHandler[*model.Enrollment](ae, rc, ae.Managers.Enrollment, MapEnrollmentToRestEntity)
+	r.checkNonAdminAccessToEnrollment(ae, rc, func() {
+		DetailWithHandler[*model.Enrollment](ae, rc, ae.Managers.Enrollment, MapEnrollmentToRestEntity)
+	})
 }
 
 func (r *EnrollmentRouter) Delete(ae *env.AppEnv, rc *response.RequestContext) {
-	if !r.allowNonAdminAccessToEnrollment(ae, rc) {
-		return
-	}
-	DeleteWithHandler(rc, ae.Managers.Enrollment)
+	r.checkNonAdminAccessToEnrollment(ae, rc, func() {
+		DeleteWithHandler(rc, ae.Managers.Enrollment)
+	})
 }
 
 func (r *EnrollmentRouter) Refresh(ae *env.AppEnv, rc *response.RequestContext, params enrollment.RefreshEnrollmentParams) {
-	if !r.allowNonAdminAccessToEnrollment(ae, rc) {
-		return
-	}
+	r.checkNonAdminAccessToEnrollment(ae, rc, func() {
+		id, err := rc.GetEntityId()
 
-	id, err := rc.GetEntityId()
-
-	if err != nil {
-		rc.RespondWithError(err)
-		return
-	}
-
-	if id == "" {
-		rc.RespondWithNotFound()
-		return
-	}
-
-	if err := ae.Managers.Enrollment.RefreshJwt(id, time.Time(*params.Refresh.ExpiresAt), rc.NewChangeContext()); err != nil {
-		if fe, ok := err.(*errorz.FieldError); ok {
-			rc.RespondWithFieldError(fe)
+		if err != nil {
+			rc.RespondWithError(err)
 			return
 		}
-		rc.RespondWithError(err)
-		return
-	}
 
-	rc.RespondWithEmptyOk()
+		if id == "" {
+			rc.RespondWithNotFound()
+			return
+		}
+
+		if err := ae.Managers.Enrollment.RefreshJwt(id, time.Time(*params.Refresh.ExpiresAt), rc.NewChangeContext()); err != nil {
+			if fe, ok := err.(*errorz.FieldError); ok {
+				rc.RespondWithFieldError(fe)
+				return
+			}
+			rc.RespondWithError(err)
+			return
+		}
+
+		rc.RespondWithEmptyOk()
+	})
 }
 
 func (r *EnrollmentRouter) Create(ae *env.AppEnv, rc *response.RequestContext, params enrollment.CreateEnrollmentParams) {
-	if !r.allowNonAdminEnrollmentForIdentity(ae, rc, stringz.OrEmpty(params.Enrollment.IdentityID)) {
+	r.checkNonAdminEnrollmentForIdentity(ae, rc, stringz.OrEmpty(params.Enrollment.IdentityID), func() {
+		Create(rc, rc, EnrollmentLinkFactory, func() (string, error) {
+			return MapCreate(ae.Managers.Enrollment.Create, MapCreateEnrollmentToModel(params.Enrollment), rc)
+		})
+	})
+}
+
+// checkNonAdminEnrollmentForIdentity ensures that a non-admin caller is not creating an enrollment
+// that targets an admin identity. An enrollment mints the one-time-token used to enroll as its
+// target identity, so allowing this would let a non-admin escalate to admin. When access is granted
+// it invokes handler; otherwise it writes the appropriate error response and does not call handler.
+func (r *EnrollmentRouter) checkNonAdminEnrollmentForIdentity(ae *env.AppEnv, rc *response.RequestContext, identityId string, handler func()) {
+	if rc.HasPermission(permissions.AdminPermission) {
+		handler()
 		return
 	}
 
-	Create(rc, rc, EnrollmentLinkFactory, func() (string, error) {
-		return MapCreate(ae.Managers.Enrollment.Create, MapCreateEnrollmentToModel(params.Enrollment), rc)
-	})
-
-}
-
-// allowNonAdminEnrollmentForIdentity ensures that a non-admin caller is not creating an enrollment
-// that targets an admin identity. An enrollment mints the one-time-token used to enroll as its
-// target identity, so allowing this would let a non-admin escalate to admin. It responds with an
-// unauthorized error and returns false when the operation should be denied.
-func (r *EnrollmentRouter) allowNonAdminEnrollmentForIdentity(ae *env.AppEnv, rc *response.RequestContext, identityId string) bool {
-	if rc.HasPermission(permissions.AdminPermission) {
-		return true
-	}
-
 	if identityId != "" {
-		if identity, _ := ae.Managers.Identity.Read(identityId); identity != nil && identity.IsAdmin {
+		identity, err := ae.Managers.Identity.Read(identityId)
+		if err != nil {
+			rc.RespondWithError(err)
+			return
+		}
+		if identity != nil && identity.IsAdmin {
 			rc.RespondWithError(nonAdminNotAllowedError(errors.New("non-admins may not manage enrollments for admin identities")))
-			return false
+			return
 		}
 	}
 
-	return true
+	handler()
 }
 
-// allowNonAdminAccessToEnrollment ensures that a non-admin caller is not reading, refreshing, or
+// checkNonAdminAccessToEnrollment ensures that a non-admin caller is not reading, refreshing, or
 // deleting an enrollment that belongs to an admin identity. The enrollment carries the live token
 // and JWT used to enroll as its target identity, so exposing or refreshing an admin identity's
-// enrollment would permit privilege escalation. It responds with an unauthorized error and returns
-// false when the operation should be denied. When the enrollment cannot be loaded, it allows the
-// request to proceed so the downstream handler can produce the appropriate not-found response.
-func (r *EnrollmentRouter) allowNonAdminAccessToEnrollment(ae *env.AppEnv, rc *response.RequestContext) bool {
+// enrollment would permit privilege escalation. When access is granted it invokes handler;
+// otherwise it writes the appropriate error response and does not call handler. When the enrollment
+// cannot be loaded it denies the request rather than relying on a downstream handler to do so.
+func (r *EnrollmentRouter) checkNonAdminAccessToEnrollment(ae *env.AppEnv, rc *response.RequestContext, handler func()) {
 	if rc.HasPermission(permissions.AdminPermission) {
-		return true
+		handler()
+		return
 	}
 
 	id, err := rc.GetEntityId()
 	if err != nil {
 		rc.RespondWithError(err)
-		return false
+		return
 	}
 
 	enrollmentEntity, err := ae.Managers.Enrollment.Read(id)
-	if err != nil || enrollmentEntity == nil || enrollmentEntity.IdentityId == nil {
-		return true
+	if err != nil {
+		rc.RespondWithError(err)
+		return
+	}
+	if enrollmentEntity == nil {
+		rc.RespondWithNotFound()
+		return
+	}
+	if enrollmentEntity.IdentityId == nil {
+		// an enrollment not tied to an identity has no admin to escalate to
+		handler()
+		return
 	}
 
-	return r.allowNonAdminEnrollmentForIdentity(ae, rc, *enrollmentEntity.IdentityId)
+	r.checkNonAdminEnrollmentForIdentity(ae, rc, *enrollmentEntity.IdentityId, handler)
 }
 
 func MapCreateEnrollmentToModel(create *rest_model.EnrollmentCreate) *model.Enrollment {

--- a/tests/permissions_enrollment_test.go
+++ b/tests/permissions_enrollment_test.go
@@ -22,6 +22,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/openziti/edge-api/rest_model"
+	"github.com/openziti/ziti/v2/common/eid"
 	"github.com/openziti/ziti/v2/controller/permissions"
 )
 
@@ -251,4 +253,83 @@ func testEnrollmentNoPermissions(ctx *TestContext) {
 	// Cleanup
 	testHelper.deleteEnrollment(ctx, ctx.AdminManagementSession, enrollmentId, http.StatusOK)
 	testHelper.deleteIdentity(ctx, ctx.AdminManagementSession, testIdentityId, http.StatusOK)
+}
+
+// Test_Permissions_Enrollment_AdminIdentityEscalation verifies that a non-admin with entity-level
+// enrollment permissions cannot use enrollments to escalate to admin. An enrollment mints and
+// exposes the one-time-token used to enroll as its target identity, so a non-admin must not be able
+// to create, read, refresh, delete, or list enrollments belonging to an admin identity. Fixes #4010.
+func Test_Permissions_Enrollment_AdminIdentityEscalation(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+	ctx.RequireAdminManagementApiLogin()
+
+	testHelper := permissionTestHelper{}
+
+	// Attacker: a non-admin identity granted the full enrollment entity permission.
+	enrollPermSession := testHelper.newIdentityWithPermissions(ctx, []string{"enrollment"})
+
+	// Target admin identity (no enrollment yet) plus a control non-admin identity.
+	adminIdentityId := testHelper.createAdminIdentityWithoutEnrollment(ctx, ctx.AdminManagementSession, eid.New(), http.StatusCreated)
+	userIdentityId := testHelper.createIdentityWithoutEnrollment(ctx, ctx.AdminManagementSession, eid.New(), http.StatusCreated)
+
+	t.Run("non-admin may not create an enrollment for an admin identity", func(t *testing.T) {
+		ctx.testContextChanged(t)
+		testHelper.createEnrollment(ctx, enrollPermSession, adminIdentityId, http.StatusUnauthorized)
+	})
+
+	t.Run("non-admin may still create an enrollment for a non-admin identity", func(t *testing.T) {
+		ctx.testContextChanged(t)
+		enrollmentId := testHelper.createEnrollment(ctx, enrollPermSession, userIdentityId, http.StatusCreated)
+		testHelper.deleteEnrollment(ctx, ctx.AdminManagementSession, enrollmentId, http.StatusOK)
+	})
+
+	// Create an enrollment on the admin identity as admin so the read/refresh/delete/list paths
+	// have an admin-owned enrollment to operate on.
+	adminEnrollmentId := testHelper.createEnrollment(ctx, ctx.AdminManagementSession, adminIdentityId, http.StatusCreated)
+
+	t.Run("non-admin may not read an admin identity's enrollment", func(t *testing.T) {
+		ctx.testContextChanged(t)
+		testHelper.getEnrollment(ctx, enrollPermSession, adminEnrollmentId, http.StatusUnauthorized)
+	})
+
+	t.Run("non-admin may not refresh an admin identity's enrollment", func(t *testing.T) {
+		ctx.testContextChanged(t)
+		testHelper.refreshEnrollment(ctx, enrollPermSession, adminEnrollmentId, http.StatusUnauthorized)
+	})
+
+	t.Run("non-admin may not delete an admin identity's enrollment", func(t *testing.T) {
+		ctx.testContextChanged(t)
+		testHelper.deleteEnrollment(ctx, enrollPermSession, adminEnrollmentId, http.StatusUnauthorized)
+	})
+
+	t.Run("non-admin enrollment list excludes admin identity enrollments", func(t *testing.T) {
+		ctx.testContextChanged(t)
+		enrollmentsResp := &rest_model.ListEnrollmentsEnvelope{}
+		resp, err := enrollPermSession.newAuthenticatedRequest().
+			SetResult(enrollmentsResp).
+			Get("/enrollments")
+
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body()))
+
+		for _, e := range enrollmentsResp.Data {
+			if e.ID != nil {
+				ctx.Req.NotEqual(adminEnrollmentId, *e.ID, "admin identity enrollment must not appear in non-admin enrollment list")
+			}
+		}
+	})
+
+	t.Run("admin may manage an admin identity's enrollment", func(t *testing.T) {
+		ctx.testContextChanged(t)
+		testHelper.getEnrollment(ctx, ctx.AdminManagementSession, adminEnrollmentId, http.StatusOK)
+		testHelper.listEnrollments(ctx, ctx.AdminManagementSession, http.StatusOK)
+		testHelper.refreshEnrollment(ctx, ctx.AdminManagementSession, adminEnrollmentId, http.StatusOK)
+		testHelper.deleteEnrollment(ctx, ctx.AdminManagementSession, adminEnrollmentId, http.StatusOK)
+	})
+
+	// Cleanup
+	testHelper.deleteIdentity(ctx, ctx.AdminManagementSession, adminIdentityId, http.StatusOK)
+	testHelper.deleteIdentity(ctx, ctx.AdminManagementSession, userIdentityId, http.StatusOK)
 }

--- a/tests/permissions_test_helper.go
+++ b/tests/permissions_test_helper.go
@@ -943,6 +943,31 @@ func (self permissionTestHelper) createIdentityWithoutEnrollment(ctx *TestContex
 	return ""
 }
 
+// createAdminIdentityWithoutEnrollment creates an admin identity without any enrollment
+func (self permissionTestHelper) createAdminIdentityWithoutEnrollment(ctx *TestContext, session *session, name string, expectedStatus int) string {
+	identityType := rest_model.IdentityTypeUser
+	identityCreate := &rest_model.IdentityCreate{
+		AuthPolicyID: ToPtr("default"),
+		IsAdmin:      ToPtr(true),
+		Name:         ToPtr(name),
+		Type:         &identityType,
+	}
+
+	identityCreateResp := &rest_model.CreateEnvelope{}
+	resp, err := session.newAuthenticatedRequest().
+		SetResult(identityCreateResp).
+		SetBody(identityCreate).
+		Post("/identities")
+
+	ctx.Req.NoError(err)
+	ctx.Req.Equal(expectedStatus, resp.StatusCode(), string(resp.Body()))
+
+	if identityCreateResp.Data != nil {
+		return identityCreateResp.Data.ID
+	}
+	return ""
+}
+
 // createEnrollment creates an enrollment for an identity
 func (self permissionTestHelper) createEnrollment(ctx *TestContext, session *session, identityId string, expected int) string {
 	enrollmentCreate := &rest_model.EnrollmentCreate{


### PR DESCRIPTION
## What

Closes a privilege-escalation hole in the entity-level permission system. A non-admin granted the `enrollment` (or `enrollment.create`) permission could create a one-time-token enrollment for an admin identity and then enroll as that admin, gaining full admin access. Because an enrollment also carries the live token/JWT, reading or refreshing an admin identity's enrollment is an equivalent leak.

## Why

The `identity` and `authenticator` routers already prevent non-admins from acting on admin identities, but the enrollment router had no such guard. This brings enrollment in line with those existing protections.

## Changes

- Non-admins can no longer create, read, refresh, or delete an enrollment that belongs to an admin identity.
- Admin identity enrollments are filtered out of enrollment lists for non-admin callers.
- Full admins are unaffected; the guards only trigger on admin-target enrollments, so existing non-admin enrollment flows against non-admin identities continue to work.
- Adds a permissions test covering each escalation path plus the admin-allowed behavior.