### PR TITLE
fixes openziti/ziti#4063 enroll with empty roles when ext-jwt attribu…

### DIFF
--- a/controller/model/token_provider_cache.go
+++ b/controller/model/token_provider_cache.go
@@ -32,10 +32,10 @@ import (
 	nfPem "github.com/openziti/foundation/v2/pem"
 	"github.com/openziti/foundation/v2/stringz"
 	"github.com/openziti/jwks"
-	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/openziti/ziti/v2/common"
 	"github.com/openziti/ziti/v2/controller/apierror"
 	"github.com/openziti/ziti/v2/controller/db"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	cmap "github.com/orcaman/concurrent-map/v2"
 	"go.etcd.io/bbolt"
 )
@@ -629,7 +629,8 @@ func (r *TokenIssuerExtJwt) VerifyToken(token string) *common.TokenVerificationR
 }
 
 // resolveStringSliceClaimProperty extracts a string or string array from JWT claims using a JSON pointer.
-// Returns a string slice even if the claim is a single string value.
+// Returns a string slice even if the claim is a single string value. An absent claim or unset selector
+// resolves to no values without error; only a malformed pointer or a present-but-wrong-type claim errors.
 func resolveStringSliceClaimProperty(claims jwt.MapClaims, property string) ([]string, error) {
 	if property == "" {
 		return nil, nil
@@ -648,7 +649,11 @@ func resolveStringSliceClaimProperty(claims jwt.MapClaims, property string) ([]s
 	val, _, err := jsonPointer.Get(claims)
 
 	if err != nil {
-		return nil, fmt.Errorf("could not resolve json pointer: %s: %w", property, err)
+		// Pointer syntax was already validated by jsonpointer.New above, so a Get
+		// failure means the path is simply not present in this token. The role
+		// attributes claim is optional, so an absent claim resolves to no attributes
+		// rather than an error, matching the unset-selector and empty-claim cases.
+		return nil, nil
 	}
 
 	strVal, ok := val.(string)

--- a/controller/model/token_provider_cache.go
+++ b/controller/model/token_provider_cache.go
@@ -629,8 +629,9 @@ func (r *TokenIssuerExtJwt) VerifyToken(token string) *common.TokenVerificationR
 }
 
 // resolveStringSliceClaimProperty extracts a string or string array from JWT claims using a JSON pointer.
-// Returns a string slice even if the claim is a single string value. An absent claim or unset selector
-// resolves to no values without error; only a malformed pointer or a present-but-wrong-type claim errors.
+// Returns a string slice even if the claim is a single string value. An unset selector, a pointer that does
+// not resolve against the claims, and a null claim all resolve to no values without error. A claim that is
+// present but neither a string nor an array of strings errors.
 func resolveStringSliceClaimProperty(claims jwt.MapClaims, property string) ([]string, error) {
 	if property == "" {
 		return nil, nil
@@ -649,10 +650,18 @@ func resolveStringSliceClaimProperty(claims jwt.MapClaims, property string) ([]s
 	val, _, err := jsonPointer.Get(claims)
 
 	if err != nil {
-		// Pointer syntax was already validated by jsonpointer.New above, so a Get
-		// failure means the path is simply not present in this token. The role
-		// attributes claim is optional, so an absent claim resolves to no attributes
-		// rather than an error, matching the unset-selector and empty-claim cases.
+		// The role attributes claim is optional, so a pointer that does not resolve against this
+		// token's claims yields no attributes rather than an error, matching the unset-selector and
+		// empty-claim cases. This covers an absent key as well as a traversal failure, such as
+		// indexing into a scalar.
+		pfxlog.Logger().WithError(err).WithField("selector", property).
+			Debug("attribute claim selector did not resolve, enrolling with no role attributes")
+		return nil, nil
+	}
+
+	if val == nil {
+		pfxlog.Logger().WithField("selector", property).
+			Warn("attribute claim selector resolved to a null claim, enrolling with no role attributes")
 		return nil, nil
 	}
 
@@ -668,7 +677,7 @@ func resolveStringSliceClaimProperty(claims jwt.MapClaims, property string) ([]s
 	arrVals, ok := val.([]any)
 
 	if !ok {
-		return nil, fmt.Errorf("could not resolve json pointer: %s: value is not a string or an array of strings, got: %v", property, arrVals)
+		return nil, fmt.Errorf("could not resolve json pointer: %s: value is not a string or an array of strings, got: %v", property, val)
 	}
 
 	var attributes []string

--- a/controller/model/token_provider_cache_test.go
+++ b/controller/model/token_provider_cache_test.go
@@ -1,0 +1,89 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_resolveStringSliceClaimProperty(t *testing.T) {
+	t.Run("returns empty when the selector is unset", func(t *testing.T) {
+		req := require.New(t)
+
+		vals, err := resolveStringSliceClaimProperty(jwt.MapClaims{"roles": "admin"}, "")
+
+		req.NoError(err)
+		req.Empty(vals)
+	})
+
+	t.Run("returns empty when the claim is absent at the selected path", func(t *testing.T) {
+		req := require.New(t)
+
+		vals, err := resolveStringSliceClaimProperty(jwt.MapClaims{"name": "bob"}, "/roles")
+
+		req.NoError(err)
+		req.Empty(vals)
+	})
+
+	t.Run("returns empty when a nested claim is absent at the selected path", func(t *testing.T) {
+		req := require.New(t)
+
+		claims := jwt.MapClaims{"resource_access": map[string]any{"other": "x"}}
+
+		vals, err := resolveStringSliceClaimProperty(claims, "/resource_access/ziti/roles")
+
+		req.NoError(err)
+		req.Empty(vals)
+	})
+
+	t.Run("returns empty when the claim is present but an empty string", func(t *testing.T) {
+		req := require.New(t)
+
+		vals, err := resolveStringSliceClaimProperty(jwt.MapClaims{"roles": ""}, "/roles")
+
+		req.NoError(err)
+		req.Empty(vals)
+	})
+
+	t.Run("returns a single value when the claim is a string", func(t *testing.T) {
+		req := require.New(t)
+
+		vals, err := resolveStringSliceClaimProperty(jwt.MapClaims{"roles": "admin"}, "/roles")
+
+		req.NoError(err)
+		req.Equal([]string{"admin"}, vals)
+	})
+
+	t.Run("returns all values when the claim is a string array", func(t *testing.T) {
+		req := require.New(t)
+
+		claims := jwt.MapClaims{"roles": []any{"admin", "support"}}
+
+		vals, err := resolveStringSliceClaimProperty(claims, "/roles")
+
+		req.NoError(err)
+		req.Equal([]string{"admin", "support"}, vals)
+	})
+
+	t.Run("resolves a nested claim that is present", func(t *testing.T) {
+		req := require.New(t)
+
+		claims := jwt.MapClaims{"resource_access": map[string]any{"ziti": map[string]any{"roles": []any{"admin"}}}}
+
+		vals, err := resolveStringSliceClaimProperty(claims, "/resource_access/ziti/roles")
+
+		req.NoError(err)
+		req.Equal([]string{"admin"}, vals)
+	})
+
+	t.Run("errors when the claim is present but not a string or array of strings", func(t *testing.T) {
+		req := require.New(t)
+
+		claims := jwt.MapClaims{"roles": map[string]any{"unexpected": "object"}}
+
+		_, err := resolveStringSliceClaimProperty(claims, "/roles")
+
+		req.Error(err)
+	})
+}

--- a/controller/model/token_provider_cache_test.go
+++ b/controller/model/token_provider_cache_test.go
@@ -37,6 +37,26 @@ func Test_resolveStringSliceClaimProperty(t *testing.T) {
 		req.Empty(vals)
 	})
 
+	t.Run("returns empty when the claim is present but null", func(t *testing.T) {
+		req := require.New(t)
+
+		vals, err := resolveStringSliceClaimProperty(jwt.MapClaims{"roles": nil}, "/roles")
+
+		req.NoError(err)
+		req.Empty(vals)
+	})
+
+	t.Run("returns empty when a nested claim is present but null", func(t *testing.T) {
+		req := require.New(t)
+
+		claims := jwt.MapClaims{"resource_access": map[string]any{"ziti": map[string]any{"roles": nil}}}
+
+		vals, err := resolveStringSliceClaimProperty(claims, "/resource_access/ziti/roles")
+
+		req.NoError(err)
+		req.Empty(vals)
+	})
+
 	t.Run("returns empty when the claim is present but an empty string", func(t *testing.T) {
 		req := require.New(t)
 
@@ -85,5 +105,6 @@ func Test_resolveStringSliceClaimProperty(t *testing.T) {
 		_, err := resolveStringSliceClaimProperty(claims, "/roles")
 
 		req.Error(err)
+		req.ErrorContains(err, "map[unexpected:object]")
 	})
 }

--- a/tests/enrollment_token_to_cert_test.go
+++ b/tests/enrollment_token_to_cert_test.go
@@ -123,6 +123,55 @@ func Test_EnrollmentToken_ToCertificate(t *testing.T) {
 			})
 		})
 
+		t.Run("when the attribute selector is set but the claim is absent", func(t *testing.T) {
+			ctx.testContextChanged(t)
+
+			extJwtSingerAttrSelectorAbsent := createExtJwtComponents("enroll-to-cert-attr-selector-absent")
+			extJwtSingerAttrSelectorAbsent.Create.EnrollToCertEnabled = true
+			extJwtSingerAttrSelectorAbsent.Create.EnrollAuthPolicyID = *authPolicyOnlyCerts.Detail.ID
+			extJwtSingerAttrSelectorAbsent.Create.EnrollAttributeClaimsSelector = "absent-attr-selector"
+			extJwtSingerAttrSelectorAbsent.Create.ClaimsProperty = nil
+			extJwtSingerAttrSelectorAbsent.Create.EnrollNameClaimsSelector = ""
+			extJwtSingerAttrSelectorAbsent.Detail, err = adminManClient.CreateExtJwtSigner(extJwtSingerAttrSelectorAbsent.Create)
+			ctx.Req.NoError(err)
+			ctx.Req.NotNil(extJwtSingerAttrSelectorAbsent.Detail)
+
+			enrollClaims := &claimsWithAttributes{}
+			enrollmentJwt, err := newJwtForExtJwtSigner(extJwtSingerAttrSelectorAbsent, enrollClaims)
+			ctx.Req.NoError(err)
+			ctx.Req.NotEmpty(enrollmentJwt)
+
+			clientApi := ctx.NewEdgeClientApi(nil)
+			ctx.Req.NotNil(clientApi)
+
+			// an optional attribute claim absent from the token enrolls with no role attributes rather than failing
+			creds, err := clientApi.CompleteJwtTokenEnrollmentToCertAuth(enrollmentJwt)
+			ctx.Req.NoError(err)
+			ctx.Req.NotNil(creds)
+			ctx.Req.NotNil(creds.Key)
+			ctx.Req.NotEmpty(creds.Certs)
+
+			t.Run("the identity has no role attributes", func(t *testing.T) {
+				ctx.testContextChanged(t)
+
+				apiSession, err := clientApi.Authenticate(creds, nil)
+				ctx.Req.NoError(err)
+				ctx.Req.NotNil(apiSession)
+
+				queryApiSession, err := clientApi.QueryCurrentApiSession()
+				ctx.Req.NoError(err)
+				ctx.Req.NotNil(queryApiSession)
+				ctx.Req.NotNil(queryApiSession.Identity)
+				ctx.Req.NotEmpty(queryApiSession.Identity.ID)
+
+				createdIdentity, err := adminManClient.GetIdentity(queryApiSession.Identity.ID)
+				ctx.Req.NoError(err)
+				ctx.Req.NotNil(createdIdentity)
+
+				ctx.Req.Empty(*createdIdentity.RoleAttributes)
+			})
+		})
+
 		t.Run("when all selectors set with multiple attributes", func(t *testing.T) {
 			ctx.testContextChanged(t)
 
@@ -330,31 +379,6 @@ func Test_EnrollmentToken_ToCertificate(t *testing.T) {
 
 			enrollClaims := &claimsWithAttributes{}
 			enrollmentJwt, err := newJwtForExtJwtSigner(extJwtSingerNameIsNumberSelectorFails, enrollClaims)
-			ctx.Req.NoError(err)
-			ctx.Req.NotEmpty(enrollmentJwt)
-
-			clientApi := ctx.NewEdgeClientApi(nil)
-			ctx.Req.NotNil(clientApi)
-
-			creds, err := clientApi.CompleteJwtTokenEnrollmentToCertAuth(enrollmentJwt)
-
-			ctx.Req.Error(err)
-			ctx.Req.ApiErrorWithCode(err, apierror.InvalidEnrollmentTokenCode)
-			ctx.Req.Nil(creds)
-		})
-
-		t.Run("if the attribute claim selector does not resolve", func(t *testing.T) {
-			extJwtSingerAttrSelectorFails := createExtJwtComponents("enroll-to-cert-attr-selector-fails")
-			extJwtSingerAttrSelectorFails.Create.EnrollAuthPolicyID = *authPolicyOnlyCerts.Detail.ID
-			extJwtSingerAttrSelectorFails.Create.Enabled = ToPtr(true)
-			extJwtSingerAttrSelectorFails.Create.EnrollToCertEnabled = true
-			extJwtSingerAttrSelectorFails.Create.EnrollAttributeClaimsSelector = "invalid-attr-selector"
-			extJwtSingerAttrSelectorFails.Detail, err = adminManClient.CreateExtJwtSigner(extJwtSingerAttrSelectorFails.Create)
-			ctx.Req.NoError(err)
-			ctx.Req.NotNil(extJwtSingerAttrSelectorFails.Detail)
-
-			enrollClaims := &claimsWithAttributes{}
-			enrollmentJwt, err := newJwtForExtJwtSigner(extJwtSingerAttrSelectorFails, enrollClaims)
 			ctx.Req.NoError(err)
 			ctx.Req.NotEmpty(enrollmentJwt)
 

--- a/tests/enrollment_token_to_cert_test.go
+++ b/tests/enrollment_token_to_cert_test.go
@@ -172,6 +172,55 @@ func Test_EnrollmentToken_ToCertificate(t *testing.T) {
 			})
 		})
 
+		t.Run("when the attribute selector is set but the claim is null", func(t *testing.T) {
+			ctx.testContextChanged(t)
+
+			extJwtSingerAttrSelectorNull := createExtJwtComponents("enroll-to-cert-attr-selector-null")
+			extJwtSingerAttrSelectorNull.Create.EnrollToCertEnabled = true
+			extJwtSingerAttrSelectorNull.Create.EnrollAuthPolicyID = *authPolicyOnlyCerts.Detail.ID
+			extJwtSingerAttrSelectorNull.Create.EnrollAttributeClaimsSelector = ClaimsWithAttributesNullClaimPropertyName
+			extJwtSingerAttrSelectorNull.Create.ClaimsProperty = nil
+			extJwtSingerAttrSelectorNull.Create.EnrollNameClaimsSelector = ""
+			extJwtSingerAttrSelectorNull.Detail, err = adminManClient.CreateExtJwtSigner(extJwtSingerAttrSelectorNull.Create)
+			ctx.Req.NoError(err)
+			ctx.Req.NotNil(extJwtSingerAttrSelectorNull.Detail)
+
+			enrollClaims := &claimsWithAttributes{}
+			enrollmentJwt, err := newJwtForExtJwtSigner(extJwtSingerAttrSelectorNull, enrollClaims)
+			ctx.Req.NoError(err)
+			ctx.Req.NotEmpty(enrollmentJwt)
+
+			clientApi := ctx.NewEdgeClientApi(nil)
+			ctx.Req.NotNil(clientApi)
+
+			// an optional attribute claim sent as null enrolls with no role attributes rather than failing
+			creds, err := clientApi.CompleteJwtTokenEnrollmentToCertAuth(enrollmentJwt)
+			ctx.Req.NoError(err)
+			ctx.Req.NotNil(creds)
+			ctx.Req.NotNil(creds.Key)
+			ctx.Req.NotEmpty(creds.Certs)
+
+			t.Run("the identity has no role attributes", func(t *testing.T) {
+				ctx.testContextChanged(t)
+
+				apiSession, err := clientApi.Authenticate(creds, nil)
+				ctx.Req.NoError(err)
+				ctx.Req.NotNil(apiSession)
+
+				queryApiSession, err := clientApi.QueryCurrentApiSession()
+				ctx.Req.NoError(err)
+				ctx.Req.NotNil(queryApiSession)
+				ctx.Req.NotNil(queryApiSession.Identity)
+				ctx.Req.NotEmpty(queryApiSession.Identity.ID)
+
+				createdIdentity, err := adminManClient.GetIdentity(queryApiSession.Identity.ID)
+				ctx.Req.NoError(err)
+				ctx.Req.NotNil(createdIdentity)
+
+				ctx.Req.Empty(*createdIdentity.RoleAttributes)
+			})
+		})
+
 		t.Run("when all selectors set with multiple attributes", func(t *testing.T) {
 			ctx.testContextChanged(t)
 
@@ -360,6 +409,33 @@ func Test_EnrollmentToken_ToCertificate(t *testing.T) {
 			clientApi := ctx.NewEdgeClientApi(nil)
 			ctx.Req.NotNil(clientApi)
 
+			creds, err := clientApi.CompleteJwtTokenEnrollmentToCertAuth(enrollmentJwt)
+
+			ctx.Req.Error(err)
+			ctx.Req.ApiErrorWithCode(err, apierror.InvalidEnrollmentTokenCode)
+			ctx.Req.Nil(creds)
+		})
+
+		t.Run("if the name claim selector resolves to a null claim", func(t *testing.T) {
+			extJwtSingerNameSelectorNull := createExtJwtComponents("enroll-to-cert-name-selector-null")
+			extJwtSingerNameSelectorNull.Create.EnrollAuthPolicyID = *authPolicyOnlyCerts.Detail.ID
+			extJwtSingerNameSelectorNull.Create.Enabled = ToPtr(true)
+			extJwtSingerNameSelectorNull.Create.EnrollToCertEnabled = true
+			extJwtSingerNameSelectorNull.Create.EnrollNameClaimsSelector = ClaimsWithAttributesNullClaimPropertyName
+			extJwtSingerNameSelectorNull.Detail, err = adminManClient.CreateExtJwtSigner(extJwtSingerNameSelectorNull.Create)
+			ctx.Req.NoError(err)
+			ctx.Req.NotNil(extJwtSingerNameSelectorNull.Detail)
+
+			enrollClaims := &claimsWithAttributes{}
+			enrollmentJwt, err := newJwtForExtJwtSigner(extJwtSingerNameSelectorNull, enrollClaims)
+			ctx.Req.NoError(err)
+			ctx.Req.NotEmpty(enrollmentJwt)
+
+			clientApi := ctx.NewEdgeClientApi(nil)
+			ctx.Req.NotNil(clientApi)
+
+			// an identity cannot be created without a name, so unlike the optional attribute claim a
+			// null name claim rejects the enrollment
 			creds, err := clientApi.CompleteJwtTokenEnrollmentToCertAuth(enrollmentJwt)
 
 			ctx.Req.Error(err)
@@ -719,6 +795,7 @@ const (
 	ClaimsWithAttributesAttributeStringPropertyName = "attributeString"
 	ClaimsWithAttributesCustomIdPropertyName        = "customId"
 	ClaimsWithAttributesCustomNamePropertyName      = "customName"
+	ClaimsWithAttributesNullClaimPropertyName       = "nullClaim"
 )
 
 type claimsWithAttributes struct {
@@ -728,4 +805,8 @@ type claimsWithAttributes struct {
 	CustomId        string   `json:"customId,omitempty"`
 	CustomName      string   `json:"customName,omitempty"`
 	NumberValue     int64    `json:"numberValue,omitempty"`
+
+	// NullClaim has no omitempty and is never populated, so it always serializes as an explicit JSON
+	// null. It models an IdP that emits an optional claim as null rather than omitting it.
+	NullClaim *string `json:"nullClaim"`
 }

--- a/tests/enrollment_token_to_token_test.go
+++ b/tests/enrollment_token_to_token_test.go
@@ -117,6 +117,53 @@ func Test_EnrollmentToken_ToToken(t *testing.T) {
 			})
 		})
 
+		t.Run("when the attribute selector is set but the claim is absent", func(t *testing.T) {
+			ctx.testContextChanged(t)
+
+			extJwtSingerAttrSelectorAbsent := createExtJwtComponents("enroll-to-token-attr-selector-absent")
+			extJwtSingerAttrSelectorAbsent.Create.EnrollToTokenEnabled = true
+			extJwtSingerAttrSelectorAbsent.Create.EnrollAuthPolicyID = *authPolicyOnlyExtJwtCreate.Detail.ID
+			extJwtSingerAttrSelectorAbsent.Create.EnrollAttributeClaimsSelector = "absent-attr-selector"
+			extJwtSingerAttrSelectorAbsent.Create.ClaimsProperty = nil
+			extJwtSingerAttrSelectorAbsent.Create.EnrollNameClaimsSelector = ""
+			extJwtSingerAttrSelectorAbsent.Detail, err = adminManClient.CreateExtJwtSigner(extJwtSingerAttrSelectorAbsent.Create)
+			ctx.Req.NoError(err)
+			ctx.Req.NotNil(extJwtSingerAttrSelectorAbsent.Detail)
+
+			enrollClaims := &claimsWithAttributes{}
+			enrollmentJwt, err := newJwtForExtJwtSigner(extJwtSingerAttrSelectorAbsent, enrollClaims)
+			ctx.Req.NoError(err)
+			ctx.Req.NotEmpty(enrollmentJwt)
+
+			clientApi := ctx.NewEdgeClientApi(nil)
+			ctx.Req.NotNil(clientApi)
+
+			// an optional attribute claim absent from the token enrolls with no role attributes rather than failing
+			err = clientApi.CompleteJwtTokenEnrollmentToTokenAuth(enrollmentJwt)
+			ctx.Req.NoError(err)
+
+			t.Run("the identity has no role attributes", func(t *testing.T) {
+				ctx.testContextChanged(t)
+
+				creds := edgeApis.NewJwtCredentials(enrollmentJwt)
+				apiSession, err := clientApi.Authenticate(creds, nil)
+				ctx.Req.NoError(err)
+				ctx.Req.NotNil(apiSession)
+
+				queryApiSession, err := clientApi.QueryCurrentApiSession()
+				ctx.Req.NoError(err)
+				ctx.Req.NotNil(queryApiSession)
+				ctx.Req.NotNil(queryApiSession.Identity)
+				ctx.Req.NotEmpty(queryApiSession.Identity.ID)
+
+				createdIdentity, err := adminManClient.GetIdentity(queryApiSession.Identity.ID)
+				ctx.Req.NoError(err)
+				ctx.Req.NotNil(createdIdentity)
+
+				ctx.Req.Empty(*createdIdentity.RoleAttributes)
+			})
+		})
+
 		t.Run("when all selectors set with multiple attributes", func(t *testing.T) {
 			ctx.testContextChanged(t)
 
@@ -371,30 +418,6 @@ func Test_EnrollmentToken_ToToken(t *testing.T) {
 			ctx.Req.Error(err)
 			ctx.Req.ApiErrorWithCode(err, apierror.InvalidEnrollmentTokenCode)
 			ctx.Req.Nil(creds)
-		})
-
-		t.Run("if the attribute claim selector does not resolve", func(t *testing.T) {
-			extJwtSingerAttrSelectorFails := createExtJwtComponents("enroll-to-token-attr-selector-fails")
-			extJwtSingerAttrSelectorFails.Create.EnrollAuthPolicyID = *authPolicyOnlyExtJwtCreate.Detail.ID
-			extJwtSingerAttrSelectorFails.Create.Enabled = ToPtr(true)
-			extJwtSingerAttrSelectorFails.Create.EnrollToTokenEnabled = true
-			extJwtSingerAttrSelectorFails.Create.EnrollAttributeClaimsSelector = "invalid-attr-selector"
-			extJwtSingerAttrSelectorFails.Detail, err = adminManClient.CreateExtJwtSigner(extJwtSingerAttrSelectorFails.Create)
-			ctx.Req.NoError(err)
-			ctx.Req.NotNil(extJwtSingerAttrSelectorFails.Detail)
-
-			enrollClaims := &claimsWithAttributes{}
-			enrollmentJwt, err := newJwtForExtJwtSigner(extJwtSingerAttrSelectorFails, enrollClaims)
-			ctx.Req.NoError(err)
-			ctx.Req.NotEmpty(enrollmentJwt)
-
-			clientApi := ctx.NewEdgeClientApi(nil)
-			ctx.Req.NotNil(clientApi)
-
-			err = clientApi.CompleteJwtTokenEnrollmentToTokenAuth(enrollmentJwt)
-
-			ctx.Req.Error(err)
-			ctx.Req.ApiErrorWithCode(err, apierror.InvalidEnrollmentTokenCode)
 		})
 
 		t.Run("if the attribute claim selector resolves to a non-string or non-string-array", func(t *testing.T) {

--- a/tests/enrollment_token_to_token_test.go
+++ b/tests/enrollment_token_to_token_test.go
@@ -164,6 +164,53 @@ func Test_EnrollmentToken_ToToken(t *testing.T) {
 			})
 		})
 
+		t.Run("when the attribute selector is set but the claim is null", func(t *testing.T) {
+			ctx.testContextChanged(t)
+
+			extJwtSingerAttrSelectorNull := createExtJwtComponents("enroll-to-token-attr-selector-null")
+			extJwtSingerAttrSelectorNull.Create.EnrollToTokenEnabled = true
+			extJwtSingerAttrSelectorNull.Create.EnrollAuthPolicyID = *authPolicyOnlyExtJwtCreate.Detail.ID
+			extJwtSingerAttrSelectorNull.Create.EnrollAttributeClaimsSelector = ClaimsWithAttributesNullClaimPropertyName
+			extJwtSingerAttrSelectorNull.Create.ClaimsProperty = nil
+			extJwtSingerAttrSelectorNull.Create.EnrollNameClaimsSelector = ""
+			extJwtSingerAttrSelectorNull.Detail, err = adminManClient.CreateExtJwtSigner(extJwtSingerAttrSelectorNull.Create)
+			ctx.Req.NoError(err)
+			ctx.Req.NotNil(extJwtSingerAttrSelectorNull.Detail)
+
+			enrollClaims := &claimsWithAttributes{}
+			enrollmentJwt, err := newJwtForExtJwtSigner(extJwtSingerAttrSelectorNull, enrollClaims)
+			ctx.Req.NoError(err)
+			ctx.Req.NotEmpty(enrollmentJwt)
+
+			clientApi := ctx.NewEdgeClientApi(nil)
+			ctx.Req.NotNil(clientApi)
+
+			// an optional attribute claim sent as null enrolls with no role attributes rather than failing
+			err = clientApi.CompleteJwtTokenEnrollmentToTokenAuth(enrollmentJwt)
+			ctx.Req.NoError(err)
+
+			t.Run("the identity has no role attributes", func(t *testing.T) {
+				ctx.testContextChanged(t)
+
+				creds := edgeApis.NewJwtCredentials(enrollmentJwt)
+				apiSession, err := clientApi.Authenticate(creds, nil)
+				ctx.Req.NoError(err)
+				ctx.Req.NotNil(apiSession)
+
+				queryApiSession, err := clientApi.QueryCurrentApiSession()
+				ctx.Req.NoError(err)
+				ctx.Req.NotNil(queryApiSession)
+				ctx.Req.NotNil(queryApiSession.Identity)
+				ctx.Req.NotEmpty(queryApiSession.Identity.ID)
+
+				createdIdentity, err := adminManClient.GetIdentity(queryApiSession.Identity.ID)
+				ctx.Req.NoError(err)
+				ctx.Req.NotNil(createdIdentity)
+
+				ctx.Req.Empty(*createdIdentity.RoleAttributes)
+			})
+		})
+
 		t.Run("when all selectors set with multiple attributes", func(t *testing.T) {
 			ctx.testContextChanged(t)
 
@@ -393,6 +440,32 @@ func Test_EnrollmentToken_ToToken(t *testing.T) {
 			ctx.Req.Error(err)
 			ctx.Req.ApiErrorWithCode(err, apierror.InvalidEnrollmentTokenCode)
 			ctx.Req.Nil(creds)
+		})
+
+		t.Run("if the name claim selector resolves to a null claim", func(t *testing.T) {
+			extJwtSingerNameSelectorNull := createExtJwtComponents("enroll-to-token-name-selector-null")
+			extJwtSingerNameSelectorNull.Create.EnrollAuthPolicyID = *authPolicyOnlyExtJwtCreate.Detail.ID
+			extJwtSingerNameSelectorNull.Create.Enabled = ToPtr(true)
+			extJwtSingerNameSelectorNull.Create.EnrollToTokenEnabled = true
+			extJwtSingerNameSelectorNull.Create.EnrollNameClaimsSelector = ClaimsWithAttributesNullClaimPropertyName
+			extJwtSingerNameSelectorNull.Detail, err = adminManClient.CreateExtJwtSigner(extJwtSingerNameSelectorNull.Create)
+			ctx.Req.NoError(err)
+			ctx.Req.NotNil(extJwtSingerNameSelectorNull.Detail)
+
+			enrollClaims := &claimsWithAttributes{}
+			enrollmentJwt, err := newJwtForExtJwtSigner(extJwtSingerNameSelectorNull, enrollClaims)
+			ctx.Req.NoError(err)
+			ctx.Req.NotEmpty(enrollmentJwt)
+
+			clientApi := ctx.NewEdgeClientApi(nil)
+			ctx.Req.NotNil(clientApi)
+
+			// an identity cannot be created without a name, so unlike the optional attribute claim a
+			// null name claim rejects the enrollment
+			err = clientApi.CompleteJwtTokenEnrollmentToTokenAuth(enrollmentJwt)
+
+			ctx.Req.Error(err)
+			ctx.Req.ApiErrorWithCode(err, apierror.InvalidEnrollmentTokenCode)
 		})
 
 		t.Run("if the name claim selector resolves to a non-string", func(t *testing.T) {


### PR DESCRIPTION
…te claim is absent

- treats an absent enrollment attribute claim as no role attributes rather than rejecting the token; a failed jsonPointer.Get means the claim is not present, since pointer syntax is already validated at jsonpointer.New
- matches the existing unset-selector and empty-claim cases, which already enroll with an empty attribute set; a present-but-wrong-type claim still errors
- adds unit coverage for resolveStringSliceClaimProperty
- moves the two ext-jwt enrollment integration subtests that asserted the old failure behavior to success cases asserting an empty role-attribute set