### PR TITLE
Add fablab log strategy and host-reachability-aware chaos helpers

### DIFF
--- a/zititest/zitilab/chaos/chaos.go
+++ b/zititest/zitilab/chaos/chaos.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/michaelquigley/pfxlog"
+	"github.com/openziti/fablab/kernel/lib/parallel"
 	"github.com/openziti/fablab/kernel/model"
 	"github.com/openziti/ziti/v2/zitirest"
 )
@@ -97,6 +98,7 @@ func StopSelected(run model.Run, list []*model.Component, concurrency int) error
 		return nil
 	}
 	return run.GetModel().ForEachComponentIn(list, concurrency, func(c *model.Component) error {
+		deadline := time.Now().Add(time.Minute)
 		if _, ok := c.Type.(model.ServerComponent); ok {
 			if err := c.Type.Stop(run, c); err != nil {
 				return err
@@ -112,6 +114,10 @@ func StopSelected(run model.Run, list []*model.Component, concurrency int) error
 				} else {
 					time.Sleep(250 * time.Millisecond)
 				}
+
+				if time.Now().After(deadline) {
+					return fmt.Errorf("timed out waiting for component %s to stop", c.Id)
+				}
 			}
 			time.Sleep(time.Second)
 			return nil
@@ -125,6 +131,7 @@ func RestartSelected(run model.Run, concurrency int, list ...*model.Component) e
 		return nil
 	}
 	return run.GetModel().ForEachComponentIn(list, concurrency, func(c *model.Component) error {
+		deadline := time.Now().Add(time.Minute)
 		if sc, ok := c.Type.(model.ServerComponent); ok {
 			if err := c.Type.Stop(run, c); err != nil {
 				return err
@@ -140,12 +147,121 @@ func RestartSelected(run model.Run, concurrency int, list ...*model.Component) e
 				} else {
 					time.Sleep(250 * time.Millisecond)
 				}
+
+				if time.Now().After(deadline) {
+					return fmt.Errorf("timed out waiting for component %s to stop", c.Id)
+				}
 			}
 			time.Sleep(time.Second)
 			return sc.Start(run, c)
 		}
 		return fmt.Errorf("component %v isn't of ServerComponent type, is of type %T", c, c.Type)
 	})
