### PR TITLE
Automate LTS point releases

### DIFF
--- a/.github/workflows/lts-release-finalize.yml
+++ b/.github/workflows/lts-release-finalize.yml
@@ -21,13 +21,15 @@ concurrency:
 jobs:
   finalize:
     name: Tag validated commit
+    # Cheap pre-filter only. Real authorization is the "Authorize reviewer" step
+    # below: author_association (e.g. MEMBER) reflects org membership, not repo
+    # write access, so it must not be the gate for a job that tags releases.
     if: >
       github.repository_owner == 'openziti'
       && github.event.review.state == 'approved'
       && startsWith(github.event.pull_request.base.ref, 'release-v')
       && startsWith(github.event.pull_request.head.ref, 'lts-bump')
       && contains(github.event.pull_request.labels.*.name, 'lts-release')
-      && contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)
     runs-on: ubuntu-24.04
     env:
       # PAT so the created tag triggers release.yml (GITHUB_TOKEN would not)
@@ -36,6 +38,25 @@ jobs:
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
+      # Authorization gate: the approving reviewer must actually hold write
+      # (or maintain/admin) permission on the repo. Org membership alone is not
+      # enough, since this job can move release branches and tag releases.
+      - name: Authorize reviewer
+        env:
+          REVIEWER: ${{ github.event.review.user.login }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          perm="$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${REVIEWER}/permission" -q '.permission' 2>/dev/null || echo "none")"
+          case "${perm}" in
+            admin|maintain|write)
+              echo "reviewer ${REVIEWER} authorized (${perm})" ;;
+            *)
+              gh pr comment "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" \
+                --body ":no_entry: Approval by \`${REVIEWER}\` ignored: releasing requires write access to the repository (found permission: ${perm}). A maintainer must approve to release."
+              echo "::error ::reviewer ${REVIEWER} lacks write permission (${perm}); not releasing"
+              exit 1 ;;
+          esac
       # Parse the version/sha/base marker recorded at validation time and verify
       # it still matches the live PR. This is what guarantees we only release the
       # commit that was actually validated: if the lts-bump branch was changed
@@ -55,6 +76,17 @@ jobs:
           version="$(printf '%s' "${marker}" | grep -oP 'version=\Kv[0-9]+\.[0-9]+\.[0-9]+')"
           marker_sha="$(printf '%s' "${marker}" | grep -oP 'sha=\K[0-9a-f]{7,40}')"
           marker_base="$(printf '%s' "${marker}" | grep -oP 'base=\Krelease-v[0-9]+\.[0-9]+\.x')"
+
+          # The version's major.minor must match the branch we are releasing on,
+          # so a tampered body cannot tag e.g. v9.9.9 onto release-v2.0.x. BASE is
+          # the event's base ref (not body-controlled), so derive the expected
+          # major.minor from it.
+          base_minor="$(printf '%s' "${BASE}" | sed -E 's/^release-v(.*)\.x$/\1/')"
+          version_minor="$(printf '%s' "${version}" | sed -E 's/^v([0-9]+\.[0-9]+)\..*$/\1/')"
+          if [[ "${version_minor}" != "${base_minor}" ]]; then
+            echo "::error ::version ${version} (minor ${version_minor}) does not match release branch ${BASE} (minor ${base_minor}); refusing to release"
+            exit 1
+          fi
 
           if [[ "${marker_sha}" != "${HEAD_SHA}" ]]; then
             gh pr comment "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" \

--- a/.github/workflows/lts-release-finalize.yml
+++ b/.github/workflows/lts-release-finalize.yml
@@ -35,6 +35,7 @@ jobs:
       # PAT so the created tag triggers release.yml (GITHUB_TOKEN would not)
       GH_TOKEN: ${{ secrets.GH_CI_KEY }}
       BASE: ${{ github.event.pull_request.base.ref }}
+      HEAD_REF: ${{ github.event.pull_request.head.ref }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
@@ -76,6 +77,21 @@ jobs:
           version="$(printf '%s' "${marker}" | grep -oP 'version=\Kv[0-9]+\.[0-9]+\.[0-9]+')"
           marker_sha="$(printf '%s' "${marker}" | grep -oP 'sha=\K[0-9a-f]{7,40}')"
           marker_base="$(printf '%s' "${marker}" | grep -oP 'base=\Krelease-v[0-9]+\.[0-9]+\.x')"
+
+          # The exact version is fixed at validation time and baked into the head
+          # branch name (lts-bump-<version>-<run_id>), which is not body-editable.
+          # Treat that as authoritative so a tampered body cannot change the patch
+          # number tagged onto the validated commit.
+          branch_version="$(printf '%s' "${HEAD_REF}" | grep -oP '^lts-bump-\Kv[0-9]+\.[0-9]+\.[0-9]+(?=-[0-9]+$)' || true)"
+          if [[ -z "${branch_version}" ]]; then
+            echo "::error ::could not parse version from head branch '${HEAD_REF}'"
+            exit 1
+          fi
+          if [[ "${version}" != "${branch_version}" ]]; then
+            echo "::error ::PR body version ${version} does not match the validated branch version ${branch_version}; refusing to release"
+            exit 1
+          fi
+          version="${branch_version}"
 
           # The version's major.minor must match the branch we are releasing on,
           # so a tampered body cannot tag e.g. v9.9.9 onto release-v2.0.x. BASE is

--- a/.github/workflows/lts-release-finalize.yml
+++ b/.github/workflows/lts-release-finalize.yml
@@ -36,20 +36,58 @@ jobs:
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
-      - name: Parse release version
+      # Parse the version/sha/base marker recorded at validation time and verify
+      # it still matches the live PR. This is what guarantees we only release the
+      # commit that was actually validated: if the lts-bump branch was changed
+      # after validation, the recorded sha no longer matches the PR head and we
+      # refuse rather than releasing an unvalidated commit.
+      - name: Verify and parse release metadata
         id: meta
         shell: bash
         run: |
           set -euo pipefail
           body="$(gh pr view "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --json body -q .body)"
-          version="$(printf '%s' "${body}" | grep -oP '(?<=lts-release version=)v[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
-          if [[ -z "${version}" ]]; then
-            echo "::error ::could not parse 'lts-release version=' marker from PR #${PR_NUMBER} body"
+          marker="$(printf '%s' "${body}" | grep -oP '<!-- lts-release version=v[0-9]+\.[0-9]+\.[0-9]+ sha=[0-9a-f]{7,40} base=release-v[0-9]+\.[0-9]+\.x -->' | head -1 || true)"
+          if [[ -z "${marker}" ]]; then
+            echo "::error ::could not parse the 'lts-release' marker from PR #${PR_NUMBER} body"
             exit 1
           fi
+          version="$(printf '%s' "${marker}" | grep -oP 'version=\Kv[0-9]+\.[0-9]+\.[0-9]+')"
+          marker_sha="$(printf '%s' "${marker}" | grep -oP 'sha=\K[0-9a-f]{7,40}')"
+          marker_base="$(printf '%s' "${marker}" | grep -oP 'base=\Krelease-v[0-9]+\.[0-9]+\.x')"
+
+          if [[ "${marker_sha}" != "${HEAD_SHA}" ]]; then
+            gh pr comment "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" \
+              --body ":warning: The branch head (\`${HEAD_SHA}\`) does not match the validated commit recorded at validation time (\`${marker_sha}\`). The branch changed after validation, so this commit is unvalidated. Re-run the **lts-release** workflow to re-validate, then approve the new PR. Not releasing."
+            echo "::error ::PR head ${HEAD_SHA} != validated commit ${marker_sha}; refusing to release"
+            exit 1
+          fi
+          if [[ "${marker_base}" != "${BASE}" ]]; then
+            echo "::error ::marker base ${marker_base} != PR base ${BASE}; refusing to release"
+            exit 1
+          fi
+
           echo "version=${version}" | tee -a "$GITHUB_OUTPUT"
