### PR TITLE
Make identity revocation timestamps deterministic across controllers

### DIFF
--- a/common/pb/cmd_pb/cmd.pb.go
+++ b/common/pb/cmd_pb/cmd.pb.go
@@ -145,9 +145,14 @@ func (CommandType) EnumDescriptor() ([]byte, []int) {
 }
 
 type ChangeContext struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Attributes    map[string]string      `protobuf:"bytes,1,rep,name=attributes,proto3" json:"attributes,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	RaftIndex     uint64                 `protobuf:"varint,2,opt,name=raftIndex,proto3" json:"raftIndex,omitempty"`
+	state      protoimpl.MessageState `protogen:"open.v1"`
+	Attributes map[string]string      `protobuf:"bytes,1,rep,name=attributes,proto3" json:"attributes,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	RaftIndex  uint64                 `protobuf:"varint,2,opt,name=raftIndex,proto3" json:"raftIndex,omitempty"`
+	// timestamp is the wall-clock time of the mutation as unix nanoseconds,
+	// stamped once on the originating controller so every raft node applies the
+	// same value. Apply-time code that needs a cluster-consistent "now" (rather
+	// than a per-node time.Now()) reads this. 0 means unset.
+	Timestamp     int64 `protobuf:"varint,3,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -192,6 +197,13 @@ func (x *ChangeContext) GetAttributes() map[string]string {
 func (x *ChangeContext) GetRaftIndex() uint64 {
 	if x != nil {
 		return x.RaftIndex
+	}
+	return 0
+}
+
+func (x *ChangeContext) GetTimestamp() int64 {
+	if x != nil {
+		return x.Timestamp
 	}
 	return 0
 }
@@ -1322,12 +1334,13 @@ var File_cmd_proto protoreflect.FileDescriptor
 
 const file_cmd_proto_rawDesc = "" +
 	"\n" +
-	"\tcmd.proto\x12\vziti.cmd.pb\"\xb8\x01\n" +
+	"\tcmd.proto\x12\vziti.cmd.pb\"\xd6\x01\n" +
 	"\rChangeContext\x12J\n" +
 	"\n" +
 	"attributes\x18\x01 \x03(\v2*.ziti.cmd.pb.ChangeContext.AttributesEntryR\n" +
 	"attributes\x12\x1c\n" +
-	"\traftIndex\x18\x02 \x01(\x04R\traftIndex\x1a=\n" +
+	"\traftIndex\x18\x02 \x01(\x04R\traftIndex\x12\x1c\n" +
+	"\ttimestamp\x18\x03 \x01(\x03R\ttimestamp\x1a=\n" +
 	"\x0fAttributesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"|\n" +

--- a/common/pb/cmd_pb/cmd.proto
+++ b/common/pb/cmd_pb/cmd.proto
@@ -31,6 +31,11 @@ enum CommandType {
 message ChangeContext {
   map<string, string> attributes = 1;
   uint64 raftIndex = 2;
+  // timestamp is the wall-clock time of the mutation as unix nanoseconds,
+  // stamped once on the originating controller so every raft node applies the
+  // same value. Apply-time code that needs a cluster-consistent "now" (rather
+  // than a per-node time.Now()) reads this. 0 means unset.
+  int64 timestamp = 3;
 }
 
 message AddPeerRequest {

--- a/common/pb/edge_cmd_pb/edge_cmd.pb.go
+++ b/common/pb/edge_cmd_pb/edge_cmd.pb.go
@@ -96,9 +96,14 @@ func (CommandType) EnumDescriptor() ([]byte, []int) {
 }
 
 type ChangeContext struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Attributes    map[string]string      `protobuf:"bytes,1,rep,name=attributes,proto3" json:"attributes,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	RaftIndex     uint64                 `protobuf:"varint,2,opt,name=raftIndex,proto3" json:"raftIndex,omitempty"`
