### PR TITLE
Fix flaky iat comparison in Test_API_Session_TOTP_Tokens

### DIFF
--- a/tests/api_session_totp_token_test.go
+++ b/tests/api_session_totp_token_test.go
@@ -191,8 +191,12 @@ func Test_API_Session_TOTP_Tokens(t *testing.T) {
 				ctx.NoError(err)
 				ctx.NotNil(issuedAt)
 
+				// The two iat claims are truncated to one-second precision (jwt's default
+				// TimePrecision), so this delta is either 0 or a whole number of seconds. Allow
+				// up to a second so a second-boundary straddle between the two issuances doesn't
+				// flake, while still catching tokens issued far apart.
 				delta := issuedAt.Time.UTC().Sub(accessClaims.IssuedAt.AsTime().UTC()).Abs()
-				ctx.True(delta < 2*time.Millisecond)
+				ctx.True(delta <= time.Second)
 
 				ctx.Equal(accessClaims.ApiSessionId, totpClaims.ApiSessionId)
 


### PR DESCRIPTION
`Test_API_Session_TOTP_Tokens` intermittently fails at `tests/api_session_totp_token_test.go:195`, asserting the TOTP token's `iat` and the API session token's `iat` are within 2ms. Both are truncated to one-second precision by jwt's default `TimePrecision`, so the delta is either 0 (same wall-clock second) or >= 1s (second-boundary straddle) — the 2ms bound flakes whenever the two issuances straddle a second, which is load-dependent.

Widens the tolerance to one second, which reflects the achievable precision and the intent ("issued at approximately the same time") while still catching tokens issued far apart. Unrelated to any feature work; surfaced on an unrelated PR's CI run.