### PR TITLE
Fix router panic when validating router data model with nested proto messages

### DIFF
--- a/common/router_data_model.go
+++ b/common/router_data_model.go
@@ -39,6 +39,7 @@ import (
 	cmap "github.com/orcaman/concurrent-map/v2"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (
@@ -2618,7 +2619,7 @@ func (rdm *RouterDataModel) Diff(o *RouterDataModel, sink DiffSink) {
 
 	diffType("configType", rdm.ConfigTypes, o.ConfigTypes, sink, ConfigType{}, DataStateConfigType{})
 	diffType("config", rdm.Configs, o.Configs, sink, Config{}, DataStateConfig{})
-	diffType("identity", rdm.Identities, o.Identities, sink, Identity{}, DataStateIdentity{}, serviceAccess{})
+	diffType("identity", rdm.Identities, o.Identities, sink, Identity{}, DataStateIdentity{}, serviceAccess{}, edge_ctrl_pb.DataState_ServiceConfigs{})
 	diffType("service", rdm.Services, o.Services, sink, Service{}, DataStateService{})
 	diffType("router", rdm.Routers, o.Routers, sink, edge_ctrl_pb.DataState_Router{})
 	diffType("service-policy", rdm.ServicePolicies, o.ServicePolicies, sink, ServicePolicy{}, DataStateServicePolicy{})
@@ -2631,7 +2632,7 @@ func (rdm *RouterDataModel) Diff(o *RouterDataModel, sink DiffSink) {
 		edge_ctrl_pb.DataState_PostureCheck_Process_{}, edge_ctrl_pb.DataState_PostureCheck_Process{},
 		edge_ctrl_pb.DataState_PostureCheck_ProcessMulti_{}, edge_ctrl_pb.DataState_PostureCheck_ProcessMulti{})
 	diffType("public-keys", rdm.PublicKeys, o.PublicKeys, sink, edge_ctrl_pb.DataState_PublicKey{})
-	diffType("revocations", rdm.Revocations, o.Revocations, sink, edge_ctrl_pb.DataState_Revocation{})
+	diffType("revocations", rdm.Revocations, o.Revocations, sink, edge_ctrl_pb.DataState_Revocation{}, timestamppb.Timestamp{})
 	diffMaps("cached-public-keys", rdm.getPublicKeysAsCmap(), o.getPublicKeysAsCmap(), sink, func(a, b crypto.PublicKey) []string {
 		if a == nil || b == nil {
 			return []string{fmt.Sprintf("cached public key is nil: orig: %v, dest: %v", a, b)}

--- a/common/router_data_model_diff_test.go
+++ b/common/router_data_model_diff_test.go
@@ -1,0 +1,114 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openziti/ziti/v2/common/pb/edge_ctrl_pb"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// TestRouterDataModelDiffNestedProtoMessages guards against go-cmp panicking when Diff
+// recurses into proto-message fields whose unexported fields are not ignored. Both
+// DataState_Revocation.ExpiresAt (a timestamppb.Timestamp) and
+// Identity.ServiceConfigs (DataState_ServiceConfigs values) are nested proto messages
+// that must be covered by the diff's ignore list.
+func TestRouterDataModelDiffNestedProtoMessages(t *testing.T) {
+	req := require.New(t)
+
+	newModel := func() *RouterDataModel {
+		rdm := NewBareRouterDataModel("router-1")
+		rdm.Revocations.Set("revocation-1", &edge_ctrl_pb.DataState_Revocation{
+			Id:        "revocation-1",
+			ExpiresAt: timestamppb.New(time.Unix(1700000000, 0)),
+		})
+		rdm.Identities.Set("identity-1", &Identity{
+			Id:   "identity-1",
+			Name: "identity-1",
+			ServiceConfigs: map[string]*edge_ctrl_pb.DataState_ServiceConfigs{
+				"service-1": {
+					Configs: map[string]string{"config-1": "value-1"},
+				},
+			},
+		})
+		return rdm
+	}
+
+	model := newModel()
+	correct := newModel()
+
+	var diffs []string
+	sink := func(entityType string, id string, diffType DiffType, detail string) {
+		diffs = append(diffs, entityType+"/"+id+": "+detail)
+	}
+
+	req.NotPanics(func() {
+		model.Validate(correct, sink)
+	})
+	req.Empty(diffs, "expected no diffs between identical models, got: %v", diffs)
+}
+
+// fixedTimelineSource is a TimelineIdSource that returns a constant id, used to construct
+// a RouterDataModelSender in tests without standing up a real timeline.
+type fixedTimelineSource struct{}
+
+func (fixedTimelineSource) TimelineId() string { return "timeline-1" }
+
+// TestRouterDataModelSenderDiffNestedProtoMessages is the sender-side counterpart to
+// TestRouterDataModelDiffNestedProtoMessages. RouterDataModelSender.Diff walks the same
+// nested proto messages (DataState_ServiceConfigs reached through SenderIdentity's embedded
+// DataState_Identity, and timestamppb.Timestamp on revocations), so its ignore list must
+// cover them too or go-cmp panics on their unexported fields.
+func TestRouterDataModelSenderDiffNestedProtoMessages(t *testing.T) {
+	req := require.New(t)
+
+	newModel := func() *RouterDataModelSender {
+		rdm := NewRouterDataModelSender(fixedTimelineSource{}, 10, 0)
+		rdm.Revocations.Set("revocation-1", &edge_ctrl_pb.DataState_Revocation{
+			Id:        "revocation-1",
+			ExpiresAt: timestamppb.New(time.Unix(1700000000, 0)),
+		})
+		rdm.Identities.Set("identity-1", &SenderIdentity{
+			DataStateIdentity: &edge_ctrl_pb.DataState_Identity{
+				Id:   "identity-1",
+				Name: "identity-1",
+				ServiceConfigs: map[string]*edge_ctrl_pb.DataState_ServiceConfigs{
+					"service-1": {
+						Configs: map[string]string{"config-1": "value-1"},
+					},
+				},
+			},
+		})
+		return rdm
+	}
+
+	model := newModel()
+	correct := newModel()
+
+	var diffs []string
+	sink := func(entityType string, id string, diffType DiffType, detail string) {
+		diffs = append(diffs, entityType+"/"+id+": "+detail)
+	}
+
+	req.NotPanics(func() {
+		model.Validate(correct, sink)
+	})
+	req.Empty(diffs, "expected no diffs between identical models, got: %v", diffs)
+}

--- a/common/router_data_model_sender.go
+++ b/common/router_data_model_sender.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openziti/foundation/v2/stringz"
 	"github.com/openziti/ziti/v2/common/pb/edge_ctrl_pb"
 	cmap "github.com/orcaman/concurrent-map/v2"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // ConfigTypeTargetRouter is the Target value on ConfigType for router-managed configs.
@@ -740,7 +741,7 @@ func (rdm *RouterDataModelSender) Diff(o *RouterDataModelSender, sink DiffSink) 
 
 	diffType("configType", rdm.ConfigTypes, o.ConfigTypes, sink, ConfigType{}, DataStateConfigType{})
 	diffType("config", rdm.Configs, o.Configs, sink, Config{}, DataStateConfig{})
-	diffType("identity", rdm.Identities, o.Identities, sink, Identity{}, DataStateIdentity{})
+	diffType("identity", rdm.Identities, o.Identities, sink, Identity{}, DataStateIdentity{}, edge_ctrl_pb.DataState_ServiceConfigs{})
 	diffType("service", rdm.Services, o.Services, sink, Service{}, DataStateService{})
 	diffType("service-policy", rdm.ServicePolicies, o.ServicePolicies, sink, ServicePolicy{}, DataStateServicePolicy{})
 	diffType("posture-check", rdm.PostureChecks, o.PostureChecks, sink,
@@ -752,7 +753,7 @@ func (rdm *RouterDataModelSender) Diff(o *RouterDataModelSender, sink DiffSink) 
 		edge_ctrl_pb.DataState_PostureCheck_Process_{}, edge_ctrl_pb.DataState_PostureCheck_Process{},
 		edge_ctrl_pb.DataState_PostureCheck_ProcessMulti_{}, edge_ctrl_pb.DataState_PostureCheck_ProcessMulti{})
 	diffType("public-keys", rdm.PublicKeys, o.PublicKeys, sink, edge_ctrl_pb.DataState_PublicKey{})
-	diffType("revocations", rdm.Revocations, o.Revocations, sink, edge_ctrl_pb.DataState_Revocation{})
+	diffType("revocations", rdm.Revocations, o.Revocations, sink, edge_ctrl_pb.DataState_Revocation{}, timestamppb.Timestamp{})
 	diffMaps("cached-public-keys", rdm.getPublicKeysAsCmap(), o.getPublicKeysAsCmap(), sink, func(a, b crypto.PublicKey) []string {
 		if a == nil || b == nil {
 			return []string{fmt.Sprintf("cached public key is nil: orig: %v, dest: %v", a, b)}


### PR DESCRIPTION
## What

Routers panic during data model validation (`ValidateDataStateRequest`) with:

```
panic: cannot handle unexported field at {*edge_ctrl_pb.DataState_Revocation}.ExpiresAt.state:
	"google.golang.org/protobuf/types/known/timestamppb".Timestamp
```

## Why

`RouterDataModel.Diff` compares entities with `go-cmp` using `cmpopts.IgnoreUnexported` over an explicit list of types. `go-cmp` panics when it recurses into a proto message whose type is not in that list. The revocations diff lists `DataState_Revocation` but not its nested `ExpiresAt *timestamppb.Timestamp`, so any revocation with an expiry crashes every router that runs validation.

The identity diff has the same latent gap for `Identity.ServiceConfigs` (`DataState_ServiceConfigs`); it only avoided crashing because the test identities had no service configs.

## Fix

Add the nested proto-message types (`timestamppb.Timestamp`, `DataState_ServiceConfigs`) to the respective ignore lists, and add a regression test that reproduces the panic without the fix.

Found via the Router Data Model validation smoke test, where all routers crashed with this panic.