### PR TITLE
ask user to pull certs again if controller no longer trusted

### DIFF
--- a/tests/cli_tests/login_test.go
+++ b/tests/cli_tests/login_test.go
@@ -597,8 +597,7 @@ func (s *cliTestState) testFileAuthIgnoresCachedServerCert(t *testing.T) {
 }
 
 func (s *cliTestState) testStaleCachedCertRefreshed(t *testing.T) {
-	// A cached CA that no longer trusts the server (e.g. dev controller rebuilt with new certs) should be
-	// detected and, with --yes, refreshed from the server rather than failing with a cryptic x509 error.
+	// A stale cached CA should be detected and, with --yes, refreshed from the server.
 	s.removeZitiDir(t)
 
 	opts1 := s.controllerUnderTest.NewTestLoginOpts()
@@ -613,13 +612,23 @@ func (s *cliTestState) testStaleCachedCertRefreshed(t *testing.T) {
 	require.NoError(t, err, "should be able to read the freshly cached CA")
 	require.NotEmpty(t, goodCertData)
 
-	// Corrupt the cached CA so it no longer verifies the server, simulating regenerated server certs.
+	// Corrupt the cached CA so it no longer verifies the server.
 	require.NoError(t, os.WriteFile(cachedCert, []byte("INVALID JUNK CERT DATA"), 0600), "corrupt cached CA")
+
+	// Without --yes and no terminal to confirm, login must fail rather than silently proceeding.
+	optsNoConfirm := s.controllerUnderTest.NewTestLoginOpts()
+	optsNoConfirm.Yes = false
+	require.Error(t, optsNoConfirm.Run(), "stale cached CA without confirmation should fail, not silently proceed")
+
+	staleAfterDecline, err := os.ReadFile(cachedCert)
+	require.NoError(t, err)
+	require.Equal(t, "INVALID JUNK CERT DATA", string(staleAfterDecline), "declined refresh must not overwrite the cached CA")
 
 	opts2 := s.controllerUnderTest.NewTestLoginOpts()
 	opts2.Yes = true // auto-accepts the refresh prompt
 	require.NoError(t, opts2.Run(), "login with a stale cached CA should refresh it and succeed")
 	require.NotEmpty(t, opts2.ApiSession)
+	require.Equal(t, cachedCert, opts2.CaCert, "refreshed CA should be written back to the same cached path")
 
 	refreshedCertData, err := os.ReadFile(cachedCert)
 	require.NoError(t, err, "cached CA should still exist after refresh")

--- a/tests/cli_tests/login_test.go
+++ b/tests/cli_tests/login_test.go
@@ -50,6 +50,7 @@ func (s *cliTestState) loginTests(t *testing.T) {
 	t.Run("switch controller file auth", s.testSwitchControllerFileAuth)
 	t.Run("file auth ignores cached server cert", s.testFileAuthIgnoresCachedServerCert)
 	t.Run("os-trusted server cert uses system store and clears cache", s.testTrustedServerCertUsesSystemStore)
+	t.Run("stale cached cert is refreshed with yes flag", s.testStaleCachedCertRefreshed)
 
 	// Edge Cases
 	t.Run("empty username", s.testEmptyUsername)
@@ -593,6 +594,37 @@ func (s *cliTestState) testFileAuthIgnoresCachedServerCert(t *testing.T) {
 	cachedCertData, err := os.ReadFile(cachedCertPath)
 	require.NoError(t, err, "cached cert file should still exist")
 	require.Equal(t, "INVALID JUNK CERT DATA", string(cachedCertData), "cached cert should remain corrupted after file-based auth succeeds")
+}
+
+func (s *cliTestState) testStaleCachedCertRefreshed(t *testing.T) {
+	// A cached CA that no longer trusts the server (e.g. dev controller rebuilt with new certs) should be
+	// detected and, with --yes, refreshed from the server rather than failing with a cryptic x509 error.
+	s.removeZitiDir(t)
+
+	opts1 := s.controllerUnderTest.NewTestLoginOpts()
+	opts1.CaCert = ""
+	opts1.Yes = true
+	require.NoError(t, opts1.Run(), "initial untrusted-path login should succeed and cache the CA")
+	require.NotEmpty(t, opts1.ApiSession)
+	require.NotEmpty(t, opts1.CaCert, "untrusted path should cache and reference a CA file")
+
+	cachedCert := opts1.CaCert
+	goodCertData, err := os.ReadFile(cachedCert)
+	require.NoError(t, err, "should be able to read the freshly cached CA")
+	require.NotEmpty(t, goodCertData)
+
+	// Corrupt the cached CA so it no longer verifies the server, simulating regenerated server certs.
+	require.NoError(t, os.WriteFile(cachedCert, []byte("INVALID JUNK CERT DATA"), 0600), "corrupt cached CA")
+
+	opts2 := s.controllerUnderTest.NewTestLoginOpts()
+	opts2.Yes = true // auto-accepts the refresh prompt
+	require.NoError(t, opts2.Run(), "login with a stale cached CA should refresh it and succeed")
+	require.NotEmpty(t, opts2.ApiSession)
+
+	refreshedCertData, err := os.ReadFile(cachedCert)
+	require.NoError(t, err, "cached CA should still exist after refresh")
+	require.NotEqual(t, "INVALID JUNK CERT DATA", string(refreshedCertData), "stale cached CA should be overwritten")
+	require.Equal(t, goodCertData, refreshedCertData, "refreshed CA should match the original server-supplied CA")
 }
 
 func (s *cliTestState) testTrustedServerCertUsesSystemStore(t *testing.T) {

--- a/ziti/cmd/edge/login.go
+++ b/ziti/cmd/edge/login.go
@@ -441,6 +441,49 @@ func (o *LoginOptions) ConfigureCerts(host string, ctrlUrl *url.URL) error {
 		return nil
 	}
 
+	// A cached (non-explicit) CA is present but the OS doesn't trust the server. Check whether the cached
+	// CA itself still trusts the server. If it doesn't, the server's certs were likely regenerated (common
+	// in dev), so print a clear message and offer to pull down the current certs instead of failing later
+	// with a cryptic x509 error.
+	if o.CaCert != "" && !explicitCa {
+		cachedClient := o.GetClient()
+		if trustedByCached, _ := util.IsServerTrusted(host, &cachedClient); trustedByCached {
+			return nil
+		}
+
+		o.Printf("WARNING: the cached certificate authority at %v no longer trusts the server at %v\n", o.CaCert, host)
+		o.Println("The server's certificates were likely regenerated. This is common when a dev controller is rebuilt.")
+		refresh := o.Yes
+		if !refresh {
+			var askErr error
+			if refresh, askErr = o.askYesNo("Pull down and trust the current server certificate authority? [Y/N]: "); askErr != nil {
+				return askErr
+			}
+		}
+		if !refresh {
+			return errors.Errorf("the cached certificate authority at %v no longer trusts the server at %v. Re-run with --ca or remove the cached cert to continue", o.CaCert, host)
+		}
+
+		httpClient := o.GetClient()
+		wellKnownCerts, _, err := util.GetWellKnownCerts(host, httpClient)
+		if err != nil {
+			return errors.Wrapf(err, "unable to retrieve server certificate authority from %v", host)
+		}
+		certsTrusted, err := util.AreCertsTrusted(host, wellKnownCerts, httpClient)
+		if err != nil {
+			return err
+		}
+		if !certsTrusted {
+			return errors.New("server supplied certs not trusted by server, unable to continue")
+		}
+		newCertFile, err := util.WriteCert(o, ctrlUrl, wellKnownCerts)
+		if err != nil {
+			return err
+		}
+		o.CaCert = newCertFile
+		return nil
+	}
+
 	if !isServerTrusted && o.CaCert == "" {
 		httpClient := o.GetClient()
 		wellKnownCerts, certs, err := util.GetWellKnownCerts(host, httpClient)

--- a/ziti/cmd/edge/login.go
+++ b/ziti/cmd/edge/login.go
@@ -407,17 +407,7 @@ func (o *LoginOptions) ConfigureCerts(host string, ctrlUrl *url.URL) error {
 	// Probe with system trust only, reusing the configured transport so overlay-only hosts (e.g.
 	// mgmt.ziti) still resolve via its zitified DialContext. An explicit --ca is honored below.
 	systemRoots, _ := o.systemCertPool()
-	probeClient := o.GetClient()
-	if t, ok := probeClient.Transport.(*http.Transport); ok && t != nil {
-		pt := t.Clone()
-		if pt.TLSClientConfig == nil {
-			pt.TLSClientConfig = &tls.Config{}
-		}
-		pt.TLSClientConfig.RootCAs = systemRoots
-		probeClient.Transport = pt
-	} else {
-		probeClient.Transport = &http.Transport{TLSClientConfig: &tls.Config{RootCAs: systemRoots}}
-	}
+	probeClient := o.probeClientWithPool(systemRoots)
 	isServerTrusted, err := util.IsServerTrusted(host, &probeClient)
 	if err != nil {
 		return err
@@ -441,13 +431,19 @@ func (o *LoginOptions) ConfigureCerts(host string, ctrlUrl *url.URL) error {
 		return nil
 	}
 
-	// A cached (non-explicit) CA is present but the OS doesn't trust the server. Check whether the cached
-	// CA itself still trusts the server. If it doesn't, the server's certs were likely regenerated (common
-	// in dev), so print a clear message and offer to pull down the current certs instead of failing later
-	// with a cryptic x509 error.
+	// OS doesn't trust the server but a cached CA is present. If the cached CA no longer trusts the
+	// server, offer to pull down the current certs rather than failing later with a raw x509 error.
 	if o.CaCert != "" && !explicitCa {
-		cachedClient := o.GetClient()
-		if trustedByCached, _ := util.IsServerTrusted(host, &cachedClient); trustedByCached {
+		cachedPool, poolErr := o.GetCaPool()
+		if poolErr != nil {
+			return poolErr
+		}
+		cachedProbe := o.probeClientWithPool(cachedPool)
+		trustedByCache, trustErr := util.IsServerTrusted(host, &cachedProbe)
+		if trustErr != nil {
+			return errors.Wrapf(trustErr, "checking whether the cached CA trusts %v", host)
+		}
+		if trustedByCache {
 			return nil
 		}
 
@@ -464,17 +460,9 @@ func (o *LoginOptions) ConfigureCerts(host string, ctrlUrl *url.URL) error {
 			return errors.Errorf("the cached certificate authority at %v no longer trusts the server at %v. Re-run with --ca or remove the cached cert to continue", o.CaCert, host)
 		}
 
-		httpClient := o.GetClient()
-		wellKnownCerts, _, err := util.GetWellKnownCerts(host, httpClient)
-		if err != nil {
-			return errors.Wrapf(err, "unable to retrieve server certificate authority from %v", host)
-		}
-		certsTrusted, err := util.AreCertsTrusted(host, wellKnownCerts, httpClient)
+		wellKnownCerts, _, err := o.fetchTrustedServerCerts(host)
 		if err != nil {
 			return err
-		}
-		if !certsTrusted {
-			return errors.New("server supplied certs not trusted by server, unable to continue")
 		}
 		newCertFile, err := util.WriteCert(o, ctrlUrl, wellKnownCerts)
 		if err != nil {
@@ -485,18 +473,9 @@ func (o *LoginOptions) ConfigureCerts(host string, ctrlUrl *url.URL) error {
 	}
 
 	if !isServerTrusted && o.CaCert == "" {
-		httpClient := o.GetClient()
-		wellKnownCerts, certs, err := util.GetWellKnownCerts(host, httpClient)
-		if err != nil {
-			return errors.Wrapf(err, "unable to retrieve server certificate authority from %v", host)
-		}
-
-		certsTrusted, err := util.AreCertsTrusted(host, wellKnownCerts, httpClient)
+		wellKnownCerts, certs, err := o.fetchTrustedServerCerts(host)
 		if err != nil {
 			return err
-		}
-		if !certsTrusted {
-			return errors.New("server supplied certs not trusted by server, unable to continue")
 		}
 
 		savedCerts, certFile, err := util.ReadCert(ctrlUrl)
@@ -543,6 +522,43 @@ func (o *LoginOptions) ConfigureCerts(host string, ctrlUrl *url.URL) error {
 	}
 
 	return nil
+}
+
+// fetchTrustedServerCerts retrieves the server's advertised CA chain and confirms the server itself
+// trusts it. It returns the PEM bundle and the parsed certificates.
+func (o *LoginOptions) fetchTrustedServerCerts(host string) ([]byte, []*x509.Certificate, error) {
+	httpClient := o.GetClient()
+	wellKnownCerts, certs, err := util.GetWellKnownCerts(host, httpClient)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "unable to retrieve server certificate authority from %v", host)
+	}
+	certsTrusted, err := util.AreCertsTrusted(host, wellKnownCerts, httpClient)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !certsTrusted {
+		return nil, nil, errors.New("server supplied certs not trusted by server, unable to continue")
+	}
+	return wellKnownCerts, certs, nil
+}
+
+// probeClientWithPool returns a copy of the configured client with its TLS trust roots replaced by pool,
+// preserving any zitified DialContext so overlay-only hosts stay reachable. Used to test whether a given
+// set of roots trusts the server without disturbing o.client.
+func (o *LoginOptions) probeClientWithPool(pool *x509.CertPool) http.Client {
+	probe := o.GetClient()
+	if t, ok := probe.Transport.(*http.Transport); ok && t != nil {
+		pt := t.Clone()
+		if pt.TLSClientConfig == nil {
+			pt.TLSClientConfig = &tls.Config{}
+		}
+		pt.TLSClientConfig.RootCAs = pool
+		pt.TLSClientConfig.InsecureSkipVerify = false
+		probe.Transport = pt
+	} else {
+		probe.Transport = &http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool}}
+	}
+	return probe
 }
 
 func (o *LoginOptions) askYesNo(prompt string) (bool, error) {


### PR DESCRIPTION
fixes #4039 

Now if the certs for a given host/port have changed the user is asked if they want to download them again. This situation occurs frequently with quickstarts that tear down the whole environment after stopping, leaving a stale ca in the cache cert location

```
ziti login
  Using controller url: https://sg4:1280/edge/management/v1 from identity 'default' in config file: C:\Users\clint\.ziti\ziti-cli.json
  WARNING: the cached certificate authority at C:\Users\clint\.ziti\certs\sg4_1280 no longer trusts the server at https://sg4:1280/edge/management/v1
  The server's certificates were likely regenerated. This is common when a dev controller is rebuilt.
  Pull down and trust the current server certificate authority? [Y/N]: y
  Server certificate chain written to C:\Users\clint\.ziti\certs\sg4_1280
  Using username: admin from identity 'default' in config file: C:\Users\clint\.ziti\ziti-cli.json
  Enter password:
  Saving identity 'default' to C:\Users\clint\.ziti\ziti-cli.json
```