### PR TITLE
Make circuit endpoint cleanup endpoint-scoped

### DIFF
--- a/router/env/env.go
+++ b/router/env/env.go
@@ -87,6 +87,7 @@ type Forwarder interface {
 	ForwardControl(srcAddr xgress.Address, control *xgress.Control) error
 	ReportForwardingFault(circuitId string, ctrlId string)
 	RegisterDestination(circuitId string, address xgress.Address, destination Destination)
+	UnregisterDestination(circuitId string, address xgress.Address)
 	EndCircuit(circuitId string)
 }
 

--- a/router/forwarder/endpoint_cleanup_test.go
+++ b/router/forwarder/endpoint_cleanup_test.go
@@ -1,0 +1,254 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package forwarder
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/openziti/sdk-golang/v2/xgress"
+)
+
+// fakeXgressDestination is a minimal XgressDestination that records whether Unrouted was called.
+type fakeXgressDestination struct {
+	unrouted atomic.Bool
+}
+
+func (f *fakeXgressDestination) SendPayload(*xgress.Payload, time.Duration, xgress.PayloadType) error {
+	return nil
+}
+func (f *fakeXgressDestination) SendAcknowledgement(*xgress.Acknowledgement) error { return nil }
+func (f *fakeXgressDestination) SendControl(*xgress.Control) error                 { return nil }
+func (f *fakeXgressDestination) InspectCircuit(*xgress.CircuitInspectDetail)       {}
+func (f *fakeXgressDestination) GetDestinationType() string                        { return "test" }
+func (f *fakeXgressDestination) Unrouted()                                         { f.unrouted.Store(true) }
+func (f *fakeXgressDestination) GetTimeOfLastRxFromLink() int64                    { return 0 }
+
+func waitUnrouted(t *testing.T, d *fakeXgressDestination) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if d.unrouted.Load() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("expected Unrouted to have been called")
+}
+
+func TestUnlinkDestinationFromCircuit(t *testing.T) {
+	dt := newDestinationTable()
+	dt.linkDestinationToCircuit("c1", "a")
+	dt.linkDestinationToCircuit("c1", "b")
+
+	if remaining := dt.unlinkDestinationFromCircuit("c1", "a"); !remaining {
+		t.Fatal("expected addresses to remain after removing one of two")
+	}
+	addrs, found := dt.getAddressesForCircuit("c1")
+	if !found || len(addrs) != 1 || addrs[0] != "b" {
+		t.Fatalf("expected only [b] to remain, got %v (found=%v)", addrs, found)
+	}
+
+	if remaining := dt.unlinkDestinationFromCircuit("c1", "b"); remaining {
+		t.Fatal("expected no addresses to remain after removing the last")
+	}
+	if _, found := dt.getAddressesForCircuit("c1"); found {
+		t.Fatal("expected circuit entry to be removed once its last address was unlinked")
+	}
+
+	// unlinking from an unknown circuit is a no-op that reports no remaining addresses
+	if remaining := dt.unlinkDestinationFromCircuit("missing", "x"); remaining {
+		t.Fatal("expected false when unlinking from an unknown circuit")
+	}
+}
+
+func TestUnregisterDestinationIsEndpointScoped(t *testing.T) {
+	f := &Forwarder{destinations: newDestinationTable()}
+
+	dialer := &fakeXgressDestination{}
+	terminator := &fakeXgressDestination{}
+	f.RegisterDestination("c1", "dialer", dialer)
+	f.RegisterDestination("c1", "terminator", terminator)
+
+	// closing the dialer endpoint must retire only its destination, leaving the co-located
+	// terminator (the single-router-circuit case) intact.
+	f.UnregisterDestination("c1", "dialer")
+
+	if f.HasDestination("dialer") {
+		t.Fatal("expected dialer destination to be removed")
+	}
+	if !f.HasDestination("terminator") {
+		t.Fatal("expected terminator destination to be preserved")
+	}
+	waitUnrouted(t, dialer)
+	if terminator.unrouted.Load() {
+		t.Fatal("terminator must not be unrouted when only the dialer endpoint closed")
+	}
+	if addrs, found := f.destinations.getAddressesForCircuit("c1"); !found || len(addrs) != 1 || addrs[0] != "terminator" {
+		t.Fatalf("expected circuit to still reference [terminator], got %v (found=%v)", addrs, found)
+	}
+
+	// closing the remaining terminator endpoint removes the circuit entry entirely.
+	f.UnregisterDestination("c1", "terminator")
+	if f.HasDestination("terminator") {
+		t.Fatal("expected terminator destination to be removed")
+	}
+	waitUnrouted(t, terminator)
+	if _, found := f.destinations.getAddressesForCircuit("c1"); found {
+		t.Fatal("expected circuit entry to be gone after its last endpoint was removed")
+	}
+}
+
+// hasAddresses reports whether addresses holds exactly want, in any order.
+func hasAddresses(addresses []xgress.Address, want ...xgress.Address) bool {
+	if len(addresses) != len(want) {
+		return false
+	}
+	for _, w := range want {
+		found := false
+		for _, a := range addresses {
+			if a == w {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+// TestLinkDestinationToCircuitConcurrent covers both endpoints of a single-router circuit
+// registering at once, which is what happens when a circuit's dialer and terminator are hosted by
+// the same router. Losing an address strands its destination: it is never unrouted, and once the
+// circuit's forward table is removed nothing can reach it again.
+func TestLinkDestinationToCircuitConcurrent(t *testing.T) {
+	const rounds = 2000
+
+	for i := 0; i < rounds; i++ {
+		dt := newDestinationTable()
+		circuitId := fmt.Sprintf("c-%d", i)
+		dialer := xgress.Address(fmt.Sprintf("dialer-%d", i))
+		terminator := xgress.Address(fmt.Sprintf("terminator-%d", i))
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		for _, addr := range []xgress.Address{dialer, terminator} {
+			go func(addr xgress.Address) {
+				defer wg.Done()
+				<-start
+				dt.linkDestinationToCircuit(circuitId, addr)
+			}(addr)
+		}
+		close(start)
+		wg.Wait()
+
+		addresses, found := dt.getAddressesForCircuit(circuitId)
+		if !found || !hasAddresses(addresses, dialer, terminator) {
+			t.Fatalf("round %d: expected both endpoints linked, got %v (found=%v)", i, addresses, found)
+		}
+	}
+}
+
+// TestUnregisterDestinationsConcurrentRegistration covers an endpoint registering while the whole
+// circuit is being torn down, which the ordinary xgress close handler reaches via EndCircuit.
+//
+// Whichever way the two interleave, the arriving endpoint must end up either retired along with
+// the rest of the circuit, or still reachable through it. Being left in the destination table
+// while unreachable from any circuit is the stranded state: nothing will ever unroute it, and no
+// later teardown can find it.
+func TestUnregisterDestinationsConcurrentRegistration(t *testing.T) {
+	const rounds = 2000
+
+	for i := 0; i < rounds; i++ {
+		f := &Forwarder{destinations: newDestinationTable()}
+		circuitId := fmt.Sprintf("c-%d", i)
+		established := xgress.Address(fmt.Sprintf("established-%d", i))
+		arriving := xgress.Address(fmt.Sprintf("arriving-%d", i))
+
+		f.RegisterDestination(circuitId, established, &fakeXgressDestination{})
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			f.UnregisterDestinations(circuitId)
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			f.RegisterDestination(circuitId, arriving, &fakeXgressDestination{})
+		}()
+		close(start)
+		wg.Wait()
+
+		if !f.HasDestination(arriving) {
+			continue // swept along with the circuit
+		}
+
+		addresses, found := f.destinations.getAddressesForCircuit(circuitId)
+		if !found || !hasAddresses(addresses, arriving) {
+			t.Fatalf("round %d: arriving endpoint is registered but unreachable from its circuit, got %v (found=%v)",
+				i, addresses, found)
+		}
+	}
+}
+
+// TestLinkAndUnlinkDestinationConcurrent covers one endpoint retiring while another registers
+// against the same circuit, which is what a reroute looks like: a disconnected side is cleaned up
+// while the side that reconnected links itself in. Either order leaves only the new endpoint, so
+// seeing the retired address survive, or the new one vanish, means an update was lost.
+func TestLinkAndUnlinkDestinationConcurrent(t *testing.T) {
+	const rounds = 2000
+
+	for i := 0; i < rounds; i++ {
+		dt := newDestinationTable()
+		circuitId := fmt.Sprintf("c-%d", i)
+		retiring := xgress.Address(fmt.Sprintf("retiring-%d", i))
+		arriving := xgress.Address(fmt.Sprintf("arriving-%d", i))
+
+		dt.linkDestinationToCircuit(circuitId, retiring)
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			dt.unlinkDestinationFromCircuit(circuitId, retiring)
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			dt.linkDestinationToCircuit(circuitId, arriving)
+		}()
+		close(start)
+		wg.Wait()
+
+		addresses, found := dt.getAddressesForCircuit(circuitId)
+		if !found || !hasAddresses(addresses, arriving) {
+			t.Fatalf("round %d: expected only the arriving endpoint linked, got %v (found=%v)", i, addresses, found)
+		}
+	}
+}

--- a/router/forwarder/forwarder.go
+++ b/router/forwarder/forwarder.go
@@ -122,7 +122,7 @@ func (forwarder *Forwarder) RegisterDestination(circuitId string, address xgress
 
 func (forwarder *Forwarder) UnregisterDestinations(circuitId string) {
 	log := routeLog.With("circuitId", circuitId)
-	if addresses, found := forwarder.destinations.getAddressesForCircuit(circuitId); found {
+	if addresses, found := forwarder.destinations.takeAddressesForCircuit(circuitId); found {
 		for _, address := range addresses {
 			if destination, found := forwarder.destinations.getDestination(address); found {
 				log.Debug("unregistering destination for circuit", "address", address)
@@ -132,9 +132,25 @@ func (forwarder *Forwarder) UnregisterDestinations(circuitId string) {
 				log.Debug("no destinations found for address", "address", address)
 			}
 		}
-		forwarder.destinations.unlinkCircuit(circuitId)
 	} else {
 		log.Debug("found no addresses to unregister for circuit")
+	}
+}
+
+// UnregisterDestination removes a single endpoint's destination (by address) for a circuit,
+// rather than every destination for the circuit as UnregisterDestinations does, and fires the
+// removed destination's Unrouted callback. Used when one endpoint of a circuit closes but other
+// endpoints for the same circuit on this router (e.g. a co-located terminator on a single-router
+// circuit) must be preserved.
+func (forwarder *Forwarder) UnregisterDestination(circuitId string, address xgress.Address) {
+	log := routeLog.With("circuitId", circuitId, "address", address)
+	if destination, found := forwarder.destinations.getDestination(address); found {
+		log.Debug("unregistering single destination for circuit")
+		forwarder.destinations.removeDestination(address)
+		forwarder.destinations.unlinkDestinationFromCircuit(circuitId, address)
+		go destination.(XgressDestination).Unrouted()
+	} else {
+		log.Debug("no destination found for address")
 	}
 }
 

--- a/router/forwarder/tables.go
+++ b/router/forwarder/tables.go
@@ -19,6 +19,7 @@ package forwarder
 import (
 	"fmt"
 	"reflect"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -103,7 +104,14 @@ func (ft *forwardTable) debug() string {
 // destinationTable implements a directory of destinations, keyed by Address.
 type destinationTable struct {
 	destinations cmap.ConcurrentMap[string, env.Destination]
-	xgress       cmap.ConcurrentMap[string, []xgress.Address]
+
+	// circuitLock serializes the read-modify-write sequences on xgress below. cmap makes each
+	// individual operation atomic but not a get followed by a set, and both endpoints of a
+	// single-router circuit link and unlink against the same circuit id concurrently. Losing an
+	// address there strands its destination: it is never returned by getAddressesForCircuit, so
+	// it is never unrouted, and once the circuit's forward table is gone nothing can reach it.
+	circuitLock sync.Mutex
+	xgress      cmap.ConcurrentMap[string, []xgress.Address]
 }
 
 func newDestinationTable() *destinationTable {
@@ -135,14 +143,11 @@ func (dt *destinationTable) removeDestinationIfMatches(addr xgress.Address, dest
 }
 
 func (dt *destinationTable) linkDestinationToCircuit(circuitId string, address xgress.Address) {
-	var addresses []xgress.Address
-	if i, found := dt.xgress.Get(circuitId); found {
-		addresses = i
-	} else {
-		addresses = make([]xgress.Address, 0)
-	}
-	addresses = append(addresses, address)
-	dt.xgress.Set(circuitId, addresses)
+	dt.circuitLock.Lock()
+	defer dt.circuitLock.Unlock()
+
+	addresses, _ := dt.xgress.Get(circuitId)
+	dt.xgress.Set(circuitId, append(addresses, address))
 }
 
 func (dt *destinationTable) getAddressesForCircuit(circuitId string) ([]xgress.Address, bool) {
@@ -152,8 +157,49 @@ func (dt *destinationTable) getAddressesForCircuit(circuitId string) ([]xgress.A
 	return nil, false
 }
 
-func (dt *destinationTable) unlinkCircuit(circuitId string) {
+// takeAddressesForCircuit removes the circuit's address list and returns it in one step, for a
+// caller retiring every endpoint of a circuit at once.
+//
+// Reading the list and clearing it separately loses any address linked in between: the caller
+// retires the addresses it snapshotted and then clears an entry that has since grown, stranding
+// the new destination with nothing able to reach it. Taking the list instead means a later link
+// starts a fresh entry, which stays discoverable for whoever ends the circuit next.
+func (dt *destinationTable) takeAddressesForCircuit(circuitId string) ([]xgress.Address, bool) {
+	dt.circuitLock.Lock()
+	defer dt.circuitLock.Unlock()
+
+	addresses, found := dt.xgress.Get(circuitId)
+	if !found {
+		return nil, false
+	}
 	dt.xgress.Remove(circuitId)
+	return addresses, true
+}
+
+// unlinkDestinationFromCircuit removes a single address from the circuit's address list, leaving
+// any other addresses linked to the circuit intact. It returns true if the circuit still has
+// addresses linked after removal (another endpoint remains on this router), false if that was the
+// last one (in which case the circuit's entry is removed entirely).
+func (dt *destinationTable) unlinkDestinationFromCircuit(circuitId string, address xgress.Address) bool {
+	dt.circuitLock.Lock()
+	defer dt.circuitLock.Unlock()
+
+	addresses, found := dt.xgress.Get(circuitId)
+	if !found {
+		return false
+	}
+	var remaining []xgress.Address
+	for _, addr := range addresses {
+		if addr != address {
+			remaining = append(remaining, addr)
+		}
+	}
+	if len(remaining) == 0 {
+		dt.xgress.Remove(circuitId)
+		return false
+	}
+	dt.xgress.Set(circuitId, remaining)
+	return true
 }
 
 func (dt *destinationTable) debug() string {

--- a/router/xgress_edge/listener.go
+++ b/router/xgress_edge/listener.go
@@ -774,7 +774,12 @@ func (self *edgeClientConn) cleanupXgressCircuit(edgeForwarder *xgEdgeForwarder)
 	circuitId := edgeForwarder.circuitId
 	log := pfxlog.Logger().WithField("circuitId", circuitId)
 
-	self.forwarder.EndCircuit(circuitId)
+	// Endpoint-scoped cleanup: retire only this endpoint's forwarding destination, not every
+	// destination for the circuit. For a multi-router circuit this router only hosts one endpoint,
+	// so it is equivalent to ending the circuit. For a single-router circuit (ingress and
+	// terminator on the same router), it preserves the co-located terminator endpoint that the
+	// other conn registered, instead of tearing the whole circuit down when one side closes.
+	self.forwarder.UnregisterDestination(circuitId, edgeForwarder.address)
 	self.xgCircuits.Remove(circuitId)
 
 	// Notify the controller of the xgress fault


### PR DESCRIPTION
Fixes #4081

`cleanupXgressCircuit` called `EndCircuit`, which removes *every* forwarding destination for a circuit even though it runs for a single closing endpoint. On a single-router circuit (ingress and terminator on the same router, hosted by two different edge connections), closing one side also tore down the co-located other side.

This adds an endpoint-scoped `Forwarder.UnregisterDestination(circuitId, address)` and switches `cleanupXgressCircuit` to it, so only the closing endpoint is retired. Behavior is identical for multi-router circuits (a router only ever hosts one endpoint of a given circuit); for single-router circuits the co-located terminator is preserved instead of being torn down locally when one side's channel closes.