### PR TITLE
fix openziti/ziti#4033

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -24,6 +24,7 @@ open source that have embedded OpenZiti into the project, or use OpenZiti for se
 | zrok        | https://zrok.io | https://github.com/openziti/zrok           | <img src="https://zrok.io/wp-content/uploads/2023/01/space3-1327x1536.png.webp" width="100px"> | An open source sharing solution built on OpenZiti, the zero trust networking platform. Available as SaaS or self-hosted. |
 | BlueBubbles  | https://bluebubbles.app  | https://github.com/BlueBubblesApp | <img src="https://raw.githubusercontent.com/BlueBubblesApp/bluebubbles-server/master/icons/regular/icon-256.png" width="100px"> | BlueBubbles is an open-source app ecosystem dedicated to bringing iMessage to Android, Windows, and Linux. Shock your iPhone friends by iMessaging them from nearly any platform!  |
 | Predalert   | https://hackaday.io/project/191509 | https://codeberg.org/papiris/predalert | <img src="https://codeberg.org/papiris/predalert/media/branch/main/assets/lynx_with_killed_sheep_prediction.png" width="100px"> | Free software which detects predators lurking around farm animals, automatically triggers alarms and provides cross-platform notifications. Securely and privately, even using black-box IP cameras. | 
+| Agyn        | https://agyn.io | https://github.com/agynio/platform | <img src="https://raw.githubusercontent.com/agynio/platform/main/docs/_assets/agyn-logo.svg" width="100px"> | Agyn is an open-source, Kubernetes-native AI agent runtime. It uses OpenZiti to securely connect agents, services, and private customer infrastructure. |
 
 
 ## Other Adopters


### PR DESCRIPTION
fix openziti/ziti#4033

## Summary

Adds Agyn to the Open Source Projects table in `ADOPTERS.md`.

- Project Name: Agyn
- Project Link: https://agyn.io
- Source URL: https://github.com/agynio/platform
- Logo: https://raw.githubusercontent.com/agynio/platform/main/docs/_assets/agyn-logo.svg
- Usage: Agyn is an open-source, Kubernetes-native AI agent runtime. It uses OpenZiti to securely connect agents, services, and private customer infrastructure.