### PR TITLE
allow bootstraping the zac with quickstart as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,29 @@ ziti run console --location <dir> --bind-address 0.0.0.0 --port 9443 \
   --tls-cert ./server.pem --tls-key ./server.key
 ```
 
+**Bootstrap it with the quickstart:**
+
+```
+ziti run quickstart --zac
+```
+
+Adding `--zac` to the quickstart downloads ZAC and configures the controller to serve it in one step,
+so the console is available at `https://<ctrl-address>:<ctrl-port>/zac` as soon as the network is up.
+The assets install under `<home>/console` by default (override with `--zac-location`), and
+`--zac-version` selects the release (defaults to `latest`). Re-running against an existing `--home`
+reconciles the binding, so adding `--zac` on a later run enables the console on a network that was first
+brought up without it. `ziti run quickstart cluster --zac` installs the assets once and serves the
+console from every node.
+
+Two related quickstart re-run fixes ship alongside this:
+
+* Re-running against an already-initialized `--home` now adopts the controller and router ports/addresses
+  the environment was first created with, instead of falling back to the flag defaults. Previously a
+  re-run that omitted `--ctrl-port` would wait on the default port while the controller listened on the
+  original one.
+* Re-running with an init-only flag (for example `--ctrl-port` or `--username`) that cannot change after
+  first init now logs which flags were ignored, rather than silently dropping them.
+
 ## Cluster Quorum Recovery
 
 A new offline CLI command, `ziti ops cluster recover <controller-config>`, lets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## What's New
 
 * [ZAC Bootstrapping CLI](#zac-bootstrapping-cli) - CLI commands to download, configure, and serve the Ziti Admin Console without hand-editing YAML
+* [Verify Traffic with ext-jwt-signers](#verify-traffic-with-ext-jwt-signers) - `ziti ops verify traffic` can authenticate with an ext-jwt-signer (OIDC) to test the certless ephemeral-cert path
 * [Cluster Quorum Recover](#cluster_quorum_recovery) - A mechanism for recovering clusters that have irrevocably lost the ability to form a quorum
 * [Quickstart Cluster](#quickstart-cluster) - `ziti run quickstart cluster` brings up a multi-node HA cluster in a single command for testing and development and learning
 * [Fully Connected Controller Mesh](#fully-connected-controller-mesh) - Controllers now proactively keep the cluster mesh fully connected
@@ -78,8 +79,17 @@ Two related quickstart re-run fixes ship alongside this:
   the environment was first created with, instead of falling back to the flag defaults. Previously a
   re-run that omitted `--ctrl-port` would wait on the default port while the controller listened on the
   original one.
-* Re-running with an init-only flag (for example `--ctrl-port` or `--username`) that cannot change after
-  first init now logs which flags were ignored, rather than silently dropping them.
+* Re-running against an existing `--home` with a flag that only takes effect when the environment is
+  first created (for example `--ctrl-port`) now reports that the flag was ignored, rather than silently
+  dropping it.
+
+## Verify Traffic with ext-jwt-signers
+
+`ziti ops verify traffic` can now authenticate with an ext-jwt-signer (OIDC), so the certless
+ephemeral-certificate path can be traffic-tested.
+
+* `--ext-jwt-signer <name>` selects the signer to authenticate with and generate a cert from.
+* `--ext-jwt-redirect-url` sets the OIDC redirect URL (default `http://localhost:20314/auth/callback`).
 
 ## Cluster Quorum Recovery
 

--- a/ziti/cmd/console/download.go
+++ b/ziti/cmd/console/download.go
@@ -51,6 +51,69 @@ const (
 	maxReleaseListBytes = 4 << 20
 )
 
+// EnsureAssets makes sure a usable ZAC install exists at location, downloading the requested
+// version (empty or "latest" tracks the newest release) only when assets are not already present.
+// It returns the concrete version installed, or the version already found on disk. Intended for
+// callers like quickstart that want ZAC assets on disk without the interactive configure flow.
+//
+// When a concrete version is requested that differs from what is already installed, the existing
+// install is replaced only if yes is true; otherwise the installed version is kept and reported.
+func EnsureAssets(out io.Writer, version, location string, yes bool) (string, error) {
+	if location == "" {
+		return "", fmt.Errorf("a console assets location is required")
+	}
+	abs, err := filepath.Abs(location)
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve location '%s' to an absolute path: %w", location, err)
+	}
+
+	requested := normalizeVersion(version)
+	explicit := requested != "" && !strings.EqualFold(requested, "latest")
+
+	if validateAssetsDir(abs) == nil {
+		installed := installedVersion(abs)
+		// An explicit version differing from the installed one is replaced only with consent. An
+		// install with no version marker counts as differing.
+		if explicit && installed != requested {
+			if !yes {
+				current := installed
+				if current == "" {
+					current = "an unversioned build"
+				}
+				_, _ = fmt.Fprintf(out, "ZAC %s is already installed at %s, keeping it (pass -y to replace it with %s)\n", current, abs, requested)
+				return installed, nil
+			}
+			// consent given: replace the existing install with `requested` below
+		} else {
+			return installed, nil
+		}
+	} else if entries, readErr := os.ReadDir(abs); readErr == nil && len(entries) > 0 && installedVersion(abs) == "" {
+		// Never wipe a non-empty directory that is not a prior console install.
+		return "", fmt.Errorf("location '%s' is not empty and is not a console install, choose an empty directory", abs)
+	}
+
+	resolved, err := resolveVersion(version)
+	if err != nil {
+		return "", err
+	}
+
+	// downloadRelease stages into a sibling of the target, so the parent must exist first.
+	if err = os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		return "", fmt.Errorf("failed to create '%s': %w", filepath.Dir(abs), err)
+	}
+
+	_, _ = fmt.Fprintf(out, "Downloading ZAC %s from %s\n  to %s ...\n", resolved, downloadURL(resolved), abs)
+	sum, err := downloadRelease(resolved, abs)
+	if err != nil {
+		return "", err
+	}
+	if err = validateAssetsDir(abs); err != nil {
+		return "", fmt.Errorf("downloaded archive did not contain a usable console: %w", err)
+	}
+	_, _ = fmt.Fprintf(out, "Downloaded ZAC %s (sha256 %s)\n", resolved, sum)
+	return resolved, nil
+}
+
 // downloadURL returns the release asset URL for a concrete (un-prefixed) version.
 func downloadURL(version string) string {
 	tag := zacTagPrefix + version

--- a/ziti/cmd/console/download.go
+++ b/ziti/cmd/console/download.go
@@ -87,9 +87,27 @@ func EnsureAssets(out io.Writer, version, location string, yes bool) (string, er
 		} else {
 			return installed, nil
 		}
-	} else if entries, readErr := os.ReadDir(abs); readErr == nil && len(entries) > 0 && installedVersion(abs) == "" {
-		// Never wipe a non-empty directory that is not a prior console install.
-		return "", fmt.Errorf("location '%s' is not empty and is not a console install, choose an empty directory", abs)
+	} else {
+		// No usable install present. A missing location is the normal fresh-install case and proceeds
+		// to download. Anything else must fail closed: never fall through to a download that removes
+		// the target when we could not confirm it is safe to replace.
+		info, statErr := os.Stat(abs)
+		switch {
+		case statErr != nil && os.IsNotExist(statErr):
+			// fresh install, proceed
+		case statErr != nil:
+			return "", fmt.Errorf("cannot inspect location '%s': %w", abs, statErr)
+		case !info.IsDir():
+			return "", fmt.Errorf("location '%s' is not a directory", abs)
+		default:
+			entries, readErr := os.ReadDir(abs)
+			if readErr != nil {
+				return "", fmt.Errorf("cannot inspect location '%s': %w", abs, readErr)
+			}
+			if len(entries) > 0 && installedVersion(abs) == "" {
+				return "", fmt.Errorf("location '%s' is not empty and is not a console install, choose an empty directory", abs)
+			}
+		}
 	}
 
 	resolved, err := resolveVersion(version)

--- a/ziti/cmd/console/download_test.go
+++ b/ziti/cmd/console/download_test.go
@@ -1,0 +1,105 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package console
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// installAssets writes a minimal valid ZAC install (index.html plus an optional version marker) into
+// a fresh temp dir and returns its path.
+func installAssets(t *testing.T, version string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, zacIndexFile), []byte("<html></html>"), 0o644); err != nil {
+		t.Fatalf("write index: %v", err)
+	}
+	if version != "" {
+		if err := os.WriteFile(filepath.Join(dir, zacVersionFile), []byte(version+"\n"), 0o644); err != nil {
+			t.Fatalf("write version: %v", err)
+		}
+	}
+	return dir
+}
+
+// TestEnsureAssetsReuse covers every branch that must NOT hit the network: reuse and keep-existing.
+// The download/replace path is intentionally not exercised here (it requires GitHub).
+func TestEnsureAssetsReuse(t *testing.T) {
+	t.Run("matching explicit version reuses", func(t *testing.T) {
+		dir := installAssets(t, "4.3.1")
+		got, err := EnsureAssets(io.Discard, "4.3.1", dir, false)
+		if err != nil || got != "4.3.1" {
+			t.Fatalf("got (%q, %v), want (4.3.1, nil)", got, err)
+		}
+	})
+
+	t.Run("latest reuses whatever is installed", func(t *testing.T) {
+		dir := installAssets(t, "4.3.1")
+		got, err := EnsureAssets(io.Discard, "latest", dir, false)
+		if err != nil || got != "4.3.1" {
+			t.Fatalf("got (%q, %v), want (4.3.1, nil)", got, err)
+		}
+	})
+
+	t.Run("different explicit version without -y keeps existing", func(t *testing.T) {
+		dir := installAssets(t, "4.3.1")
+		got, err := EnsureAssets(io.Discard, "3.0.0", dir, false)
+		if err != nil || got != "4.3.1" {
+			t.Fatalf("got (%q, %v), want (4.3.1, nil)", got, err)
+		}
+		// The install must be untouched (no replace happened).
+		if v := installedVersion(dir); v != "4.3.1" {
+			t.Fatalf("installedVersion = %q, want 4.3.1 (must not be replaced without -y)", v)
+		}
+	})
+
+	// Regression for the review finding: valid assets with NO version marker plus an explicit
+	// version and no -y must be treated as "different" and kept (not silently reused), rather than
+	// short-circuiting the explicit request. It must still not hit the network.
+	t.Run("unversioned install with explicit version without -y keeps existing", func(t *testing.T) {
+		dir := installAssets(t, "") // no .version marker
+		got, err := EnsureAssets(io.Discard, "3.0.0", dir, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "" {
+			t.Fatalf("got %q, want empty (unknown installed version)", got)
+		}
+		if _, statErr := os.Stat(filepath.Join(dir, zacVersionFile)); !os.IsNotExist(statErr) {
+			t.Fatal("a version marker was written; no replace should have happened without -y")
+		}
+	})
+
+	t.Run("non-empty non-install directory errors", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "some-user-file.txt"), []byte("x"), 0o644); err != nil {
+			t.Fatalf("seed dir: %v", err)
+		}
+		if _, err := EnsureAssets(io.Discard, "latest", dir, false); err == nil {
+			t.Fatal("expected an error for a non-empty directory that is not a console install")
+		}
+	})
+
+	t.Run("empty location errors", func(t *testing.T) {
+		if _, err := EnsureAssets(io.Discard, "latest", "", false); err == nil {
+			t.Fatal("expected an error for an empty location")
+		}
+	})
+}