+	state      protoimpl.MessageState `protogen:"open.v1"`
+	Attributes map[string]string      `protobuf:"bytes,1,rep,name=attributes,proto3" json:"attributes,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	RaftIndex  uint64                 `protobuf:"varint,2,opt,name=raftIndex,proto3" json:"raftIndex,omitempty"`
+	// timestamp is the wall-clock time of the mutation as unix nanoseconds,
+	// stamped once on the originating controller so every raft node applies the
+	// same value. Apply-time code that needs a cluster-consistent "now" (rather
+	// than a per-node time.Now()) reads this. 0 means unset.
+	Timestamp     int64 `protobuf:"varint,3,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -143,6 +148,13 @@ func (x *ChangeContext) GetAttributes() map[string]string {
 func (x *ChangeContext) GetRaftIndex() uint64 {
 	if x != nil {
 		return x.RaftIndex
+	}
+	return 0
+}
+
+func (x *ChangeContext) GetTimestamp() int64 {
+	if x != nil {
+		return x.Timestamp
 	}
 	return 0
 }
@@ -4763,12 +4775,13 @@ var File_edge_cmd_proto protoreflect.FileDescriptor
 
 const file_edge_cmd_proto_rawDesc = "" +
 	"\n" +
-	"\x0eedge_cmd.proto\x12\x10ziti.edge_cmd.pb\x1a\x1fgoogle/protobuf/timestamp.proto\"\xbd\x01\n" +
+	"\x0eedge_cmd.proto\x12\x10ziti.edge_cmd.pb\x1a\x1fgoogle/protobuf/timestamp.proto\"\xdb\x01\n" +
 	"\rChangeContext\x12O\n" +
 	"\n" +
 	"attributes\x18\x01 \x03(\v2/.ziti.edge_cmd.pb.ChangeContext.AttributesEntryR\n" +
 	"attributes\x12\x1c\n" +
-	"\traftIndex\x18\x02 \x01(\x04R\traftIndex\x1a=\n" +
+	"\traftIndex\x18\x02 \x01(\x04R\traftIndex\x12\x1c\n" +
+	"\ttimestamp\x18\x03 \x01(\x03R\ttimestamp\x1a=\n" +
 	"\x0fAttributesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"x\n" +