+}
+
+// hardKillable is implemented by component types that support an immediate
+// SIGKILL (no graceful SIGTERM), simulating an OOM kill / power loss / panic.
+type hardKillable interface {
+	Kill(run model.Run, c *model.Component) error
+}
+
+// RestartTasks returns one parallel.Task per component that stops the component,
+// waits for it to exit, then starts it again. Unlike RestartSelected the caller
+// controls scheduling, so restarts can be interleaved with other chaos tasks
+// (e.g. connection disruptions) in a single parallel.Execute batch.
+func RestartTasks(run model.Run, list ...*model.Component) []parallel.Task {
+	return restartTasks(run, false, list...)
+}
+
+// HardKillRestartTasks is like RestartTasks but stops each component with a hard
+// SIGKILL (no graceful shutdown), so it gets no chance to close links or send
+// faults. Exercises orphan creation from un-closed links / undelivered faults.
+// Components whose type doesn't implement hardKillable fall back to a graceful stop.
+func HardKillRestartTasks(run model.Run, list ...*model.Component) []parallel.Task {
+	return restartTasks(run, true, list...)
+}
+
+// freezable is implemented by component types that can be paused (SIGSTOP) and
+// resumed (SIGCONT), simulating a node that is alive but not processing (long GC
+// pause, hung disk, debugger stop).
+type freezable interface {
+	Freeze(run model.Run, c *model.Component) error
+	Resume(run model.Run, c *model.Component) error
+}
+
+// FreezeResumeTasks returns one parallel.Task per component that freezes it
+// (SIGSTOP), waits a random duration in [minFreeze, maxFreeze), then resumes it
+// (SIGCONT). A frozen node holds its TCP connections open but stops responding,
+// so peers time out and close its links while it is paused; on resume it has
+// stale link state that the gossip reconcile paths must converge. To exercise
+// that path the freeze window should exceed the peer link-close timeout (~60s).
+// Components whose type doesn't implement freezable are skipped.
+func FreezeResumeTasks(run model.Run, minFreeze, maxFreeze time.Duration, list ...*model.Component) []parallel.Task {
+	var tasks []parallel.Task
+	for _, c := range list {
+		f, ok := c.Type.(freezable)
+		if !ok {
+			continue
+		}
+		tasks = append(tasks, func() error {
+			window := minFreeze
+			if maxFreeze > minFreeze {
+				window += time.Duration(rand.Int63n(int64(maxFreeze - minFreeze)))
+			}
+			if err := f.Freeze(run, c); err != nil {
+				return err
+			}
+			pfxlog.Logger().Infof("froze %s for %s", c.Id, window)
+			time.Sleep(window)
+			pfxlog.Logger().Infof("resuming %s", c.Id)
+			return f.Resume(run, c)
+		})
+	}
+	return tasks
+}
+
+func restartTasks(run model.Run, hardKill bool, list ...*model.Component) []parallel.Task {
+	var tasks []parallel.Task
+	for _, c := range list {
+		tasks = append(tasks, func() error {
+			sc, ok := c.Type.(model.ServerComponent)
+			if !ok {
+				return fmt.Errorf("component %v isn't of ServerComponent type, is of type %T", c, c.Type)
+			}
+
+			if err := stopComponent(run, c, hardKill); err != nil {
+				return err
+			}
+
+			deadline := time.Now().Add(time.Minute)
+			for {
+				isRunning, err := c.IsRunning(run)
+				if err != nil {
+					return err
+				}
+				if !isRunning {
+					break
+				}
+				time.Sleep(250 * time.Millisecond)
+
+				if time.Now().After(deadline) {
+					return fmt.Errorf("timed out waiting for component %s to stop", c.Id)
+				}
+			}
+			time.Sleep(time.Second)
+			return sc.Start(run, c)
+		})
+	}
+	return tasks
+}
+
+func stopComponent(run model.Run, c *model.Component, hardKill bool) error {
+	if hardKill {
+		if hk, ok := c.Type.(hardKillable); ok {
+			return hk.Kill(run, c)
+		}
+	}
+	return c.Type.Stop(run, c)
 }
 
 func ValidateUp(run model.Run, spec string, concurrency int, timeout time.Duration) error {

--- a/zititest/zitilab/chaos/deadline.go
+++ b/zititest/zitilab/chaos/deadline.go
@@ -1,0 +1,110 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package chaos
+
+import (
+	"time"
+
+	"github.com/openziti/fablab/kernel/model"
+)
+
+// HostReachable reports whether a component's host can be reached, independent of
+// the application process on it. It uses the host process check (over SSH), so a
+// non-nil error means the host itself is unreachable (a network or infrastructure
+// problem) rather than the process being down on a reachable host. Validation
+// uses this to tell "the component died" (host reachable, process gone or wedged)
+// apart from "the host is unreachable" (infra), which warrant different handling.
+// Intended for ServerComponents.
+func HostReachable(run model.Run, c *model.Component) bool {
+	_, err := c.IsRunning(run)
+	return err == nil
+}
+
+// ConvergenceDeadline is a deadline for a poll-until-converged validation loop
+// that does not charge wall-clock time during which a component's host is
+// unreachable to the convergence budget. An infra or network outage is not a
+// convergence failure, so the time a host spends unreachable is credited back to
+// the deadline, up to a cap. This keeps a network outage from failing an
+// otherwise-converging run, while still failing fast on real non-convergence
+// (host reachable, state wrong) and on a permanently gone host (the cap bounds
+// total credit).
+//
+// The loop must record an observation once per poll while it has not yet
+// converged: call ExtendForUnreachableHost when the poll failed and reachability
+// is unknown (it probes the host), or Observe(true) when the poll already knows
+// the host is reachable (e.g. an API call succeeded but the state is not yet
+// converged). Each observation credits the time since the previous one only when
+// the host is unreachable, so skipping the reachable polls would mis-attribute
+// that reachable time as unreachable.
+type ConvergenceDeadline struct {
+	now          func() time.Time
+	deadline     time.Time
+	lastObserved time.Time
+	extended     time.Duration
+	maxExtend    time.Duration
+}
+
+// NewConvergenceDeadline returns a deadline that expires timeout from now and may
+// be extended by up to maxExtend in total to cover time a host is unreachable.
+func NewConvergenceDeadline(timeout, maxExtend time.Duration) *ConvergenceDeadline {
+	return newConvergenceDeadline(time.Now, timeout, maxExtend)
+}
+
+// newConvergenceDeadline is NewConvergenceDeadline with an injectable clock, so
+// the extension accounting can be exercised deterministically in tests.
+func newConvergenceDeadline(now func() time.Time, timeout, maxExtend time.Duration) *ConvergenceDeadline {
+	start := now()
+	return &ConvergenceDeadline{
+		now:          now,
+		deadline:     start.Add(timeout),
+		lastObserved: start,
+		maxExtend:    maxExtend,
+	}
+}
+
+// Expired reports whether the deadline has passed.
+func (d *ConvergenceDeadline) Expired() bool {
+	return !d.now().Before(d.deadline)
+}
+
+// ExtendForUnreachableHost probes the component's host and records the resulting
+// observation via Observe. Use it on a failed poll where reachability is unknown;
+// use Observe directly when the caller already knows the host is reachable.
+// Returns true if it extended the deadline.
+func (d *ConvergenceDeadline) ExtendForUnreachableHost(run model.Run, c *model.Component) bool {
+	return d.Observe(HostReachable(run, c))
+}
+
+// Observe records a poll observation with known reachability: it measures the time
+// since the previous observation and, when reachable is false, credits that time
+// to the deadline (up to maxExtend of total credit) so an outage is not charged to
+// the convergence budget. When reachable is true it only advances the internal
+// clock. Returns true if it extended the deadline.
+func (d *ConvergenceDeadline) Observe(reachable bool) bool {
+	now := d.now()
+	elapsed := now.Sub(d.lastObserved)
+	d.lastObserved = now
+	if reachable || elapsed <= 0 || d.extended >= d.maxExtend {
+		return false
+	}
+	if elapsed > d.maxExtend-d.extended {
+		elapsed = d.maxExtend - d.extended
+	}
+	d.deadline = d.deadline.Add(elapsed)
+	d.extended += elapsed
+	return true
+}

--- a/zititest/zitilab/chaos/deadline_test.go
+++ b/zititest/zitilab/chaos/deadline_test.go
@@ -1,0 +1,97 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package chaos
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Test_ConvergenceDeadline_CreditsUnreachableTime verifies that the full duration
+// a host is unreachable is credited back to the deadline, even for an outage that
+// starts immediately in a long timeout. A 6m outage at the start of a 10m timeout
+// pushes the deadline to 16m, so none of the outage is charged to convergence.
+func Test_ConvergenceDeadline_CreditsUnreachableTime(t *testing.T) {
+	req := require.New(t)
+
+	start := time.Unix(0, 0)
+	now := start
+	d := newConvergenceDeadline(func() time.Time { return now }, 10*time.Minute, 30*time.Minute)
+
+	// Host unreachable for the first 6 minutes, polled once a minute. Each poll
+	// credits the minute since the previous one back to the deadline.
+	for i := 0; i < 6; i++ {
+		now = now.Add(time.Minute)
+		req.True(d.Observe(false))
+	}
+	req.Equal(6*time.Minute, d.extended)
+
+	// Past the original 10m timeout the run would have failed without the credit;
+	// with it there is still budget left.
+	now = start.Add(10*time.Minute + time.Second)
+	req.False(d.Expired(), "the 6m outage must not be charged to the convergence budget")
+
+	// Past the extended 16m deadline it finally expires.
+	now = start.Add(16*time.Minute + time.Second)
+	req.True(d.Expired())
+}
+
+// Test_ConvergenceDeadline_DoesNotCreditReachableTime verifies that time while the
+// host is reachable is charged normally, so a reachable-but-failing component
+// still expires at the original timeout.
+func Test_ConvergenceDeadline_DoesNotCreditReachableTime(t *testing.T) {
+	req := require.New(t)
+
+	start := time.Unix(0, 0)
+	now := start
+	d := newConvergenceDeadline(func() time.Time { return now }, 10*time.Minute, 30*time.Minute)
+
+	for i := 0; i < 6; i++ {
+		now = now.Add(time.Minute)
+		req.False(d.Observe(true))
+	}
+	req.Equal(time.Duration(0), d.extended)
+
+	now = start.Add(10*time.Minute + time.Second)
+	req.True(d.Expired(), "reachable time is charged, so it expires at the original timeout")
+}
+
+// Test_ConvergenceDeadline_ExtensionCapped verifies the credited time is capped at
+// maxExtend, so a permanently gone host still eventually fails.
+func Test_ConvergenceDeadline_ExtensionCapped(t *testing.T) {
+	req := require.New(t)
+
+	start := time.Unix(0, 0)
+	now := start
+	d := newConvergenceDeadline(func() time.Time { return now }, 10*time.Minute, 2*time.Minute)
+
+	// A 5m unreachable gap is credited only up to the 2m cap.
+	now = now.Add(5 * time.Minute)
+	req.True(d.Observe(false))
+	req.Equal(2*time.Minute, d.extended, "credit should be clamped to the cap")
+
+	// Once the cap is exhausted, further unreachable time is not credited.
+	now = now.Add(5 * time.Minute)
+	req.False(d.Observe(false), "no credit once the cap is exhausted")
+	req.Equal(2*time.Minute, d.extended)
+
+	// Deadline is the original 10m plus the 2m cap.
+	now = start.Add(12*time.Minute + time.Second)
+	req.True(d.Expired())
+}

--- a/zititest/zitilab/component_common.go
+++ b/zititest/zitilab/component_common.go
@@ -19,12 +19,140 @@ package zitilab
 import (
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/openziti/fablab/kernel/model"
 	zitilib_actions "github.com/openziti/ziti/zititest/zitilab/actions"
+	"github.com/openziti/ziti/zititest/zitilab/stageziti"
 	"github.com/sirupsen/logrus"
 )
+
+// LogStrategy controls how a ziti component's stdout/stderr is written to its
+// log file. Set the "logStrategy" variable (per-component or model-wide) to one
+// of these values; the default is truncate.
+type LogStrategy string
+
+const (
+	// LogStrategyTruncate overwrites the log file on each (re)start (the default).
+	// History is lost on restart.
+	LogStrategyTruncate LogStrategy = "truncate"
+	// LogStrategyAppend appends to the log file, preserving history across
+	// restarts. The file is not rotated and can grow unbounded over a long run.
+	LogStrategyAppend LogStrategy = "append"
+	// LogStrategyRotate pipes the log through "ziti ops log-pipe", size-rotating
+	// it (same lumberjack rotation as the controller's event/metrics logs). This
+	// preserves recent history across restarts without growing unbounded. The
+	// log-pipe side runs the component's own binary by default, so a component
+	// pinned to a ziti version that predates "ops log-pipe" must select a newer
+	// binary via the "logPipeBinaryVersion" variable (see resolveLogPipeBinary);
+	// otherwise the pipe breaks and takes the component's stdout down with it.
+	LogStrategyRotate LogStrategy = "rotate"
+)
+
+const (
+	// defaultLogRotateMaxSizeMb and defaultLogRotateMaxBackups are the rotate
+	// strategy defaults. The per-component log footprint is
+	// maxSizeMb * (maxBackups + 1); on hosts that pack many components onto one
+	// disk (e.g. links-test runs 10 routers per host), set the "logRotateMaxSizeMb"
+	// and "logRotateMaxBackups" variables lower so the total stays well under disk.
+	defaultLogRotateMaxSizeMb  = 50
+	defaultLogRotateMaxBackups = 10
+)
+
+// resolveLogStrategy returns the component's configured log strategy, defaulting
+// to truncate.
+func resolveLogStrategy(c *model.Component) LogStrategy {
+	switch LogStrategy(strings.ToLower(c.GetStringVariableOr("logStrategy", string(LogStrategyTruncate)))) {
+	case LogStrategyAppend:
+		return LogStrategyAppend
+	case LogStrategyRotate:
+		return LogStrategyRotate
+	default:
+		return LogStrategyTruncate
+	}
+}
+
+// logPipeBinaryVersion is the model variable naming the ziti version whose binary
+// runs "ops log-pipe" for the rotate log strategy. When unset, a component uses
+// its own binary; when set it selects the binary for that version, with the empty
+// string meaning the current local build. The override exists because a component
+// can be pinned to a ziti version that predates "ops log-pipe": piping its output
+// through that binary's (nonexistent) log-pipe exits immediately and breaks the
+// component's stdout, so such a model points this at a version that has the
+// command. StageFiles stages the selected binary so switching to rotate never
+// needs the environment rebuilt.
+const logPipeBinaryVersion = "logPipeBinaryVersion"
+
+// resolveLogPipeBinaryVersion returns the configured log-pipe binary version and
+// whether it was set. An unset variable means the component should use its own
+// binary; a set-but-empty value means the current local build. The version is
+// canonicalized the same way component versions are, so "1.2.3" and "v1.2.3"
+// resolve to the same binary and staging op rather than duplicating either.
+func resolveLogPipeBinaryVersion(c *model.Component) (version string, set bool) {
+	v, found := c.GetVariable(logPipeBinaryVersion)
+	if !found {
+		return "", false
+	}
+	s, _ := v.(string)
+	canonicalizeGoAppVersion(&s)
+	return s, true
+}
+
+// resolveLogPipeBinary returns the ziti binary path used to run "ops log-pipe" for
+// the rotate log strategy. It defaults to the component's own binary (binaryPath),
+// but resolves to the logPipeBinaryVersion binary when that variable is set.
+func resolveLogPipeBinary(c *model.Component, binaryPath string) string {
+	if version, set := resolveLogPipeBinaryVersion(c); set {
+		return GetZitiBinaryPath(c, version)
+	}
+	return binaryPath
+}
+
+// stageLogPipeBinary stages the binary selected by logPipeBinaryVersion when that
+// variable is set to a version other than the component's own (ownVersion). This
+// ensures the rotate log strategy has a log-pipe-capable binary on the host even
+// when the component itself is pinned to an older version. It stages regardless of
+// the current log strategy, so switching a component to rotate later doesn't
+// require re-staging the environment.
+func stageLogPipeBinary(r model.Run, c *model.Component, ownVersion string) error {
+	version, set := resolveLogPipeBinaryVersion(c)
+	if !set || version == ownVersion {
+		return nil
+	}
+	return stageziti.StageZitiOnce(r, c, version, "")
+}
+
+// resolveLogRotate returns the rotate strategy's max file size (MB) and max
+// number of retained backups for the component, from the "logRotateMaxSizeMb"
+// and "logRotateMaxBackups" variables, defaulting when unset.
+func resolveLogRotate(c *model.Component) (maxSizeMb int, maxBackups int) {
+	maxSizeMb = logRotateIntVar(c, "logRotateMaxSizeMb", defaultLogRotateMaxSizeMb)
+	maxBackups = logRotateIntVar(c, "logRotateMaxBackups", defaultLogRotateMaxBackups)
+	return maxSizeMb, maxBackups
+}
+
+// logRotateIntVar reads an int-valued model variable, tolerating the int and
+// string forms a variable may take, and falls back to def when unset or invalid.
+func logRotateIntVar(c *model.Component, name string, def int) int {
+	v, found := c.GetVariable(name)
+	if !found {
+		return def
+	}
+	switch tv := v.(type) {
+	case int:
+		return tv
+	case int64:
+		return int(tv)
+	case float64:
+		return int(tv)
+	case string:
+		if n, err := strconv.Atoi(tv); err == nil {
+			return n
+		}
+	}
+	return def
+}
 
 func getZitiProcessFilter(c *model.Component, zitiType string) func(string) bool {
 	return func(s string) bool {
@@ -48,8 +176,32 @@ func startZitiComponent(c *model.Component, zitiType string, version string, con
 		useSudo = "sudo"
 	}
 
-	serviceCmd := fmt.Sprintf("nohup %s %s %s run %s --cli-agent-alias %s --log-formatter json %s > %s 2>&1 &",
-		useSudo, binaryPath, zitiType, extraArgs, c.Id, configPath, logsPath)
+	// Default to truncate (the long-standing behavior) so existing models are
+	// unaffected; models opt into append or rotate per-component as appropriate.
+	// Truncating on each start discards pre-restart history, which is often
+	// exactly what's needed to debug a failure, so chaos-heavy models will want
+	// append (survives restarts) or rotate (survives restarts, size-bounded).
+	var logRedirect string
+	switch resolveLogStrategy(c) {
+	case LogStrategyTruncate:
+		logRedirect = fmt.Sprintf("> %s 2>&1", logsPath)
+	case LogStrategyRotate:
+		// Pipe the run process's output into log-pipe for rotation. log-pipe's
+		// OWN stdout/stderr must go to /dev/null (and it must be nohup'd) so it
+		// doesn't hold the start command's ssh channel open (which made the
+		// backgrounded start never return) or die on SIGHUP when the channel
+		// closes. log-pipe runs the component's own binary unless the model
+		// overrides it (needed when the component predates "ops log-pipe").
+		maxSizeMb, maxBackups := resolveLogRotate(c)
+		logPipeBinary := resolveLogPipeBinary(c, binaryPath)
+		logRedirect = fmt.Sprintf("2>&1 | nohup %s ops log-pipe %s --max-size-mb %d --max-backups %d >/dev/null 2>&1",
+			logPipeBinary, logsPath, maxSizeMb, maxBackups)
+	default: // append
+		logRedirect = fmt.Sprintf(">> %s 2>&1", logsPath)
+	}
+
+	serviceCmd := fmt.Sprintf("nohup %s %s %s run %s --cli-agent-alias %s --log-formatter json %s %s &",
+		useSudo, binaryPath, zitiType, extraArgs, c.Id, configPath, logRedirect)
 
 	if quiet, _ := c.GetBoolVariable("quiet_startup"); !quiet {
 		logrus.Info(serviceCmd)

--- a/zititest/zitilab/component_controller.go
+++ b/zititest/zitilab/component_controller.go
@@ -114,7 +114,11 @@ func (self *ControllerType) StageFiles(r model.Run, c *model.Component) error {
 		return err
 	}
 
-	return stageziti.StageZitiOnce(r, c, self.Version, self.LocalPath)
+	if err := stageziti.StageZitiOnce(r, c, self.Version, self.LocalPath); err != nil {
+		return err
+	}
+
+	return stageLogPipeBinary(r, c, self.Version)
 }
 
 func (self *ControllerType) getConfigName(c *model.Component) string {
@@ -155,6 +159,12 @@ func (self *ControllerType) Start(r model.Run, c *model.Component) error {
 
 func (self *ControllerType) Stop(_ model.Run, c *model.Component) error {
 	return c.GetHost().KillProcesses("-TERM", self.getProcessFilter(c))
+}
+
+// Kill hard-kills the controller with SIGKILL, skipping the graceful SIGTERM,
+// simulating an OOM kill / power loss / panic.
+func (self *ControllerType) Kill(_ model.Run, c *model.Component) error {
+	return c.GetHost().KillProcesses("-KILL", self.getProcessFilter(c))
 }
 
 func (self *ControllerType) GetBinaryPath(c *model.Component) string {

--- a/zititest/zitilab/component_router.go
+++ b/zititest/zitilab/component_router.go
@@ -104,7 +104,11 @@ func (self *RouterType) StageFiles(r model.Run, c *model.Component) error {
 		}
 	}
 
-	return stageziti.StageZitiOnce(r, c, self.Version, self.LocalPath)
+	if err := stageziti.StageZitiOnce(r, c, self.Version, self.LocalPath); err != nil {
+		return err
+	}
+
+	return stageLogPipeBinary(r, c, self.Version)
 }
 
 func (self *RouterType) isTunneler(c *model.Component) bool {
@@ -159,6 +163,27 @@ func (self *RouterType) Stop(run model.Run, c *model.Component) error {
 		time.Sleep(100 * time.Millisecond)
 	}
 	return c.GetHost().KillProcesses("-KILL", self.getProcessFilter(c))
+}
+
+// Kill hard-kills the router with SIGKILL, skipping the graceful SIGTERM. The
+// process gets no chance to close links or send faults, simulating an OOM kill /
+// power loss / panic. Used by chaos to exercise orphan creation from un-closed
+// links and undelivered faults.
+func (self *RouterType) Kill(_ model.Run, c *model.Component) error {
+	return c.GetHost().KillProcesses("-KILL", self.getProcessFilter(c))
+}
+
+// Freeze pauses the router with SIGSTOP, simulating a node that is alive but not
+// processing (a long GC pause, a hung disk, a debugger stop). The process keeps
+// its TCP connections open but stops responding, so peers time out and close its
+// links while it is paused; Resume (SIGCONT) lets it continue with stale state.
+func (self *RouterType) Freeze(_ model.Run, c *model.Component) error {
+	return c.GetHost().KillProcesses("-STOP", self.getProcessFilter(c))
+}
+
+// Resume continues a router previously paused by Freeze (SIGCONT).
+func (self *RouterType) Resume(_ model.Run, c *model.Component) error {
+	return c.GetHost().KillProcesses("-CONT", self.getProcessFilter(c))
 }
 
 func (self *RouterType) CreateAndEnroll(run model.Run, c *model.Component) error {


### PR DESCRIPTION
Fablab test-harness improvements used for long-running soak tests.

- adds a configurable LogStrategy (truncate/append/rotate) to zitilab components; rotate pipes component output through `ziti ops log-pipe`
- adds host-reachability checks and a convergence deadline that excludes time a host is unreachable, so a validation loop can distinguish a dead process from unreachable infrastructure
- extends the chaos toolkit used to disrupt components during runs

Carved out of the gossip link-state work as an independent base change. The rotate strategy pairs with the `ziti ops log-pipe` PR.
