### PR TITLE
Add serial DNS upstream query modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [Router Configs](#router-configs) - Allow routers to have a list of associated configs
 * [Multiple LAN Interfaces for tproxy](#multiple-lan-interfaces-for-tproxy) - `lanIf` now accepts a single interface or a list of interfaces
 * [Multiple Resolver Addresses for tproxy](#multiple-resolver-addresses-for-tproxy) - `resolver` now accepts a single address or a list of addresses
+* [DNS Upstream Query Modes](#dns-upstream-query-modes) - choose how multiple DNS upstreams are queried: parallel fan-out (default) or serial fail-through
 * [Logging Now Uses slog with an Async Handler](#logging-now-uses-slog-with-an-async-handler) - Logging moves to Go's `log/slog` behind an asynchronous sink; output is unchanged by default, with new flags to tune buffering
 
 ## ZAC Bootstrapping CLI
@@ -258,6 +259,48 @@ across interfaces. Existing single-address configs are unchanged.
     resolver:
       - udp://172.18.102.70:53
       - udp://192.168.10.1:53
+```
+
+## DNS Upstream Query Modes
+
+When more than one DNS upstream is configured for tproxy host-side resolution, the
+resolver previously always fanned out: every upstream was queried in parallel and
+the first NOERROR response won. For a high-volume router with several upstreams this
+multiplies outbound DNS traffic, since every request hits every upstream.
+
+A new `dnsUpstreamMode` option (router config) / `--dnsUpstreamMode` flag
+(`ziti tunnel`) controls how multiple upstreams are queried:
+
+* `parallel` (default) - query all upstreams at once; first NOERROR wins. Unchanged
+  behavior.
+* `serial` - query upstreams one at a time in order, starting at the first. Fail
+  through to the next only on timeout, transport error, or a non-NOERROR response.
+* `failover` - like `serial`, but the upstream that last answered is reused as the
+  starting point, so a healthy upstream isn't re-probed from the top on every query.
+* `random` - like `serial`, but each query starts at a randomly chosen upstream.
+
+In all serial modes a healthy upstream costs exactly one outbound query regardless of
+how many upstreams are configured. The single-upstream case is unaffected.
+
+In a router's `xgress_edge_tunnel` tproxy config:
+
+```yaml
+- binding: tunnel
+  options:
+    mode: tproxy
+    dnsUpstreamMode: serial
+    dnsUpstream:
+      - udp://10.96.0.10:53
+      - tcp://8.8.8.8:53
+```
+
+The standalone `ziti tunnel` gains a matching `--dnsUpstreamMode` flag (default
+`parallel`):
+
+```
+ziti tunnel run --dnsUpstreamMode serial \
+  --dnsUpstream udp://10.96.0.10:53 \
+  --dnsUpstream tcp://8.8.8.8:53
 ```
 
 ## Logging Now Uses slog with an Async Handler

--- a/router/xgress_edge_tunnel/factory.go
+++ b/router/xgress_edge_tunnel/factory.go
@@ -33,6 +33,7 @@ import (
 	"github.com/openziti/ziti/v2/router/env"
 	"github.com/openziti/ziti/v2/router/state"
 	"github.com/openziti/ziti/v2/router/xgress_router"
+	"github.com/openziti/ziti/v2/tunnel/dns"
 	"github.com/pkg/errors"
 )
 
@@ -42,6 +43,7 @@ const (
 	DefaultDnsResolver       = "udp://127.0.0.1:53"
 	DefaultDnsServiceIpRange = "100.64.0.1/10"
 	DefaultDnsUnanswerable   = "refused"
+	DefaultDnsUpstreamMode   = "parallel"
 )
 
 var fabricProviderF concurrenz.AtomicValue[func(env.RouterEnv, *HostedServiceRegistry) TunnelFabricProvider]
@@ -164,6 +166,7 @@ type Options struct {
 	resolver         []string
 	dnsSvcIpRange    string
 	dnsUpstreams     []string
+	dnsUpstreamMode  string
 	dnsUnanswerable  string
 	lanIf            []string
 	services         []string
@@ -177,6 +180,7 @@ func (options *Options) load(data xgress.OptionsData) error {
 	options.resolver = []string{DefaultDnsResolver}
 	options.dnsSvcIpRange = DefaultDnsServiceIpRange
 	options.dnsUnanswerable = DefaultDnsUnanswerable
+	options.dnsUpstreamMode = DefaultDnsUpstreamMode
 
 	var err error
 	options.Options, err = xgress.LoadOptions(data)
@@ -245,8 +249,22 @@ func (options *Options) load(data xgress.OptionsData) error {
 			}
 		}
 
+		if value, found := data["dnsUpstreamMode"]; found {
+			if strVal, ok := value.(string); ok {
+				if err := dns.ValidateUpstreamMode(strVal); err != nil {
+					return errors.Wrapf(err, "invalid value '%v' for dnsUpstreamMode", value)
+				}
+				options.dnsUpstreamMode = strVal
+			} else {
+				return errors.Errorf("invalid value '%v' for dnsUpstreamMode, must be string value", value)
+			}
+		}
+
 		if value, found := data["dnsUnanswerable"]; found {
 			if strVal, ok := value.(string); ok {
+				if err := dns.ValidateUnansweredDisposition(strVal); err != nil {
+					return errors.Wrapf(err, "invalid value '%v' for dnsUnanswerable", value)
+				}
 				options.dnsUnanswerable = strVal
 			} else {
 				return errors.Errorf("invalid value '%v' for dnsUnanswerable, must be string value", value)

--- a/router/xgress_edge_tunnel/tunneler.go
+++ b/router/xgress_edge_tunnel/tunneler.go
@@ -79,7 +79,7 @@ func (self *tunneler) Start() error {
 	log := pfxlog.Logger()
 	if strings.HasPrefix(self.listenOptions.mode, "tproxy") {
 		log.WithField("mode", self.listenOptions.mode).Info("creating interceptor")
-		resolver, err = dns.NewResolver(self.listenOptions.resolver, self.listenOptions.dnsUpstreams, self.listenOptions.dnsUnanswerable)
+		resolver, err = dns.NewResolver(self.listenOptions.resolver, self.listenOptions.dnsUpstreams, self.listenOptions.dnsUnanswerable, self.listenOptions.dnsUpstreamMode)
 		if err != nil {
 			pfxlog.Logger().WithError(err).Error("failed to start DNS resolver. using dummy resolver")
 			resolver = dns.NewDummyResolver()

--- a/tunnel/dns/dns.go
+++ b/tunnel/dns/dns.go
@@ -20,7 +20,7 @@ package dns
 
 // these functions are only implemented when OS=linux
 
-func NewDnsServer(addrs []string, upstreams []string, unanswered unansweredDisposition) (Resolver, error) {
+func NewDnsServer(addrs []string, upstreams []string, unanswered unansweredDisposition, mode upstreamMode) (Resolver, error) {
 	return nil, nil
 }
 

--- a/tunnel/dns/dns_linux.go
+++ b/tunnel/dns/dns_linux.go
@@ -34,18 +34,19 @@ import (
 // zero or more upstream DNS servers for recursive forwarding. All listeners
 // share a single resolver instance so hostname mappings are consistent across
 // addresses. Each upstream is a URL of the form udp://host:port or
-// tcp://host:port. When multiple upstreams are provided, queries are fanned
-// out in parallel; see resolver.queryUpstreams for winner-selection semantics.
-func NewDnsServer(addrs []string, upstreams []string, unanswered unansweredDisposition) (Resolver, error) {
+// tcp://host:port. The mode argument selects how multiple upstreams are queried;
+// see resolver.queryUpstreams for the dispatch and winner-selection semantics.
+func NewDnsServer(addrs []string, upstreams []string, unanswered unansweredDisposition, mode upstreamMode) (Resolver, error) {
 	log.Infof("starting dns server...")
 
 	r := &resolver{
-		names:      make(map[string]net.IP),
-		ips:        make(map[string]string),
-		namesMtx:   sync.Mutex{},
-		domains:    make(map[string]*domainEntry),
-		domainsMtx: sync.Mutex{},
-		unanswered: unanswered,
+		names:        make(map[string]net.IP),
+		ips:          make(map[string]string),
+		namesMtx:     sync.Mutex{},
+		domains:      make(map[string]*domainEntry),
+		domainsMtx:   sync.Mutex{},
+		upstreamMode: mode,
+		unanswered:   unanswered,
 	}
 
 	for _, upstreamConfig := range upstreams {

--- a/tunnel/dns/server.go
+++ b/tunnel/dns/server.go
@@ -19,10 +19,12 @@ package dns
 import (
 	"errors"
 	"fmt"
+	"math/rand"
 	"net"
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/miekg/dns"
 	"github.com/sirupsen/logrus"
@@ -44,6 +46,56 @@ var unansweredKeywords = map[string]unansweredDisposition{
 	"timeout":  unansweredTimeout,
 }
 
+// upstreamMode controls how the resolver dispatches a query across multiple
+// configured upstream DNS servers.
+type upstreamMode int
+
+const (
+	// upstreamParallel queries every upstream concurrently and returns the
+	// first NOERROR response. This is the historical default; with N upstreams
+	// it produces up to N outbound queries per request.
+	upstreamParallel upstreamMode = iota
+	// upstreamSerial queries upstreams one at a time in configured order,
+	// always starting at the first and failing through to the next only when
+	// an upstream times out, errors, or returns a non-NOERROR response.
+	upstreamSerial
+	// upstreamFailover behaves like upstreamSerial but remembers the upstream
+	// that last answered NOERROR and starts subsequent queries there, so a
+	// healthy upstream is reused rather than re-probing from the top each time.
+	upstreamFailover
+	// upstreamRandom queries upstreams serially starting from a randomly chosen
+	// upstream and failing through to the rest in order.
+	upstreamRandom
+)
+
+var upstreamModeKeywords = map[string]upstreamMode{
+	"parallel": upstreamParallel,
+	"serial":   upstreamSerial,
+	"failover": upstreamFailover,
+	"random":   upstreamRandom,
+}
+
+// parseUpstreamMode resolves an upstream-dispatch keyword to its upstreamMode.
+// An empty string yields the default upstreamParallel mode.
+func parseUpstreamMode(raw string) (upstreamMode, error) {
+	if raw == "" {
+		return upstreamParallel, nil
+	}
+
+	if mode, found := upstreamModeKeywords[strings.ToLower(strings.TrimSpace(raw))]; found {
+		return mode, nil
+	}
+
+	return upstreamParallel, fmt.Errorf("invalid dns upstream mode '%s': must be one of parallel, serial, failover, or random", raw)
+}
+
+// ValidateUpstreamMode returns an error if raw is not a recognized upstream
+// query mode keyword. An empty string is valid and selects the default mode.
+func ValidateUpstreamMode(raw string) error {
+	_, err := parseUpstreamMode(raw)
+	return err
+}
+
 // upstream represents a single upstream DNS server the resolver can forward to.
 type upstream struct {
 	server string
@@ -51,14 +103,16 @@ type upstream struct {
 }
 
 type resolver struct {
-	servers    []*dns.Server
-	names      map[string]net.IP
-	ips        map[string]string
-	namesMtx   sync.Mutex
-	domains    map[string]*domainEntry
-	domainsMtx sync.Mutex
-	upstreams  []upstream
-	unanswered unansweredDisposition
+	servers      []*dns.Server
+	names        map[string]net.IP
+	ips          map[string]string
+	namesMtx     sync.Mutex
+	domains      map[string]*domainEntry
+	domainsMtx   sync.Mutex
+	upstreams    []upstream
+	upstreamMode upstreamMode
+	preferred    atomic.Uint32 // start index for upstreamFailover mode
+	unanswered   unansweredDisposition
 }
 
 func parseUnansweredDisposition(raw string) (unansweredDisposition, error) {
@@ -73,11 +127,20 @@ func parseUnansweredDisposition(raw string) (unansweredDisposition, error) {
 	return unansweredRefused, fmt.Errorf("invalid unanswerable response '%s': must be one of timeout, servfail, or refused", raw)
 }
 
+// ValidateUnansweredDisposition returns an error if raw is not a recognized
+// unanswerable-query disposition keyword. An empty string is valid and selects
+// the default disposition.
+func ValidateUnansweredDisposition(raw string) error {
+	_, err := parseUnansweredDisposition(raw)
+	return err
+}
+
 // NewResolver constructs a Resolver from a listener URL, zero or more upstream URLs,
-// and an unanswered-query disposition. An empty upstreams slice disables upstream
-// forwarding. When multiple upstreams are provided, queries are fanned out in
-// parallel and the first NOERROR response wins (see queryUpstreams).
-func NewResolver(configs []string, upstreams []string, unansweredConfig string) (Resolver, error) {
+// an unanswered-query disposition, and an upstream-dispatch mode. An empty upstreams
+// slice disables upstream forwarding. The upstreamModeConfig keyword (parallel, serial,
+// failover, or random; empty defaults to parallel) selects how multiple upstreams are
+// queried (see queryUpstreams).
+func NewResolver(configs []string, upstreams []string, unansweredConfig string, upstreamModeConfig string) (Resolver, error) {
 	flushDnsCaches()
 	if len(configs) == 0 || (len(configs) == 1 && configs[0] == "") {
 		return nil, nil
@@ -87,6 +150,11 @@ func NewResolver(configs []string, upstreams []string, unansweredConfig string) 
 	firstURL, err := url.Parse(configs[0])
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse resolver configuration '%s': %w", configs[0], err)
+	}
+
+	mode, err := parseUpstreamMode(upstreamModeConfig)
+	if err != nil {
+		return nil, err
 	}
 
 	unanswered := unansweredRefused
@@ -135,7 +203,7 @@ func NewResolver(configs []string, upstreams []string, unansweredConfig string) 
 			}
 			addrs = append(addrs, u.Host)
 		}
-		dnsResolver, err := NewDnsServer(addrs, upstreams, unanswered)
+		dnsResolver, err := NewDnsServer(addrs, upstreams, unanswered, mode)
 		if err != nil {
 			return nil, err
 		}
@@ -231,7 +299,77 @@ func rcodeScore(rcode int) int {
 	}
 }
 
-// queryUpstreams forwards the query to all configured upstreams concurrently
+// queryUpstreams forwards the query to the configured upstreams and returns the
+// selected response. The dispatch strategy is governed by the resolver's
+// upstreamMode: upstreamParallel fans out to all upstreams at once, while the
+// serial modes query one upstream at a time and fail through to the next.
+func (r *resolver) queryUpstreams(query *dns.Msg) (*dns.Msg, error) {
+	if len(r.upstreams) == 0 {
+		return nil, errors.New("no upstream server configured")
+	}
+
+	switch r.upstreamMode {
+	case upstreamSerial:
+		return r.queryUpstreamsSerial(query, 0, false)
+	case upstreamFailover:
+		start := int(r.preferred.Load()) % len(r.upstreams)
+		return r.queryUpstreamsSerial(query, start, true)
+	case upstreamRandom:
+		return r.queryUpstreamsSerial(query, rand.Intn(len(r.upstreams)), false)
+	default:
+		return r.queryUpstreamsParallel(query)
+	}
+}
+
+// queryUpstreamsSerial queries upstreams one at a time, starting at startIdx and
+// wrapping around the list. It returns the first NOERROR response; failing that,
+// the best-ranked non-NOERROR response (NXDOMAIN > SERVFAIL > REFUSED > other);
+// failing that, the last transport error so the caller can fall through to
+// handleUnanswerable.
+//
+// Unlike the parallel path, at most one upstream query is in flight at a time and
+// iteration stops as soon as an upstream answers NOERROR, so a healthy first
+// upstream costs exactly one outbound query regardless of how many are configured.
+// When updatePreferred is set (failover mode), the index of the upstream that
+// produced the winning NOERROR is recorded so subsequent queries start there.
+func (r *resolver) queryUpstreamsSerial(query *dns.Msg, startIdx int, updatePreferred bool) (*dns.Msg, error) {
+	var bestResp *dns.Msg
+	bestScore := -1
+	var lastErr error
+
+	n := len(r.upstreams)
+	for i := 0; i < n; i++ {
+		idx := (startIdx + i) % n
+		u := r.upstreams[idx]
+		log.Debugf("forwarding query to upstream server %s: %s", u.server, query.Question[0].Name)
+		resp, _, err := u.client.Exchange(query, u.server)
+		if err != nil || resp == nil {
+			if err != nil {
+				log.Warnf("upstream query to %s failed: %v", u.server, err)
+				lastErr = err
+			}
+			continue
+		}
+		if resp.Rcode == dns.RcodeSuccess {
+			log.Debugf("received NOERROR from %s: %d answers", u.server, len(resp.Answer))
+			if updatePreferred {
+				r.preferred.Store(uint32(idx))
+			}
+			return resp, nil
+		}
+		if s := rcodeScore(resp.Rcode); s > bestScore {
+			bestScore = s
+			bestResp = resp
+		}
+	}
+
+	if bestResp != nil {
+		return bestResp, nil
+	}
+	return nil, lastErr
+}
+
+// queryUpstreamsParallel forwards the query to all configured upstreams concurrently
 // and selects a winner based on response code:
 //   - the first NOERROR response is returned immediately;
 //   - otherwise, after all upstreams have returned, the best-ranked
@@ -244,11 +382,7 @@ func rcodeScore(rcode int) int {
 // buffered so these late writes don't block. This is a bounded wait, not a
 // leak — miekg/dns ExchangeContext honors ctx.Deadline but not ctx.Done,
 // so there's no mechanism to abort an in-flight UDP read sooner.
-func (r *resolver) queryUpstreams(query *dns.Msg) (*dns.Msg, error) {
-	if len(r.upstreams) == 0 {
-		return nil, errors.New("no upstream server configured")
-	}
-
+func (r *resolver) queryUpstreamsParallel(query *dns.Msg) (*dns.Msg, error) {
 	type result struct {
 		resp *dns.Msg
 		err  error

--- a/tunnel/dns/upstream_test.go
+++ b/tunnel/dns/upstream_test.go
@@ -228,6 +228,173 @@ func TestQueryUpstreams_EmptyList(t *testing.T) {
 	require.Contains(t, err.Error(), "no upstream")
 }
 
+func TestParseUpstreamMode(t *testing.T) {
+	cases := map[string]upstreamMode{
+		"":         upstreamParallel,
+		"parallel": upstreamParallel,
+		"serial":   upstreamSerial,
+		"failover": upstreamFailover,
+		"random":   upstreamRandom,
+		"SERIAL":   upstreamSerial,
+		" serial ": upstreamSerial,
+	}
+	for raw, expected := range cases {
+		mode, err := parseUpstreamMode(raw)
+		require.NoError(t, err, "raw=%q", raw)
+		require.Equal(t, expected, mode, "raw=%q", raw)
+	}
+
+	_, err := parseUpstreamMode("bogus")
+	require.Error(t, err)
+}
+
+func TestValidateUpstreamMode(t *testing.T) {
+	require.NoError(t, ValidateUpstreamMode(""))
+	require.NoError(t, ValidateUpstreamMode("serial"))
+	require.NoError(t, ValidateUpstreamMode("FAILOVER"))
+	require.Error(t, ValidateUpstreamMode("bogus"))
+}
+
+func TestValidateUnansweredDisposition(t *testing.T) {
+	require.NoError(t, ValidateUnansweredDisposition(""))
+	require.NoError(t, ValidateUnansweredDisposition("servfail"))
+	require.NoError(t, ValidateUnansweredDisposition("REFUSED"))
+	require.Error(t, ValidateUnansweredDisposition("bogus"))
+}
+
+// In serial mode a healthy first upstream answers every query, and the
+// remaining upstreams are never contacted (no fan-out traffic).
+func TestQueryUpstreams_SerialFirstUpstreamWinsNoFanout(t *testing.T) {
+	upstreamFirst := startTestUpstream(t, func(q *dns.Msg) *dns.Msg {
+		return responseA(q, "10.0.0.1")
+	})
+	upstreamSecond := startTestUpstream(t, func(q *dns.Msg) *dns.Msg {
+		return responseA(q, "10.0.0.2")
+	})
+	r := makeResolver(upstreamFirst.addr, upstreamSecond.addr)
+	r.upstreamMode = upstreamSerial
+
+	for i := 0; i < 3; i++ {
+		resp, err := r.queryUpstreams(newQuery("example.com"))
+		require.NoError(t, err)
+		require.Equal(t, "10.0.0.1", resp.Answer[0].(*dns.A).A.String())
+	}
+
+	require.Equal(t, int32(3), upstreamFirst.queries.Load())
+	require.Equal(t, int32(0), upstreamSecond.queries.Load(), "second upstream must not be queried while the first answers")
+}
+
+// In serial mode a transport failure on the first upstream fails through to the
+// next, which answers.
+func TestQueryUpstreams_SerialFailsThroughOnError(t *testing.T) {
+	upstreamDrop := startTestUpstream(t, func(q *dns.Msg) *dns.Msg { return nil })
+	upstreamOk := startTestUpstream(t, func(q *dns.Msg) *dns.Msg {
+		return responseA(q, "10.0.0.55")
+	})
+	r := makeResolver(upstreamDrop.addr, upstreamOk.addr)
+	r.upstreamMode = upstreamSerial
+
+	resp, err := r.queryUpstreams(newQuery("example.com"))
+	require.NoError(t, err)
+	require.Equal(t, "10.0.0.55", resp.Answer[0].(*dns.A).A.String())
+	require.Equal(t, int32(1), upstreamDrop.queries.Load())
+	require.Equal(t, int32(1), upstreamOk.queries.Load())
+}
+
+// In serial mode a non-NOERROR response fails through to the next upstream
+// rather than being returned, even though that response would win a parallel
+// rcode-ranked comparison.
+func TestQueryUpstreams_SerialFailsThroughOnNXDOMAIN(t *testing.T) {
+	upstreamNx := startTestUpstream(t, func(q *dns.Msg) *dns.Msg {
+		return responseRcode(q, dns.RcodeNameError)
+	})
+	upstreamOk := startTestUpstream(t, func(q *dns.Msg) *dns.Msg {
+		return responseA(q, "10.0.0.66")
+	})
+	r := makeResolver(upstreamNx.addr, upstreamOk.addr)
+	r.upstreamMode = upstreamSerial
+
+	resp, err := r.queryUpstreams(newQuery("example.com"))
+	require.NoError(t, err)
+	require.Equal(t, dns.RcodeSuccess, resp.Rcode)
+	require.Equal(t, "10.0.0.66", resp.Answer[0].(*dns.A).A.String())
+}
+
+// When no upstream returns NOERROR, serial mode returns the best-ranked
+// non-NOERROR response, matching the parallel path's selection.
+func TestQueryUpstreams_SerialBestRcodeWhenNoNoerror(t *testing.T) {
+	upstreamServfail := startTestUpstream(t, func(q *dns.Msg) *dns.Msg {
+		return responseRcode(q, dns.RcodeServerFailure)
+	})
+	upstreamNx := startTestUpstream(t, func(q *dns.Msg) *dns.Msg {
+		return responseRcode(q, dns.RcodeNameError)
+	})
+	r := makeResolver(upstreamServfail.addr, upstreamNx.addr)
+	r.upstreamMode = upstreamSerial
+
+	resp, err := r.queryUpstreams(newQuery("example.com"))
+	require.NoError(t, err)
+	require.Equal(t, dns.RcodeNameError, resp.Rcode)
+}
+
+// In failover mode, once the first upstream stops answering the resolver sticks
+// to the upstream that answered and stops re-probing the dead one on every query.
+func TestQueryUpstreams_FailoverSticksToHealthyUpstream(t *testing.T) {
+	var firstUp atomic.Bool
+	firstUp.Store(true)
+	upstreamFirst := startTestUpstream(t, func(q *dns.Msg) *dns.Msg {
+		if firstUp.Load() {
+			return responseA(q, "10.0.0.1")
+		}
+		return nil // simulate the first upstream going down
+	})
+	upstreamSecond := startTestUpstream(t, func(q *dns.Msg) *dns.Msg {
+		return responseA(q, "10.0.0.2")
+	})
+	r := makeResolver(upstreamFirst.addr, upstreamSecond.addr)
+	r.upstreamMode = upstreamFailover
+
+	// first query: first upstream answers, preferred stays at index 0
+	resp, err := r.queryUpstreams(newQuery("example.com"))
+	require.NoError(t, err)
+	require.Equal(t, "10.0.0.1", resp.Answer[0].(*dns.A).A.String())
+
+	// first upstream goes down; next query fails through to the second, which
+	// becomes the new preferred upstream
+	firstUp.Store(false)
+	resp, err = r.queryUpstreams(newQuery("example.com"))
+	require.NoError(t, err)
+	require.Equal(t, "10.0.0.2", resp.Answer[0].(*dns.A).A.String())
+
+	firstQueriesAfterFailover := upstreamFirst.queries.Load()
+
+	// subsequent queries go straight to the second upstream without re-probing
+	// the dead first upstream
+	for i := 0; i < 3; i++ {
+		resp, err = r.queryUpstreams(newQuery("example.com"))
+		require.NoError(t, err)
+		require.Equal(t, "10.0.0.2", resp.Answer[0].(*dns.A).A.String())
+	}
+	require.Equal(t, firstQueriesAfterFailover, upstreamFirst.queries.Load(), "dead upstream must not be re-probed once failover settles")
+	// second upstream answered the failover query plus the 3 follow-ups (the
+	// very first query was served by the then-healthy first upstream).
+	require.Equal(t, int32(4), upstreamSecond.queries.Load())
+}
+
+// Random mode still returns a NOERROR answer; with a single upstream the start
+// index is deterministic.
+func TestQueryUpstreams_RandomSingleUpstream(t *testing.T) {
+	upstream := startTestUpstream(t, func(q *dns.Msg) *dns.Msg {
+		return responseA(q, "10.0.0.9")
+	})
+	r := makeResolver(upstream.addr)
+	r.upstreamMode = upstreamRandom
+
+	resp, err := r.queryUpstreams(newQuery("example.com"))
+	require.NoError(t, err)
+	require.Equal(t, "10.0.0.9", resp.Answer[0].(*dns.A).A.String())
+}
+
 // When a fast upstream produces NOERROR, queryUpstreams returns without
 // waiting for slower upstreams — the caller must not be blocked by them.
 func TestQueryUpstreams_FastPathDoesNotWaitForSlow(t *testing.T) {

--- a/ziti/tunnel/root.go
+++ b/ziti/tunnel/root.go
@@ -48,6 +48,7 @@ const (
 	resolverCfgFlag     = "resolver"
 	dnsSvcIpRangeFlag   = "dnsSvcIpRange"
 	dnsUpstreamFlag     = "dnsUpstream"
+	dnsUpstreamModeFlag = "dnsUpstreamMode"
 	dnsUnanswerableFlag = "dnsUnanswerable"
 )
 
@@ -66,7 +67,8 @@ func NewTunnelCmd(legacy bool) *cobra.Command {
 	root.PersistentFlags().String("identity-dir", "", "Path to directory file that contains one or more enrolled identities")
 	root.PersistentFlags().Uint(svcPollRateFlag, 15, "Set poll rate for service updates (seconds). Polling in proxy mode is disabled unless this value is explicitly set")
 	root.PersistentFlags().StringP(resolverCfgFlag, "r", "udp://127.0.0.1:53", "Resolver configuration")
-	root.PersistentFlags().StringSlice(dnsUpstreamFlag, nil, "Upstream DNS server(s) for recursive queries (e.g., udp://10.96.0.10:53 or tcp://8.8.8.8:53). Repeat or comma-separate to query multiple in parallel; first NOERROR response wins.")
+	root.PersistentFlags().StringSlice(dnsUpstreamFlag, nil, "Upstream DNS server(s) for recursive queries (e.g., udp://10.96.0.10:53 or tcp://8.8.8.8:53). Repeat or comma-separate to specify multiple. See --dnsUpstreamMode for how multiple upstreams are queried.")
+	root.PersistentFlags().String(dnsUpstreamModeFlag, "", "How multiple DNS upstreams are queried (parallel|serial|failover|random, default: parallel). parallel fans out to all at once; serial/failover/random query one at a time and fail through to the next.")
 	root.PersistentFlags().String(dnsUnanswerableFlag, "", "Disposition for unanswerable DNS queries (timeout|servfail|refused, default: refused)")
 	root.PersistentFlags().StringVar(&logFormatter, "log-formatter", "", "Specify log formatter [json|pfxlog|text]")
 	root.PersistentFlags().StringP(dnsSvcIpRangeFlag, "d", "100.64.0.1/10", "cidr to use when assigning IPs to unresolvable intercept hostnames")
@@ -161,8 +163,9 @@ func rootPostRun(cmd *cobra.Command, _ []string) {
 
 	resolverConfig := cmd.Flag(resolverCfgFlag).Value.String()
 	upstreams, _ := cmd.Flags().GetStringSlice(dnsUpstreamFlag)
+	upstreamMode, _ := cmd.Flags().GetString(dnsUpstreamModeFlag)
 	unansweredDisposition, _ := cmd.Flags().GetString(dnsUnanswerableFlag)
-	resolver, err := dns.NewResolver([]string{resolverConfig}, upstreams, unansweredDisposition)
+	resolver, err := dns.NewResolver([]string{resolverConfig}, upstreams, unansweredDisposition, upstreamMode)
 	if err != nil {
 		log.WithError(err).Fatal("failed to start DNS resolver")
 	}


### PR DESCRIPTION
## What

Adds a `dnsUpstreamMode` option (router `xgress_edge_tunnel` config) and a matching `--dnsUpstreamMode` flag for `ziti tunnel` that controls how multiple DNS upstreams are queried for tproxy host-side resolution:

- **`parallel`** (default) - existing fan-out; all upstreams queried at once, first NOERROR wins
- **`serial`** - query one at a time in order, starting at the first; fail through on timeout/error/non-NOERROR
- **`failover`** - like serial, but reuses the upstream that last answered as the starting point
- **`random`** - like serial, but starts at a randomly chosen upstream

In all serial modes a healthy upstream costs exactly one outbound query regardless of how many are configured. Default behavior is unchanged.

## Why

The resolver previously always fanned out to every upstream in parallel. For a high-volume Edge Router with several upstreams, that multiplies outbound DNS traffic since every request hits every server. Serial fail-through lets operators cap that to one query per request against a healthy upstream.

While in here, `dnsUpstreamMode` and `dnsUnanswerable` are now validated at router config-load time. Previously a bad value errored only when the resolver was built, and the router silently fell back to a dummy resolver (breaking all DNS for that tunnel) instead of failing fast.

Fixes #3881