--- a/ziti/cmd/console/download_test.go
+++ b/ziti/cmd/console/download_test.go
@@ -70,9 +70,8 @@ func TestEnsureAssetsReuse(t *testing.T) {
 		}
 	})
 
-	// Regression for the review finding: valid assets with NO version marker plus an explicit
-	// version and no -y must be treated as "different" and kept (not silently reused), rather than
-	// short-circuiting the explicit request. It must still not hit the network.
+	// Valid assets with no version marker plus an explicit version and no -y are kept, not replaced,
+	// and no download happens.
 	t.Run("unversioned install with explicit version without -y keeps existing", func(t *testing.T) {
 		dir := installAssets(t, "") // no .version marker
 		got, err := EnsureAssets(io.Discard, "3.0.0", dir, false)
@@ -100,6 +99,22 @@ func TestEnsureAssetsReuse(t *testing.T) {
 	t.Run("empty location errors", func(t *testing.T) {
 		if _, err := EnsureAssets(io.Discard, "latest", "", false); err == nil {
 			t.Fatal("expected an error for an empty location")
+		}
+	})
+
+	// A location that exists but is not a usable directory (here a regular file) fails closed and
+	// leaves the target in place instead of downloading over it.
+	t.Run("uninspectable location fails closed", func(t *testing.T) {
+		dir := t.TempDir()
+		file := filepath.Join(dir, "not-a-dir")
+		if err := os.WriteFile(file, []byte("keep me"), 0o644); err != nil {
+			t.Fatalf("seed file: %v", err)
+		}
+		if _, err := EnsureAssets(io.Discard, "latest", file, false); err == nil {
+			t.Fatal("expected an error when the location is not an inspectable directory")
+		}
+		if _, err := os.Stat(file); err != nil {
+			t.Fatalf("target file must survive a failed EnsureAssets: %v", err)
 		}
 	})
 }

--- a/ziti/cmd/ops/verify/ops_verify_traffic.go
+++ b/ziti/cmd/ops/verify/ops_verify_traffic.go
@@ -130,8 +130,6 @@ func NewVerifyTraffic(out io.Writer, errOut io.Writer) *cobra.Command {
 			} else {
 				return fmt.Errorf("unknown mode: %s", t.mode)
 			}
-
-			return nil
 		},
 	}
 