+          echo "sha=${marker_sha}" | tee -a "$GITHUB_OUTPUT"
+
+      # Preflight before moving anything: if the tag already exists, a prior run
+      # already released this version. Refuse rather than advancing the branch.
+      - name: Preflight - tag must not already exist
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${VERSION}" >/dev/null 2>&1; then
+            gh pr comment "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" \
+              --body ":warning: Tag \`${VERSION}\` already exists; this version was already released. Not re-releasing."
+            echo "::error ::tag ${VERSION} already exists"
+            exit 1
+          fi
 
       - name: Fast-forward LTS branch
+        env:
+          SHA: ${{ steps.meta.outputs.sha }}
         shell: bash
         run: |
           set -euo pipefail
@@ -57,21 +95,22 @@ jobs:
           # advanced since validation (e.g. a backport landed), the API returns
           # an error and we ask for a re-validation rather than merging untested code.
           if ! gh api -X PATCH "repos/${GITHUB_REPOSITORY}/git/refs/heads/${BASE}" \
-                -f "sha=${HEAD_SHA}" -F "force=false" >/dev/null 2>err.txt; then
+                -f "sha=${SHA}" -F "force=false" >/dev/null 2>err.txt; then
             cat err.txt >&2
             gh pr comment "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" \
-              --body ":warning: Could not fast-forward \`${BASE}\` to the validated commit \`${HEAD_SHA}\` (the branch moved since validation). Re-run the **lts-release** workflow to re-validate on top of the updated branch, then approve the new PR."
+              --body ":warning: Could not fast-forward \`${BASE}\` to the validated commit \`${SHA}\` (the branch moved since validation). Re-run the **lts-release** workflow to re-validate on top of the updated branch, then approve the new PR."
             exit 1
           fi
 
       - name: Tag the validated commit
         env:
           VERSION: ${{ steps.meta.outputs.version }}
+          SHA: ${{ steps.meta.outputs.sha }}
         shell: bash
         run: |
           set -euo pipefail
           gh api -X POST "repos/${GITHUB_REPOSITORY}/git/refs" \
             -f "ref=refs/tags/${VERSION}" \
-            -f "sha=${HEAD_SHA}" >/dev/null
+            -f "sha=${SHA}" >/dev/null
           gh pr comment "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" \
-            --body ":white_check_mark: Fast-forwarded \`${BASE}\` and tagged \`${VERSION}\` at \`${HEAD_SHA}\`. The release build (\`release.yml\`) will run from the tag."
+            --body ":white_check_mark: Fast-forwarded \`${BASE}\` and tagged \`${VERSION}\` at \`${SHA}\`. The release build (\`release.yml\`) will run from the tag."

--- a/.github/workflows/lts-release-finalize.yml
+++ b/.github/workflows/lts-release-finalize.yml
@@ -1,0 +1,77 @@
+name: lts-release-finalize
+
+# Phase 2 of the automated LTS release. When a maintainer approves an
+# lts-release PR (opened by lts-release.yml), this fast-forwards the LTS branch
+# to the validated commit and tags it. The tag is created with GH_CI_KEY (a PAT)
+# so release.yml fires and builds the release; the default GITHUB_TOKEN would
+# not trigger downstream workflows.
+#
+# Approval is the release gate: the smoketest and validation already ran in
+# Phase 1 against the exact commit being tagged, so nothing is re-run here.
+
+on:
+  pull_request_review:
+    types: [ submitted ]
+
+# don't let two approvals on the same PR race
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  finalize:
+    name: Tag validated commit
+    if: >
+      github.repository_owner == 'openziti'
+      && github.event.review.state == 'approved'
+      && startsWith(github.event.pull_request.base.ref, 'release-v')
+      && startsWith(github.event.pull_request.head.ref, 'lts-bump')
+      && contains(github.event.pull_request.labels.*.name, 'lts-release')
+      && contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)
+    runs-on: ubuntu-24.04
+    env:
+      # PAT so the created tag triggers release.yml (GITHUB_TOKEN would not)
+      GH_TOKEN: ${{ secrets.GH_CI_KEY }}
+      BASE: ${{ github.event.pull_request.base.ref }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Parse release version
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          body="$(gh pr view "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --json body -q .body)"
+          version="$(printf '%s' "${body}" | grep -oP '(?<=lts-release version=)v[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+          if [[ -z "${version}" ]]; then
+            echo "::error ::could not parse 'lts-release version=' marker from PR #${PR_NUMBER} body"
+            exit 1
+          fi
+          echo "version=${version}" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Fast-forward LTS branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          # force=false makes this a fast-forward-only update. If the branch has
+          # advanced since validation (e.g. a backport landed), the API returns
+          # an error and we ask for a re-validation rather than merging untested code.
+          if ! gh api -X PATCH "repos/${GITHUB_REPOSITORY}/git/refs/heads/${BASE}" \
+                -f "sha=${HEAD_SHA}" -F "force=false" >/dev/null 2>err.txt; then
+            cat err.txt >&2
+            gh pr comment "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" \
+              --body ":warning: Could not fast-forward \`${BASE}\` to the validated commit \`${HEAD_SHA}\` (the branch moved since validation). Re-run the **lts-release** workflow to re-validate on top of the updated branch, then approve the new PR."
+            exit 1
+          fi
+
+      - name: Tag the validated commit
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh api -X POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+            -f "ref=refs/tags/${VERSION}" \
+            -f "sha=${HEAD_SHA}" >/dev/null
+          gh pr comment "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" \
+            --body ":white_check_mark: Fast-forwarded \`${BASE}\` and tagged \`${VERSION}\` at \`${HEAD_SHA}\`. The release build (\`release.yml\`) will run from the tag."

--- a/.github/workflows/lts-release.yml
+++ b/.github/workflows/lts-release.yml
@@ -79,7 +79,6 @@ jobs:
       minor: ${{ steps.resolve.outputs.minor }}
       is_active: ${{ steps.resolve.outputs.is_active }}
       run_validation: ${{ steps.resolve.outputs.run_validation }}
-      update_internal: ${{ steps.resolve.outputs.update_internal }}
       version: ${{ steps.version.outputs.version }}
       branch: ${{ steps.push.outputs.branch }}
       sha: ${{ steps.push.outputs.sha }}
@@ -160,16 +159,14 @@ jobs:
             *) run_validation="${is_active}" ;;
           esac
 
-          # Internal openziti libraries are only auto-updated on the Active LTS line.
-          # Maintenance and older lines take external dependency updates only, leaving
-          # the openziti libraries pinned to what that line shipped with.
-          update_internal="${is_active}"
+          # Internal openziti libraries are intentionally NOT auto-updated on any
+          # line (see the "Update dependencies" step). They stay pinned to what
+          # the line shipped with; bumping them is a deliberate, separate step.
 
           echo "minor=${minor}" | tee -a "$GITHUB_OUTPUT"
           echo "base=${base}" | tee -a "$GITHUB_OUTPUT"
           echo "is_active=${is_active}" | tee -a "$GITHUB_OUTPUT"
           echo "run_validation=${run_validation}" | tee -a "$GITHUB_OUTPUT"
