### PR TITLE
Add ziti ops log-pipe command

### DIFF
--- a/tests/testdata/configs/oidc-listener-bind-failure/ctrl.yml
+++ b/tests/testdata/configs/oidc-listener-bind-failure/ctrl.yml
@@ -3,12 +3,13 @@ v: 3
 db: ${ZITI_TEST_DB}
 
 identity:
-  cert: testdata/ca/intermediate/certs/ctrl-client.cert.pem
-  server_cert: testdata/ca/intermediate/certs/ctrl-server.cert.pem
-  key: testdata/ca/intermediate/private/ctrl.key.pem
-  ca: testdata/ca/intermediate/certs/ca-chain.cert.pem
+  cert: testdata/pki/ctrl1/certs/client.chain.pem
+  server_cert: testdata/pki/ctrl1/certs/server.chain.pem
+  key: testdata/pki/ctrl1/keys/client.key
+  server_key: testdata/pki/ctrl1/keys/server.key
+  ca: testdata/pki/root/certs/root.cert
 
-trustDomain: at-test
+trustDomain: ziti.test
 
 ctrl:
   listener: tls:127.0.0.1:6262
@@ -26,9 +27,9 @@ edge:
     address: 127.0.0.1:1281
   enrollment:
     signingCert:
-      cert: testdata/ca/intermediate/certs/intermediate.cert.pem
-      key: testdata/ca/intermediate/private/intermediate.key.decrypted.pem
-      ca: testdata/ca/intermediate/certs/ca-chain.cert.pem
+      cert: testdata/pki/ctrl1/certs/ctrl1.chain.pem
+      key: testdata/pki/ctrl1/keys/ctrl1.key
+      ca: testdata/pki/root/certs/root.cert
     edgeIdentity:
       duration: 20m
     edgeRouter:

--- a/ziti/cmd/cmd.go
+++ b/ziti/cmd/cmd.go
@@ -243,6 +243,9 @@ func NewV1CmdRoot(in io.Reader, out, err io.Writer, cmd *cobra.Command) *cobra.C
 	clusterCmd.AddCommand(cluster.NewCmdRecover(out, err))
 	opsCommands.AddCommand(clusterCmd)
 	opsCommands.AddCommand(ops.NewCmdLogFormat(out, err))
+	logPipeCmd := ops.NewCmdLogPipe(out, err)
+	logPipeCmd.Hidden = true
+	opsCommands.AddCommand(logPipeCmd)
 	opsCommands.AddCommand(ops.NewUnwrapIdentityFileCommand(out, err))
 	opsCommands.AddCommand(verify.NewVerifyCommand(out, err, context.Background()))
 	opsCommands.AddCommand(exporter.NewExportCmd(out, err))
@@ -426,6 +429,9 @@ func NewV2CmdRoot(in io.Reader, out, err io.Writer, cmd *cobra.Command) *cobra.C
 		Short: "miscellaneous utility tools",
 	}
 	toolsCmd.AddCommand(ops.NewCmdLogFormat(out, err))
+	logPipeTool := ops.NewCmdLogPipe(out, err)
+	logPipeTool.Hidden = true
+	toolsCmd.AddCommand(logPipeTool)
 	toolsCmd.AddCommand(ops.NewUnwrapIdentityFileCommand(out, err))
 	toolsCmd.AddCommand(newCompletionCmd())
 	toolsCmd.AddCommand(lets_encrypt.NewCmdLE(out, err))
@@ -925,10 +931,14 @@ func addV1BackwardCompatCommands(
 	hiddenEnrollEdgeRouter.Hidden = true
 	enrollCmd.AddCommand(hiddenEnrollEdgeRouter)
 
-	// 6. ziti ops log-format and ziti ops unwrap (V1 paths, now under ops tools)
+	// 6. ziti ops log-format, ziti ops log-pipe and ziti ops unwrap (V1 paths, now under ops tools)
 	hiddenLogFormat := ops.NewCmdLogFormat(out, errOut)
 	hiddenLogFormat.Hidden = true
 	opsCommands.AddCommand(hiddenLogFormat)
+
+	hiddenLogPipe := ops.NewCmdLogPipe(out, errOut)
+	hiddenLogPipe.Hidden = true
+	opsCommands.AddCommand(hiddenLogPipe)
 
 	hiddenUnwrap := ops.NewUnwrapIdentityFileCommand(out, errOut)
 	hiddenUnwrap.Hidden = true

--- a/ziti/cmd/ops/log_pipe.go
+++ b/ziti/cmd/ops/log_pipe.go
@@ -1,0 +1,68 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package ops
+
+import (
+	"io"
+	"os"
+
+	"github.com/natefinch/lumberjack"
+	"github.com/spf13/cobra"
+)
+
+type logPipeOptions struct {
+	maxSizeMb  int
+	maxBackups int
+	maxAgeDays int
+	compress   bool
+}
+
+// NewCmdLogPipe creates the "log-pipe" command. It copies stdin to a size-rotated
+// file using the same rotation (lumberjack) as the controller's event and metrics
+// logs. It's intended as a redirect target for long-running processes whose stdout
+// would otherwise grow unbounded or be lost on restart, e.g.:
+//
+//	ziti controller run ... 2>&1 | ziti ops log-pipe ctrl.log --max-size-mb 50 --max-backups 10
+func NewCmdLogPipe(out io.Writer, errOut io.Writer) *cobra.Command {
+	options := &logPipeOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "log-pipe <file>",
+		Short: "Copy stdin to a size-rotated log file",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			writer := &lumberjack.Logger{
+				Filename:   args[0],
+				MaxSize:    options.maxSizeMb,
+				MaxBackups: options.maxBackups,
+				MaxAge:     options.maxAgeDays,
+				Compress:   options.compress,
+			}
+			defer func() { _ = writer.Close() }()
+
+			_, err := io.Copy(writer, os.Stdin)
+			return err
+		},
+	}
+
+	cmd.Flags().IntVar(&options.maxSizeMb, "max-size-mb", 50, "max size in MB before a file is rotated")
+	cmd.Flags().IntVar(&options.maxBackups, "max-backups", 10, "max number of rotated files to keep (0 keeps all)")
+	cmd.Flags().IntVar(&options.maxAgeDays, "max-age-days", 0, "max age in days to keep rotated files (0 = no age limit)")
+	cmd.Flags().BoolVar(&options.compress, "compress", false, "gzip rotated files")
+
+	return cmd
+}

--- a/ziti/util/identities_token_test.go
+++ b/ziti/util/identities_token_test.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
-	edge_apis "github.com/openziti/sdk-golang/edge-apis"
+	edge_apis "github.com/openziti/sdk-golang/v2/edge-apis"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
Adds a small log-capture command so a component's stdout/stderr can be written to a file with a chosen retention strategy, rather than relying on external tooling.

- adds `ziti ops log-pipe`, which reads stdin and writes it to a log file
- registers the command under both the ops and tools command groups

Carved out of the gossip link-state work as an independent base change.
