### PR TITLE
Emit source_entity_id label on prometheus metrics. Fixes #4035

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -352,3 +352,4 @@ today and expand as packages are converted. The global `ziti agent set-log-level
     * [Issue #3849](https://github.com/openziti/ziti/issues/3849) - Add a recover mechanism for when a controller cluster can't form a quorum
     * [Issue #3972](https://github.com/openziti/ziti/issues/3972) - Support multiple LAN interfaces for tproxy mode
     * [Issue #3988](https://github.com/openziti/ziti/issues/3988) - Support multiple resolver addresses for tproxy mode
+    * [Issue #4035](https://github.com/openziti/ziti/issues/4035) - Prometheus metrics endpoint emits per-router ctrl/link metrics as identical time series, causing dropped samples

--- a/controller/events/formatter.go
+++ b/controller/events/formatter.go
@@ -392,6 +392,12 @@ func (event *PrometheusMetricsEvent) getTags() *[]string {
 		}
 	}
 	tags = append(tags, event.newTag("source_id", event.SourceAppId))
+	// Some metrics (e.g. per-router ctrl channel metrics, per-link metrics) share a single source_id
+	// but are scoped to an entity whose id is carried in SourceEntityId. Without emitting it as a label,
+	// those metrics collapse into identical time series and Prometheus drops the duplicate samples.
+	if event.SourceEntityId != "" {
+		tags = append(tags, event.newTag("source_entity_id", event.SourceEntityId))
+	}
 	return &tags
 }
 

--- a/controller/events/metrics_test.go
+++ b/controller/events/metrics_test.go
@@ -116,6 +116,49 @@ func Test_FilterMetrics(t *testing.T) {
 	req.NotNil(evt.Metrics["m1_rate"])
 }
 
+func Test_PrometheusMetricsLabels(t *testing.T) {
+	req := require.New(t)
+
+	baseEvent := func() *PrometheusMetricsEvent {
+		return &PrometheusMetricsEvent{
+			Namespace:   event.MetricsEventNS,
+			MetricType:  "meter",
+			Metric:      "ctrl.rx.msgrate",
+			SourceAppId: "ctrl1",
+			Timestamp:   time.Now(),
+			Metrics:     map[string]any{"m1_rate": 0.235},
+			Version:     event.MetricsEventsVersion,
+		}
+	}
+
+	// without a source entity id, only source_id is emitted
+	evt := baseEvent()
+	buf, err := evt.Marshal(false)
+	req.NoError(err)
+	out := string(buf)
+	req.Contains(out, `source_id="ctrl1"`)
+	req.NotContains(out, "source_entity_id")
+
+	// per-router ctrl metrics share a source_id but must be distinguished by source_entity_id
+	router1 := baseEvent()
+	router1.SourceEntityId = "router1"
+	buf, err = router1.Marshal(false)
+	req.NoError(err)
+	out1 := string(buf)
+	req.Contains(out1, `source_id="ctrl1"`)
+	req.Contains(out1, `source_entity_id="router1"`)
+
+	router2 := baseEvent()
+	router2.SourceEntityId = "router2"
+	buf, err = router2.Marshal(false)
+	req.NoError(err)
+	out2 := string(buf)
+	req.Contains(out2, `source_entity_id="router2"`)
+
+	// the two routers' series must not be identical (which would cause Prometheus to drop samples)
+	req.NotEqual(out1, out2)
+}
+
 func Test_MetricsFormat(t *testing.T) {
 	req := require.New(t)
 


### PR DESCRIPTION
## What

The Prometheus metrics endpoint emits per-router control-channel metrics (and per-link metrics) as identical time series. They all share a single `source_id` (the controller's identity), with the only distinguishing value, the router/link id, carried in `SourceEntityId`, which the Prometheus formatter ignored. Prometheus sees multiple samples with the same name, same labels, and different values, and drops all but one per scrape.

## Why

Control-channel metrics are registered in the controller's own registry with the router id embedded in the metric name (`ctrl.rx.msgrate:<routerId>`). The metrics mapper already parses that id out into `SourceEntityId`, but the Prometheus formatter only emitted `source_id` and the event tags, so the per-router scoping was lost.

## Fix

The formatter now emits a `source_entity_id` label whenever the event carries one. This gives per-router ctrl metrics and per-link metrics distinct label sets, so Prometheus no longer collapses them.

Fixes #4035