### PR TITLE
fix(oidc_auth): hex-encode peer signer kid in KeySet()

### DIFF
--- a/controller/oidc_auth/storage.go
+++ b/controller/oidc_auth/storage.go
@@ -989,7 +989,7 @@ func (s *HybridStorage) KeySet(_ context.Context) ([]op.Key, error) {
 	signers := s.env.GetPeerSigners()
 
 	for _, cert := range signers {
-		kid := fmt.Sprintf("%s", sha1.Sum(cert.Raw))
+		kid := fmt.Sprintf("%x", sha1.Sum(cert.Raw))
 
 		if _, found := s.keys.Get(kid); found {
 			continue


### PR DESCRIPTION
## Summary

One-character fix for #4067: `KeySet()` in `controller/oidc_auth/storage.go`
formatted a peer signer's SHA1 cert fingerprint with `%s` instead of `%x`,
producing an undecodable raw-byte `kid` in the `/oidc/keys` JWKS response for
every entry sourced from `GetPeerSigners()`. The error-path logging four lines
below this same function already used `%x` correctly, which is how this was
spotted.

```diff
- kid := fmt.Sprintf("%s", sha1.Sum(cert.Raw))
+ kid := fmt.Sprintf("%x", sha1.Sum(cert.Raw))
```

## Impact

This affects OIDC verification wherever more than one controller can serve
JWKS / verify each other's tokens (e.g. a raft-based HA controller cluster).
A JWKS lookup landing on a controller other than the one that signed the
token in hand sees the real signer's key advertised under this corrupt peer
`kid` and cannot match it against the token's `kid` header, failing
verification. Each controller correctly renders its own key as a clean
40-char hex `kid`, but renders each peer's key as raw undecodable bytes.

## Test plan

- `gofmt -l` clean on the changed file.
- Manually confirmed the JWKS output: peer entries show corrupt (non-hex,
  non-printable) `kid` values while self entries are clean hex, consistent
  with the `%s`/`%x` mismatch.

Fixes #4067
