### PR TITLE
use refresh token to reauth

### DIFF
--- a/ziti/cmd/cmd.go
+++ b/ziti/cmd/cmd.go
@@ -74,6 +74,7 @@ var rootCommand = RootCmd{
 	cobraCommand: &cobra.Command{
 		Use:   "ziti",
 		Short: "ziti is a CLI for working with Ziti",
+		SilenceErrors: true, // errors are printed by exitWithError, this prevents cobra from also printing them
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			cmd.SilenceUsage = true
 		},

--- a/ziti/cmd/edge/login.go
+++ b/ziti/cmd/edge/login.go
@@ -801,7 +801,21 @@ func (o *LoginOptions) Login() (edge_apis.ApiSession, error) {
 			return edge_apis.NewApiSessionLegacy(o.Token), nil
 		}
 	} else if o.ApiSession != nil {
-		return o.ApiSession, nil
+		if o.ApiSession.GetType() != edge_apis.ApiSessionTypeOidc || !util.OidcAccessTokenExpired(o.ApiSession) {
+			return o.ApiSession, nil
+		}
+		// The cached OIDC access token is expired. It can only be refreshed if the cached refresh
+		// token is itself still valid, otherwise the user must authenticate from scratch.
+		if !util.OidcRefreshTokenValid(o.ApiSession) {
+			return nil, fmt.Errorf("the cached access token has expired and the refresh token can no longer be used to re-authenticate, please login again")
+		}
+		o.Println("Access token has expired, refreshing it using the cached refresh token...")
+		refreshed, refreshErr := o.mgmtClient.AuthenticateWithPreviousSession(&edge_apis.EmptyCredentials{}, o.ApiSession)
+		if refreshErr != nil || refreshed == nil {
+			return nil, fmt.Errorf("failed to refresh the access token using the cached refresh token, please login again: %w", refreshErr)
+		}
+		o.Println("Successfully refreshed the access token")
+		return refreshed, nil
 	} else if o.Username != "" && o.Password != "" {
 		authCreds = edge_apis.NewUpdbCredentials(o.Username, o.Password)
 	} else if o.ClientCert != "" || o.ClientKey != "" {

--- a/ziti/cmd/edge/login.go
+++ b/ziti/cmd/edge/login.go
@@ -809,6 +809,9 @@ func (o *LoginOptions) Login() (edge_apis.ApiSession, error) {
 		if !util.OidcRefreshTokenValid(o.ApiSession) {
 			return nil, fmt.Errorf("the cached access token has expired and the refresh token can no longer be used to re-authenticate, please login again")
 		}
+		if o.mgmtClient == nil {
+			return nil, fmt.Errorf("cannot refresh the access token, no management client is available")
+		}
 		o.Println("Access token has expired, refreshing it using the cached refresh token...")
 		refreshed, refreshErr := o.mgmtClient.AuthenticateWithPreviousSession(&edge_apis.EmptyCredentials{}, o.ApiSession)
 		if refreshErr != nil || refreshed == nil {

--- a/ziti/util/identities.go
+++ b/ziti/util/identities.go
@@ -229,7 +229,7 @@ func OidcRefreshTokenValid(sess edge_apis.ApiSession) bool {
 	if err != nil || exp == nil {
 		return false
 	}
-	return time.Now().Before(exp.Time)
+	return time.Now().Add(oidcTokenLeeway).Before(exp.Time)
 }
 
 // refreshOidcTokenIfExpired refreshes the cached OIDC access token when it has expired and the
@@ -453,8 +453,10 @@ func LoadSelectedIdentity() (RestClientIdentity, error) {
 		if refreshed, err := clientIdentity.refreshOidcTokenIfExpired(); err != nil {
 			return nil, err
 		} else if refreshed {
+			// the refresh already succeeded server side, so use the new token even if saving fails,
+			// otherwise a write error would waste a single-use refresh token
 			if persistErr := PersistRestClientConfig(config); persistErr != nil {
-				return nil, errors.Wrap(persistErr, "could not persist refreshed token to CLI config")
+				_, _ = fmt.Fprintf(os.Stderr, "warning: could not save refreshed token to CLI config: %v\n", persistErr)
 			}
 		}
 

--- a/ziti/util/identities.go
+++ b/ziti/util/identities.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	httptransport "github.com/go-openapi/runtime/client"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/openziti/edge-api/rest_management_api_client"
 	edge_apis "github.com/openziti/sdk-golang/edge-apis"
 	"github.com/openziti/sdk-golang/ziti"
@@ -187,6 +188,86 @@ func (self *RestClientEdgeIdentity) NewRequest(client *resty.Client) *resty.Requ
 		r.SetHeader(env.ZitiSession, self.Token)
 	}
 	return r
+}
+
+// oidcTokenLeeway skews the OIDC token expiration slightly before its true expiry so it is
+// used on the border, requests won't fail 401s.
+const oidcTokenLeeway = 30 * time.Second
+
+// OidcAccessTokenExpired reports whether sess is an OIDC session whose access token is expired (or
+// will expire within oidcTokenLeeway). Non-OIDC sessions always report false. An unreadable token is
+// treated as expired so the caller refreshes rather than sending a token it cannot validate.
+func OidcAccessTokenExpired(sess edge_apis.ApiSession) bool {
+	oidcSess, ok := sess.(*edge_apis.ApiSessionOidc)
+	if !ok {
+		return false
+	}
+	claims, err := oidcSess.GetAccessClaims()
+	if err != nil {
+		return true
+	}
+	exp, err := claims.GetExpirationTime()
+	if err != nil || exp == nil {
+		return true
+	}
+	return time.Now().Add(oidcTokenLeeway).After(exp.Time)
+}
+
+// OidcRefreshTokenValid reports whether sess carries an OIDC refresh token that is present and not
+// yet expired. A missing, unreadable, or expired refresh token returns false, indicating the user
+// must authenticate again rather than refresh.
+func OidcRefreshTokenValid(sess edge_apis.ApiSession) bool {
+	oidcSess, ok := sess.(*edge_apis.ApiSessionOidc)
+	if !ok || oidcSess.OidcTokens == nil || oidcSess.OidcTokens.RefreshToken == "" {
+		return false
+	}
+	claims := &jwt.RegisteredClaims{}
+	if _, _, err := jwt.NewParser().ParseUnverified(oidcSess.OidcTokens.RefreshToken, claims); err != nil {
+		return false
+	}
+	exp, err := claims.GetExpirationTime()
+	if err != nil || exp == nil {
+		return false
+	}
+	return time.Now().Before(exp.Time)
+}
+
+// refreshOidcTokenIfExpired refreshes the cached OIDC access token when it has expired and the
+// refresh token is still valid. It returns true when the session was refreshed so the caller can
+// persist the updated config. Non-OIDC sessions and still-valid access tokens are no-ops. An expired
+// refresh token, or a failed refresh, returns an error telling the user to log in again.
+func (self *RestClientEdgeIdentity) refreshOidcTokenIfExpired() (bool, error) {
+	if self.ApiSession == nil || self.ApiSession.ApiSession == nil {
+		return false, nil
+	}
+	if !OidcAccessTokenExpired(self.ApiSession.ApiSession) {
+		return false, nil
+	}
+	if !OidcRefreshTokenValid(self.ApiSession.ApiSession) {
+		return false, errors.New("the cached access token has expired and the refresh token can no longer be used to re-authenticate, please login again")
+	}
+
+	ctrlUrl, err := url.Parse(self.Url)
+	if err != nil {
+		return false, errors.Wrapf(err, "could not parse controller url %v while refreshing token", self.Url)
+	}
+
+	tlsClientConfig, err := self.NewTlsClientConfig()
+	if err != nil {
+		return false, err
+	}
+
+	_, _ = fmt.Fprintln(os.Stderr, "Access token has expired, refreshing it using the cached refresh token...")
+
+	mgmtClient := edge_apis.NewManagementApiClient([]*url.URL{ctrlUrl}, tlsClientConfig.RootCAs, nil)
+	refreshed, refreshErr := mgmtClient.AuthenticateWithPreviousSession(&edge_apis.EmptyCredentials{}, self.ApiSession.ApiSession)
+	if refreshErr != nil || refreshed == nil {
+		return false, errors.Wrap(refreshErr, "failed to refresh the access token using the cached refresh token, please login again")
+	}
+
+	self.ApiSession = &edge_apis.ApiSessionJsonWrapper{ApiSession: refreshed}
+	_, _ = fmt.Fprintln(os.Stderr, "Successfully refreshed the access token")
+	return true, nil
 }
 
 func (self *RestClientEdgeIdentity) GetBaseUrlForApi(api API) (string, error) {
@@ -367,6 +448,16 @@ func LoadSelectedIdentity() (RestClientIdentity, error) {
 				return nil, errors.Errorf("no identity '%v' found in CLI config %v. You can select an existing identity using 'ziti edge use <identity_name>'", id, configFile)
 			}
 		}
+
+		// refresh an expired OIDC access token before any request uses it, persisting the new tokens
+		if refreshed, err := clientIdentity.refreshOidcTokenIfExpired(); err != nil {
+			return nil, err
+		} else if refreshed {
+			if persistErr := PersistRestClientConfig(config); persistErr != nil {
+				return nil, errors.Wrap(persistErr, "could not persist refreshed token to CLI config")
+			}
+		}
+
 		selectedIdentity = clientIdentity
 	}
 	return selectedIdentity, nil

--- a/ziti/util/identities_token_test.go
+++ b/ziti/util/identities_token_test.go
@@ -93,6 +93,11 @@ func TestOidcRefreshTokenValid(t *testing.T) {
 		require.False(t, OidcRefreshTokenValid(sess))
 	})
 
