### PR TITLE
Use latest ZET release for ZET integration tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,7 @@ jobs:
     with:
       ziti-artifact: release-${{ github.run_id }}
       tests-repo: openziti/ziti-tunnel-sdk-c
-      zetA-version: v1.17.0
+      zetA-version: latest
       label: ${{ github.ref_name }}
 
   publish:


### PR DESCRIPTION
The release workflow pinned zetA-version to v1.17.0 because the tests need ZET 1.17+ 
'Latest' is now acceptable.