### PR TITLE
Add striped per-link locking and cache-before-txn router reads

### DIFF
--- a/common/concurrency/striped_id_locker.go
+++ b/common/concurrency/striped_id_locker.go
@@ -1,0 +1,66 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package concurrency
+
+import "sync"
+
+// StripedIdLocker is a fixed-size set of mutexes selected by hashing a string
+// id. Operations on the same id always serialize; operations on different ids
+// proceed concurrently unless they happen to hash to the same slot. Ids that
+// collide on a slot share a lock (false contention), so size the locker
+// comfortably above the expected concurrency to keep collisions rare.
+//
+// It is intended as a lighter-weight alternative to a single coarse mutex when
+// the protected work is keyed by id and most concurrent callers touch
+// different ids.
+type StripedIdLocker struct {
+	locks []sync.Mutex
+}
+
+// NewStripedIdLocker returns a StripedIdLocker with the given number of slots.
+// slots is clamped to a minimum of 1.
+func NewStripedIdLocker(slots int) *StripedIdLocker {
+	if slots < 1 {
+		slots = 1
+	}
+	return &StripedIdLocker{locks: make([]sync.Mutex, slots)}
+}
+
+// LockFor locks the slot for id and returns a function that unlocks it. The
+// returned function must be called exactly once. Typical use:
+//
+//	defer locker.LockFor(id)()
+func (self *StripedIdLocker) LockFor(id string) func() {
+	m := &self.locks[self.indexFor(id)]
+	m.Lock()
+	return m.Unlock
+}
+
+// indexFor maps id to a slot using FNV-1a (inlined to avoid allocating a hasher
+// on this hot path).
+func (self *StripedIdLocker) indexFor(id string) uint32 {
+	const (
+		offset32 = 2166136261
+		prime32  = 16777619
+	)
+	h := uint32(offset32)
+	for i := 0; i < len(id); i++ {
+		h ^= uint32(id[i])
+		h *= prime32
+	}
+	return h % uint32(len(self.locks))
+}