+	t.Run("refresh token expiring inside the leeway window is invalid", func(t *testing.T) {
+		sess := edge_apis.NewApiSessionOidc(makeJwtWithExp(t, now.Add(-time.Hour)), makeJwtWithExp(t, now.Add(5*time.Second)))
+		require.False(t, OidcRefreshTokenValid(sess))
+	})
+
 	t.Run("unexpired refresh token is valid", func(t *testing.T) {
 		sess := edge_apis.NewApiSessionOidc(makeJwtWithExp(t, now.Add(-time.Hour)), makeJwtWithExp(t, now.Add(time.Hour)))
 		require.True(t, OidcRefreshTokenValid(sess))

--- a/ziti/util/identities_token_test.go
+++ b/ziti/util/identities_token_test.go
@@ -1,0 +1,100 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	edge_apis "github.com/openziti/sdk-golang/edge-apis"
+	"github.com/stretchr/testify/require"
+)
+
+// makeJwtWithExp builds a signed JWT carrying only an exp claim. The token helpers parse it
+// unverified, so the signing key is irrelevant.
+func makeJwtWithExp(t *testing.T, exp time.Time) string {
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.RegisteredClaims{
+		ExpiresAt: jwt.NewNumericDate(exp),
+	})
+	s, err := tok.SignedString([]byte("test-signing-key"))
+	require.NoError(t, err)
+	return s
+}
+
+func TestOidcAccessTokenExpired(t *testing.T) {
+	now := time.Now()
+
+	t.Run("non-oidc session is never treated as expired", func(t *testing.T) {
+		legacy := edge_apis.NewApiSessionLegacy("zt-session-token")
+		require.False(t, OidcAccessTokenExpired(legacy))
+	})
+
+	t.Run("token expiring well in the future is not expired", func(t *testing.T) {
+		sess := edge_apis.NewApiSessionOidc(makeJwtWithExp(t, now.Add(time.Hour)), "refresh")
+		require.False(t, OidcAccessTokenExpired(sess))
+	})
+
+	t.Run("already expired token is expired", func(t *testing.T) {
+		sess := edge_apis.NewApiSessionOidc(makeJwtWithExp(t, now.Add(-time.Hour)), "refresh")
+		require.True(t, OidcAccessTokenExpired(sess))
+	})
+
+	t.Run("token expiring inside the leeway window is treated as expired", func(t *testing.T) {
+		sess := edge_apis.NewApiSessionOidc(makeJwtWithExp(t, now.Add(5*time.Second)), "refresh")
+		require.True(t, OidcAccessTokenExpired(sess))
+	})
+
+	t.Run("token expiring just past the leeway window is not expired", func(t *testing.T) {
+		sess := edge_apis.NewApiSessionOidc(makeJwtWithExp(t, now.Add(oidcTokenLeeway+time.Minute)), "refresh")
+		require.False(t, OidcAccessTokenExpired(sess))
+	})
+
+	t.Run("unreadable token is treated as expired so the caller refreshes", func(t *testing.T) {
+		sess := edge_apis.NewApiSessionOidc("not-a-jwt", "refresh")
+		require.True(t, OidcAccessTokenExpired(sess))
+	})
+}
+
+func TestOidcRefreshTokenValid(t *testing.T) {
+	now := time.Now()
+
+	t.Run("non-oidc session has no refresh token", func(t *testing.T) {
+		legacy := edge_apis.NewApiSessionLegacy("zt-session-token")
+		require.False(t, OidcRefreshTokenValid(legacy))
+	})
+
+	t.Run("missing refresh token is invalid", func(t *testing.T) {
+		sess := edge_apis.NewApiSessionOidc(makeJwtWithExp(t, now.Add(time.Hour)), "")
+		require.False(t, OidcRefreshTokenValid(sess))
+	})
+
+	t.Run("unreadable refresh token is invalid", func(t *testing.T) {
+		sess := edge_apis.NewApiSessionOidc(makeJwtWithExp(t, now.Add(time.Hour)), "not-a-jwt")
+		require.False(t, OidcRefreshTokenValid(sess))
+	})
+
+	t.Run("expired refresh token is invalid", func(t *testing.T) {
+		sess := edge_apis.NewApiSessionOidc(makeJwtWithExp(t, now.Add(-time.Hour)), makeJwtWithExp(t, now.Add(-time.Minute)))
+		require.False(t, OidcRefreshTokenValid(sess))
+	})
+
+	t.Run("unexpired refresh token is valid", func(t *testing.T) {
+		sess := edge_apis.NewApiSessionOidc(makeJwtWithExp(t, now.Add(-time.Hour)), makeJwtWithExp(t, now.Add(time.Hour)))
+		require.True(t, OidcRefreshTokenValid(sess))
+	})
+}

