### PR TITLE
Load revocations when rebuilding the router data model

### DIFF
--- a/controller/sync_strats/sync_instant.go
+++ b/controller/sync_strats/sync_instant.go
@@ -991,6 +991,55 @@ func (strategy *InstantStrategy) BuildPublicKeys(tx *bbolt.Tx, rdm *common.Route
 	return nil
 }
 
+// BuildRevocations loads every unexpired revocation from the store into the
+// router data model. Without it, a data model rebuilt from the store (on startup,
+// on becoming leader, or after a snapshot install) would silently omit every
+// revocation already persisted, so routers syncing from that controller would
+// stop enforcing them.
+func (strategy *InstantStrategy) BuildRevocations(tx *bbolt.Tx, rdm *common.RouterDataModelSender) error {
+	return loadRevocations(strategy.ae.GetStores().Revocation, tx, rdm, time.Now())
+}
+
+// loadRevocations applies each revocation in the store into rdm, skipping any
+// that have already expired. Expired revocations are left out because the
+// revocation enforcer purges them, so re-adding them here would only strand them
+// on routers until the next purge.
+func loadRevocations(store db.RevocationStore, tx *bbolt.Tx, rdm *common.RouterDataModelSender, now time.Time) error {
+	for cursor := store.IterateIds(tx, ast.BoolNodeTrue); cursor.IsValid(); cursor.Next() {
+		id := string(cursor.Current())
+
+		revocation, err := store.LoadById(tx, id)
+		if err != nil {
+			return err
+		}
+
+		if revocation.ExpiresAt.Before(now) {
+			continue
+		}
+
+		var issuedBefore *timestamppb.Timestamp
+		if !revocation.IssuedBefore.IsZero() {
+			issuedBefore = timestamppb.New(revocation.IssuedBefore)
+		}
+
+		model := &edge_ctrl_pb.DataState_Event_Revocation{
+			Revocation: &edge_ctrl_pb.DataState_Revocation{
+				Id:           revocation.Id,
+				ExpiresAt:    timestamppb.New(revocation.ExpiresAt),
+				Type:         revocation.Type,
+				IssuedBefore: issuedBefore,
+			},
+		}
+		event := &edge_ctrl_pb.DataState_Event{
+			Action: edge_ctrl_pb.DataState_Create,
+			Model:  model,
+		}
+		rdm.HandleRevocationEvent(event, model)
+	}
+
+	return nil
+}
+
 func (strategy *InstantStrategy) BuildAll(rdm *common.RouterDataModelSender) error {
 	err := strategy.ae.GetDb().View(func(tx *bbolt.Tx) error {
 		index := strategy.indexProvider.CurrentIndex()
@@ -1023,6 +1072,10 @@ func (strategy *InstantStrategy) BuildAll(rdm *common.RouterDataModelSender) err
 		}
 
 		if err := strategy.BuildPublicKeys(tx, rdm); err != nil {
+			return err
+		}
+
+		if err := strategy.BuildRevocations(tx, rdm); err != nil {
 			return err
 		}
 

--- a/controller/sync_strats/sync_instant.go
+++ b/controller/sync_strats/sync_instant.go
@@ -1084,6 +1084,55 @@ func (strategy *InstantStrategy) BuildPublicKeys(tx *bbolt.Tx, rdm *common.Route
 	return nil
 }
 
+// BuildRevocations loads every unexpired revocation from the store into the
+// router data model. Without it, a data model rebuilt from the store (on startup,
+// on becoming leader, or after a snapshot install) would silently omit every
+// revocation already persisted, so routers syncing from that controller would
+// stop enforcing them.
+func (strategy *InstantStrategy) BuildRevocations(tx *bbolt.Tx, rdm *common.RouterDataModelSender) error {
+	return loadRevocations(strategy.ae.GetStores().Revocation, tx, rdm, time.Now())
+}
+
+// loadRevocations applies each revocation in the store into rdm, skipping any
+// that have already expired. Expired revocations are left out because the
+// revocation enforcer purges them, so re-adding them here would only strand them
+// on routers until the next purge.
+func loadRevocations(store db.RevocationStore, tx *bbolt.Tx, rdm *common.RouterDataModelSender, now time.Time) error {
+	for cursor := store.IterateIds(tx, ast.BoolNodeTrue); cursor.IsValid(); cursor.Next() {
+		id := string(cursor.Current())
+
+		revocation, err := store.LoadById(tx, id)
+		if err != nil {
+			return err
+		}
+
+		if revocation.ExpiresAt.Before(now) {
+			continue
+		}
+
+		var issuedBefore *timestamppb.Timestamp
+		if !revocation.IssuedBefore.IsZero() {
+			issuedBefore = timestamppb.New(revocation.IssuedBefore)
+		}
+
+		model := &edge_ctrl_pb.DataState_Event_Revocation{
+			Revocation: &edge_ctrl_pb.DataState_Revocation{
+				Id:           revocation.Id,
+				ExpiresAt:    timestamppb.New(revocation.ExpiresAt),
+				Type:         revocation.Type,
+				IssuedBefore: issuedBefore,
+			},
+		}
+		event := &edge_ctrl_pb.DataState_Event{
+			Action: edge_ctrl_pb.DataState_Create,
+			Model:  model,
+		}
+		rdm.HandleRevocationEvent(event, model)
+	}
+
+	return nil
+}
+
 func (strategy *InstantStrategy) BuildAll(rdm *common.RouterDataModelSender) error {
 	err := strategy.ae.GetDb().View(func(tx *bbolt.Tx) error {
 		index := strategy.indexProvider.CurrentIndex()
@@ -1116,6 +1165,10 @@ func (strategy *InstantStrategy) BuildAll(rdm *common.RouterDataModelSender) err
 		}
 
 		if err := strategy.BuildPublicKeys(tx, rdm); err != nil {
+			return err
+		}
+
+		if err := strategy.BuildRevocations(tx, rdm); err != nil {
 			return err
 		}
 

--- a/controller/sync_strats/sync_instant_revocations_test.go
+++ b/controller/sync_strats/sync_instant_revocations_test.go
@@ -1,0 +1,76 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package sync_strats
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openziti/ziti/v2/common"
+	"github.com/openziti/ziti/v2/controller/db"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
+	"github.com/openziti/ziti/v2/controller/storage/boltztest"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
+)
+
+// TestLoadRevocations verifies that rebuilding the router data model from the
+// store loads unexpired revocations and skips expired ones. It guards the
+// regression where the rebuild omitted revocations entirely, which dropped
+// revocation enforcement on routers after a controller restart or leadership
+// change and stranded stale revocations on routers.
+func TestLoadRevocations(t *testing.T) {
+	ctx := db.NewTestContext(t)
+	defer ctx.Cleanup()
+
+	now := time.Unix(1700000000, 0)
+
+	const validId = "revocation-valid"
+	const expiredId = "revocation-expired"
+
+	boltztest.RequireCreate(ctx, &db.Revocation{
+		BaseExtEntity: *boltz.NewExtEntity(validId, nil),
+		Type:          "IDENTITY",
+		ExpiresAt:     now.Add(time.Hour),
+		IssuedBefore:  now,
+	})
+	boltztest.RequireCreate(ctx, &db.Revocation{
+		BaseExtEntity: *boltz.NewExtEntity(expiredId, nil),
+		Type:          "IDENTITY",
+		ExpiresAt:     now.Add(-time.Hour),
+	})
+
+	rdm := common.NewRouterDataModelSender(stubTimelineSource("test-timeline"), 16, 1)
+
+	err := ctx.GetDb().View(func(tx *bbolt.Tx) error {
+		return loadRevocations(ctx.GetStores().Revocation, tx, rdm, now)
+	})
+	require.NoError(t, err)
+
+	t.Run("loads an unexpired revocation", func(t *testing.T) {
+		rev, found := rdm.Revocations.Get(validId)
+		require.True(t, found, "expected the unexpired revocation to be loaded into the data model")
+		require.Equal(t, "IDENTITY", rev.Type)
+		require.NotNil(t, rev.IssuedBefore)
+		require.Equal(t, now.Unix(), rev.IssuedBefore.AsTime().Unix())
+	})
+
+	t.Run("skips an expired revocation", func(t *testing.T) {
+		_, found := rdm.Revocations.Get(expiredId)
+		require.False(t, found, "expected the expired revocation to be skipped")
+	})
+}


### PR DESCRIPTION
Fixes #4102

## Problem

`InstantStrategy.BuildAll` rebuilds a controller's in-memory router data model from the store but never loaded revocations, so any revocation already in the store was dropped whenever a controller rebuilt its model (startup, becoming leader, snapshot install). A router syncing from a rebuilt controller then stopped enforcing those revocations, and stale revocations lingered on routers that already had them until expiry.

Found via the router-data-model validation suite: routers held revocations the controller's data state lacked, persistently, and revocations were the only entity type affected because they were the only type `BuildAll` omitted.

## Change

- Add `BuildRevocations` and call it from `BuildAll`, loading each stored revocation into the data model (same pattern as the other entity types).
- Skip already-expired revocations at load time so a rebuild doesn't reintroduce entries the enforcer would immediately purge.
- Add a test covering the load and the expiry skip.

Related to #4088.