### PR TITLE
[Backport-2.0.x] Defer xweb initialized signal until config is loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Component Updates and Bug Fixes
 
 * github.com/openziti/ziti/v2: [v2.0.0 -> v2.0.1](https://github.com/openziti/ziti/compare/v2.0.0...v2.0.1)
+    * [Issue #4070](https://github.com/openziti/ziti/issues/4070) - [Backport-2.0] Controller can cache empty apiAddresses forever due to startup race between raft mesh and xweb config load
     * [Issue #4049](https://github.com/openziti/ziti/issues/4049) - [Backport-2.0] Non-admin with enrollment permission can escalate to admin identity
     * [Issue #4031](https://github.com/openziti/ziti/issues/4031) - [Backport-2.0] Router deletes terminators ~12m after creation when host SDK replies with wrong inspect content type
     * [Issue #4054](https://github.com/openziti/ziti/issues/4054) - [Backport-2.0] Router panics evaluating an AnyOf process posture check when client reports no process/OS data

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -400,7 +400,6 @@ func (c *Controller) initWeb() {
 		// if no edge  we need 1 default API, make the fabric api the default
 		fabricManagementFactory.MakeDefault = true
 	}
-	c.xwebInitialized.MarkInitialized()
 }
 
 func (c *Controller) IsEdgeEnabled() bool {
@@ -562,6 +561,11 @@ func (c *Controller) Run() error {
 	if err = c.config.Configure(c.xweb); err != nil {
 		panic(err)
 	}
+
+	// Signal that xweb is fully configured. GetApiAddresses waits on this before reading the
+	// xweb config, so that mesh hellos triggered by early raft connections can't cache an empty
+	// address set (populated only once Configure has run) for the lifetime of the process.
+	c.xwebInitialized.MarkInitialized()
 
 	c.xweb.Run()
 


### PR DESCRIPTION
Backport of #4074 to the 2.0.x line. Fixes #4070

Under a startup race, a controller could permanently advertise an empty set of `apiAddresses` to its peers. The xweb "initialized" signal was being fired at the end of `initWeb()`, before the web config had actually been loaded. If a raft mesh hello arrived in that window (as can happen when peers connect quickly on startup), `GetApiAddresses` would read an empty config and cache the empty result for the lifetime of the process, so the affected controller showed no `apiAddresses` in `/edge/management/v1/controllers` until a restart that happened to win the race.

This moves the signal to after `config.Configure` has populated the xweb config, so callers wait for a fully-configured instance before reading addresses.

Reported on the community forum: https://openziti.discourse.group/t/the-apiaddresses-of-the-controller-do-not-appear/5922