-          echo "update_internal=${update_internal}" | tee -a "$GITHUB_OUTPUT"
 
       - name: Git Checkout
         uses: actions/checkout@v6
@@ -201,7 +198,6 @@ jobs:
       - name: Update dependencies
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          UPDATE_INTERNAL: ${{ steps.resolve.outputs.update_internal }}
         shell: bash
         run: |
           set -euxo pipefail
@@ -217,16 +213,16 @@ jobs:
             echo "${ext}" | xargs -r -n1 -I{} go get {}@latest
           fi
 
-          # Internal openziti libraries (Active LTS line only): latest point/bugfix.
-          # The @patch query selects the highest patch of each module's currently
-          # required minor, so no minor/feature bumps slip in. Older / maintenance
-          # lines leave these pinned.
-          if [[ "${UPDATE_INTERNAL}" == "true" ]]; then
-            oz=$(directs | grep '/openziti/' || true)
-            if [[ -n "${oz}" ]]; then
-              echo "${oz}" | xargs -r -n1 -I{} go get {}@patch
-            fi
-          fi
+          # Internal openziti libraries are deliberately left pinned. Most LTS bug
+          # fixes land as commits on the release branch itself (already captured by
+          # this bump branch), and auto-bumping the libraries via @patch would trust
+          # their semver tags, which are not yet enforced.
+          #
+          # TODO: once the openziti library repos gate their releases on an
+          # API-compatibility check (e.g. golang.org/x/exp/cmd/gorelease) so a
+          # patch tag is guaranteed non-breaking, re-enable point/bugfix bumps of
+          # the openziti modules on the active LTS line:
+          #   if active: directs | grep '/openziti/' | xargs -n1 -I{} go get {}@patch
 
           go mod tidy
           if [[ -f zititest/go.mod ]]; then
@@ -235,8 +231,6 @@ jobs:
 
       - name: Commit and push bump branch
         id: push
-        env:
-          UPDATE_INTERNAL: ${{ steps.resolve.outputs.update_internal }}
         shell: bash
         run: |
           set -euxo pipefail
@@ -257,14 +251,9 @@ jobs:
             # accumulated backports on the branch.
             git commit --allow-empty -m "Cut LTS release ${{ steps.version.outputs.version }} (no dependency changes)"
           else
-            if [[ "${UPDATE_INTERNAL}" == "true" ]]; then
-              internal_note="- bumps internal openziti dependencies to latest point/bugfix"
-            else
-              internal_note="- internal openziti dependencies left pinned (non-active LTS line)"
-            fi
             git commit -m "Update dependencies for LTS release ${{ steps.version.outputs.version }}" \
                        -m "- bumps external dependencies to latest compatible (minor + patch)" \
-                       -m "${internal_note}" \
+                       -m "- leaves internal openziti dependencies pinned" \
                        -m "- runs go mod tidy in root and zititest"
           fi
 