@@ -310,9 +308,9 @@ func createIdentity(client *rest_management_api_client.ZitiEdgeManagement, name 
 	if err != nil {
 		id := mgmt.IdentityFromFilter(client, mgmt.NameFilter(name))
 		if id != nil {
-			return nil, fmt.Errorf("Identity named %s exists. Remove the identity before trying again or use --cleanup.", name)
+			return nil, fmt.Errorf("identity named %s exists, remove it before trying again or use --cleanup", name)
 		} else {
-			return nil, fmt.Errorf("Failed to create the identity: %v", err)
+			return nil, fmt.Errorf("failed to create the identity: %v", err)
 		}
 	}
 	return ident, nil
@@ -334,7 +332,7 @@ func createServicePolicy(client *rest_management_api_client.ZitiEdgeManagement, 
 	params.SetTimeout(5 * time.Second)
 	resp, err := client.ServicePolicy.CreateServicePolicy(params, nil)
 	if resp == nil || err != nil {
-		return nil, fmt.Errorf("Failed to create service policy: %s", name)
+		return nil, fmt.Errorf("failed to create service policy: %s", name)
 	}
 	return resp.Payload.Data, nil
 }
@@ -357,7 +355,7 @@ func createService(client *rest_management_api_client.ZitiEdgeManagement, name s
 	serviceParams.SetTimeout(5 * time.Second)
 	resp, err := client.Service.CreateService(serviceParams, nil)
 	if resp == nil || err != nil {
-		return nil, fmt.Errorf("Failed to create service: %s. %v", name, err)
+		return nil, fmt.Errorf("failed to create service %s: %v", name, err)
 	}
 	return resp.Payload.Data, nil
 }

--- a/ziti/run/quickstart.go
+++ b/ziti/run/quickstart.go
@@ -27,6 +27,7 @@ import (
 	"os/signal"
 	"os/user"
 	"path"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -287,7 +288,11 @@ func (o *QuickstartOpts) run(ctx context.Context) error {
 		if o.ZacLocation == "" {
 			o.ZacLocation = path.Join(o.Home, "console")
 		}
-		// Normalize separators to match the location the config generator writes when creating the config.
+		// Resolve to an absolute path so the persisted config's SPA location does not depend on the
+		// working directory, then normalize separators to match what the config generator writes.
+		if abs, absErr := filepath.Abs(o.ZacLocation); absErr == nil {
+			o.ZacLocation = abs
+		}
 		o.ZacLocation = helpers.NormalizePath(o.ZacLocation)
 		version, zacErr := console.EnsureAssets(o.out, o.ZacVersion, o.ZacLocation, o.Yes)
 		if zacErr != nil {
@@ -493,6 +498,9 @@ func (o *QuickstartOpts) run(ctx context.Context) error {
 		fmt.Printf("    --router-port %d %s\n", o.RouterPort+1, cont)
 		fmt.Printf("    --home \"%s\" %s\n", o.Home, cont)
 		fmt.Printf("    --trust-domain=\"%s\" %s\n", o.TrustDomain, cont)
+		if o.Zac {
+			fmt.Printf("    --zac --zac-location \"%s\" %s\n", o.ZacLocation, cont)
+		}
 		fmt.Printf("    --cluster-member tls:%s:%d %s\n", o.ControllerAddress, o.ControllerPort, cont)
 		fmt.Printf("    --instance-id \"%s\"\n", nextInstId)
 		fmt.Println("=======================================================================================")

--- a/ziti/run/quickstart.go
+++ b/ziti/run/quickstart.go
@@ -77,8 +77,8 @@ type QuickstartOpts struct {
 	ZacLocation        string
 	Yes                bool
 
-	// changedFlags is the set of flags the user explicitly set on this invocation.
-	changedFlags map[string]bool
+	// flags is this invocation's parsed flag set, used to tell a user-supplied flag from a default.
+	flags *pflag.FlagSet
 	// ignoredSetupFlags are flags supplied on a re-run that only take effect when the environment is
 	// first created, so they had no effect this run.
 	ignoredSetupFlags []string
@@ -131,7 +131,7 @@ func NewQuickStartCmd(out io.Writer, errOut io.Writer, context context.Context) 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options.out = out
 			options.errOut = errOut
-			options.recordChangedFlags(cmd)
+			options.flags = cmd.Flags()
 			if options.TrustDomain == "" {
 				options.TrustDomain = "quickstart"
 			}
@@ -157,7 +157,7 @@ func NewQuickStartJoinClusterCmd(out io.Writer, errOut io.Writer, context contex
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options.out = out
 			options.errOut = errOut
-			options.recordChangedFlags(cmd)
+			options.flags = cmd.Flags()
 			return options.join(context)
 		},
 	}
@@ -263,7 +263,7 @@ func (o *QuickstartOpts) run(ctx context.Context) error {
 		// The controller and router boot from the configs written when the environment was created.
 		// Report any supplied flags that no longer take effect, then use the persisted address/port.
 		o.noteIgnoredSetupFlags()
-		o.adoptPersistedEndpoints(routerName)
+		o.applyConfiguredEndpoints(routerName)
 	} else {
 		if o.ControllerAddress != "" {
 			_ = os.Setenv(constants.CtrlAdvertisedAddressVarName, o.ControllerAddress)
@@ -533,30 +533,23 @@ func (o *QuickstartOpts) printDetails() {
 	}
 }
 
-// recordChangedFlags records the flags the user explicitly set on this invocation.
-func (o *QuickstartOpts) recordChangedFlags(cmd *cobra.Command) {
-	o.changedFlags = map[string]bool{}
-	cmd.Flags().Visit(func(f *pflag.Flag) {
-		o.changedFlags[f.Name] = true
-	})
-}
-
 // noteIgnoredSetupFlags records, for the closing banner, the flags supplied on a re-run of an existing
-// --home that only take effect when the environment is first created. username and password are
-// excluded: a crash-resume login still uses them.
+// --home that only take effect when the environment is first created. Cobra flags always carry a value,
+// so o.flags.Changed distinguishes a flag the user typed from one left at its default. username and
+// password are excluded: a crash-resume login still uses them.
 func (o *QuickstartOpts) noteIgnoredSetupFlags() {
 	setupOnlyFlags := []string{"ctrl-address", "ctrl-port", "router-address", "router-port", "trust-domain"}
 	o.ignoredSetupFlags = nil
 	for _, name := range setupOnlyFlags {
-		if o.changedFlags[name] {
+		if o.flags != nil && o.flags.Changed(name) {
 			o.ignoredSetupFlags = append(o.ignoredSetupFlags, "--"+name)
 		}
 	}
 }
 
-// adoptPersistedEndpoints sets the advertised address/port from the existing controller and router
+// applyConfiguredEndpoints sets the advertised address/port from the existing controller and router
 // configs. Best-effort: on a read or parse error it logs and leaves the current values unchanged.
-func (o *QuickstartOpts) adoptPersistedEndpoints(routerName string) {
+func (o *QuickstartOpts) applyConfiguredEndpoints(routerName string) {
 	if host, port, ok := readAdvertisedFromCtrlConfig(o.ConfigFile); ok {
 		o.ControllerAddress = host
 		o.ControllerPort = port

--- a/ziti/run/quickstart.go
+++ b/ziti/run/quickstart.go
@@ -79,8 +79,9 @@ type QuickstartOpts struct {
 
 	// changedFlags is the set of flags the user explicitly set on this invocation.
 	changedFlags map[string]bool
-	// ignoredInitFlags is the set of init-only flags supplied on a re-run of an initialized --home.
-	ignoredInitFlags []string
+	// ignoredSetupFlags are flags supplied on a re-run that only take effect when the environment is
+	// first created, so they had no effect this run.
+	ignoredSetupFlags []string
 
 	joinCommand bool
 	verbose     bool
@@ -156,6 +157,7 @@ func NewQuickStartJoinClusterCmd(out io.Writer, errOut io.Writer, context contex
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options.out = out
 			options.errOut = errOut
+			options.recordChangedFlags(cmd)
 			return options.join(context)
 		},
 	}
@@ -258,9 +260,9 @@ func (o *QuickstartOpts) run(ctx context.Context) error {
 	}
 
 	if o.AlreadyInitialized {
-		// The controller and router boot from the configs written on first init. Report the
-		// init-only flags supplied here, then use the persisted advertised address/port.
-		o.noteIgnoredInitFlags()
+		// The controller and router boot from the configs written when the environment was created.
+		// Report any supplied flags that no longer take effect, then use the persisted address/port.
+		o.noteIgnoredSetupFlags()
 		o.adoptPersistedEndpoints(routerName)
 	} else {
 		if o.ControllerAddress != "" {
@@ -285,6 +287,8 @@ func (o *QuickstartOpts) run(ctx context.Context) error {
 		if o.ZacLocation == "" {
 			o.ZacLocation = path.Join(o.Home, "console")
 		}
+		// Normalize separators to match the location the config generator writes when creating the config.
+		o.ZacLocation = helpers.NormalizePath(o.ZacLocation)
 		version, zacErr := console.EnsureAssets(o.out, o.ZacVersion, o.ZacLocation, o.Yes)
 		if zacErr != nil {
 			return fmt.Errorf("failed to install ZAC: %w", zacErr)
@@ -292,7 +296,7 @@ func (o *QuickstartOpts) run(ctx context.Context) error {
 		if version != "" {
 			logrus.Infof("ZAC %s ready at '%s'", version, o.ZacLocation)
 		}
-		// Read by controller config generation on a first init to emit the "spa" web binding.
+		// Read by controller config generation, which emits the "spa" web binding when it writes the config.
 		_ = os.Setenv(constants.CtrlConsoleLocationVarName, o.ZacLocation)
 	}
 
@@ -523,9 +527,9 @@ func (o *QuickstartOpts) printDetails() {
 		// The console is served on the edge listener, so use the edge address and port.
 		fmt.Printf("    console (ZAC) at       : https://%s:%s/zac\n", helpers.GetCtrlEdgeAdvertisedAddress(), helpers.GetCtrlEdgeAdvertisedPort())
 	}
-	if len(o.ignoredInitFlags) > 0 {
+	if len(o.ignoredSetupFlags) > 0 {
 		fmt.Println()
-		fmt.Println("    NOTE: --home was already initialized. these init-only flags were ignored: " + strings.Join(o.ignoredInitFlags, ", "))
+		fmt.Println("    NOTE: --home already exists. these flags only take effect when first creating it, so they were ignored: " + strings.Join(o.ignoredSetupFlags, ", "))
 	}
 }
 
@@ -537,15 +541,15 @@ func (o *QuickstartOpts) recordChangedFlags(cmd *cobra.Command) {
 	})
 }
 
-// noteIgnoredInitFlags records, for the closing banner, the init-only flags supplied on a re-run of
-// an initialized --home. These apply only during first-init config generation. username and password
-// are excluded: a crash-resume login still uses them.
-func (o *QuickstartOpts) noteIgnoredInitFlags() {
-	initOnly := []string{"ctrl-address", "ctrl-port", "router-address", "router-port", "trust-domain"}
-	o.ignoredInitFlags = nil
-	for _, name := range initOnly {
+// noteIgnoredSetupFlags records, for the closing banner, the flags supplied on a re-run of an existing
+// --home that only take effect when the environment is first created. username and password are
+// excluded: a crash-resume login still uses them.
+func (o *QuickstartOpts) noteIgnoredSetupFlags() {
+	setupOnlyFlags := []string{"ctrl-address", "ctrl-port", "router-address", "router-port", "trust-domain"}
+	o.ignoredSetupFlags = nil
+	for _, name := range setupOnlyFlags {
 		if o.changedFlags[name] {
-			o.ignoredInitFlags = append(o.ignoredInitFlags, "--"+name)
+			o.ignoredSetupFlags = append(o.ignoredSetupFlags, "--"+name)
 		}
 	}
 }

--- a/ziti/run/quickstart.go
+++ b/ziti/run/quickstart.go
@@ -42,6 +42,7 @@ import (
 	"github.com/openziti/ziti/v2/ziti/cmd/agentcli"
 	"github.com/openziti/ziti/v2/ziti/cmd/api"
 	"github.com/openziti/ziti/v2/ziti/cmd/common"
+	"github.com/openziti/ziti/v2/ziti/cmd/console"
 	"github.com/openziti/ziti/v2/ziti/cmd/create"
 	"github.com/openziti/ziti/v2/ziti/cmd/helpers"
 	"github.com/openziti/ziti/v2/ziti/cmd/pki"
@@ -49,6 +50,8 @@ import (
 	"github.com/openziti/ziti/v2/ziti/util"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"gopkg.in/yaml.v3"
 )
 
 type QuickstartOpts struct {
@@ -69,6 +72,15 @@ type QuickstartOpts struct {
 	Routerless         bool
 	ConfigureAndExit   bool
 	ConfigFile         string
+	Zac                bool
+	ZacVersion         string
+	ZacLocation        string
+	Yes                bool
+
+	// changedFlags is the set of flags the user explicitly set on this invocation.
+	changedFlags map[string]bool
+	// ignoredInitFlags is the set of init-only flags supplied on a re-run of an initialized --home.
+	ignoredInitFlags []string
 
 	joinCommand bool
 	verbose     bool
@@ -96,6 +108,11 @@ func addCommonQuickstartFlags(cmd *cobra.Command, options *QuickstartOpts) {
 
 	cmd.Flags().BoolVar(&options.verbose, "verbose", false, "Show additional output.")
 	cmd.Flags().BoolVar(&options.ConfigureAndExit, "configure-and-exit", false, "Configures everything and then exits gracefully")
+
+	cmd.Flags().BoolVar(&options.Zac, "zac", false, "download the Ziti Admin Console (ZAC) and configure the controller to serve it")
+	cmd.Flags().StringVar(&options.ZacVersion, "zac-version", "latest", "ZAC version to download when --zac is set")
+	cmd.Flags().StringVar(&options.ZacLocation, "zac-location", "", "directory to install ZAC into; defaults to <home>/console")
+	cmd.Flags().BoolVarP(&options.Yes, "yes", "y", false, "answer yes to prompts (e.g. replacing installed ZAC assets with a different --zac-version)")
 }
 
 func addQuickstartHaFlags(cmd *cobra.Command, options *QuickstartOpts) {
@@ -113,6 +130,7 @@ func NewQuickStartCmd(out io.Writer, errOut io.Writer, context context.Context) 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options.out = out
 			options.errOut = errOut
+			options.recordChangedFlags(cmd)
 			if options.TrustDomain == "" {
 				options.TrustDomain = "quickstart"
 			}
@@ -200,21 +218,6 @@ func (o *QuickstartOpts) run(ctx context.Context) error {
 		}
 		logrus.Infof("permanent --home '%s' will not be removed on exit", o.Home)
 	}
-	if o.ControllerAddress != "" {
-		_ = os.Setenv(constants.CtrlAdvertisedAddressVarName, o.ControllerAddress)
-		_ = os.Setenv(constants.CtrlEdgeAdvertisedAddressVarName, o.ControllerAddress)
-	}
-	if o.ControllerPort > 0 {
-		_ = os.Setenv(constants.CtrlAdvertisedPortVarName, strconv.Itoa(int(o.ControllerPort)))
-		_ = os.Setenv(constants.CtrlEdgeAdvertisedPortVarName, strconv.Itoa(int(o.ControllerPort)))
-	}
-	if o.RouterAddress != "" {
-		_ = os.Setenv(constants.ZitiEdgeRouterAdvertisedAddressVarName, o.RouterAddress)
-	}
-	if o.RouterPort > 0 {
-		_ = os.Setenv(constants.ZitiEdgeRouterPortVarName, strconv.Itoa(int(o.RouterPort)))
-		_ = os.Setenv(constants.ZitiEdgeRouterListenerBindPortVarName, strconv.Itoa(int(o.RouterPort)))
-	}
 	if o.Username == "" {
 		o.Username = "admin"
 	}
@@ -250,9 +253,50 @@ func (o *QuickstartOpts) run(ctx context.Context) error {
 	}
 
 	dbDir := path.Join(o.instHome(), "db")
-	if _, err := os.Stat(dbDir); !os.IsNotExist(err) {
+	if _, statErr := os.Stat(dbDir); !os.IsNotExist(statErr) {
 		o.AlreadyInitialized = true
+	}
+
+	if o.AlreadyInitialized {
+		// The controller and router boot from the configs written on first init. Report the
+		// init-only flags supplied here, then use the persisted advertised address/port.
+		o.noteIgnoredInitFlags()
+		o.adoptPersistedEndpoints(routerName)
 	} else {
+		if o.ControllerAddress != "" {
+			_ = os.Setenv(constants.CtrlAdvertisedAddressVarName, o.ControllerAddress)
+			_ = os.Setenv(constants.CtrlEdgeAdvertisedAddressVarName, o.ControllerAddress)
+		}
+		if o.ControllerPort > 0 {
+			_ = os.Setenv(constants.CtrlAdvertisedPortVarName, strconv.Itoa(int(o.ControllerPort)))
+			_ = os.Setenv(constants.CtrlEdgeAdvertisedPortVarName, strconv.Itoa(int(o.ControllerPort)))
+		}
+		if o.RouterAddress != "" {
+			_ = os.Setenv(constants.ZitiEdgeRouterAdvertisedAddressVarName, o.RouterAddress)
+		}
+		if o.RouterPort > 0 {
+			_ = os.Setenv(constants.ZitiEdgeRouterPortVarName, strconv.Itoa(int(o.RouterPort)))
+			_ = os.Setenv(constants.ZitiEdgeRouterListenerBindPortVarName, strconv.Itoa(int(o.RouterPort)))
+		}
+	}
+
+	// Install the console assets before the controller starts.
+	if o.Zac {
+		if o.ZacLocation == "" {
+			o.ZacLocation = path.Join(o.Home, "console")
+		}
+		version, zacErr := console.EnsureAssets(o.out, o.ZacVersion, o.ZacLocation, o.Yes)
+		if zacErr != nil {
+			return fmt.Errorf("failed to install ZAC: %w", zacErr)
+		}
+		if version != "" {
+			logrus.Infof("ZAC %s ready at '%s'", version, o.ZacLocation)
+		}
+		// Read by controller config generation on a first init to emit the "spa" web binding.
+		_ = os.Setenv(constants.CtrlConsoleLocationVarName, o.ZacLocation)
+	}
+
+	if !o.AlreadyInitialized {
 		_ = os.MkdirAll(dbDir, 0o700)
 		logrus.Debugf("made directory '%s'", dbDir)
 
@@ -262,13 +306,30 @@ func (o *QuickstartOpts) run(ctx context.Context) error {
 
 		_ = os.Setenv("ZITI_HOME", o.instHome())
 		ctrl := create.NewCmdCreateConfigController()
-		args := []string{
+		ctrl.SetArgs([]string{
 			fmt.Sprintf("--output=%s", o.ConfigFile),
-		}
-		ctrl.SetArgs(args)
-		err = ctrl.Execute()
-		if err != nil {
+		})
+		if err := ctrl.Execute(); err != nil {
 			return err
+		}
+	}
+
+	// On a re-run the config already exists and was not regenerated. Reconcile the "spa" binding:
+	// add it if the first run omitted --zac, or point it at the current --zac-location.
+	if o.Zac && o.AlreadyInitialized {
+		cfg := &console.ConfigureOptions{
+			Out:        o.out,
+			Err:        o.errOut,
+			In:         os.Stdin,
+			ConfigFile: o.ConfigFile,
+			All:        true,
+			Location:   o.ZacLocation,
+			Path:       "zac",
+			IndexFile:  "index.html",
+			Yes:        true,
+		}
+		if err := cfg.Run(); err != nil {
+			return fmt.Errorf("failed to configure console binding: %w", err)
 		}
 	}
 
@@ -458,6 +519,137 @@ func (o *QuickstartOpts) printDetails() {
 	fmt.Println("    config dir located at  : " + o.Home)
 	fmt.Println("    configured trust domain: " + o.TrustDomain)
 	fmt.Printf("    instance pid           : %d\n", os.Getpid())
+	if o.Zac {
+		// The console is served on the edge listener, so use the edge address and port.
+		fmt.Printf("    console (ZAC) at       : https://%s:%s/zac\n", helpers.GetCtrlEdgeAdvertisedAddress(), helpers.GetCtrlEdgeAdvertisedPort())
+	}
+	if len(o.ignoredInitFlags) > 0 {
+		fmt.Println()
+		fmt.Println("    NOTE: --home was already initialized. these init-only flags were ignored: " + strings.Join(o.ignoredInitFlags, ", "))
+	}
+}
+
+// recordChangedFlags records the flags the user explicitly set on this invocation.
+func (o *QuickstartOpts) recordChangedFlags(cmd *cobra.Command) {
+	o.changedFlags = map[string]bool{}
+	cmd.Flags().Visit(func(f *pflag.Flag) {
+		o.changedFlags[f.Name] = true
+	})
+}
+
+// noteIgnoredInitFlags records, for the closing banner, the init-only flags supplied on a re-run of
+// an initialized --home. These apply only during first-init config generation. username and password
+// are excluded: a crash-resume login still uses them.
+func (o *QuickstartOpts) noteIgnoredInitFlags() {
+	initOnly := []string{"ctrl-address", "ctrl-port", "router-address", "router-port", "trust-domain"}
+	o.ignoredInitFlags = nil
+	for _, name := range initOnly {
+		if o.changedFlags[name] {
+			o.ignoredInitFlags = append(o.ignoredInitFlags, "--"+name)
+		}
+	}
+}
+
+// adoptPersistedEndpoints sets the advertised address/port from the existing controller and router
+// configs. Best-effort: on a read or parse error it logs and leaves the current values unchanged.
+func (o *QuickstartOpts) adoptPersistedEndpoints(routerName string) {
+	if host, port, ok := readAdvertisedFromCtrlConfig(o.ConfigFile); ok {
+		o.ControllerAddress = host
+		o.ControllerPort = port
+		// The ctrl-plane and edge address/port are equal in quickstart, so the edge value sets both.
+		_ = os.Setenv(constants.CtrlAdvertisedAddressVarName, host)
+		_ = os.Setenv(constants.CtrlEdgeAdvertisedAddressVarName, host)
+		_ = os.Setenv(constants.CtrlAdvertisedPortVarName, strconv.Itoa(int(port)))
+		_ = os.Setenv(constants.CtrlEdgeAdvertisedPortVarName, strconv.Itoa(int(port)))
+	} else {
+		logrus.Warnf("could not read persisted controller address from '%s', using flag/default values", o.ConfigFile)
+	}
+
+	if o.Routerless {
+		return
+	}
+	routerCfg := path.Join(o.instHome(), routerName+".yaml")
+	if host, port, ok := readAdvertisedFromRouterConfig(routerCfg); ok {
+		o.RouterAddress = host
+		o.RouterPort = port
+		_ = os.Setenv(constants.ZitiEdgeRouterAdvertisedAddressVarName, host)
+		_ = os.Setenv(constants.ZitiEdgeRouterPortVarName, strconv.Itoa(int(port)))
+		_ = os.Setenv(constants.ZitiEdgeRouterListenerBindPortVarName, strconv.Itoa(int(port)))
+	} else {
+		logrus.Warnf("could not read persisted router address from '%s', using flag/default values", routerCfg)
+	}
+}
+
+// readAdvertisedFromCtrlConfig returns the advertised host and port from the first web listener
+// bind point in a controller config file.
+func readAdvertisedFromCtrlConfig(file string) (string, uint16, bool) {
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return "", 0, false
+	}
+	var cfg struct {
+		Web []struct {
+			BindPoints []struct {
+				Address string `yaml:"address"`
+			} `yaml:"bindPoints"`
+		} `yaml:"web"`
+	}
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return "", 0, false
+	}
+	for _, w := range cfg.Web {
+		for _, bp := range w.BindPoints {
+			if h, p, ok := splitHostPortU16(bp.Address); ok {
+				return h, p, true
+			}
+		}
+	}
+	return "", 0, false
+}
+
+// readAdvertisedFromRouterConfig returns the advertised host and port of the edge listener in a
+// router config file.
+func readAdvertisedFromRouterConfig(file string) (string, uint16, bool) {
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return "", 0, false
+	}
+	var cfg struct {
+		Listeners []struct {
+			Binding string `yaml:"binding"`
+			Options struct {
+				Advertise string `yaml:"advertise"`
+			} `yaml:"options"`
+		} `yaml:"listeners"`
+	}
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return "", 0, false
+	}
+	for _, l := range cfg.Listeners {
+		if l.Binding == "edge" {
+			if h, p, ok := splitHostPortU16(l.Options.Advertise); ok {
+				return h, p, true
+			}
+		}
+	}
+	return "", 0, false
+}
+
+// splitHostPortU16 parses a "host:port" string into its host and a uint16 port.
+func splitHostPortU16(addr string) (string, uint16, bool) {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return "", 0, false
+	}
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", 0, false
+	}
+	p, err := strconv.Atoi(portStr)
+	if err != nil || p <= 0 || p > 65535 {
+		return "", 0, false
+	}
+	return host, uint16(p), true
 }
 
 func (o *QuickstartOpts) configureRouter(ctx context.Context, routerName string, configFile string, ctrlUrl string) error {

--- a/ziti/run/quickstart_cluster.go
+++ b/ziti/run/quickstart_cluster.go
@@ -436,6 +436,9 @@ func (o *QuickstartClusterOpts) printDetails(ctrlAddr string, children []*exec.C
 		fmt.Printf("    node %d  controller: %s:%d  router: %s:%d  pid: %d\n",
 			i+1, ctrlAddr, o.CtrlPort+uint16(i), o.routerAddrOrDefault(), o.RouterPort+uint16(i), pid)
 	}
+	if o.Zac {
+		fmt.Printf("    console (ZAC)          : each node serves it on its controller port, e.g. https://%s:%d/zac\n", ctrlAddr, o.CtrlPort)
+	}
 	fmt.Println("    home directory         : " + o.Home)
 	fmt.Println("    configured trust domain: " + o.TrustDomain)
 	fmt.Println("    per-node logs:")

--- a/ziti/run/quickstart_cluster.go
+++ b/ziti/run/quickstart_cluster.go
@@ -144,12 +144,16 @@ func (o *QuickstartClusterOpts) run(ctx context.Context) error {
 		if o.ZacLocation == "" {
 			o.ZacLocation = filepath.Join(o.Home, "console")
 		}
+		// Normalize separators to match the location the config generator writes when creating the config.
+		o.ZacLocation = helpers.NormalizePath(o.ZacLocation)
 		version, zacErr := console.EnsureAssets(o.out, o.ZacVersion, o.ZacLocation, o.Yes)
 		if zacErr != nil {
 			return fmt.Errorf("failed to install ZAC: %w", zacErr)
 		}
 		if version != "" {
 			logrus.Infof("ZAC %s ready at '%s' (shared by all nodes)", version, o.ZacLocation)
+			// Pin children to the concrete version the parent installed, not the "latest" request.
+			o.ZacVersion = version
 		}
 	}
 

--- a/ziti/run/quickstart_cluster.go
+++ b/ziti/run/quickstart_cluster.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/michaelquigley/pfxlog"
+	"github.com/openziti/ziti/v2/ziti/cmd/console"
 	"github.com/openziti/ziti/v2/ziti/cmd/helpers"
 	"github.com/openziti/ziti/v2/ziti/constants"
 	"github.com/sirupsen/logrus"
@@ -53,6 +54,10 @@ type QuickstartClusterOpts struct {
 	TrustDomain       string
 	Size              int
 	ShutdownGrace     time.Duration
+	Zac               bool
+	ZacVersion        string
+	ZacLocation       string
+	Yes               bool
 
 	out         io.Writer
 	errOut      io.Writer
@@ -88,6 +93,10 @@ func NewQuickStartClusterCmd(out io.Writer, errOut io.Writer, ctx context.Contex
 	cmd.Flags().StringVar(&options.TrustDomain, "trust-domain", "quickstart", "trust domain used in SPIFFE ids")
 	cmd.Flags().IntVar(&options.Size, "size", 3, "number of nodes in the cluster (3-9)")
 	cmd.Flags().DurationVar(&options.ShutdownGrace, "shutdown-grace", 30*time.Second, "max time to wait for nodes to shut down cleanly before the parent gives up waiting")
+	cmd.Flags().BoolVar(&options.Zac, "zac", false, "download the Ziti Admin Console (ZAC) and configure every node to serve it")
+	cmd.Flags().StringVar(&options.ZacVersion, "zac-version", "latest", "ZAC version to download when --zac is set")
+	cmd.Flags().StringVar(&options.ZacLocation, "zac-location", "", "directory to install ZAC into; defaults to <home>/console (shared by all nodes)")
+	cmd.Flags().BoolVarP(&options.Yes, "yes", "y", false, "answer yes to prompts (e.g. replacing installed ZAC assets with a different --zac-version)")
 	cmd.Flags().BoolVar(&options.verbose, "verbose", false, "show additional output")
 
 	return cmd
@@ -128,6 +137,20 @@ func (o *QuickstartClusterOpts) run(ctx context.Context) error {
 
 	if err := o.resolveHome(); err != nil {
 		return err
+	}
+
+	// Install ZAC once in the parent. Nodes reuse the shared location.
+	if o.Zac {
+		if o.ZacLocation == "" {
+			o.ZacLocation = filepath.Join(o.Home, "console")
+		}
+		version, zacErr := console.EnsureAssets(o.out, o.ZacVersion, o.ZacLocation, o.Yes)
+		if zacErr != nil {
+			return fmt.Errorf("failed to install ZAC: %w", zacErr)
+		}
+		if version != "" {
+			logrus.Infof("ZAC %s ready at '%s' (shared by all nodes)", version, o.ZacLocation)
+		}
 	}
 
 	ctrlAddr := o.ControllerAddress
@@ -338,6 +361,16 @@ func (o *QuickstartClusterOpts) childArgs(idx int, ctrlAddr string) []string {
 	}
 	if o.verbose {
 		args = append(args, "--verbose")
+	}
+	if o.Zac {
+		// Each node serves the parent-installed assets from the shared location.
+		args = append(args, "--zac", "--zac-location", o.ZacLocation)
+		if o.ZacVersion != "" {
+			args = append(args, "--zac-version", o.ZacVersion)
+		}
+		if o.Yes {
+			args = append(args, "--yes")
+		}
 	}
 	if idx > 0 {
 		args = append(args, "--cluster-member", fmt.Sprintf("tls:%s:%d", ctrlAddr, o.CtrlPort))

--- a/ziti/run/quickstart_cluster.go
+++ b/ziti/run/quickstart_cluster.go
@@ -144,7 +144,11 @@ func (o *QuickstartClusterOpts) run(ctx context.Context) error {
 		if o.ZacLocation == "" {
 			o.ZacLocation = filepath.Join(o.Home, "console")
 		}
-		// Normalize separators to match the location the config generator writes when creating the config.
+		// Resolve to an absolute path so the SPA location the children persist does not depend on the
+		// working directory, then normalize separators to match what the config generator writes.
+		if abs, absErr := filepath.Abs(o.ZacLocation); absErr == nil {
+			o.ZacLocation = abs
+		}
 		o.ZacLocation = helpers.NormalizePath(o.ZacLocation)
 		version, zacErr := console.EnsureAssets(o.out, o.ZacVersion, o.ZacLocation, o.Yes)
 		if zacErr != nil {

--- a/ziti/run/quickstart_rerun_test.go
+++ b/ziti/run/quickstart_rerun_test.go
@@ -113,24 +113,24 @@ listeners:
 	}
 }
 
-func TestNoteIgnoredInitFlags(t *testing.T) {
+func TestNoteIgnoredSetupFlags(t *testing.T) {
 	// username/password are intentionally NOT reported as ignored (a crash-resume login uses them).
 	o := &QuickstartOpts{changedFlags: map[string]bool{
 		"ctrl-port": true,
 		"username":  true,
 		"password":  true,
-		"home":      true, // not an init-only flag
+		"home":      true, // takes effect on a re-run, so not reported
 	}}
-	o.noteIgnoredInitFlags()
-	if len(o.ignoredInitFlags) != 1 || o.ignoredInitFlags[0] != "--ctrl-port" {
-		t.Fatalf("ignoredInitFlags = %v, want [--ctrl-port]", o.ignoredInitFlags)
+	o.noteIgnoredSetupFlags()
+	if len(o.ignoredSetupFlags) != 1 || o.ignoredSetupFlags[0] != "--ctrl-port" {
+		t.Fatalf("ignoredSetupFlags = %v, want [--ctrl-port]", o.ignoredSetupFlags)
 	}
 
-	// Nothing init-only changed: empty.
+	// No setup-only flag changed: empty.
 	o2 := &QuickstartOpts{changedFlags: map[string]bool{"zac": true, "home": true}}
-	o2.noteIgnoredInitFlags()
-	if len(o2.ignoredInitFlags) != 0 {
-		t.Fatalf("ignoredInitFlags = %v, want empty", o2.ignoredInitFlags)
+	o2.noteIgnoredSetupFlags()
+	if len(o2.ignoredSetupFlags) != 0 {
+		t.Fatalf("ignoredSetupFlags = %v, want empty", o2.ignoredSetupFlags)
 	}
 }
 

--- a/ziti/run/quickstart_rerun_test.go
+++ b/ziti/run/quickstart_rerun_test.go
@@ -20,6 +20,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/spf13/pflag"
 )
 
 func TestSplitHostPortU16(t *testing.T) {
@@ -114,24 +116,33 @@ listeners:
 }
 
 func TestNoteIgnoredSetupFlags(t *testing.T) {
-	// username/password are intentionally NOT reported as ignored (a crash-resume login uses them).
-	o := &QuickstartOpts{changedFlags: map[string]bool{
-		"ctrl-port": true,
-		"username":  true,
-		"password":  true,
-		"home":      true, // takes effect on a re-run, so not reported
-	}}
+	// username/password are supplied but intentionally NOT reported (a crash-resume login uses them);
+	// home takes effect on a re-run, so it is not reported either.
+	o := &QuickstartOpts{flags: flagSetWith(t, "ctrl-port", "username", "password", "home")}
 	o.noteIgnoredSetupFlags()
 	if len(o.ignoredSetupFlags) != 1 || o.ignoredSetupFlags[0] != "--ctrl-port" {
 		t.Fatalf("ignoredSetupFlags = %v, want [--ctrl-port]", o.ignoredSetupFlags)
 	}
 
 	// No setup-only flag changed: empty.
-	o2 := &QuickstartOpts{changedFlags: map[string]bool{"zac": true, "home": true}}
+	o2 := &QuickstartOpts{flags: flagSetWith(t, "zac", "home")}
 	o2.noteIgnoredSetupFlags()
 	if len(o2.ignoredSetupFlags) != 0 {
 		t.Fatalf("ignoredSetupFlags = %v, want empty", o2.ignoredSetupFlags)
 	}
+}
+
+// flagSetWith returns a flag set with each named flag defined and marked as explicitly set.
+func flagSetWith(t *testing.T, names ...string) *pflag.FlagSet {
+	t.Helper()
+	fs := pflag.NewFlagSet("quickstart", pflag.ContinueOnError)
+	for _, name := range names {
+		fs.String(name, "", "")
+		if err := fs.Set(name, "x"); err != nil {
+			t.Fatalf("set %s: %v", name, err)
+		}
+	}
+	return fs
 }
 
 func writeFile(t *testing.T, path, content string) {

--- a/ziti/run/quickstart_rerun_test.go
+++ b/ziti/run/quickstart_rerun_test.go
@@ -31,7 +31,7 @@ func TestSplitHostPortU16(t *testing.T) {
 		wantPort uint16
 		wantOK   bool
 	}{
-		{"sg4:20000", "sg4", 20000, true},
+		{"testhost:20000", "testhost", 20000, true},
 		{"localhost:1280", "localhost", 1280, true},
 		{"[::1]:8443", "::1", 8443, true},
 		{"host", "", 0, false},              // missing port
@@ -40,7 +40,7 @@ func TestSplitHostPortU16(t *testing.T) {
 		{"host:-1", "", 0, false},           // negative
 		{"tls:host:20000", "", 0, false},    // scheme-prefixed, not a bare host:port
 		{"", "", 0, false},                  // empty
-		{"  sg4:20000  ", "sg4", 20000, true}, // trimmed
+		{"  testhost:20000  ", "testhost", 20000, true}, // trimmed
 	}
 	for _, c := range cases {
 		host, port, ok := splitHostPortU16(c.in)
@@ -61,11 +61,11 @@ web:
   - name: client-management
     bindPoints:
       - interface: 0.0.0.0:20000
-        address: sg4:20000
+        address: testhost:20000
 `)
 	host, port, ok := readAdvertisedFromCtrlConfig(good)
-	if !ok || host != "sg4" || port != 20000 {
-		t.Fatalf("ctrl config = (%q, %d, %v), want (sg4, 20000, true)", host, port, ok)
+	if !ok || host != "testhost" || port != 20000 {
+		t.Fatalf("ctrl config = (%q, %d, %v), want (testhost, 20000, true)", host, port, ok)
 	}
 
 	// No web section: fail safe (caller keeps flag/default).
@@ -92,19 +92,19 @@ link:
   listeners:
     - binding: transport
       bind: tls:0.0.0.0:20001
-      advertise: tls:sg4:20001
+      advertise: tls:testhost:20001
 listeners:
   - binding: edge
     address: tls:0.0.0.0:20001
     options:
-      advertise: sg4:20001
+      advertise: testhost:20001
   - binding: tunnel
     options:
       mode: host
 `)
 	host, port, ok := readAdvertisedFromRouterConfig(good)
-	if !ok || host != "sg4" || port != 20001 {
-		t.Fatalf("router config = (%q, %d, %v), want (sg4, 20001, true)", host, port, ok)
+	if !ok || host != "testhost" || port != 20001 {
+		t.Fatalf("router config = (%q, %d, %v), want (testhost, 20001, true)", host, port, ok)
 	}
 
 	// No edge listener: fail safe.

--- a/ziti/run/quickstart_rerun_test.go
+++ b/ziti/run/quickstart_rerun_test.go
@@ -1,0 +1,142 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package run
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSplitHostPortU16(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantHost string
+		wantPort uint16
+		wantOK   bool
+	}{
+		{"sg4:20000", "sg4", 20000, true},
+		{"localhost:1280", "localhost", 1280, true},
+		{"[::1]:8443", "::1", 8443, true},
+		{"host", "", 0, false},              // missing port
+		{"host:0", "", 0, false},            // zero port
+		{"host:70000", "", 0, false},        // out of range
+		{"host:-1", "", 0, false},           // negative
+		{"tls:host:20000", "", 0, false},    // scheme-prefixed, not a bare host:port
+		{"", "", 0, false},                  // empty
+		{"  sg4:20000  ", "sg4", 20000, true}, // trimmed
+	}
+	for _, c := range cases {
+		host, port, ok := splitHostPortU16(c.in)
+		if ok != c.wantOK || host != c.wantHost || port != c.wantPort {
+			t.Errorf("splitHostPortU16(%q) = (%q, %d, %v), want (%q, %d, %v)",
+				c.in, host, port, ok, c.wantHost, c.wantPort, c.wantOK)
+		}
+	}
+}
+
+func TestReadAdvertisedFromCtrlConfig(t *testing.T) {
+	dir := t.TempDir()
+
+	// Mirrors the web bindPoint section of config_templates/controller.yml.
+	good := filepath.Join(dir, "ctrl.yaml")
+	writeFile(t, good, `
+web:
+  - name: client-management
+    bindPoints:
+      - interface: 0.0.0.0:20000
+        address: sg4:20000
+`)
+	host, port, ok := readAdvertisedFromCtrlConfig(good)
+	if !ok || host != "sg4" || port != 20000 {
+		t.Fatalf("ctrl config = (%q, %d, %v), want (sg4, 20000, true)", host, port, ok)
+	}
+
+	// No web section: fail safe (caller keeps flag/default).
+	noWeb := filepath.Join(dir, "noweb.yaml")
+	writeFile(t, noWeb, "ctrl:\n  listener: tls:0.0.0.0:6262\n")
+	if _, _, ok := readAdvertisedFromCtrlConfig(noWeb); ok {
+		t.Error("expected ok=false for a config with no web listeners")
+	}
+
+	// Missing file: fail safe.
+	if _, _, ok := readAdvertisedFromCtrlConfig(filepath.Join(dir, "nope.yaml")); ok {
+		t.Error("expected ok=false for a missing file")
+	}
+}
+
+func TestReadAdvertisedFromRouterConfig(t *testing.T) {
+	dir := t.TempDir()
+
+	// Mirrors the edge listener section of config_templates/router.yml, including the transport
+	// link listener whose advertise is tls-prefixed and must NOT be picked.
+	good := filepath.Join(dir, "router.yaml")
+	writeFile(t, good, `
+link:
+  listeners:
+    - binding: transport
+      bind: tls:0.0.0.0:20001
+      advertise: tls:sg4:20001
+listeners:
+  - binding: edge
+    address: tls:0.0.0.0:20001
+    options:
+      advertise: sg4:20001
+  - binding: tunnel
+    options:
+      mode: host
+`)
+	host, port, ok := readAdvertisedFromRouterConfig(good)
+	if !ok || host != "sg4" || port != 20001 {
+		t.Fatalf("router config = (%q, %d, %v), want (sg4, 20001, true)", host, port, ok)
+	}
+
+	// No edge listener: fail safe.
+	noEdge := filepath.Join(dir, "noedge.yaml")
+	writeFile(t, noEdge, "listeners:\n  - binding: tunnel\n    options:\n      mode: host\n")
+	if _, _, ok := readAdvertisedFromRouterConfig(noEdge); ok {
+		t.Error("expected ok=false for a router config with no edge listener")
+	}
+}
+
+func TestNoteIgnoredInitFlags(t *testing.T) {
+	// username/password are intentionally NOT reported as ignored (a crash-resume login uses them).
+	o := &QuickstartOpts{changedFlags: map[string]bool{
+		"ctrl-port": true,
+		"username":  true,
+		"password":  true,
+		"home":      true, // not an init-only flag
+	}}
+	o.noteIgnoredInitFlags()
+	if len(o.ignoredInitFlags) != 1 || o.ignoredInitFlags[0] != "--ctrl-port" {
+		t.Fatalf("ignoredInitFlags = %v, want [--ctrl-port]", o.ignoredInitFlags)
+	}
+
+	// Nothing init-only changed: empty.
+	o2 := &QuickstartOpts{changedFlags: map[string]bool{"zac": true, "home": true}}
+	o2.noteIgnoredInitFlags()
+	if len(o2.ignoredInitFlags) != 0 {
+		t.Fatalf("ignoredInitFlags = %v, want empty", o2.ignoredInitFlags)
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
closes #4066 

Adds --zac to `ziti run quickstart` and `ziti run quickstart cluster`. It downloads the Ziti Admin Console, installs it, and configures the controller to serve it at /zac, in one step. Flags: --zac, --zac-version (default latest), --zac-location (default <home>/console), and -y.

Also fixes two quickstart re-run issues found along the way: a re-run against an existing --home now adopts the ports and addresses it was first created with instead of the flag defaults, and re-supplying a flags now reports that it was ignored rather than silently dropping it.