--- a/ziti/util/rest.go
+++ b/ziti/util/rest.go
@@ -258,8 +258,11 @@ func controllerResponseError(action string, resp *resty.Response) error {
 
 // controllerResponseErrorFromParts is the testable core of controllerResponseError.
 func controllerResponseErrorFromParts(action string, statusCode int, status string, body []byte) error {
-	if statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden {
+	if statusCode == http.StatusUnauthorized {
 		return fmt.Errorf("not authorized: your session is invalid or has expired, please run 'ziti edge login' again (%s)", status)
+	}
+	if statusCode == http.StatusForbidden {
+		return fmt.Errorf("not authorized: this identity does not have permission to perform this action (%s)", status)
 	}
 	if msg := parseApiErrorMessage(body); msg != "" {
 		return fmt.Errorf("error %s. Status code: %s, %s", action, status, msg)

--- a/ziti/util/rest.go
+++ b/ziti/util/rest.go
@@ -103,8 +103,7 @@ func ControllerDetailEntity(api API, entityType, entityId string, logJSON bool, 
 	}
 
 	if resp.StatusCode() != http.StatusOK {
-		return nil, fmt.Errorf("error listing %v in Ziti Edge Controller. Status code: %v, Server returned: %v",
-			queryUrl, resp.Status(), PrettyPrintResponse(resp))
+		return nil, controllerResponseError(fmt.Sprintf("listing %v", queryUrl), resp)
 	}
 
 	if logJSON {
@@ -165,8 +164,7 @@ func ControllerList(api API, path string, params url.Values, logJSON bool, out i
 	}
 
 	if resp.StatusCode() != http.StatusOK {
-		return nil, fmt.Errorf("error listing %v in Ziti Edge Controller. Status code: %v, Server returned: %v",
-			queryUrl, resp.Status(), PrettyPrintResponse(resp))
+		return nil, controllerResponseError(fmt.Sprintf("listing %v", queryUrl), resp)
 	}
 
 	if logJSON {
@@ -251,6 +249,34 @@ func WrapIfApiError(err error) error {
 	return err
 }
 
+// controllerResponseError builds a concise error for a non-success controller response. Authentication
+// failures get an actionable hint instead of the raw server body, and other failures surface the API
+// error's code and message rather than dumping the full JSON envelope and metadata.
+func controllerResponseError(action string, resp *resty.Response) error {
+	return controllerResponseErrorFromParts(action, resp.StatusCode(), resp.Status(), resp.Body())
+}
+
+// controllerResponseErrorFromParts is the testable core of controllerResponseError.
+func controllerResponseErrorFromParts(action string, statusCode int, status string, body []byte) error {
+	if statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden {
+		return fmt.Errorf("not authorized: your session is invalid or has expired, please run 'ziti edge login' again (%s)", status)
+	}
+	if msg := parseApiErrorMessage(body); msg != "" {
+		return fmt.Errorf("error %s. Status code: %s, %s", action, status, msg)
+	}
+	return fmt.Errorf("error %s. Status code: %s", action, status)
+}
+
+// parseApiErrorMessage extracts the "CODE - message" summary from a controller API error envelope,
+// returning "" when the body is not a recognizable error envelope.
+func parseApiErrorMessage(body []byte) string {
+	env := &rest_model.APIErrorEnvelope{}
+	if err := json.Unmarshal(body, env); err != nil || env.Error == nil {
+		return ""
+	}
+	return formatApiError(env.Error)
+}
+
 type ClientOpts interface {
 	OutputRequestJson() bool
 	OutputResponseJson() bool
@@ -318,8 +344,7 @@ func ControllerCreate(api API, entityType string, body string, out io.Writer, lo
 	}
 
 	if resp.StatusCode() != http.StatusCreated {
-		return nil, fmt.Errorf("error creating %v instance in Ziti Edge Controller at %v. Status code: %v, Server returned: %v",
-			entityType, baseUrl, resp.Status(), PrettyPrintResponse(resp))
+		return nil, controllerResponseError(fmt.Sprintf("creating %v instance", entityType), resp)
 	}
 
 	if logResponseJson {
@@ -373,8 +398,7 @@ func ControllerDelete(api API, entityType string, id string, body string, out io
 
 	if resp.StatusCode() != http.StatusOK {
 		statusCode := resp.StatusCode()
-		return &statusCode, fmt.Errorf("error deleting %v instance in Ziti Edge Controller at %v. Status code: %v, Server returned: %v",
-			entityPath, baseUrl, resp.Status(), PrettyPrintResponse(resp))
+		return &statusCode, controllerResponseError(fmt.Sprintf("deleting %v instance", entityPath), resp)
 	}
 
 	if logResponseJson {
@@ -416,8 +440,7 @@ func ControllerUpdate(api API, entityType string, body string, out io.Writer, me
 	}
 
 	if resp.StatusCode() != http.StatusOK && resp.StatusCode() != http.StatusAccepted {
-		return nil, fmt.Errorf("error updating %v instance in Ziti Edge Controller at %v. Status code: %v, Server returned: %v",
-			entityType, baseUrl, resp.Status(), PrettyPrintResponse(resp))
+		return nil, controllerResponseError(fmt.Sprintf("updating %v instance", entityType), resp)
 	}
 
 	if logResponseJSON {
@@ -466,8 +489,7 @@ func EdgeControllerVerify(entityType, id, body string, out io.Writer, logJSON bo
 	}
 
 	if resp.StatusCode() != http.StatusOK {
-		return fmt.Errorf("error verifying %v instance (%v) in Ziti Edge Controller at %v. Status code: %v, Server returned: %v",
-			entityType, id, baseUrl, resp.Status(), PrettyPrintResponse(resp))
+		return controllerResponseError(fmt.Sprintf("verifying %v instance (%v)", entityType, id), resp)
 	}
 
 	if logJSON {
@@ -500,8 +522,7 @@ func EdgeControllerRequest(entityType string, out io.Writer, logJSON bool, timeo
 	}
 
 	if resp.StatusCode() != http.StatusOK {
-		return nil, fmt.Errorf("error performing request [%s] %v instance in Ziti Edge Controller at %v. Status code: %v, Server returned: %v",
-			request.Method, entityType, baseUrl, resp.Status(), PrettyPrintResponse(resp))
+		return nil, controllerResponseError(fmt.Sprintf("performing request [%s] %v instance", request.Method, entityType), resp)
 	}
 
 	if logJSON {

--- a/ziti/util/rest_error_test.go
+++ b/ziti/util/rest_error_test.go
@@ -1,0 +1,66 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package util
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestControllerResponseErrorFromParts(t *testing.T) {
+	const unauthorizedBody = `{
+		"error": {"code": "UNAUTHORIZED", "message": "The request could not be completed. The session is not authorized or the credentials are invalid", "requestId": "aszEJJLVr"},
+		"meta": {"apiEnrollmentVersion": "0.0.1", "apiVersion": "0.0.1"}
+	}`
+
+	t.Run("401 returns a clean login hint and no server body", func(t *testing.T) {
+		err := controllerResponseErrorFromParts("listing identities", http.StatusUnauthorized, "401 Unauthorized", []byte(unauthorizedBody))
+		require.EqualError(t, err, "not authorized: your session is invalid or has expired, please run 'ziti edge login' again (401 Unauthorized)")
+		require.NotContains(t, err.Error(), "requestId")
+		require.NotContains(t, err.Error(), "apiVersion")
+	})
+
+	t.Run("403 is treated like 401", func(t *testing.T) {
+		err := controllerResponseErrorFromParts("deleting identity", http.StatusForbidden, "403 Forbidden", nil)
+		require.EqualError(t, err, "not authorized: your session is invalid or has expired, please run 'ziti edge login' again (403 Forbidden)")
+	})
+
+	t.Run("other errors surface the api error code and message, not the raw body", func(t *testing.T) {
+		body := `{"error": {"code": "NOT_FOUND", "message": "resource not found"}}`
+		err := controllerResponseErrorFromParts("getting identity", http.StatusNotFound, "404 Not Found", []byte(body))
+		require.EqualError(t, err, "error getting identity. Status code: 404 Not Found, NOT_FOUND - resource not found")
+	})
+
+	t.Run("unparseable body falls back to status only", func(t *testing.T) {
+		err := controllerResponseErrorFromParts("creating identity", http.StatusInternalServerError, "500 Internal Server Error", []byte("<html>boom</html>"))
+		require.EqualError(t, err, "error creating identity. Status code: 500 Internal Server Error")
+	})
+}
+
+func TestParseApiErrorMessage(t *testing.T) {
+	t.Run("valid envelope", func(t *testing.T) {
+		require.Equal(t, "NOT_FOUND - missing", parseApiErrorMessage([]byte(`{"error":{"code":"NOT_FOUND","message":"missing"}}`)))
+	})
+	t.Run("no error field", func(t *testing.T) {
+		require.Equal(t, "", parseApiErrorMessage([]byte(`{"data":{}}`)))
+	})
+	t.Run("not json", func(t *testing.T) {
+		require.Equal(t, "", parseApiErrorMessage([]byte("nope")))
+	})
+}

--- a/ziti/util/rest_error_test.go
+++ b/ziti/util/rest_error_test.go
@@ -47,7 +47,7 @@ func TestControllerResponseErrorFromParts(t *testing.T) {
 		require.EqualError(t, err, "error getting identity. Status code: 404 Not Found, NOT_FOUND - resource not found")
 	})
 
-	t.Run("unparseable body falls back to status only", func(t *testing.T) {
+	t.Run("unparsable body falls back to status only", func(t *testing.T) {
 		err := controllerResponseErrorFromParts("creating identity", http.StatusInternalServerError, "500 Internal Server Error", []byte("<html>boom</html>"))
 		require.EqualError(t, err, "error creating identity. Status code: 500 Internal Server Error")
 	})

--- a/ziti/util/rest_error_test.go
+++ b/ziti/util/rest_error_test.go
@@ -36,9 +36,9 @@ func TestControllerResponseErrorFromParts(t *testing.T) {
 		require.NotContains(t, err.Error(), "apiVersion")
 	})
 
-	t.Run("403 is treated like 401", func(t *testing.T) {
+	t.Run("403 reports a permission problem, not an expired session", func(t *testing.T) {
 		err := controllerResponseErrorFromParts("deleting identity", http.StatusForbidden, "403 Forbidden", nil)
-		require.EqualError(t, err, "not authorized: your session is invalid or has expired, please run 'ziti edge login' again (403 Forbidden)")
+		require.EqualError(t, err, "not authorized: this identity does not have permission to perform this action (403 Forbidden)")
 	})
 
 	t.Run("other errors surface the api error code and message, not the raw body", func(t *testing.T) {


### PR DESCRIPTION
closes #4052 

* allow ziti cli to use refresh token to re-auth when access token expires
* some DRY code (controllerResponseError)
* add tests