### PR TITLE
adds test verifying ext-jwt bearer auth fails before token enrollment

### DIFF
--- a/tests/api_client_management.go
+++ b/tests/api_client_management.go
@@ -159,6 +159,19 @@ func (helper *ManagementHelperClient) GetIdentity(identityId string) (*rest_mode
 	return resp.Payload.Data, nil
 }
 
+// ListIdentitiesByFilter returns all identities matching the supplied ziti filter expression.
+func (helper *ManagementHelperClient) ListIdentitiesByFilter(filter string) ([]*rest_model.IdentityDetail, error) {
+	resp, err := helper.API.Identity.ListIdentities(&managementIdentity.ListIdentitiesParams{
+		Filter: &filter,
+	}, nil)
+
+	if err != nil {
+		return nil, rest_util.WrapErr(err)
+	}
+
+	return resp.Payload.Data, nil
+}
+
 func (helper *ManagementHelperClient) CreateEnrollmentOtt(identityId *string, expiresAt *time.Time) (*rest_model.CreateLocation, error) {
 	var expAt *strfmt.DateTime
 

--- a/tests/enrollment_token_to_token_test.go
+++ b/tests/enrollment_token_to_token_test.go
@@ -19,6 +19,7 @@
 package tests
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -255,6 +256,48 @@ func Test_EnrollmentToken_ToToken(t *testing.T) {
 				})
 			})
 		})
+	})
+
+	t.Run("a bearer token cannot authenticate before enrollment and provisions no identity", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		extJwtSigner := createExtJwtComponents("auth-before-enroll-to-token")
+		extJwtSigner.Create.EnrollToTokenEnabled = true
+		extJwtSigner.Create.EnrollAuthPolicyID = *authPolicyOnlyExtJwtCreate.Detail.ID
+		extJwtSigner.Create.EnrollAttributeClaimsSelector = ""
+		extJwtSigner.Create.ClaimsProperty = nil
+		extJwtSigner.Create.EnrollNameClaimsSelector = ""
+		extJwtSigner.Detail, err = adminManClient.CreateExtJwtSigner(extJwtSigner.Create)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(extJwtSigner.Detail)
+
+		enrollClaims := &claimsWithAttributes{}
+		bearerJwt, err := newJwtForExtJwtSigner(extJwtSigner, enrollClaims)
+		ctx.Req.NoError(err)
+		ctx.Req.NotEmpty(bearerJwt)
+
+		filter := fmt.Sprintf(`externalId="%s"`, enrollClaims.Subject)
+
+		// nothing exists for this subject yet
+		before, err := adminManClient.ListIdentitiesByFilter(filter)
+		ctx.Req.NoError(err)
+		ctx.Req.Len(before, 0)
+
+		clientApi := ctx.NewEdgeClientApi(nil)
+		ctx.Req.NotNil(clientApi)
+
+		// present the bearer token to /authenticate WITHOUT enrolling first
+		creds := edgeApis.NewJwtCredentials(bearerJwt)
+		apiSession, err := clientApi.Authenticate(creds, nil)
+
+		// expect failure: a valid IdP token alone has no identity to bind to
+		ctx.Req.Error(err)
+		ctx.Req.Nil(apiSession)
+
+		// and auth must NOT have provisioned an identity as a side effect
+		after, err := adminManClient.ListIdentitiesByFilter(filter)
+		ctx.Req.NoError(err)
+		ctx.Req.Len(after, 0)
 	})
 
 	t.Run("a token for token auth is invalid", func(t *testing.T) {


### PR DESCRIPTION
- adds Test_EnrollmentToken_ToToken subtest asserting a valid bearer token presented to /authenticate before enrolling is rejected and creates no identity
- confirms the auth path never provisions an identity as a side effect; provisioning happens only via token enrollment
- adds ListIdentitiesByFilter helper to ManagementHelperClient