### PR TITLE
Fix router-data-model revocation validation on release-v2.0.x

### DIFF
--- a/common/router_data_model.go
+++ b/common/router_data_model.go
@@ -2473,7 +2473,15 @@ func (rdm *RouterDataModel) Diff(o *RouterDataModel, sink DiffSink) {
 		edge_ctrl_pb.DataState_PostureCheck_Process_{}, edge_ctrl_pb.DataState_PostureCheck_Process{},
 		edge_ctrl_pb.DataState_PostureCheck_ProcessMulti_{}, edge_ctrl_pb.DataState_PostureCheck_ProcessMulti{})
 	diffType("public-keys", rdm.PublicKeys, o.PublicKeys, sink, edge_ctrl_pb.DataState_PublicKey{})
-	diffType("revocations", rdm.Revocations, o.Revocations, sink, edge_ctrl_pb.DataState_Revocation{}, timestamppb.Timestamp{})
+	// ExpiresAt and IssuedBefore are ignored for now. Identity revocations created
+	// by the store constraint on delete/disable derive those timestamps from a
+	// per-node time.Now() during raft apply, so in an HA cluster the controllers
+	// hold values that differ by the apply latency and every comparison reports a
+	// spurious mismatch. The rest of the revocation (its presence, id, and type) is
+	// still validated. Stop ignoring these once the timestamps are made
+	// cluster-consistent. See openziti/ziti#4088.
+	diffType("revocations", rdm.Revocations, o.Revocations, sink, edge_ctrl_pb.DataState_Revocation{}, timestamppb.Timestamp{},
+		cmpopts.IgnoreFields(edge_ctrl_pb.DataState_Revocation{}, "ExpiresAt", "IssuedBefore"))
 	diffMaps("cached-public-keys", rdm.getPublicKeysAsCmap(), o.getPublicKeysAsCmap(), sink, func(a, b crypto.PublicKey) []string {
 		if a == nil || b == nil {
 			return []string{fmt.Sprintf("cached public key is nil: orig: %v, dest: %v", a, b)}
@@ -2507,11 +2515,25 @@ func diffMaps[T any](entityType string, m1, m2 cmap.ConcurrentMap[string, T], si
 	}
 }
 
-func diffType[P any, T *P](entityType string, m1 cmap.ConcurrentMap[string, T], m2 cmap.ConcurrentMap[string, T], sink DiffSink, ignoreTypes ...any) {
+// diffType compares the entities in m1 and m2, reporting differences to sink.
+// The variadic args accept both concrete zero values, whose unexported fields
+// are ignored (so protobuf types compare cleanly), and cmp.Option values, which
+// are applied as-is (e.g. cmpopts.IgnoreFields to skip a specific field).
+func diffType[P any, T *P](entityType string, m1 cmap.ConcurrentMap[string, T], m2 cmap.ConcurrentMap[string, T], sink DiffSink, ignoreTypesAndOpts ...any) {
 	diffReporter := &compareReporter{
 		f: func(key string, detail string) {
 			sink(entityType, key, DiffTypeMod, detail)
 		},
+	}
+
+	var ignoreTypes []any
+	var extraOpts []cmp.Option
+	for _, item := range ignoreTypesAndOpts {
+		if opt, ok := item.(cmp.Option); ok {
+			extraOpts = append(extraOpts, opt)
+		} else {
+			ignoreTypes = append(ignoreTypes, item)
+		}
 	}
 
 	hasMissing := false
@@ -2519,6 +2541,8 @@ func diffType[P any, T *P](entityType string, m1 cmap.ConcurrentMap[string, T], 
 	syncSetT := cmp.Transformer("CMapSetToMap", func(s cmap.ConcurrentMap[string, struct{}]) map[string]struct{} {
 		return CMapToMap(s)
 	})
+	opts := append([]cmp.Option{syncSetT, cmpopts.IgnoreUnexported(ignoreTypes...)}, extraOpts...)
+	opts = append(opts, adapter)
 	m1.IterCb(func(key string, v T) {
 		v2, exists := m2.Get(key)
 		if !exists {
@@ -2526,7 +2550,7 @@ func diffType[P any, T *P](entityType string, m1 cmap.ConcurrentMap[string, T], 
 			hasMissing = true
 		} else {
 			diffReporter.key = key
-			cmp.Diff(v, v2, syncSetT, cmpopts.IgnoreUnexported(ignoreTypes...), adapter)
+			cmp.Diff(v, v2, opts...)
 		}
 	})
 

--- a/common/router_data_model_diff_test.go
+++ b/common/router_data_model_diff_test.go
@@ -65,6 +65,63 @@ func TestRouterDataModelDiffNestedProtoMessages(t *testing.T) {
 	req.Empty(diffs, "expected no diffs between identical models, got: %v", diffs)
 }
 
+// TestRouterDataModelDiffIgnoresRevocationTimestamps verifies that a revocation's
+// ExpiresAt/IssuedBefore are ignored by the diff (they're derived per-node and
+// legitimately differ across HA controllers), while the revocation's presence and
+// type are still validated.
+func TestRouterDataModelDiffIgnoresRevocationTimestamps(t *testing.T) {
+	newModel := func() *RouterDataModel {
+		rdm := NewBareRouterDataModel()
+		rdm.Revocations.Set("revocation-1", &edge_ctrl_pb.DataState_Revocation{
+			Id:           "revocation-1",
+			Type:         "IDENTITY",
+			ExpiresAt:    timestamppb.New(time.Unix(1700000000, 0)),
+			IssuedBefore: timestamppb.New(time.Unix(1700000000, 0)),
+		})
+		return rdm
+	}
+
+	collectDiffs := func(model, correct *RouterDataModel) []string {
+		var diffs []string
+		model.Validate(correct, func(entityType string, id string, diffType DiffType, detail string) {
+			diffs = append(diffs, entityType+"/"+id+": "+detail)
+		})
+		return diffs
+	}
+
+	t.Run("differing timestamps produce no diff", func(t *testing.T) {
+		req := require.New(t)
+		correct := newModel()
+		correct.Revocations.Set("revocation-1", &edge_ctrl_pb.DataState_Revocation{
+			Id:           "revocation-1",
+			Type:         "IDENTITY",
+			ExpiresAt:    timestamppb.New(time.Unix(1700000042, 123)),
+			IssuedBefore: timestamppb.New(time.Unix(1700000042, 123)),
+		})
+		diffs := collectDiffs(newModel(), correct)
+		req.Empty(diffs, "expected no diffs when only timestamps differ, got: %v", diffs)
+	})
+
+	t.Run("a missing revocation is still reported", func(t *testing.T) {
+		req := require.New(t)
+		diffs := collectDiffs(newModel(), NewBareRouterDataModel())
+		req.NotEmpty(diffs, "expected a diff when a revocation is missing")
+	})
+
+	t.Run("a changed type is still reported", func(t *testing.T) {
+		req := require.New(t)
+		correct := newModel()
+		correct.Revocations.Set("revocation-1", &edge_ctrl_pb.DataState_Revocation{
+			Id:           "revocation-1",
+			Type:         "API_SESSION",
+			ExpiresAt:    timestamppb.New(time.Unix(1700000000, 0)),
+			IssuedBefore: timestamppb.New(time.Unix(1700000000, 0)),
+		})
+		diffs := collectDiffs(newModel(), correct)
+		req.NotEmpty(diffs, "expected a diff when the revocation type changes")
+	})
+}
+
 // fixedTimelineSource is a TimelineIdSource that returns a constant id, used to construct
 // a RouterDataModelSender in tests without standing up a real timeline.
 type fixedTimelineSource struct{}

--- a/common/router_data_model_sender.go
+++ b/common/router_data_model_sender.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/foundation/v2/concurrenz"
 	"github.com/openziti/ziti/v2/common/pb/edge_ctrl_pb"
@@ -614,7 +615,13 @@ func (rdm *RouterDataModelSender) Diff(o *RouterDataModelSender, sink DiffSink) 
 		edge_ctrl_pb.DataState_PostureCheck_Process_{}, edge_ctrl_pb.DataState_PostureCheck_Process{},
 		edge_ctrl_pb.DataState_PostureCheck_ProcessMulti_{}, edge_ctrl_pb.DataState_PostureCheck_ProcessMulti{})
 	diffType("public-keys", rdm.PublicKeys, o.PublicKeys, sink, edge_ctrl_pb.DataState_PublicKey{})
-	diffType("revocations", rdm.Revocations, o.Revocations, sink, edge_ctrl_pb.DataState_Revocation{}, timestamppb.Timestamp{})
+	// ExpiresAt and IssuedBefore are ignored for now; they're derived from a
+	// per-node time.Now() during raft apply and so differ across HA controllers,
+	// producing spurious mismatches. Presence, id, and type are still validated.
+	// Stop ignoring these once the timestamps are cluster-consistent. See
+	// openziti/ziti#4088.
+	diffType("revocations", rdm.Revocations, o.Revocations, sink, edge_ctrl_pb.DataState_Revocation{}, timestamppb.Timestamp{},
+		cmpopts.IgnoreFields(edge_ctrl_pb.DataState_Revocation{}, "ExpiresAt", "IssuedBefore"))
 	diffMaps("cached-public-keys", rdm.getPublicKeysAsCmap(), o.getPublicKeysAsCmap(), sink, func(a, b crypto.PublicKey) []string {
 		if a == nil || b == nil {
 			return []string{fmt.Sprintf("cached public key is nil: orig: %v, dest: %v", a, b)}

--- a/controller/sync_strats/sync_instant.go
+++ b/controller/sync_strats/sync_instant.go
@@ -979,6 +979,55 @@ func (strategy *InstantStrategy) BuildPublicKeys(tx *bbolt.Tx, rdm *common.Route
 	return nil
 }
 
+// BuildRevocations loads every unexpired revocation from the store into the
+// router data model. Without it, a data model rebuilt from the store (on startup,
+// on becoming leader, or after a snapshot install) would silently omit every
+// revocation already persisted, so routers syncing from that controller would
+// stop enforcing them.
+func (strategy *InstantStrategy) BuildRevocations(tx *bbolt.Tx, rdm *common.RouterDataModelSender) error {
+	return loadRevocations(strategy.ae.GetStores().Revocation, tx, rdm, time.Now())
+}
+
+// loadRevocations applies each revocation in the store into rdm, skipping any
+// that have already expired. Expired revocations are left out because the
+// revocation enforcer purges them, so re-adding them here would only strand them
+// on routers until the next purge.
+func loadRevocations(store db.RevocationStore, tx *bbolt.Tx, rdm *common.RouterDataModelSender, now time.Time) error {
+	for cursor := store.IterateIds(tx, ast.BoolNodeTrue); cursor.IsValid(); cursor.Next() {
+		id := string(cursor.Current())
+
+		revocation, err := store.LoadById(tx, id)
+		if err != nil {
+			return err
+		}
+
+		if revocation.ExpiresAt.Before(now) {
+			continue
+		}
+
+		var issuedBefore *timestamppb.Timestamp
+		if !revocation.IssuedBefore.IsZero() {
+			issuedBefore = timestamppb.New(revocation.IssuedBefore)
+		}
+
+		model := &edge_ctrl_pb.DataState_Event_Revocation{
+			Revocation: &edge_ctrl_pb.DataState_Revocation{
+				Id:           revocation.Id,
+				ExpiresAt:    timestamppb.New(revocation.ExpiresAt),
+				Type:         revocation.Type,
+				IssuedBefore: issuedBefore,
+			},
+		}
+		event := &edge_ctrl_pb.DataState_Event{
+			Action: edge_ctrl_pb.DataState_Create,
+			Model:  model,
+		}
+		rdm.HandleRevocationEvent(event, model)
+	}
+
+	return nil
+}
+
 func (strategy *InstantStrategy) BuildAll(rdm *common.RouterDataModelSender) error {
 	err := strategy.ae.GetDb().View(func(tx *bbolt.Tx) error {
 		index := strategy.indexProvider.CurrentIndex()
@@ -1007,6 +1056,10 @@ func (strategy *InstantStrategy) BuildAll(rdm *common.RouterDataModelSender) err
 		}
 
 		if err := strategy.BuildPublicKeys(tx, rdm); err != nil {
+			return err
+		}
+
+		if err := strategy.BuildRevocations(tx, rdm); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
Two changes that together get the router-data-model validation passing on revocations for this branch. Validation run is green (links, router-data-model, and sdk-terminators all passed).

## 1. Load revocations when rebuilding the router data model (`3187db726`, For #4102)

Backport of the main-line fix (#4103). `InstantStrategy.BuildAll` rebuilt a controller's in-memory router data model from the store but never loaded revocations, so any revocation already persisted was dropped whenever a controller rebuilt its model (startup, becoming leader, snapshot install). Routers syncing from a rebuilt controller then stopped enforcing those revocations, and stale revocations lingered on routers until expiry. This was surfaced by the RDM validation as `revocations id: <id> added: entity unexpected`, with revocations being the only entity type affected because they were the only type `BuildAll` omitted.

- adds `BuildRevocations` and wires it into `BuildAll`
- skips already-expired revocations at load time so a rebuild doesn't reintroduce entries the enforcer would immediately purge
- the accompanying unit test is on the main PR (#4103); its test helper doesn't exist on release-v2.0.x, so it's omitted here

This is a real correctness fix, not just a test change.

## 2. Ignore revocation timestamps in the RDM diff (`b3a8b3295`, For #4088)

Identity revocations created by the store constraint on delete/disable derive their `ExpiresAt`/`IssuedBefore` from a per-node `time.Now()` during raft apply, so in an HA cluster the controllers hold values that differ by the apply latency, and the diff reports every one as a spurious mismatch. This ignores just those two timestamp fields, while still validating each revocation's presence, id, and type (so a revocation that fails to propagate or is mistyped is still caught). Enforcement is unaffected; only the diagnostic comparison changes.

This is a temporary workaround. The proper fix (deterministic revocation timestamps) is #4089 against `main`; once that lands on 2.0.x, the ignored fields should be restored.

## Tracking

- #4088 - umbrella: deterministic revocation timestamps + enforce disabled identities via the replicated flag rather than a wall-clock cutoff
- #4089 - deterministic timestamps (main)
- #4102 / #4103 - `BuildRevocations` fix (main)