--- a/.github/workflows/lts-release.yml
+++ b/.github/workflows/lts-release.yml
@@ -1,0 +1,532 @@
+name: lts-release
+
+# Automated LTS point-release preparation.
+#
+# Runs monthly for the Active LTS line (and on demand for either line). It bumps
+# dependencies, validates the result with the smoketest and full validation
+# suite, and opens a PR against the LTS release branch. Approving that PR
+# (handled by lts-release-finalize.yml) fast-forwards the branch to the
+# validated commit and tags it, which triggers release.yml.
+#
+# See RELEASE_POLICY.md for the dependency-update and testing policy.
+
+on:
+  schedule:
+    # 08:00 UTC on the 1st of each month: Active LTS line (smoketest + full validation).
+    - cron: '0 8 1 * *'
+    # 09:00 UTC on the 1st of each month: older extended-support line, smoketest only.
+    # This branch is not in lts-versions.json, so it is named explicitly here.
+    # Change or remove this entry as extended-support lines come and go.
+    - cron: '0 9 1 * *'
+  workflow_dispatch:
+    inputs:
+      line:
+        description: Which LTS line to release (resolved from lts-versions.json). Ignored if 'branch' is set.
+        type: choice
+        options:
+          - active
+          - maintenance
+        default: active
+      branch:
+        description: Explicit release branch to target (e.g. release-v1.5.x). Overrides 'line'; use for older lines not in lts-versions.json.
+        type: string
+        default: ''
+      validation:
+        description: Whether to run the full validation suite. 'auto' runs it only for the active LTS line (per RELEASE_POLICY.md).
+        type: choice
+        options:
+          - auto
+          - run
+          - skip
+        default: auto
+      validation_duration:
+        description: How long to run each validation test.
+        type: string
+        default: '2h'
+      force_release:
+        description: Open the PR even if the full validation suite failed (for flaky validation only; the smoketest must still pass).
+        type: boolean
+        default: false
+
+# never run two preparation runs for the same line at once
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.branch || inputs.line || github.event.schedule || 'active' }}
+  cancel-in-progress: false
+
+# prepare pushes the bump branch; the PR and failure issue are created with
+# GH_CI_KEY (a PAT) so their events trigger the Mattermost forwarder.
+permissions:
+  contents: write
+
+env:
+  GOFLAGS: "-tags=pkcs11 -trimpath"
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_DEFAULT_REGION: "us-east-2"
+  gh_ci_key: ${{ secrets.GH_CI_KEY }}
+  BUILD_NUMBER: ${{ format('{0}-{1}-{2}', github.run_id, github.run_number, github.run_attempt) }}
+
+jobs:
+  # Resolve the target LTS branch, compute the next patch version, bump
+  # dependencies, and push a bump branch whose head commit is what everything
+  # downstream validates and (on approval) tags.
+  prepare:
+    name: Prepare dependency bump
+    if: github.repository_owner == 'openziti'
+    runs-on: ubuntu-24.04
+    outputs:
+      base: ${{ steps.resolve.outputs.base }}
+      minor: ${{ steps.resolve.outputs.minor }}
+      run_validation: ${{ steps.resolve.outputs.run_validation }}
+      update_internal: ${{ steps.resolve.outputs.update_internal }}
+      version: ${{ steps.version.outputs.version }}
+      branch: ${{ steps.push.outputs.branch }}
+      sha: ${{ steps.push.outputs.sha }}
+    steps:
+      - name: Resolve target release branch and validation policy
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # empty on schedule; populated on workflow_dispatch
+          IN_LINE: ${{ inputs.line }}
+          IN_BRANCH: ${{ inputs.branch }}
+          IN_VALIDATION: ${{ inputs.validation }}
+          SCHEDULE: ${{ github.event.schedule }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          manifest() {
+            gh api "repos/${GITHUB_REPOSITORY}/contents/lts-versions.json" \
+              -H "Accept: application/vnd.github.raw" | jq -r ".$1 // empty"
+          }
+          active_minor="$(manifest active)"
+          if [[ -z "${active_minor}" ]]; then
+            echo "::error ::no 'active' entry in lts-versions.json"
+            exit 1
+          fi
+
+          base=""
+          key=""
+          if [[ -n "${IN_BRANCH}" ]]; then
+            # explicit branch override (e.g. an older line not in the manifest)
+            base="${IN_BRANCH}"
+          elif [[ -n "${SCHEDULE}" ]]; then
+            # map each scheduled cron to a target
+            case "${SCHEDULE}" in
+              '0 8 1 * *') key="active" ;;
+              '0 9 1 * *') base="release-v1.5.x" ;;
+              *) echo "::error ::unmapped schedule '${SCHEDULE}'"; exit 1 ;;
+            esac
+          else
+            key="${IN_LINE:-active}"
+          fi
+
+          if [[ -n "${key}" ]]; then
+            if [[ "${key}" != "active" && "${key}" != "maintenance" ]]; then
+              echo "::error ::invalid line '${key}' (expected active or maintenance)"
+              exit 1
+            fi
+            minor="$(manifest "${key}")"
+            if [[ -z "${minor}" ]]; then
+              echo "::error ::no '${key}' entry in lts-versions.json"
+              exit 1
+            fi
+            base="release-v${minor}.x"
+          fi
+
+          if ! [[ "${base}" =~ ^release-v[0-9]+\.[0-9]+\.x$ ]]; then
+            echo "::error ::resolved branch '${base}' is not a release-v<major>.<minor>.x branch"
+            exit 1
+          fi
+          minor="$(printf '%s' "${base}" | sed -E 's/^release-v(.*)\.x$/\1/')"
+
+          is_active="false"
+          [[ "${minor}" == "${active_minor}" ]] && is_active="true"
+
+          # Validation policy: by default only the Active LTS line runs the full
+          # suite (RELEASE_POLICY.md). Maintenance and older lines are smoketest-only.
+          case "${IN_VALIDATION:-auto}" in
+            run) run_validation="true" ;;
+            skip) run_validation="false" ;;
+            *) run_validation="${is_active}" ;;
+          esac
+
+          # Internal openziti libraries are only auto-updated on the Active LTS line.
+          # Maintenance and older lines take external dependency updates only, leaving
+          # the openziti libraries pinned to what that line shipped with.
+          update_internal="${is_active}"
+
+          echo "minor=${minor}" | tee -a "$GITHUB_OUTPUT"
+          echo "base=${base}" | tee -a "$GITHUB_OUTPUT"
+          echo "run_validation=${run_validation}" | tee -a "$GITHUB_OUTPUT"
+          echo "update_internal=${update_internal}" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Git Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.resolve.outputs.base }}
+          fetch-depth: 0
+
+      - name: Install Go
+        uses: ./.github/actions/setup-go
+
+      - name: Install Ziti CI
+        uses: openziti/ziti-ci@v1
+
+      - name: Compute next version
+        id: version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -o pipefail
+          ver="$($(go env GOPATH)/bin/ziti-ci -q get-next-version)"
+          ver="v${ver#v}"
+          if ! [[ "${ver}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error ::computed version '${ver}' is not a release semver"
+            exit 1
+          fi
+          echo "version=${ver}" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Update dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATE_INTERNAL: ${{ steps.resolve.outputs.update_internal }}
+        shell: bash
+        run: |
+          set -euxo pipefail
+
+          directs() {
+            go mod edit -json | jq -r '.Require[] | select((.Indirect // false) | not) | .Path'
+          }
+
+          # External dependencies (every line): direct, non-openziti, non-pfxlog
+          # modules to latest compatible version. Mirrors ~/bin/update-ext-deps.
+          ext=$(directs | grep -v 'ziti' | grep -v 'pfxlog' || true)
+          if [[ -n "${ext}" ]]; then
+            echo "${ext}" | xargs -r -n1 -I{} go get {}@latest
+          fi
+
+          # Internal openziti libraries (Active LTS line only): latest point/bugfix.
+          # Older / maintenance lines leave these pinned.
+          if [[ "${UPDATE_INTERNAL}" == "true" ]]; then
+            oz=$(directs | grep '/openziti/' || true)
+            if [[ -n "${oz}" ]]; then
+              echo "${oz}" | xargs -r -n1 -I{} go get -u=patch {}
+            fi
+          fi
+
+          go mod tidy
+          if [[ -f zititest/go.mod ]]; then
+            ( cd zititest && go mod tidy )
+          fi
+
+      - name: Commit and push bump branch
+        id: push
+        env:
+          UPDATE_INTERNAL: ${{ steps.resolve.outputs.update_internal }}
+        shell: bash
+        run: |
+          set -euxo pipefail
+          $(go env GOPATH)/bin/ziti-ci configure-git
+
+          branch="lts-bump-${{ steps.version.outputs.version }}"
+          git checkout -b "${branch}"
+
+          git add go.mod go.sum
+          if [[ -f zititest/go.mod ]]; then
+            git add zititest/go.mod zititest/go.sum
+          fi
+
+          if git diff --cached --quiet; then
+            # No dependency changes this cycle; still cut a release to ship any
+            # accumulated backports on the branch.
+            git commit --allow-empty -m "Cut LTS release ${{ steps.version.outputs.version }} (no dependency changes)"
+          else
+            if [[ "${UPDATE_INTERNAL}" == "true" ]]; then
+              internal_note="- bumps internal openziti dependencies to latest point/bugfix"
+            else
+              internal_note="- internal openziti dependencies left pinned (non-active LTS line)"
+            fi
+            git commit -m "Update dependencies for LTS release ${{ steps.version.outputs.version }}" \
+                       -m "- bumps external dependencies to latest compatible (minor + patch)" \
+                       -m "${internal_note}" \
+                       -m "- runs go mod tidy in root and zititest"
+          fi
+
+          git push origin "${branch}"
+          echo "branch=${branch}" | tee -a "$GITHUB_OUTPUT"
+          echo "sha=$(git rev-parse HEAD)" | tee -a "$GITHUB_OUTPUT"
+
+  # Smoketest the validated commit. This is the gate for committing the bump:
+  # if it fails, no PR is opened. Self-contained (creates and tears down its own
+  # fablab environment in one job).
+  smoketest:
+    name: Smoketest
+    needs: prepare
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
+          fetch-depth: 0
+
+      - name: Install Go
+        uses: ./.github/actions/setup-go
+
+      - name: Install Ziti CI
+        uses: openziti/ziti-ci@v1
+
+      - name: Install Terraform CLI
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: ~1.5
+
+      - name: Build and Test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ziti_ci_gpg_key: ${{ secrets.ZITI_CI_GPG_KEY }}
+          ziti_ci_gpg_key_id: ${{ secrets.ZITI_CI_GPG_KEY_ID }}
+        shell: bash
+        run: |
+          $(go env GOPATH)/bin/ziti-ci configure-git
+          $(go env GOPATH)/bin/ziti-ci generate-build-info common/version/info_generated.go version
+          pushd zititest && go mod tidy && go install -tags all ./... && popd
+          go install -tags=all,tests ./...
+
+      - name: Create Test Environment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          echo "ZITI_ROOT=$(go env GOPATH)/bin" >> "$GITHUB_ENV"
+          $(go env GOPATH)/bin/smoketest create -d smoketest-lts-${GITHUB_RUN_NUMBER} -n smoketest-lts-${GITHUB_RUN_NUMBER} -l environment=gh-fablab-lts-smoketest,ziti_version=$($(go env GOPATH)/bin/ziti-ci -q get-current-version)
+          $(go env GOPATH)/bin/smoketest up
+
+      - name: Test Ziti Command
+        shell: bash
+        run: |
+          echo "ZITI_ROOT=$(go env GOPATH)/bin" >> "$GITHUB_ENV"
+          pushd zititest && go test -timeout 30m -v ./tests/... 2>&1 | tee test.out && popd
+
+      - name: Create Logs Archive
+        if: always()
+        run: |
+          $(go env GOPATH)/bin/smoketest get files '*' "./logs/{{ .Id }}/" ./logs
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: lts-smoketest-logs-${{ github.run_id }}
+          path: logs/
+          compression-level: 7
+          retention-days: 5
+
+      - name: Tear down Test Environment
+        timeout-minutes: 30
+        if: always()
+        shell: bash
+        run: |
+          $(go env GOPATH)/bin/smoketest dispose
+
+  # Full validation suite against the validated commit. Each test is its own job
+  # so a flaky failure can be resumed with "re-run failed jobs".
+  validation-circuit:
+    name: Validation (Circuits)
+    needs: [ prepare, smoketest ]
+    if: needs.prepare.outputs.run_validation == 'true'
+    uses: ./.github/workflows/validation-test.yml
+    secrets: inherit
+    with:
+      test: circuit-test
+      ref: ${{ needs.prepare.outputs.sha }}
+      duration: ${{ inputs.validation_duration || '2h' }}
+
+  validation-ert:
+    name: Validation (ER/T Terminators)
+    needs: [ prepare, smoketest ]
+    if: needs.prepare.outputs.run_validation == 'true'
+    uses: ./.github/workflows/validation-test.yml
+    secrets: inherit
+    with:
+      test: ert-hosting-test
+      ref: ${{ needs.prepare.outputs.sha }}
+      duration: ${{ inputs.validation_duration || '2h' }}
+
+  validation-sdk-terminators:
+    name: Validation (SDK Terminators)
+    needs: [ prepare, smoketest ]
+    if: needs.prepare.outputs.run_validation == 'true'
+    uses: ./.github/workflows/validation-test.yml
+    secrets: inherit
+    with:
+      test: sdk-hosting-test
+      ref: ${{ needs.prepare.outputs.sha }}
+      duration: ${{ inputs.validation_duration || '2h' }}
+
+  validation-links:
+    name: Validation (Links)
+    needs: [ prepare, smoketest ]
+    if: needs.prepare.outputs.run_validation == 'true'
+    uses: ./.github/workflows/validation-test.yml
+    secrets: inherit
+    with:
+      test: links-test
+      ref: ${{ needs.prepare.outputs.sha }}
+      duration: ${{ inputs.validation_duration || '2h' }}
+
+  validation-router-data-model:
+    name: Validation (Router Data Model)
+    needs: [ prepare, smoketest ]
+    if: needs.prepare.outputs.run_validation == 'true'
+    uses: ./.github/workflows/validation-test.yml
+    secrets: inherit
+    with:
+      test: router-data-model-test
+      ref: ${{ needs.prepare.outputs.sha }}
+      duration: ${{ inputs.validation_duration || '2h' }}
+
+  validation-sdk-status:
+    name: Validation (SDK Status)
+    needs: [ prepare, smoketest ]
+    if: needs.prepare.outputs.run_validation == 'true'
+    uses: ./.github/workflows/validation-test.yml
+    secrets: inherit
+    with:
+      test: sdk-status-test
+      ref: ${{ needs.prepare.outputs.sha }}
+      duration: ${{ inputs.validation_duration || '2h' }}
+
+  # Open the review PR once the smoketest passed and validation passed (or was
+  # force-bypassed). Created with GH_CI_KEY so the pull_request:opened event
+  # fires and is forwarded to Mattermost by mattermost-channel-posts.yml.
+  open-pr:
+    name: Open release PR
+    needs:
+      - prepare
+      - smoketest
+      - validation-circuit
+      - validation-ert
+      - validation-sdk-terminators
+      - validation-links
+      - validation-router-data-model
+      - validation-sdk-status
+    if: >
+      !cancelled()
+      && needs.prepare.result == 'success'
+      && needs.smoketest.result == 'success'
+      && (
+        needs.prepare.outputs.run_validation != 'true'
+        || inputs.force_release
+        || (
+          needs.validation-circuit.result == 'success'
+          && needs.validation-ert.result == 'success'
+          && needs.validation-sdk-terminators.result == 'success'
+          && needs.validation-links.result == 'success'
+          && needs.validation-router-data-model.result == 'success'
+          && needs.validation-sdk-status.result == 'success'
+        )
+      )
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ secrets.GH_CI_KEY }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+          BASE: ${{ needs.prepare.outputs.base }}
+          BRANCH: ${{ needs.prepare.outputs.branch }}
+          SHA: ${{ needs.prepare.outputs.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          FORCED: ${{ inputs.force_release }}
+          RUN_VALIDATION: ${{ needs.prepare.outputs.run_validation }}
+          R_SMOKE: ${{ needs.smoketest.result }}
+          R_CIRCUIT: ${{ needs.validation-circuit.result }}
+          R_ERT: ${{ needs.validation-ert.result }}
+          R_SDK_TERM: ${{ needs.validation-sdk-terminators.result }}
+          R_LINKS: ${{ needs.validation-links.result }}
+          R_RDM: ${{ needs.validation-router-data-model.result }}
+          R_SDK_STATUS: ${{ needs.validation-sdk-status.result }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          emoji() { [[ "$1" == "success" ]] && echo ":white_check_mark:" || echo ":warning: $1"; }
+
+          body_file="${RUNNER_TEMP}/lts-pr-body.md"
+          {
+            printf '## LTS release %s\n\n' "${VERSION}"
+            printf 'Automated dependency update for the `%s` line.\n\n' "${BASE}"
+            printf 'Validated commit: `%s`\n\n' "${SHA}"
+            printf '| Gate | Result |\n|---|---|\n'
+            printf '| Smoketest | %s |\n' "$(emoji "${R_SMOKE}")"
+            if [[ "${RUN_VALIDATION}" == "true" ]]; then
+              printf '| Validation: circuit-test | %s |\n' "$(emoji "${R_CIRCUIT}")"
+              printf '| Validation: ert-hosting-test | %s |\n' "$(emoji "${R_ERT}")"
+              printf '| Validation: sdk-hosting-test | %s |\n' "$(emoji "${R_SDK_TERM}")"
+              printf '| Validation: links-test | %s |\n' "$(emoji "${R_LINKS}")"
+              printf '| Validation: router-data-model-test | %s |\n' "$(emoji "${R_RDM}")"
+              printf '| Validation: sdk-status-test | %s |\n\n' "$(emoji "${R_SDK_STATUS}")"
+            else
+              printf '| Full validation suite | skipped (smoketest-only line, per RELEASE_POLICY.md) |\n\n'
+            fi
+            printf 'Full run: %s\n\n' "${RUN_URL}"
+            if [[ "${RUN_VALIDATION}" == "true" && "${FORCED}" == "true" ]]; then
+              printf '> :warning: **Validation was force-bypassed for this run.** Review the validation results above before approving.\n\n'
+            fi
+            printf '### How this gets released\n\n'
+            printf '**Approving** this PR fast-forwards `%s` to the validated commit and tags `%s`, which triggers the release build. No re-run of the smoketest or validation happens on this PR; the results above are the gate.\n\n' "${BASE}" "${VERSION}"
+            printf 'If `%s` has moved since this run (e.g. a backport landed), the fast-forward will be refused and you will be asked to re-run the **lts-release** workflow to re-validate.\n\n' "${BASE}"
+            printf '<!-- lts-release version=%s sha=%s base=%s -->\n' "${VERSION}" "${SHA}" "${BASE}"
+          } > "${body_file}"
+
+          gh label create lts-release --color 0e8a16 --description "Automated LTS release PR" 2>/dev/null || true
+
+          gh pr create \
+            --repo "${GITHUB_REPOSITORY}" \
+            --base "${BASE}" \
+            --head "${BRANCH}" \
+            --title "LTS release ${VERSION} (${BASE})" \
+            --label lts-release \
+            --body-file "${body_file}"
+
+  # On a failed *scheduled* run, open a tracking issue. Created with GH_CI_KEY so
+  # the issues:opened event is forwarded to Mattermost by mattermost-channel-posts.yml.
+  notify-failure:
+    name: Notify on scheduled failure
+    needs:
+      - prepare
+      - smoketest
+      - validation-circuit
+      - validation-ert
+      - validation-sdk-terminators
+      - validation-links
+      - validation-router-data-model
+      - validation-sdk-status
+      - open-pr
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Open failure issue
+        env:
+          GH_TOKEN: ${{ secrets.GH_CI_KEY }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh label create lts-release-failure --color b60205 --description "Automated LTS release run failed" 2>/dev/null || true
+
+          body_file="${RUNNER_TEMP}/lts-failure-body.md"
+          {
+            printf 'The scheduled **lts-release** workflow failed.\n\n'
+            printf 'Run: %s\n\n' "${RUN_URL}"
+            printf 'To continue, **re-run failed jobs** on that run (the bump commit is already pushed, so it resumes from where it stopped). If the failure is flaky validation, dispatch **lts-release** manually with `force_release: true` to open the PR anyway (the smoketest must still pass).\n'
+          } > "${body_file}"
+
+          gh issue create \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "Scheduled LTS release run failed (run ${GITHUB_RUN_ID})" \
+            --label lts-release-failure \
+            --body-file "${body_file}"

--- a/.github/workflows/lts-release.yml
+++ b/.github/workflows/lts-release.yml
@@ -427,7 +427,9 @@ jobs:
   # so a flaky failure can be resumed with "re-run failed jobs".
   validation-circuit:
     name: Validation (Circuits)
-    needs: [ prepare, smoketest, ha-smoketest ]
+    # depends on the basic smoketest only (not ha-smoketest, which is skipped on
+    # non-active lines); the HA gate is still enforced by open-pr below
+    needs: [ prepare, smoketest ]
     if: needs.prepare.outputs.run_validation == 'true'
     uses: ./.github/workflows/validation-test.yml
     secrets: inherit
@@ -438,7 +440,9 @@ jobs:
 
   validation-ert:
     name: Validation (ER/T Terminators)
-    needs: [ prepare, smoketest, ha-smoketest ]
+    # depends on the basic smoketest only (not ha-smoketest, which is skipped on
+    # non-active lines); the HA gate is still enforced by open-pr below
+    needs: [ prepare, smoketest ]
     if: needs.prepare.outputs.run_validation == 'true'
     uses: ./.github/workflows/validation-test.yml
     secrets: inherit
@@ -449,7 +453,9 @@ jobs:
 
   validation-sdk-terminators:
     name: Validation (SDK Terminators)
-    needs: [ prepare, smoketest, ha-smoketest ]
+    # depends on the basic smoketest only (not ha-smoketest, which is skipped on
+    # non-active lines); the HA gate is still enforced by open-pr below
+    needs: [ prepare, smoketest ]
     if: needs.prepare.outputs.run_validation == 'true'
     uses: ./.github/workflows/validation-test.yml
     secrets: inherit
@@ -460,7 +466,9 @@ jobs:
 
   validation-links:
     name: Validation (Links)
-    needs: [ prepare, smoketest, ha-smoketest ]
+    # depends on the basic smoketest only (not ha-smoketest, which is skipped on
+    # non-active lines); the HA gate is still enforced by open-pr below
+    needs: [ prepare, smoketest ]
     if: needs.prepare.outputs.run_validation == 'true'
     uses: ./.github/workflows/validation-test.yml
     secrets: inherit
@@ -471,7 +479,9 @@ jobs:
 
   validation-router-data-model:
     name: Validation (Router Data Model)
-    needs: [ prepare, smoketest, ha-smoketest ]
+    # depends on the basic smoketest only (not ha-smoketest, which is skipped on
+    # non-active lines); the HA gate is still enforced by open-pr below
+    needs: [ prepare, smoketest ]
     if: needs.prepare.outputs.run_validation == 'true'
     uses: ./.github/workflows/validation-test.yml
     secrets: inherit
@@ -482,7 +492,9 @@ jobs:
 
   validation-sdk-status:
     name: Validation (SDK Status)
-    needs: [ prepare, smoketest, ha-smoketest ]
+    # depends on the basic smoketest only (not ha-smoketest, which is skipped on
+    # non-active lines); the HA gate is still enforced by open-pr below
+    needs: [ prepare, smoketest ]
     if: needs.prepare.outputs.run_validation == 'true'
     uses: ./.github/workflows/validation-test.yml
     secrets: inherit

--- a/.github/workflows/lts-release.yml
+++ b/.github/workflows/lts-release.yml
@@ -77,6 +77,7 @@ jobs:
     outputs:
       base: ${{ steps.resolve.outputs.base }}
       minor: ${{ steps.resolve.outputs.minor }}
+      is_active: ${{ steps.resolve.outputs.is_active }}
       run_validation: ${{ steps.resolve.outputs.run_validation }}
       update_internal: ${{ steps.resolve.outputs.update_internal }}
       version: ${{ steps.version.outputs.version }}
@@ -159,6 +160,7 @@ jobs:
 
           echo "minor=${minor}" | tee -a "$GITHUB_OUTPUT"
           echo "base=${base}" | tee -a "$GITHUB_OUTPUT"
+          echo "is_active=${is_active}" | tee -a "$GITHUB_OUTPUT"
           echo "run_validation=${run_validation}" | tee -a "$GITHUB_OUTPUT"
           echo "update_internal=${update_internal}" | tee -a "$GITHUB_OUTPUT"
 
@@ -209,11 +211,13 @@ jobs:
           fi
 
           # Internal openziti libraries (Active LTS line only): latest point/bugfix.
-          # Older / maintenance lines leave these pinned.
+          # The @patch query selects the highest patch of each module's currently
+          # required minor, so no minor/feature bumps slip in. Older / maintenance
+          # lines leave these pinned.
           if [[ "${UPDATE_INTERNAL}" == "true" ]]; then
             oz=$(directs | grep '/openziti/' || true)
             if [[ -n "${oz}" ]]; then
-              echo "${oz}" | xargs -r -n1 -I{} go get -u=patch {}
+              echo "${oz}" | xargs -r -n1 -I{} go get {}@patch
             fi
           fi
 
@@ -231,7 +235,9 @@ jobs:
           set -euxo pipefail
           $(go env GOPATH)/bin/ziti-ci configure-git
 
-          branch="lts-bump-${{ steps.version.outputs.version }}"
+          # include the run id so a fresh dispatch after a failed run (e.g. the
+          # force_release recovery path) does not collide with an orphaned branch
+          branch="lts-bump-${{ steps.version.outputs.version }}-${{ github.run_id }}"
           git checkout -b "${branch}"
 
           git add go.mod go.sum
@@ -332,11 +338,85 @@ jobs:
         run: |
           $(go env GOPATH)/bin/smoketest dispose
 
+  # HA smoketest, mirroring the regular smoketest gate that main.yml runs. Only
+  # the Active LTS line runs it; maintenance and older lines are basic-smoketest
+  # only (HA may predate or differ on those lines). Self-contained.
+  ha-smoketest:
+    name: HA Smoketest
+    needs: prepare
+    if: needs.prepare.outputs.is_active == 'true'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
+          fetch-depth: 0
+
+      - name: Install Go
+        uses: ./.github/actions/setup-go
+
+      - name: Install Ziti CI
+        uses: openziti/ziti-ci@v1
+
+      - name: Install Terraform CLI
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: ~1.5
+
+      - name: Build and Test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ziti_ci_gpg_key: ${{ secrets.ZITI_CI_GPG_KEY }}
+          ziti_ci_gpg_key_id: ${{ secrets.ZITI_CI_GPG_KEY_ID }}
+        shell: bash
+        run: |
+          $(go env GOPATH)/bin/ziti-ci configure-git
+          $(go env GOPATH)/bin/ziti-ci generate-build-info common/version/info_generated.go version
+          pushd zititest && go mod tidy && go install -tags all ./... && popd
+          go install -tags=all,tests ./...
+
+      - name: Create Test Environment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          echo "ZITI_ROOT=$(go env GOPATH)/bin" >> "$GITHUB_ENV"
+          $(go env GOPATH)/bin/smoketest create -d smoketest-lts-ha-${GITHUB_RUN_NUMBER} -n smoketest-lts-ha-${GITHUB_RUN_NUMBER} -l ha=true,environment=gh-fablab-lts-ha-smoketest,ziti_version=$($(go env GOPATH)/bin/ziti-ci -q get-current-version)
+          $(go env GOPATH)/bin/smoketest up
+
+      - name: Test Ziti Command
+        shell: bash
+        run: |
+          echo "ZITI_ROOT=$(go env GOPATH)/bin" >> "$GITHUB_ENV"
+          pushd zititest && go test -timeout 30m -v ./tests/... 2>&1 | tee test.out && popd
+
+      - name: Create Logs Archive
+        if: always()
+        run: |
+          $(go env GOPATH)/bin/smoketest get files '*' "./logs/{{ .Id }}/" ./logs
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: lts-ha-smoketest-logs-${{ github.run_id }}
+          path: logs/
+          compression-level: 7
+          retention-days: 5
+
+      - name: Tear down Test Environment
+        timeout-minutes: 30
+        if: always()
+        shell: bash
+        run: |
+          $(go env GOPATH)/bin/smoketest dispose
+
   # Full validation suite against the validated commit. Each test is its own job
   # so a flaky failure can be resumed with "re-run failed jobs".
   validation-circuit:
     name: Validation (Circuits)
-    needs: [ prepare, smoketest ]
+    needs: [ prepare, smoketest, ha-smoketest ]
     if: needs.prepare.outputs.run_validation == 'true'
     uses: ./.github/workflows/validation-test.yml
     secrets: inherit
@@ -347,7 +427,7 @@ jobs:
 
   validation-ert:
     name: Validation (ER/T Terminators)
-    needs: [ prepare, smoketest ]
+    needs: [ prepare, smoketest, ha-smoketest ]
     if: needs.prepare.outputs.run_validation == 'true'
     uses: ./.github/workflows/validation-test.yml
     secrets: inherit
@@ -358,7 +438,7 @@ jobs:
 
   validation-sdk-terminators:
     name: Validation (SDK Terminators)
-    needs: [ prepare, smoketest ]
+    needs: [ prepare, smoketest, ha-smoketest ]
     if: needs.prepare.outputs.run_validation == 'true'
     uses: ./.github/workflows/validation-test.yml
     secrets: inherit
@@ -369,7 +449,7 @@ jobs:
 
   validation-links:
     name: Validation (Links)
-    needs: [ prepare, smoketest ]
+    needs: [ prepare, smoketest, ha-smoketest ]
     if: needs.prepare.outputs.run_validation == 'true'
     uses: ./.github/workflows/validation-test.yml
     secrets: inherit
@@ -380,7 +460,7 @@ jobs:
 
   validation-router-data-model:
     name: Validation (Router Data Model)
-    needs: [ prepare, smoketest ]
+    needs: [ prepare, smoketest, ha-smoketest ]
     if: needs.prepare.outputs.run_validation == 'true'
     uses: ./.github/workflows/validation-test.yml
     secrets: inherit
@@ -391,7 +471,7 @@ jobs:
 
   validation-sdk-status:
     name: Validation (SDK Status)
-    needs: [ prepare, smoketest ]
+    needs: [ prepare, smoketest, ha-smoketest ]
     if: needs.prepare.outputs.run_validation == 'true'
     uses: ./.github/workflows/validation-test.yml
     secrets: inherit
@@ -408,6 +488,7 @@ jobs:
     needs:
       - prepare
       - smoketest
+      - ha-smoketest
       - validation-circuit
       - validation-ert
       - validation-sdk-terminators
@@ -418,6 +499,7 @@ jobs:
       !cancelled()
       && needs.prepare.result == 'success'
       && needs.smoketest.result == 'success'
+      && (needs.ha-smoketest.result == 'success' || needs.ha-smoketest.result == 'skipped')
       && (
         needs.prepare.outputs.run_validation != 'true'
         || inputs.force_release
@@ -499,6 +581,7 @@ jobs:
     needs:
       - prepare
       - smoketest
+      - ha-smoketest
       - validation-circuit
       - validation-ert
       - validation-sdk-terminators

--- a/.github/workflows/lts-release.yml
+++ b/.github/workflows/lts-release.yml
@@ -147,6 +147,13 @@ jobs:
 
           # Validation policy: by default only the Active LTS line runs the full
           # suite (RELEASE_POLICY.md). Maintenance and older lines are smoketest-only.
+          #
+          # NOTE: the HA smoketest and the full validation suite are currently
+          # gated to the active line because the older lines (1.5/1.6) predate
+          # full HA/validation support. Once 2.0.0 ages into the Maintenance LTS
+          # slot, it DOES support both, so the maintenance line should then also
+          # run the HA smoketest and the full validation suite. Revisit this
+          # gating (here and the ha-smoketest job's `if`) at that transition.
           case "${IN_VALIDATION:-auto}" in
             run) run_validation="true" ;;
             skip) run_validation="false" ;;
@@ -341,6 +348,10 @@ jobs:
   # HA smoketest, mirroring the regular smoketest gate that main.yml runs. Only
   # the Active LTS line runs it; maintenance and older lines are basic-smoketest
   # only (HA may predate or differ on those lines). Self-contained.
+  #
+  # TODO: once 2.0.0 becomes the Maintenance LTS, run the HA smoketest (and the
+  # full validation suite) on the maintenance line too -- 2.0 supports both. See
+  # the validation-policy note in the prepare job's resolve step.
   ha-smoketest:
     name: HA Smoketest
     needs: prepare

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -191,7 +191,7 @@ jobs:
   fablab-smoketest:
     name: Fablab Smoketest
     # not applicable to forks. shouldn't run on release build
-    if: github.repository_owner == 'openziti' && !startsWith(github.ref_name, 'release-v') && !contains(github.actor, 'dependabot')
+    if: github.repository_owner == 'openziti' && !startsWith(github.ref_name, 'release-v') && !contains(github.actor, 'dependabot') && !startsWith(github.head_ref, 'lts-bump')
     runs-on: ubuntu-24.04
     steps:
       - name: Git Checkout
@@ -316,7 +316,7 @@ jobs:
   fablab-ha-smoketest:
     name: Fablab HA Smoketest
     # not applicable to forks. shouldn't run on release build
-    if: github.repository_owner == 'openziti' && !startsWith(github.ref_name, 'release-v') && !contains(github.actor, 'dependabot')
+    if: github.repository_owner == 'openziti' && !startsWith(github.ref_name, 'release-v') && !contains(github.actor, 'dependabot') && !startsWith(github.head_ref, 'lts-bump')
     runs-on: ubuntu-24.04
     steps:
       - name: Git Checkout

--- a/.github/workflows/validation-test.yml
+++ b/.github/workflows/validation-test.yml
@@ -10,6 +10,11 @@ on:
         type: string
         required: false
         default: '2h'
+      ref:
+        description: The git ref (branch, tag, or commit SHA) to check out and test. Defaults to the ref that triggered the run.
+        type: string
+        required: false
+        default: ''
 
 # cancel older, redundant runs of same workflow on same branch
 concurrency:
@@ -37,6 +42,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Install Go
         uses: ./.github/actions/setup-go

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -61,9 +61,13 @@ OpenZiti is an open-source project with community consumers. LTS here establishe
 | Phase | Duration | Scope | Notes |
 |---|---|---|---|
 | Latest Development | Rolling | Features + Security + Bug Fixes | Continuous releases; no LTS guarantees |
-| Active LTS (N) | 12 months | Security + Critical Bug Fixes | Dependency updates restricted to security fixes, required vulnerability SLA remediation, build/toolchain compatibility, and explicitly approved low-risk updates |
+| Active LTS (N) | 12 months | Security + Critical Bug Fixes | Dependency updates accept compatible (minor and patch) updates of external dependencies and point/bugfix updates of internal dependencies, gated by the smoketest and full validation suite. Breaking (major) updates and feature backports remain excluded |
 | Maintenance LTS (N-1) | Months 13–24 | Security + Critical Production Defects Only | Dependency updates restricted to security fixes and required vulnerability SLA remediation |
 | End of Life | Month 25+ | No Support | Deprecation announced in release notes; archive only. See [No Support](#definitions) definition above. |
+
+#### Dependency Update Stance (Active LTS)
+
+Security vulnerabilities in transitive dependencies are common enough that holding an Active LTS to security-only dependency updates leaves it carrying known issues between cuts. Active LTS therefore accepts compatible (minor and patch) updates of external dependencies and point/bugfix updates of internal OpenZiti dependencies on each monthly cut. The churn this introduces is mitigated by gating every cut on the smoketest and the full validation suite: a dependency update ships only if the validated build passes. Breaking (major) dependency updates and feature backports are out of scope and follow the [Feature Backport Exception](#feature-backport-exception) rules where applicable. Maintenance LTS (N-1) remains restricted to security and required vulnerability-SLA updates only.
 
 ### Patch Release Cadence
 

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -61,13 +61,17 @@ OpenZiti is an open-source project with community consumers. LTS here establishe
 | Phase | Duration | Scope | Notes |
 |---|---|---|---|
 | Latest Development | Rolling | Features + Security + Bug Fixes | Continuous releases; no LTS guarantees |
-| Active LTS (N) | 12 months | Security + Critical Bug Fixes | Dependency updates accept compatible (minor and patch) updates of external dependencies and point/bugfix updates of internal dependencies, gated by the smoketest and full validation suite. Breaking (major) updates and feature backports remain excluded |
+| Active LTS (N) | 12 months | Security + Critical Bug Fixes | External dependency updates accept compatible (minor and patch) versions, gated by the smoketest and full validation suite. Internal OpenZiti library updates are deliberate, not part of the automated cut. Breaking (major) updates and feature backports remain excluded |
 | Maintenance LTS (N-1) | Months 13–24 | Security + Critical Production Defects Only | Dependency updates restricted to security fixes and required vulnerability SLA remediation |
 | End of Life | Month 25+ | No Support | Deprecation announced in release notes; archive only. See [No Support](#definitions) definition above. |
 
 #### Dependency Update Stance (Active LTS)
 
-Security vulnerabilities in transitive dependencies are common enough that holding an Active LTS to security-only dependency updates leaves it carrying known issues between cuts. Active LTS therefore accepts compatible (minor and patch) updates of external dependencies and point/bugfix updates of internal OpenZiti dependencies on each monthly cut. The churn this introduces is mitigated by gating every cut on the smoketest and the full validation suite: a dependency update ships only if the validated build passes. Breaking (major) dependency updates and feature backports are out of scope and follow the [Feature Backport Exception](#feature-backport-exception) rules where applicable. Maintenance LTS (N-1) remains restricted to security and required vulnerability-SLA updates only.
+Security vulnerabilities in transitive dependencies are common enough that holding an Active LTS to security-only dependency updates leaves it carrying known issues between cuts. Active LTS therefore accepts compatible (minor and patch) updates of external dependencies on each monthly cut. The churn this introduces is mitigated by gating every cut on the smoketest and the full validation suite: a dependency update ships only if the validated build passes. Breaking (major) dependency updates and feature backports are out of scope and follow the [Feature Backport Exception](#feature-backport-exception) rules where applicable.
+
+Internal OpenZiti library dependencies (`sdk-golang`, `channel`, `edge-api`, etc.) are **not** auto-updated by the cut. Most LTS-relevant fixes land as commits on the release branch itself rather than as library releases, and auto-bumping the libraries would trust their semver tags, which are not yet enforced by an API-compatibility gate. Bumping them remains a deliberate step. Once the library repos gate releases on a semver-compatibility check, point/bugfix updates of the internal libraries can be folded into the automated Active LTS cut.
+
+Maintenance LTS (N-1) remains restricted to security and required vulnerability-SLA updates only.
 
 ### Patch Release Cadence
 


### PR DESCRIPTION
Automates LTS point releases per `RELEASE_POLICY.md`. Fixes #4021.

Two-phase, with a human approval as the release gate:

- **Phase 1 (`lts-release.yml`)** runs monthly (and on demand). It resolves the target line from `lts-versions.json`, updates dependencies, runs the smoketest, runs the full validation suite for the active line, and opens a review PR for the validated commit linking the passed runs.
- **Phase 2 (`lts-release-finalize.yml`)** runs when a maintainer approves that PR. It fast-forwards the LTS branch to the validated commit (FF-only) and tags it, which triggers `release.yml`. The smoketest and validation are not re-run on the PR.

Dependency policy:
- External dependencies update to latest compatible (minor + patch) on every line.
- Internal openziti libraries update to latest point/bugfix on the **active** LTS line only; maintenance and older lines leave them pinned (mirrors `update-ext-deps`).
- Full validation runs for the active line only; maintenance and older lines are smoketest-only, per the policy testing matrix.

Validation bypass for flaky tests is supported via a `force_release` dispatch input, and partial re-runs continue from where they stopped (the bump commit is pushed before validation).

Notifications reuse the existing Mattermost forwarder: PR-open, approval, tag, and release events are already forwarded; a failed scheduled run opens a tracking issue (which is also forwarded).

Also updates `RELEASE_POLICY.md` to accept compatible dependency updates on the active LTS line, backed by the smoketest + validation gate.

## Notes for reviewers / deployment prerequisites

- The tag in Phase 2 and the PR/issue creation use `GH_CI_KEY` (a PAT) so their events trigger downstream workflows; the default `GITHUB_TOKEN` would not.
- Branch protection on `release-v*.x` must allow the bot's fast-forward ref update.
- The `release-v1.5.x` monthly cron is hardcoded (it is not in `lts-versions.json`); change or remove it as extended-support lines rotate.
- Validated locally against `release-v1.5.x`: external-only bump produces a clean, compatible, buildable tree. The fablab smoketest, `get-next-version`, and the Phase 2 FF/tag path are only exercisable in CI.
