### PR TITLE
Use MaxTokenDuration for identity revocation lifetime

### DIFF
--- a/controller/model/identity_manager.go
+++ b/controller/model/identity_manager.go
@@ -89,7 +89,7 @@ func NewIdentityManager(env Env) *IdentityManager {
 	env.GetStores().Identity.AddEntityConstraint(db.NewIdentityRevocationConstraint(
 		env.GetStores().Revocation,
 		common.RevocationTypeIdentity,
-		func() time.Duration { return env.GetConfig().Edge.Oidc.RefreshTokenDuration },
+		func() time.Duration { return env.GetConfig().Edge.Oidc.MaxTokenDuration() },
 	))
 
 	return manager


### PR DESCRIPTION
Addresses a review comment on the #3929 backport (#3985).

The identity revocation constraint was using `Oidc.RefreshTokenDuration` for the revocation lifetime. While the refresh token is normally the longest-lived token, that isn't guaranteed by config. Switch to `Oidc.MaxTokenDuration()`, which returns the greatest of the refresh, access, and id token durations, so the revocation always outlives every issued token.

For #3929