### PR TITLE
backport: fix peer-signer JWKS kid format (#4068) to release-v2.0.x

### DIFF
--- a/controller/oidc_auth/storage.go
+++ b/controller/oidc_auth/storage.go
@@ -989,7 +989,7 @@ func (s *HybridStorage) KeySet(_ context.Context) ([]op.Key, error) {
 	signers := s.env.GetPeerSigners()
 
 	for _, cert := range signers {
-		kid := fmt.Sprintf("%s", sha1.Sum(cert.Raw))
+		kid := fmt.Sprintf("%x", sha1.Sum(cert.Raw))
 
 		if _, found := s.keys.Get(kid); found {
 			continue


### PR DESCRIPTION
fix openziti/ziti#4067

Backports commit 4a8b63d9 (#4068, merged to `main` 2026-07-08) to `release-v2.0.x`, which is not yet on the fix and has no `v2.0.1` tag.

## What it fixes

`KeySet()` in `controller/oidc_auth/storage.go` formatted a peer controller's SHA1 cert fingerprint with `%s` instead of `%x` when building JWKS entries sourced from `GetPeerSigners()`, producing an undecodable raw-byte `kid`. The error-path logging four lines below already used `%x` correctly.

In a multi-controller raft HA deployment, each controller signs OIDC/OTT JWTs with its own root ctrl-plane-identity key (`GetRootTlsJwtSigner()`, independent of raft role). A JWKS lookup landing on a controller other than the signer sees the true signer's key advertised under this corrupt `kid` in `/oidc/keys` and cannot match it against the token's `kid` header, failing verification.

## Cherry-pick provenance

Straight cherry-pick (`-x`) of 4a8b63d9 onto `release-v2.0.x` (tip `35c78c834`) — applied with no conflicts, no adaptation needed.

## Test evidence

- `go build ./controller/...` — clean
- `go test ./controller/oidc_auth/...` — `ok`

## Production context

We run this controller in a 3-node raft HA cluster and hit this exact bug: it forces our client-facing Service to pin to a single controller instead of load-balancing across the cluster, since only same-node JWKS lookups succeed. We'll report deployment verification (JWKS kids resolving correctly across all 3 nodes) on #4067 once we've rolled a patched build.
