### PR TITLE
Document v1.3.0 router floor in backward-compatibility test

### DIFF
--- a/.github/workflows/backward-compatibility.yml
+++ b/.github/workflows/backward-compatibility.yml
@@ -24,6 +24,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Router versions are floored at v1.3.0. Pre-1.3.0 routers (1.1.x/1.2.x) gate JWT
+        # session-token handling behind the HA flag. A 2.0 controller issues every service
+        # session as a JWT (even legacy ones), so when such a router hosts SDK terminators
+        # the bind request is sent with an empty api session token and the controller
+        # rejects it with "invalid api-session". The fix (removing the HA gate) landed in
+        # v1.3.0 and was never backported to 1.1.x. The dial path is unaffected, since it
+        # always sends the api session token. oidc is disabled for <1.6 routers, which
+        # lack full OIDC support.
         include:
           - name: east-1.6
             labels: "router_east_1_version=v1.6.12,router_east_2_version=v1.6.12"


### PR DESCRIPTION
Adds a comment to the backward-compatibility smoke test explaining why the router version matrix is floored at v1.3.0 and doesn't include the older 1.1.x/1.2.x lines.

Pre-1.3.0 routers gate JWT session-token handling behind the HA flag. Since a 2.0 controller issues every service session as a JWT (including legacy ones), such a router fails when hosting SDK terminators against it: the bind request goes out with an empty api session token and the controller rejects it as "invalid api-session". The fix removed that gate in v1.3.0 and was never backported to 1.1.x, so 1.3.0 is the realistic floor for an old router hosting through a 2.0 controller.

Comment-only change, no behavior change.