--- a/common/pb/edge_cmd_pb/edge_cmd.proto
+++ b/common/pb/edge_cmd_pb/edge_cmd.proto
@@ -22,6 +22,11 @@ enum CommandType {
 message ChangeContext {
   map<string, string> attributes = 1;
   uint64 raftIndex = 2;
+  // timestamp is the wall-clock time of the mutation as unix nanoseconds,
+  // stamped once on the originating controller so every raft node applies the
+  // same value. Apply-time code that needs a cluster-consistent "now" (rather
+  // than a per-node time.Now()) reads this. 0 means unset.
+  int64 timestamp = 3;
 }
 
 

--- a/controller/change/context.go
+++ b/controller/change/context.go
@@ -18,9 +18,10 @@ package change
 
 import (
 	"context"
+	"time"
 
-	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/openziti/ziti/v2/common/pb/cmd_pb"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
 )
 
 type ContextKeyType string
@@ -65,6 +66,13 @@ func New() *Context {
 type Context struct {
 	Attributes map[string]string
 	RaftIndex  uint64
+	// Timestamp is the wall-clock time of the mutation, stamped once on the
+	// originating controller when the command is dispatched. Because it travels
+	// with the replicated command, every raft node applies the same value.
+	// Apply-time code that must be consistent across the cluster (e.g. a store
+	// constraint deriving a revocation cutoff) uses this instead of a per-node
+	// time.Now(). Zero when unset.
+	Timestamp time.Time
 }
 
 type Author struct {
@@ -169,7 +177,26 @@ func (self *Context) ToProtoBuf() *cmd_pb.ChangeContext {
 	return &cmd_pb.ChangeContext{
 		Attributes: self.Attributes,
 		RaftIndex:  self.RaftIndex,
+		Timestamp:  TimeToUnixNanos(self.Timestamp),
 	}
+}
+
+// TimeToUnixNanos encodes a time as unix nanoseconds for the wire, mapping the
+// zero time to 0 so it round-trips as "unset".
+func TimeToUnixNanos(t time.Time) int64 {
+	if t.IsZero() {
+		return 0
+	}
+	return t.UnixNano()
+}
+
+// UnixNanosToTime decodes a wire timestamp produced by TimeToUnixNanos, mapping
+// 0 back to the zero time.
+func UnixNanosToTime(nanos int64) time.Time {
+	if nanos == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, nanos)
 }
 
 func (self *Context) GetContext() context.Context {
@@ -205,6 +232,7 @@ func FromProtoBuf(ctx *cmd_pb.ChangeContext) *Context {
 	result := &Context{
 		Attributes: ctx.Attributes,
 		RaftIndex:  ctx.RaftIndex,
+		Timestamp:  UnixNanosToTime(ctx.Timestamp),
 	}
 	if result.Attributes == nil {
 		result.Attributes = map[string]string{}

--- a/controller/change/context_test.go
+++ b/controller/change/context_test.go
@@ -1,0 +1,51 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package change
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnixNanosRoundTrip(t *testing.T) {
+	t.Run("zero time maps to 0 and back", func(t *testing.T) {
+		require.Equal(t, int64(0), TimeToUnixNanos(time.Time{}))
+		require.True(t, UnixNanosToTime(0).IsZero())
+	})
+
+	t.Run("a real time survives the round trip to the nanosecond", func(t *testing.T) {
+		orig := time.Unix(1783090265, 36219890)
+		require.Equal(t, orig.UnixNano(), UnixNanosToTime(TimeToUnixNanos(orig)).UnixNano())
+	})
+}
+
+func TestContextTimestampProtoRoundTrip(t *testing.T) {
+	t.Run("timestamp survives ToProtoBuf/FromProtoBuf", func(t *testing.T) {
+		ctx := New()
+		ctx.Timestamp = time.Unix(1783090265, 36219890)
+
+		restored := FromProtoBuf(ctx.ToProtoBuf())
+		require.Equal(t, ctx.Timestamp.UnixNano(), restored.Timestamp.UnixNano())
+	})
+
+	t.Run("an unset timestamp stays zero", func(t *testing.T) {
+		restored := FromProtoBuf(New().ToProtoBuf())
+		require.True(t, restored.Timestamp.IsZero())
+	})
+}

--- a/controller/command/command.go
+++ b/controller/command/command.go
@@ -18,14 +18,15 @@ package command
 
 import (
 	"reflect"
+	"time"
 
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/channel/v5"
 	"github.com/openziti/foundation/v2/debugz"
 	"github.com/openziti/foundation/v2/rate"
-	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/openziti/ziti/v2/common/pb/ctrl_pb"
 	"github.com/openziti/ziti/v2/controller/change"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/sirupsen/logrus"
 )
 
@@ -110,6 +111,13 @@ func (self *LocalDispatcher) Dispatch(command Command) error {
 	changeCtx := command.GetChangeContext()
 	if changeCtx == nil {
 		changeCtx = change.New().SetSourceType("unattributed").SetChangeAuthorType(change.AuthorTypeUnattributed)
+	}
+
+	// Stamp the mutation time so apply-time code sees a populated timestamp,
+	// mirroring the clustered dispatcher. A single node can't diverge, so the
+	// value only needs to be present, not agreed upon.
+	if changeCtx.Timestamp.IsZero() {
+		changeCtx.Timestamp = time.Now()
 	}
 
 	if self.EncodeDecodeCommands {

--- a/controller/db/identity_revocation_constraint.go
+++ b/controller/db/identity_revocation_constraint.go
@@ -56,10 +56,13 @@ func (self *IdentityRevocationConstraint) ProcessPreCommit(state *boltz.EntityCh
 	switch state.ChangeType {
 	case boltz.EntityDeleted:
 		if state.InitialState != nil {
-			// A deleted identity can never re-authenticate, so the cutoff is the
-			// moment of deletion. Take it from the replicated change context so
-			// every raft node writes the same value.
-			return self.revoke(state, state.InitialState.Id, self.mutationTime(state))
+			// A deleted identity can never re-authenticate, so there's nothing to
+			// preserve past a cutoff: revoke all of its sessions (a zero
+			// IssuedBefore). This also avoids a cutoff window; any token minted
+			// while the delete was in flight is still covered. ExpiresAt only bounds
+			// how long the revocation lingers, so it uses the replicated change
+			// context time to stay identical across nodes.
+			return self.revoke(state, state.InitialState.Id, self.mutationTime(state), time.Time{})
 		}
 	case boltz.EntityUpdated:
 		// Only the transition into the disabled state warrants a revocation;
@@ -67,11 +70,14 @@ func (self *IdentityRevocationConstraint) ProcessPreCommit(state *boltz.EntityCh
 		// existing revocation untouched.
 		if state.InitialState != nil && state.FinalState != nil &&
 			state.InitialState.DisabledAt == nil && state.FinalState.DisabledAt != nil {
-			// DisabledAt is stamped once on the originating controller and carried
-			// in the update command, so it's identical on every node and is exactly
-			// the cutoff we want: sessions issued before the disable are revoked,
-			// while one re-authenticated after a re-enable survives.
-			return self.revoke(state, state.FinalState.Id, *state.FinalState.DisabledAt)
+			// A disabled identity can be re-enabled, so the revocation lingers with
+			// a cutoff (Enable does not clear it): sessions issued before the
+			// disable stay revoked, while one authenticated after a re-enable
+			// survives. DisabledAt is stamped once on the originating controller and
+			// carried in the update command, so it's identical on every node and is
+			// exactly that cutoff.
+			disabledAt := *state.FinalState.DisabledAt
+			return self.revoke(state, state.FinalState.Id, disabledAt, disabledAt)
 		}
 	}
 	return nil
@@ -93,16 +99,18 @@ func (self *IdentityRevocationConstraint) mutationTime(state *boltz.EntityChange
 func (self *IdentityRevocationConstraint) ProcessPostCommit(*boltz.EntityChangeState[*Identity]) {}
 
 // revoke creates, replacing any prior entry, an identity-scoped revocation within
-// the change's transaction. The cutoff is at, so a session re-authenticated
-// after a re-enable survives the still-lingering revocation. at must be a
-// cluster-consistent value (not a per-node time.Now()) so the revocation is
-// identical across controllers and routers.
-func (self *IdentityRevocationConstraint) revoke(state *boltz.EntityChangeState[*Identity], identityId string, at time.Time) error {
+// the change's transaction. It expires revocationTtl() past expiresBase. A
+// non-zero issuedBefore revokes only sessions issued before that cutoff, so one
+// authenticated after a re-enable survives the still-lingering revocation; a zero
+// issuedBefore revokes all of the identity's sessions. Both expiresBase and
+// issuedBefore must be cluster-consistent values (not a per-node time.Now()) so
+// the revocation is identical across controllers and routers.
+func (self *IdentityRevocationConstraint) revoke(state *boltz.EntityChangeState[*Identity], identityId string, expiresBase time.Time, issuedBefore time.Time) error {
 	revocation := &Revocation{
 		BaseExtEntity: *boltz.NewExtEntity(identityId, nil),
-		ExpiresAt:     at.Add(self.revocationTtl()),
+		ExpiresAt:     expiresBase.Add(self.revocationTtl()),
 		Type:          self.revocationType,
-		IssuedBefore:  at,
+		IssuedBefore:  issuedBefore,
 	}
 
 	ctx := state.GetCtx()

--- a/controller/db/identity_revocation_constraint.go
+++ b/controller/db/identity_revocation_constraint.go
@@ -19,6 +19,7 @@ package db
 import (
 	"time"
 
+	"github.com/openziti/ziti/v2/controller/change"
 	"github.com/openziti/ziti/v2/controller/storage/boltz"
 )
 
@@ -39,8 +40,8 @@ type IdentityRevocationConstraint struct {
 }
 
 // NewIdentityRevocationConstraint builds an IdentityRevocationConstraint that
-// writes revocations of the given type into revocationStore, with an expiry of
-// now plus revocationTtl() (the longest a token could remain valid).
+// writes revocations of the given type into revocationStore, expiring
+// revocationTtl() (the longest a token could remain valid) past the mutation.
 func NewIdentityRevocationConstraint(revocationStore RevocationStore, revocationType string, revocationTtl func() time.Duration) *IdentityRevocationConstraint {
 	return &IdentityRevocationConstraint{
 		revocationStore: revocationStore,
@@ -55,7 +56,10 @@ func (self *IdentityRevocationConstraint) ProcessPreCommit(state *boltz.EntityCh
 	switch state.ChangeType {
 	case boltz.EntityDeleted:
 		if state.InitialState != nil {
-			return self.revoke(state, state.InitialState.Id)
+			// A deleted identity can never re-authenticate, so the cutoff is the
+			// moment of deletion. Take it from the replicated change context so
+			// every raft node writes the same value.
+			return self.revoke(state, state.InitialState.Id, self.mutationTime(state))
 		}
 	case boltz.EntityUpdated:
 		// Only the transition into the disabled state warrants a revocation;
@@ -63,10 +67,25 @@ func (self *IdentityRevocationConstraint) ProcessPreCommit(state *boltz.EntityCh
 		// existing revocation untouched.
 		if state.InitialState != nil && state.FinalState != nil &&
 			state.InitialState.DisabledAt == nil && state.FinalState.DisabledAt != nil {
-			return self.revoke(state, state.FinalState.Id)
+			// DisabledAt is stamped once on the originating controller and carried
+			// in the update command, so it's identical on every node and is exactly
+			// the cutoff we want: sessions issued before the disable are revoked,
+			// while one re-authenticated after a re-enable survives.
+			return self.revoke(state, state.FinalState.Id, *state.FinalState.DisabledAt)
 		}
 	}
 	return nil
+}
+
+// mutationTime returns the cluster-consistent time of the current mutation,
+// read from the replicated change context so it's identical on every raft node.
+// It falls back to time.Now() only when no change context is present, a path
+// with no raft peer to diverge from.
+func (self *IdentityRevocationConstraint) mutationTime(state *boltz.EntityChangeState[*Identity]) time.Time {
+	if changeCtx := change.FromContext(state.GetCtx().Context()); changeCtx != nil && !changeCtx.Timestamp.IsZero() {
+		return changeCtx.Timestamp
+	}
+	return time.Now()
 }
 
 // ProcessPostCommit is a no-op; the revocation is persisted in ProcessPreCommit
@@ -74,15 +93,16 @@ func (self *IdentityRevocationConstraint) ProcessPreCommit(state *boltz.EntityCh
 func (self *IdentityRevocationConstraint) ProcessPostCommit(*boltz.EntityChangeState[*Identity]) {}
 
 // revoke creates, replacing any prior entry, an identity-scoped revocation within
-// the change's transaction. The cutoff is now, so a session re-authenticated
-// after a re-enable survives the still-lingering revocation.
-func (self *IdentityRevocationConstraint) revoke(state *boltz.EntityChangeState[*Identity], identityId string) error {
-	now := time.Now()
+// the change's transaction. The cutoff is at, so a session re-authenticated
+// after a re-enable survives the still-lingering revocation. at must be a
+// cluster-consistent value (not a per-node time.Now()) so the revocation is
+// identical across controllers and routers.
+func (self *IdentityRevocationConstraint) revoke(state *boltz.EntityChangeState[*Identity], identityId string, at time.Time) error {
 	revocation := &Revocation{
 		BaseExtEntity: *boltz.NewExtEntity(identityId, nil),
-		ExpiresAt:     now.Add(self.revocationTtl()),
+		ExpiresAt:     at.Add(self.revocationTtl()),
 		Type:          self.revocationType,
-		IssuedBefore:  now,
+		IssuedBefore:  at,
 	}
 
 	ctx := state.GetCtx()

--- a/controller/env/appenv.go
+++ b/controller/env/appenv.go
@@ -50,7 +50,6 @@ import (
 	"github.com/openziti/identity"
 	"github.com/openziti/metrics"
 	"github.com/openziti/sdk-golang/v2/ziti"
-	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/openziti/xweb/v3"
 	"github.com/openziti/ziti/v2/common"
 	"github.com/openziti/ziti/v2/common/cert"
@@ -64,6 +63,7 @@ import (
 	"github.com/openziti/ziti/v2/controller/events"
 	"github.com/openziti/ziti/v2/controller/jwtsigner"
 	"github.com/openziti/ziti/v2/controller/model"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
 
 	"github.com/openziti/ziti/v2/controller/network"
 	"github.com/openziti/ziti/v2/controller/permissions"
@@ -229,7 +229,7 @@ func (ae *AppEnv) ValidateAccessToken(token string) (*common.AccessClaims, error
 		return nil, err
 	}
 
-	if revocation != nil && !revocation.CreatedAt.Truncate(time.Second).Before(accessClaims.IssuedAt.AsTime()) {
+	if revocation != nil && revocation.RevokesSessionIssuedAt(accessClaims.IssuedAt.AsTime()) {
 		return nil, errors.New("access token has been revoked by identity")
 	}
 
@@ -295,7 +295,7 @@ func (ae *AppEnv) ValidateServiceAccessToken(token string, apiSessionId *string)
 		return nil, err
 	}
 
-	if revocation != nil && revocation.CreatedAt.After(serviceAccessClaims.IssuedAt.Time) {
+	if revocation != nil && revocation.RevokesSessionIssuedAt(serviceAccessClaims.IssuedAt.Time) {
 		return nil, errors.New("service access token has been revoked by identity")
 	}
 

--- a/controller/env/security_ctx.go
+++ b/controller/env/security_ctx.go
@@ -27,12 +27,12 @@ import (
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/edge-api/rest_model"
 	"github.com/openziti/foundation/v2/errorz"
-	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/openziti/ziti/v2/common"
 	"github.com/openziti/ziti/v2/common/spiffehlp"
 	"github.com/openziti/ziti/v2/controller/model"
 	"github.com/openziti/ziti/v2/controller/models"
 	"github.com/openziti/ziti/v2/controller/permissions"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
 )
 
 // SecurityCtx resolves and caches the full authentication context for a single HTTP request.
@@ -415,7 +415,7 @@ func (ctx *SecurityCtx) resolveOidcSession(securityToken *common.SecurityToken) 
 		ctx.setApiSessionError(errorz.NewUnauthorizedOidcInvalid())
 		return
 	}
-	if identityRevocation != nil && !identityRevocation.CreatedAt.Truncate(time.Second).Before(claims.IssuedAt.AsTime()) {
+	if identityRevocation != nil && identityRevocation.RevokesSessionIssuedAt(claims.IssuedAt.AsTime()) {
 		ctx.setApiSessionError(errorz.NewUnauthorizedOidcInvalid())
 		return
 	}

--- a/controller/model/pbutils.go
+++ b/controller/model/pbutils.go
@@ -47,6 +47,7 @@ func ContextToProtobuf(context *change.Context) *edge_cmd_pb.ChangeContext {
 	return &edge_cmd_pb.ChangeContext{
 		Attributes: context.Attributes,
 		RaftIndex:  context.RaftIndex,
+		Timestamp:  change.TimeToUnixNanos(context.Timestamp),
 	}
 }
 
@@ -57,5 +58,6 @@ func ProtobufToContext(context *edge_cmd_pb.ChangeContext) *change.Context {
 	return &change.Context{
 		Attributes: context.Attributes,
 		RaftIndex:  context.RaftIndex,
+		Timestamp:  change.UnixNanosToTime(context.Timestamp),
 	}
 }

--- a/controller/model/revocation_model.go
+++ b/controller/model/revocation_model.go
@@ -32,6 +32,19 @@ type Revocation struct {
 	IssuedBefore time.Time
 }
 
+// RevokesSessionIssuedAt reports whether this identity revocation applies to a
+// session issued at issuedAt. A zero IssuedBefore revokes all of the identity's
+// sessions; otherwise only those issued strictly before the cutoff are revoked,
+// so a session authenticated after a re-enable survives a still-lingering
+// revocation. This mirrors RouterDataModel.IsIdentityRevoked so the controller
+// and the routers agree on the cutoff.
+func (entity *Revocation) RevokesSessionIssuedAt(issuedAt time.Time) bool {
+	if entity.IssuedBefore.IsZero() {
+		return true
+	}
+	return issuedAt.Before(entity.IssuedBefore)
+}
+
 func (entity *Revocation) toBoltEntityForUpdate(tx *bbolt.Tx, env Env, _ boltz.FieldChecker) (*db.Revocation, error) {
 	return entity.toBoltEntityForCreate(tx, env)
 }

--- a/controller/model/revocation_model_test.go
+++ b/controller/model/revocation_model_test.go
@@ -1,0 +1,45 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package model
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRevocationRevokesSessionIssuedAt(t *testing.T) {
+	cutoff := time.Unix(1783090265, 0)
+
+	t.Run("a zero cutoff revokes every session", func(t *testing.T) {
+		rev := &Revocation{}
+		require.True(t, rev.RevokesSessionIssuedAt(cutoff.Add(-time.Hour)))
+		require.True(t, rev.RevokesSessionIssuedAt(cutoff.Add(time.Hour)))
+	})
+
+	t.Run("a session issued before the cutoff is revoked", func(t *testing.T) {
+		rev := &Revocation{IssuedBefore: cutoff}
+		require.True(t, rev.RevokesSessionIssuedAt(cutoff.Add(-time.Second)))
+	})
+
+	t.Run("a session issued at or after the cutoff survives", func(t *testing.T) {
+		rev := &Revocation{IssuedBefore: cutoff}
+		require.False(t, rev.RevokesSessionIssuedAt(cutoff))
+		require.False(t, rev.RevokesSessionIssuedAt(cutoff.Add(time.Second)))
+	})
+}

--- a/controller/raft/raft.go
+++ b/controller/raft/raft.go
@@ -41,7 +41,6 @@ import (
 	"github.com/openziti/foundation/v2/versions"
 	"github.com/openziti/identity"
 	"github.com/openziti/metrics"
-	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/openziti/ziti/v2/common/pb/cmd_pb"
 	"github.com/openziti/ziti/v2/common/pb/ctrl_pb"
 	"github.com/openziti/ziti/v2/controller/apierror"
@@ -53,6 +52,7 @@ import (
 	"github.com/openziti/ziti/v2/controller/model"
 	"github.com/openziti/ziti/v2/controller/peermsg"
 	"github.com/openziti/ziti/v2/controller/raft/mesh"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/sirupsen/logrus"
 	"github.com/teris-io/shortid"
 )
@@ -318,6 +318,13 @@ func (self *Controller) Dispatch(cmd command.Command) error {
 
 	if self.Mesh.IsReadOnly() {
 		return errors.New("unable to execute command. In a readonly state: different versions detected in cluster")
+	}
+
+	// Stamp the mutation time once here, before the command is encoded and
+	// replicated, so every raft node applies the same value rather than each
+	// deriving its own time.Now() during apply.
+	if changeCtx := cmd.GetChangeContext(); changeCtx != nil && changeCtx.Timestamp.IsZero() {
+		changeCtx.Timestamp = time.Now()
 	}
 
 	if self.IsLeader() {


### PR DESCRIPTION
Fixes #4088

## Problem

In a multi-controller cluster, deleting or disabling an identity produced a revocation whose `ExpiresAt`/`IssuedBefore` timestamps differed on each controller, because the `IdentityRevocationConstraint` runs inside the replicated command's apply on every node and set them from a per-node `time.Now()`. The router-data-model validation flags the resulting divergence, and the controllers genuinely enforce inconsistent revocation cutoffs.

## Change

Carry a deterministic mutation timestamp on the change context, stamped once when the command is dispatched (before it's encoded and replicated), so every raft node applies the same value. The revocation constraint then derives its timestamps from a cluster-consistent source: the carried `DisabledAt` on a disable (which is also the semantically correct cutoff) and the change-context timestamp on a delete.

The OIDC/management revocation paths were already deterministic (leader computes, command carries) and are unchanged.

## Testing

- revocation enforcement integration tests (`apitests`) pass
- new change-context timestamp round-trip unit tests

Multi-node divergence is only reproducible in the router-data-model fablab suite, but the fix is deterministic by construction.

## Follow-up

Targets `main`; a backport to `release-v2.0.x` will follow.