--- a/common/concurrency/striped_id_locker_test.go
+++ b/common/concurrency/striped_id_locker_test.go
@@ -1,0 +1,127 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package concurrency
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestStripedIdLocker_SameIdSerializes verifies that two lockers for the same id
+// are mutually exclusive: the second LockFor blocks until the first unlocks.
+func TestStripedIdLocker_SameIdSerializes(t *testing.T) {
+	locker := NewStripedIdLocker(16)
+
+	unlock := locker.LockFor("link-1")
+
+	acquired := make(chan struct{})
+	go func() {
+		secondUnlock := locker.LockFor("link-1")
+		close(acquired)
+		secondUnlock()
+	}()
+
+	select {
+	case <-acquired:
+		t.Fatal("second LockFor for the same id acquired while the first was still held")
+	case <-time.After(50 * time.Millisecond):
+		// expected: still blocked
+	}
+
+	unlock()
+
+	select {
+	case <-acquired:
+		// expected: unblocked once the first lock was released
+	case <-time.After(time.Second):
+		t.Fatal("second LockFor did not acquire after the first was released")
+	}
+}
+
+// TestStripedIdLocker_MutualExclusion runs many goroutines incrementing per-id
+// counters guarded only by the striped locker. With correct per-id
+// serialization every counter ends at the expected total. Run with -race to
+// also catch incorrect sharing.
+func TestStripedIdLocker_MutualExclusion(t *testing.T) {
+	const (
+		ids           = 50
+		goroutines    = 32
+		incsPerWorker = 200
+	)
+
+	// Use more ids than slots so multiple ids share slots; correctness must not
+	// depend on a 1:1 id-to-slot mapping.
+	locker := NewStripedIdLocker(8)
+	counters := make([]int, ids)
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < incsPerWorker; i++ {
+				id := fmt.Sprintf("id-%d", i%ids)
+				unlock := locker.LockFor(id)
+				counters[i%ids]++
+				unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	expected := goroutines * incsPerWorker / ids
+	for i, c := range counters {
+		if c != expected {
+			t.Fatalf("counter[%d] = %d, expected %d", i, c, expected)
+		}
+	}
+}
+
+// TestStripedIdLocker_DifferentIdsConcurrent verifies that ids landing on
+// different slots do not block each other.
+func TestStripedIdLocker_DifferentIdsConcurrent(t *testing.T) {
+	locker := NewStripedIdLocker(256)
+
+	// Find two ids that map to different slots.
+	a := "router-a"
+	var b string
+	for i := 0; ; i++ {
+		candidate := fmt.Sprintf("router-%d", i)
+		if locker.indexFor(candidate) != locker.indexFor(a) {
+			b = candidate
+			break
+		}
+	}
+
+	unlockA := locker.LockFor(a)
+	defer unlockA()
+
+	done := make(chan struct{})
+	go func() {
+		locker.LockFor(b)() // should not block on a's slot
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// expected
+	case <-time.After(time.Second):
+		t.Fatal("LockFor on a different slot blocked while an unrelated slot was held")
+	}
+}

--- a/controller/model/link_manager.go
+++ b/controller/model/link_manager.go
@@ -18,22 +18,26 @@ package model
 
 import (
 	"math"
-	"sync"
 	"time"
 
-	"github.com/michaelquigley/pfxlog"
-	"github.com/openziti/ziti/v2/controller/storage/boltz"
-	"github.com/openziti/ziti/v2/controller/storage/objectz"
+	"github.com/openziti/ziti/v2/common/concurrency"
 	"github.com/openziti/ziti/v2/common/datastructures"
+	"github.com/openziti/ziti/v2/common/logging"
 	"github.com/openziti/ziti/v2/common/pb/ctrl_pb"
 	"github.com/openziti/ziti/v2/controller/config"
 	"github.com/openziti/ziti/v2/controller/models"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
+	"github.com/openziti/ziti/v2/controller/storage/objectz"
 	"github.com/orcaman/concurrent-map/v2"
 )
 
+// linkLog is the logger for the controller's link manager. Its channel name is
+// "controller.link".
+var linkLog = logging.For("controller.link")
+
 type LinkManager struct {
 	linkTable      *linkTable
-	lock           sync.Mutex
+	linkLocks      *concurrency.StripedIdLocker
 	initialLatency time.Duration
 	models.BaseObjectStoreManager[*Link]
 }
@@ -46,6 +50,7 @@ func NewLinkManager(env Env) *LinkManager {
 
 	result := &LinkManager{
 		linkTable:      newLinkTable(),
+		linkLocks:      concurrency.NewStripedIdLocker(256),
 		initialLatency: initialLatency,
 	}
 
@@ -139,8 +144,10 @@ func (self *LinkManager) ScanForDeadLinks() {
 }
 
 func (self *LinkManager) RouterReportedLink(reportedLink *ctrl_pb.RouterLinks_RouterLink, src, dst *Router) (*Link, bool) {
-	self.lock.Lock()
-	defer self.lock.Unlock()
+	// Striped by link id so concurrent reports for different links proceed in
+	// parallel; reports for the same link still serialize. Replaces a single
+	// global mutex that funneled every router's link reports through one lock.
+	defer self.linkLocks.LockFor(reportedLink.Id)()
 
 	link, _ := self.Get(reportedLink.Id)
 	if link != nil && link.Iteration >= reportedLink.Iteration {
@@ -149,14 +156,17 @@ func (self *LinkManager) RouterReportedLink(reportedLink *ctrl_pb.RouterLinks_Ro
 
 	// remove the older link before adding the new one
 	if link != nil {
-		log := pfxlog.Logger().
-			WithField("routerId", src.Id).
-			WithField("linkId", reportedLink.Id).
-			WithField("destRouterId", reportedLink.DestRouterId).
-			WithField("iteration", reportedLink.Iteration)
+		log := linkLog.With(
+			"routerId", src.Id,
+			"linkId", reportedLink.Id,
+			"destRouterId", reportedLink.DestRouterId,
+			"iteration", reportedLink.Iteration)
 
+		oldIteration := link.Iteration
 		self.Remove(link)
-		log.Infof("replaced link with newer iteration %v => %v", link.Iteration, reportedLink.Iteration)
+		log.Info("replaced link with newer iteration",
+			"oldIteration", oldIteration,
+			"newIteration", reportedLink.Iteration)
 	}
 
 	link = newLink(reportedLink.Id, reportedLink.LinkProtocol, reportedLink.DialAddress, self.initialLatency)

--- a/controller/model/link_manager_test.go
+++ b/controller/model/link_manager_test.go
@@ -17,10 +17,13 @@
 package model
 
 import (
+	"sync"
 	"sync/atomic"
 	"testing"
 
+	"github.com/openziti/ziti/v2/common/pb/ctrl_pb"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // A simple test to check for failure of alignment on atomic operations for 64 bit variables in a struct
@@ -83,4 +86,67 @@ func TestNeighbors(t *testing.T) {
 	neighbors := linkController.ConnectedNeighborsOfRouter(r0)
 	assert.Equal(t, 1, len(neighbors))
 	assert.Equal(t, r1, neighbors[0])
+}
+
+// Test_RouterReportedLink_serializesAndStableOnStaleReport covers two
+// RouterReportedLink guarantees: concurrent reports for the same link serialize
+// through the striped per-link lock (no corruption under -race, and the highest
+// reported iteration wins regardless of arrival order), and a stale/same-iteration
+// report is a no-op that returns the existing link without replacing it or its
+// source/dest routers.
+func Test_RouterReportedLink_serializesAndStableOnStaleReport(t *testing.T) {
+	req := require.New(t)
+	lm := NewLinkManager(nil)
+
+	src := NewRouter("r0", "", "", 0, true)
+	src.Connected.Store(true)
+	dst := NewRouter("r1", "", "", 0, true)
+	dst.Connected.Store(true)
+
+	report := func(iteration uint32) *ctrl_pb.RouterLinks_RouterLink {
+		return &ctrl_pb.RouterLinks_RouterLink{
+			Id:           "l0",
+			DestRouterId: dst.Id,
+			LinkProtocol: "tls",
+			DialAddress:  "tcp:localhost:1234",
+			Iteration:    iteration,
+		}
+	}
+
+	link, created := lm.RouterReportedLink(report(1), src, dst)
+	req.True(created)
+	req.NotNil(link)
+	req.Same(src, link.Src)
+	req.Same(dst, link.GetDest())
+
+	// A stale/same-iteration report returns the existing link unchanged: created is
+	// false, the same link object comes back, and the source router is not swapped
+	// even though a different (also connected) router object with the same id reports.
+	otherSrc := NewRouter("r0", "", "", 0, true)
+	otherSrc.Connected.Store(true)
+	again, created2 := lm.RouterReportedLink(report(1), otherSrc, dst)
+	req.False(created2)
+	req.Same(link, again, "same-iteration report returns the existing link")
+	req.Same(src, again.Src, "same-iteration report must not replace the source router")
+
+	// Concurrent reports for the same link serialize through the per-link lock. With
+	// mixed iterations arriving in arbitrary order the highest iteration must win
+	// (lower ones are rejected as stale once it lands), and the table holds exactly
+	// one link. Run under -race to catch unsynchronized access.
+	const maxIteration = 32
+	var wg sync.WaitGroup
+	for i := uint32(1); i <= maxIteration; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			lm.RouterReportedLink(report(i), src, dst)
+		}()
+	}
+	wg.Wait()
+
+	got, ok := lm.Get("l0")
+	req.True(ok)
+	req.Equal(uint32(maxIteration), got.Iteration, "highest reported iteration wins regardless of arrival order")
+	req.Len(lm.All(), 1, "exactly one link remains in the table")
 }

--- a/controller/model/router_manager.go
+++ b/controller/model/router_manager.go
@@ -177,6 +177,16 @@ func (self *RouterManager) ApplyCreate(cmd *command.CreateEntityCommand[*Router]
 }
 
 func (self *RouterManager) Read(id string) (entity *Router, err error) {
+	// Fast path: the router cache is read-through (populated by readInTx) and
+	// invalidated on update/delete, so a cache hit can return without opening a
+	// bolt read transaction at all. readInTx already trusts the cache; checking
+	// it here too just avoids paying for beginTx (and its contention on bbolt's
+	// metalock) on hot paths like VerifyRouter, which otherwise opens a
+	// transaction per call.
+	if cached, _ := self.cache.Get(id); cached != nil {
+		return cached, nil
+	}
+
 	err = self.GetDb().View(func(tx *bbolt.Tx) error {
 		entity, err = self.readInTx(tx, id)
 		return err


### PR DESCRIPTION
Fixes #4045

Reduces lock contention in the controller's link and router management paths under high link churn.

- adds a striped id locker (`common/concurrency`) that shards locking by entity id
- switches the link manager from a single global lock to striped per-link locking
- adds a cache-before-transaction read path to the router manager so hot reads avoid a store transaction

Carved out of the gossip link-state work as an independent base change so it can land and be rebased under that branch.
