### PR TITLE
Controller cluster bootstrapping fixes

### DIFF
--- a/common/pb/cmd_pb/cmd.pb.go
+++ b/common/pb/cmd_pb/cmd.pb.go
@@ -576,6 +576,7 @@ type SyncSnapshotCommand struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	SnapshotId    string                 `protobuf:"bytes,1,opt,name=snapshotId,proto3" json:"snapshotId,omitempty"`
 	Snapshot      []byte                 `protobuf:"bytes,2,opt,name=snapshot,proto3" json:"snapshot,omitempty"`
+	ClusterId     string                 `protobuf:"bytes,3,opt,name=clusterId,proto3" json:"clusterId,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -622,6 +623,13 @@ func (x *SyncSnapshotCommand) GetSnapshot() []byte {
 		return x.Snapshot
 	}
 	return nil
+}
+
+func (x *SyncSnapshotCommand) GetClusterId() string {
+	if x != nil {
+		return x.ClusterId
+	}
+	return ""
 }
 
 type InitClusterIdCommand struct {
@@ -1366,12 +1374,13 @@ const file_cmd_proto_rawDesc = "" +
 	"\n" +
 	"entityType\x18\x02 \x01(\tR\n" +
 	"entityType\x12,\n" +
-	"\x03ctx\x18\x03 \x01(\v2\x1a.ziti.cmd.pb.ChangeContextR\x03ctx\"Q\n" +
+	"\x03ctx\x18\x03 \x01(\v2\x1a.ziti.cmd.pb.ChangeContextR\x03ctx\"o\n" +
 	"\x13SyncSnapshotCommand\x12\x1e\n" +
 	"\n" +
 	"snapshotId\x18\x01 \x01(\tR\n" +
 	"snapshotId\x12\x1a\n" +
-	"\bsnapshot\x18\x02 \x01(\fR\bsnapshot\"T\n" +
+	"\bsnapshot\x18\x02 \x01(\fR\bsnapshot\x12\x1c\n" +
+	"\tclusterId\x18\x03 \x01(\tR\tclusterId\"T\n" +
 	"\x14InitClusterIdCommand\x12\x1c\n" +
 	"\tclusterId\x18\x01 \x01(\tR\tclusterId\x12\x1e\n" +
 	"\n" +

--- a/common/pb/cmd_pb/cmd.proto
+++ b/common/pb/cmd_pb/cmd.proto
@@ -75,6 +75,7 @@ message DeleteEntityCommand {
 message SyncSnapshotCommand {
   string snapshotId = 1;
   bytes snapshot = 2;
+  string clusterId = 3;
 }
 
 message InitClusterIdCommand {

--- a/controller/command/command.go
+++ b/controller/command/command.go
@@ -23,9 +23,9 @@ import (
 	"github.com/openziti/channel/v5"
 	"github.com/openziti/foundation/v2/debugz"
 	"github.com/openziti/foundation/v2/rate"
-	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/openziti/ziti/v2/common/pb/ctrl_pb"
 	"github.com/openziti/ziti/v2/controller/change"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/sirupsen/logrus"
 )
 
@@ -40,6 +40,14 @@ type Command interface {
 
 	// Encode returns a serialized representation of the command
 	Encode() ([]byte, error)
+}
+
+// CriticalCommand marks commands that establish base state (e.g. a snapshot restore). A failed apply
+// of one must halt the node rather than log-and-advance the raft index, which would leave the node
+// caught up on index but missing data. Ordinary commands are logged and skipped on failure.
+type CriticalCommand interface {
+	Command
+	IsCriticalCommand()
 }
 
 // Validatable instances can be validated. Command instances which implement Validable will be validated

--- a/controller/command/generic_cmds.go
+++ b/controller/command/generic_cmds.go
@@ -149,6 +149,7 @@ var _ CriticalCommand = (*SyncSnapshotCommand)(nil)
 type SyncSnapshotCommand struct {
 	TimelineId   string
 	Snapshot     []byte
+	ClusterId    string
 	SnapshotSink func(cmd *SyncSnapshotCommand, index uint64) error
 }
 
@@ -164,6 +165,7 @@ func (self *SyncSnapshotCommand) Encode() ([]byte, error) {
 	return cmd_pb.EncodeProtobuf(&cmd_pb.SyncSnapshotCommand{
 		SnapshotId: self.TimelineId,
 		Snapshot:   self.Snapshot,
+		ClusterId:  self.ClusterId,
 	})
 }
 

--- a/controller/command/generic_cmds.go
+++ b/controller/command/generic_cmds.go
@@ -1,11 +1,11 @@
 package command
 
 import (
-	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/openziti/ziti/v2/common/pb/cmd_pb"
 	"github.com/openziti/ziti/v2/controller/change"
 	"github.com/openziti/ziti/v2/controller/fields"
 	"github.com/openziti/ziti/v2/controller/models"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/pkg/errors"
 )
 
@@ -144,6 +144,8 @@ func (self *DeleteEntityCommand) GetChangeContext() *change.Context {
 	return self.Context
 }
 
+var _ CriticalCommand = (*SyncSnapshotCommand)(nil)
+
 type SyncSnapshotCommand struct {
 	TimelineId   string
 	Snapshot     []byte
@@ -154,6 +156,9 @@ func (self *SyncSnapshotCommand) Apply(ctx boltz.MutateContext) error {
 	changeCtx := change.FromContext(ctx.Context())
 	return self.SnapshotSink(self, changeCtx.RaftIndex)
 }
+
+// IsCriticalCommand marks SyncSnapshotCommand as base state: a failed apply halts rather than advances.
+func (self *SyncSnapshotCommand) IsCriticalCommand() {}
 
 func (self *SyncSnapshotCommand) Encode() ([]byte, error) {
 	return cmd_pb.EncodeProtobuf(&cmd_pb.SyncSnapshotCommand{

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -69,6 +69,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/teris-io/shortid"
+	"go.etcd.io/bbolt"
 )
 
 type Controller struct {
@@ -842,6 +843,32 @@ func (c *Controller) InitializeRaftFromBoltDb(sourceDbPath string) error {
 	return c.RaftRestoreFromBoltDb(sourceDbPath)
 }
 
+// validateMigrationSourceDb rejects a migration source that is not an initialized controller db.
+// db.Open creates the root bucket on any file, so existence is not enough; it checks for a default
+// admin identity, which an initialized controller always has. The check is read-only.
+func validateMigrationSourceDb(sourceDb boltz.Db) error {
+	hasDefaultAdmin := false
+	err := sourceDb.View(func(tx *bbolt.Tx) error {
+		identities := boltz.Path(tx, db.RootBucket, db.EntityTypeIdentities)
+		if identities == nil {
+			return nil
+		}
+		return identities.ForEachTypedBucket(func(_ string, identity *boltz.TypedBucket) error {
+			if identity.GetBoolWithDefault(db.FieldIdentityIsDefaultAdmin, false) {
+				hasDefaultAdmin = true
+			}
+			return nil
+		})
+	})
+	if err != nil {
+		return errors.Wrap(err, "unable to read identities from source db")
+	}
+	if !hasDefaultAdmin {
+		return errors.New("source db has no default admin identity; it is empty or was never a fully initialized controller")
+	}
+	return nil
+}
+
 func (c *Controller) RaftRestoreFromBoltDb(sourceDbPath string) error {
 	log := pfxlog.Logger()
 
@@ -865,6 +892,10 @@ func (c *Controller) RaftRestoreFromBoltDb(sourceDbPath string) error {
 			log.WithError(err).Error("error closing migration source bolt db")
 		}
 	}()
+
+	if err = validateMigrationSourceDb(sourceDb); err != nil {
+		return errors.Wrapf(err, "migration source db [%v] is not a valid initialized controller database", sourceDbPath)
+	}
 
 	timelineId, err := sourceDb.GetTimelineId(boltz.TimelineModeForceReset, shortid.Generate)
 	if err != nil {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -313,8 +313,15 @@ func NewController(cfg *config.Config, versionProvider versions.VersionProvider)
 
 	c.initWeb() // need to init web before bootstrapping, so we can provide our endpoints to peers
 
-	if c.raftController != nil && !c.raftController.IsBootstrapped() {
-		if err = c.TryInitializeRaftFromBoltDb(); err != nil {
+	if c.raftController != nil {
+		_, dbConfigured := c.config.Src["db"]
+		if c.raftController.IsBootstrapped() {
+			// On a clustered config 'db' only seeds a new cluster on first bootstrap; once
+			// initialized it is dead config, so warn rather than let a stale setting sit unnoticed.
+			if dbConfigured {
+				log.Warn("'db' is set but this clustered controller is already initialized; the 'db' setting is ignored and should be removed from the configuration")
+			}
+		} else if err = c.TryInitializeRaftFromBoltDb(); err != nil {
 			log.WithError(err).Panic("error bootstrapping raft")
 		}
 	}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -933,6 +933,13 @@ func (c *Controller) RaftRestoreFromBoltDb(sourceDbPath string) error {
 		return fmt.Errorf("unable to bootstrap cluster (%w)", err)
 	}
 
+	// Carry the cluster id Bootstrap established so RestoreSnapshot can write it back after the
+	// restore (the migration source has none). Blank here means a bug in Bootstrap, so fail.
+	cmd.ClusterId = c.raftController.GetClusterId()
+	if cmd.ClusterId == "" {
+		return errors.New("cluster id is blank after bootstrap; refusing to restore without a durable cluster id")
+	}
+
 	return c.raftController.Dispatch(cmd)
 }
 

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -1,0 +1,66 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package controller
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/openziti/ziti/v2/controller/db"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateMigrationSourceDb(t *testing.T) {
+	t.Run("rejects a db with no identities", func(t *testing.T) {
+		// db.Open creates the root bucket but no identities, mimicking an empty or stray file.
+		sourceDb, err := db.Open(filepath.Join(t.TempDir(), "empty.db"))
+		require.NoError(t, err)
+		defer func() { _ = sourceDb.Close() }()
+
+		require.Error(t, validateMigrationSourceDb(sourceDb))
+	})
+
+	t.Run("rejects a db whose identities include no default admin", func(t *testing.T) {
+		sourceDb, err := db.Open(filepath.Join(t.TempDir(), "no-admin.db"))
+		require.NoError(t, err)
+		defer func() { _ = sourceDb.Close() }()
+
+		require.NoError(t, addIdentity(sourceDb, "regular-identity", false))
+		require.Error(t, validateMigrationSourceDb(sourceDb))
+	})
+
+	t.Run("accepts a db that has a default admin identity", func(t *testing.T) {
+		sourceDb, err := db.Open(filepath.Join(t.TempDir(), "populated.db"))
+		require.NoError(t, err)
+		defer func() { _ = sourceDb.Close() }()
+
+		require.NoError(t, addIdentity(sourceDb, "regular-identity", false))
+		require.NoError(t, addIdentity(sourceDb, "admin-identity", true))
+		require.NoError(t, validateMigrationSourceDb(sourceDb))
+	})
+}
+
+// addIdentity writes an identity bucket with the isDefaultAdmin field set, using boltz so the
+// stored value is read back the same way the controller reads it.
+func addIdentity(sourceDb boltz.Db, id string, isDefaultAdmin bool) error {
+	return sourceDb.Update(nil, func(ctx boltz.MutateContext) error {
+		idBucket := boltz.GetOrCreatePath(ctx.Tx(), db.RootBucket, db.EntityTypeIdentities, id)
+		idBucket.SetBool(db.FieldIdentityIsDefaultAdmin, isDefaultAdmin, nil)
+		return idBucket.GetError()
+	})
+}

--- a/controller/db/db.go
+++ b/controller/db/db.go
@@ -17,8 +17,7 @@
 package db
 
 import (
-	"fmt"
-
+	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"go.etcd.io/bbolt"
 )
@@ -74,20 +73,29 @@ func LoadClusterId(db boltz.Db) (string, error) {
 	return result, err
 }
 
-func InitClusterId(db boltz.Db, ctx boltz.MutateContext, clusterId string) error {
-	return db.Update(ctx, func(ctx boltz.MutateContext) error {
+// InitClusterId sets the cluster id if unset and returns the effective id (an existing id wins). It
+// is set-once: a differing id is kept with a warning rather than an error, so redundant or racing
+// writes (e.g. backfill across leadership changes) cannot fail.
+func InitClusterId(db boltz.Db, ctx boltz.MutateContext, clusterId string) (string, error) {
+	effective := clusterId
+	err := db.Update(ctx, func(ctx boltz.MutateContext) error {
 		raftBucket := boltz.GetOrCreatePath(ctx.Tx(), RootBucket, MetadataBucket)
 		if raftBucket.HasError() {
 			return raftBucket.Err
 		}
 		currentId := raftBucket.GetStringWithDefault(FieldClusterId, "")
 		if currentId != "" {
-			if currentId == clusterId {
-				return nil
+			effective = currentId
+			if currentId != clusterId {
+				pfxlog.Logger().
+					WithField("existingClusterId", currentId).
+					WithField("ignoredClusterId", clusterId).
+					Warn("cluster id already set; keeping existing value and ignoring the new one")
 			}
-			return fmt.Errorf("cluster id already initialized to %s", currentId)
+			return nil
 		}
 		raftBucket.SetString(FieldClusterId, clusterId, nil)
 		return raftBucket.Err
 	})
+	return effective, err
 }

--- a/controller/network/network.go
+++ b/controller/network/network.go
@@ -1360,11 +1360,13 @@ func (network *Network) RestoreSnapshot(cmd *command.SyncSnapshotCommand, index 
 	}
 	if currentTimelineId != "" && currentTimelineId == cmd.TimelineId {
 		log.WithField("timelineId", cmd.TimelineId).Info("snapshot already current, skipping reload")
+		// The DB is already the restored snapshot, but a prior apply may have halted after the
+		// restore and before the raft index was recorded. Ensure the index is persisted so the node
+		// does not stay caught up in raft with a stale stored index.
+		if err = network.ensureRaftIndex(index); err != nil {
+			return fmt.Errorf("failed to set raft index for already-current snapshot (%w)", err)
+		}
 		return nil
-	}
-
-	if err != nil {
-		log.WithError(err).Error("unable to read current raft index before DB restore")
 	}
 
 	buf := bytes.NewBuffer(cmd.Snapshot)
@@ -1374,14 +1376,11 @@ func (network *Network) RestoreSnapshot(cmd *command.SyncSnapshotCommand, index 
 	}
 
 	network.GetDb().RestoreFromReader(reader)
-	err = network.GetDb().Update(nil, func(ctx boltz.MutateContext) error {
-		raftBucket := boltz.GetOrCreatePath(ctx.Tx(), db.RootBucket, db.MetadataBucket)
-		raftBucket.SetInt64(db.FieldRaftIndex, int64(index), nil)
-		return nil
-	})
-
-	if err != nil {
-		log.WithError(err).Errorf("failed to set index after restore")
+	if err = network.ensureRaftIndex(index); err != nil {
+		// The database was restored but its raft index was not recorded. Return the error so the
+		// command apply fails loudly (SyncSnapshotCommand is a critical command) rather than the
+		// restore being treated as successful with an unrecorded index.
+		return fmt.Errorf("failed to set raft index after db restore (%w)", err)
 	}
 
 	time.AfterFunc(5*time.Second, func() {
@@ -1390,6 +1389,19 @@ func (network *Network) RestoreSnapshot(cmd *command.SyncSnapshotCommand, index 
 	})
 
 	return nil
+}
+
+// ensureRaftIndex records the raft index if the stored one is behind it, returning an error on
+// failure so a missed index update surfaces rather than being treated as success.
+func (network *Network) ensureRaftIndex(index uint64) error {
+	return network.GetDb().Update(nil, func(ctx boltz.MutateContext) error {
+		if db.LoadCurrentRaftIndex(ctx.Tx()) >= index {
+			return nil
+		}
+		raftBucket := boltz.GetOrCreatePath(ctx.Tx(), db.RootBucket, db.MetadataBucket)
+		raftBucket.SetInt64(db.FieldRaftIndex, int64(index), nil)
+		return raftBucket.GetError()
+	})
 }
 
 func (network *Network) AddInspectTarget(target InspectTarget) {

--- a/controller/network/network.go
+++ b/controller/network/network.go
@@ -190,6 +190,7 @@ func (self *Network) decodeSyncSnapshotCommand(_ int32, data []byte) (command.Co
 	cmd := &command.SyncSnapshotCommand{
 		TimelineId:   msg.SnapshotId,
 		Snapshot:     msg.Snapshot,
+		ClusterId:    msg.ClusterId,
 		SnapshotSink: self.RestoreSnapshot,
 	}
 
@@ -1360,9 +1361,10 @@ func (network *Network) RestoreSnapshot(cmd *command.SyncSnapshotCommand, index 
 	}
 	if currentTimelineId != "" && currentTimelineId == cmd.TimelineId {
 		log.WithField("timelineId", cmd.TimelineId).Info("snapshot already current, skipping reload")
-		// The DB is already the restored snapshot, but a prior apply may have halted after the
-		// restore and before the raft index was recorded. Ensure the index is persisted so the node
-		// does not stay caught up in raft with a stale stored index.
+		// DB already restored; ensure cluster id then raft index (index last, see main path).
+		if err = network.ensureClusterId(cmd.ClusterId); err != nil {
+			return fmt.Errorf("failed to set cluster id for already-current snapshot (%w)", err)
+		}
 		if err = network.ensureRaftIndex(index); err != nil {
 			return fmt.Errorf("failed to set raft index for already-current snapshot (%w)", err)
 		}
@@ -1376,10 +1378,14 @@ func (network *Network) RestoreSnapshot(cmd *command.SyncSnapshotCommand, index 
 	}
 
 	network.GetDb().RestoreFromReader(reader)
+
+	// Write the cluster id before the raft index. The index is the completion gate on restart (the
+	// FSM skips entries at or below the stored index), so persist it last: any earlier failure then
+	// replays and retries instead of skipping the command with a blank cluster id.
+	if err = network.ensureClusterId(cmd.ClusterId); err != nil {
+		return fmt.Errorf("failed to set cluster id after db restore (%w)", err)
+	}
 	if err = network.ensureRaftIndex(index); err != nil {
-		// The database was restored but its raft index was not recorded. Return the error so the
-		// command apply fails loudly (SyncSnapshotCommand is a critical command) rather than the
-		// restore being treated as successful with an unrecorded index.
 		return fmt.Errorf("failed to set raft index after db restore (%w)", err)
 	}
 
@@ -1389,6 +1395,15 @@ func (network *Network) RestoreSnapshot(cmd *command.SyncSnapshotCommand, index 
 	})
 
 	return nil
+}
+
+// ensureClusterId writes the cluster id if one is not already set (no-op when empty or matching).
+// The snapshot restore replaces the whole db, which carries no cluster id, so it must be set here.
+func (network *Network) ensureClusterId(clusterId string) error {
+	if clusterId == "" {
+		return nil
+	}
+	return db.InitClusterId(network.GetDb(), nil, clusterId)
 }
 
 // ensureRaftIndex records the raft index if the stored one is behind it, returning an error on

--- a/controller/network/network.go
+++ b/controller/network/network.go
@@ -1403,7 +1403,8 @@ func (network *Network) ensureClusterId(clusterId string) error {
 	if clusterId == "" {
 		return nil
 	}
-	return db.InitClusterId(network.GetDb(), nil, clusterId)
+	_, err := db.InitClusterId(network.GetDb(), nil, clusterId)
+	return err
 }
 
 // ensureRaftIndex records the raft index if the stored one is behind it, returning an error on

--- a/controller/raft/fsm.go
+++ b/controller/raft/fsm.go
@@ -30,11 +30,11 @@ import (
 
 	"github.com/hashicorp/raft"
 	"github.com/michaelquigley/pfxlog"
-	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/openziti/ziti/v2/controller/change"
 	"github.com/openziti/ziti/v2/controller/command"
 	"github.com/openziti/ziti/v2/controller/db"
 	"github.com/openziti/ziti/v2/controller/event"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/sirupsen/logrus"
 	"go.etcd.io/bbolt"
 	bbolterrors "go.etcd.io/bbolt/errors"
@@ -333,7 +333,8 @@ func (self *BoltDbFsm) Apply(log *raft.Log) interface{} {
 				return err
 			}
 
-			logger.Infof("apply log with type %T", cmd)
+			logger = logger.WithField("cmdType", fmt.Sprintf("%T", cmd))
+			logger.Info("applying log")
 			changeCtx := cmd.GetChangeContext()
 			if changeCtx == nil {
 				changeCtx = change.New().SetSourceType("unattributed").SetChangeAuthorType(change.AuthorTypeUnattributed)
@@ -346,8 +347,13 @@ func (self *BoltDbFsm) Apply(log *raft.Log) interface{} {
 			})
 
 			if err = cmd.Apply(ctx); err != nil {
+				if _, critical := cmd.(command.CriticalCommand); critical {
+					// Base-state command failed; halt instead of advancing over incomplete state. The
+					// in-tx index update rolled back with the apply, so raft replays it on restart.
+					logger.WithError(err).Fatal("failed to apply critical base-state command; halting rather than advancing over incomplete state")
+				}
 				logger.WithError(err).Error("applying log resulted in error")
-				// if this errored, assume that we haven't updated the index in the db
+				// apply rolled back the in-tx index update; persist it here since raft advances regardless
 				self.updateIndex(log.Index)
 			}
 

--- a/controller/raft/mesh/mesh.go
+++ b/controller/raft/mesh/mesh.go
@@ -69,11 +69,12 @@ type Peer struct {
 	Id              raft.ServerID
 	Address         string
 	Channel         channel.Channel
-	RaftConns       concurrenz.CopyOnWriteMap[uint32, *raftPeerConn]
+	ClusterId       string
 	Version         *versions.VersionInfo
 	SigningCerts    []*x509.Certificate
 	ApiAddresses    map[string][]event.ApiAddress
 	PreferredLeader bool
+	RaftConns       concurrenz.CopyOnWriteMap[uint32, *raftPeerConn]
 	raftPeerIdGen   uint32
 }
 
@@ -331,6 +332,10 @@ type Mesh interface {
 
 	RegisterClusterStateHandler(f func(state ClusterState))
 	Init(bindHandler channel.BindHandler)
+
+	// RevalidatePeerClusterIds drops connected peers whose cluster id no longer matches the local
+	// cluster id. It is called when the local node acquires or changes its cluster id.
+	RevalidatePeerClusterIds()
 
 	// GetNodeId returns the local node's SPIFFE ID used for deterministic tie-breaking.
 	GetNodeId() string
@@ -605,6 +610,7 @@ func (self *impl) DialPeer(address string, timeout time.Duration, stripSigningCe
 		if err = self.validateConnection(peer.Channel); err != nil {
 			return err
 		}
+		peer.ClusterId = getPeerClusterId(peer.Channel)
 
 		underlay := binding.GetChannel().Underlay()
 		id, err := self.extractPeerId(underlay.GetRemoteAddr().String(), underlay.Certificates())
@@ -663,12 +669,53 @@ func (self *impl) validateConnection(ch channel.Channel) error {
 }
 
 func (self *impl) checkClusterIds(ch channel.Channel) error {
-	clusterIdBytes, _ := headerWithFallback(ch.Underlay().Headers(), ClusterIdHeader, LegacyClusterIdHeader)
-	clusterId := string(clusterIdBytes)
+	clusterId := getPeerClusterId(ch)
 	if clusterId != "" && self.env.GetClusterId() != "" && clusterId != self.env.GetClusterId() {
 		return fmt.Errorf("local cluster id %s doesn't match peer cluster id %s", self.env.GetClusterId(), clusterId)
 	}
 	return nil
+}
+
+// getPeerClusterId returns the cluster id the peer advertised, or "" if none (a blank node not yet
+// joined or bootstrapped).
+func getPeerClusterId(ch channel.Channel) string {
+	clusterIdBytes, _ := headerWithFallback(ch.Underlay().Headers(), ClusterIdHeader, LegacyClusterIdHeader)
+	return string(clusterIdBytes)
+}
+
+// RevalidatePeerClusterIds drops connected peers whose known cluster id differs from the local one.
+// The bind-time check runs once and skips empty ids, so a node that connected while blank and later
+// acquired a different id would otherwise stay cross-connected. Called when the local id is set.
+func (self *impl) RevalidatePeerClusterIds() {
+	localId := self.env.GetClusterId()
+	for _, peer := range peersWithMismatchedClusterId(localId, self.GetPeers()) {
+		pfxlog.Logger().
+			WithField("peerId", string(peer.Id)).
+			WithField("peerAddress", peer.Address).
+			WithField("peerClusterId", peer.ClusterId).
+			WithField("localClusterId", localId).
+			Error("dropping peer connection with mismatched cluster id")
+		if err := peer.Channel.Close(); err != nil {
+			pfxlog.Logger().WithError(err).
+				WithField("peerId", string(peer.Id)).
+				Error("error closing peer channel with mismatched cluster id")
+		}
+	}
+}
+
+// peersWithMismatchedClusterId returns peers whose known cluster id differs from localId. Peers with
+// an empty id (legitimate blank joiners) are never returned, nor is anything when localId is empty.
+func peersWithMismatchedClusterId(localId string, peers map[string]*Peer) []*Peer {
+	if localId == "" {
+		return nil
+	}
+	var mismatched []*Peer
+	for _, peer := range peers {
+		if peer.ClusterId != "" && peer.ClusterId != localId {
+			mismatched = append(mismatched, peer)
+		}
+	}
+	return mismatched
 }
 
 func (self *impl) checkCerts(ch channel.Channel) error {
@@ -819,6 +866,12 @@ func (self *impl) PeerConnected(peer *Peer, dial bool) error {
 		WithField("peerAddr", peer.Address)
 
 	self.lock.Lock()
+	// Re-check the cluster id under the lock: the bind-time check can race a local-id change that
+	// lands before the peer is registered, which RevalidatePeerClusterIds would then miss.
+	if localId := self.env.GetClusterId(); localId != "" && peer.ClusterId != "" && peer.ClusterId != localId {
+		self.lock.Unlock()
+		return fmt.Errorf("peer %v cluster id %s does not match local cluster id %s", peer.Id, peer.ClusterId, localId)
+	}
 	if existing := self.Peers[peer.Address]; existing != nil {
 		// Deterministic tie-breaking: the node with the lexicographically lower
 		// SPIFFE ID is the "preferred dialer" whose connection wins.
@@ -1069,6 +1122,7 @@ func (self *impl) AcceptUnderlay(underlay channel.Underlay) error {
 		if err = self.validateConnection(peer.Channel); err != nil {
 			return err
 		}
+		peer.ClusterId = getPeerClusterId(peer.Channel)
 
 		peer.Version = versionInfo
 		if certHeader, found := headerWithFallback(ch.Underlay().Headers(), SigningCertHeader, LegacySigningCertHeader); found {

--- a/controller/raft/mesh/mesh_test.go
+++ b/controller/raft/mesh/mesh_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/raft"
+	"github.com/openziti/channel/v5"
 	"github.com/openziti/foundation/v2/versions"
 	"github.com/openziti/ziti/v2/controller/event"
 
@@ -57,6 +58,7 @@ func Test_AddPeer_PassesReadonlyWhenVersionsMatch(t *testing.T) {
 		Peers:           map[string]*Peer{},
 		version:         NewVersionProviderTest(),
 		eventDispatcher: event.DispatcherMock{},
+		env:             &clusterIdEnv{},
 	}
 
 	p := &Peer{Version: testVersion("1")}
@@ -70,6 +72,7 @@ func Test_AddPeer_TurnsReadonlyWhenVersionsDoNotMatch(t *testing.T) {
 		Peers:           map[string]*Peer{},
 		version:         NewVersionProviderTest(),
 		eventDispatcher: event.DispatcherMock{},
+		env:             &clusterIdEnv{},
 	}
 
 	p := &Peer{Version: testVersion("dne")}
@@ -191,6 +194,85 @@ func Test_GetOrConnectPeer_ReusesExistingConnection(t *testing.T) {
 
 func testVersion(v string) *versions.VersionInfo {
 	return &versions.VersionInfo{Version: v}
+}
+
+func Test_peersWithMismatchedClusterId(t *testing.T) {
+	t.Run("returns nothing when local cluster id is empty", func(t *testing.T) {
+		peers := map[string]*Peer{
+			"a": {Id: "a", ClusterId: "cluster-1"},
+		}
+		assert.Empty(t, peersWithMismatchedClusterId("", peers))
+	})
+
+	t.Run("returns nothing when all peers match", func(t *testing.T) {
+		peers := map[string]*Peer{
+			"a": {Id: "a", ClusterId: "cluster-1"},
+			"b": {Id: "b", ClusterId: "cluster-1"},
+		}
+		assert.Empty(t, peersWithMismatchedClusterId("cluster-1", peers))
+	})
+
+	t.Run("ignores a peer with an empty cluster id", func(t *testing.T) {
+		// A blank peer is a legitimate joiner that has not yet adopted a cluster id.
+		peers := map[string]*Peer{
+			"a": {Id: "a", ClusterId: ""},
+		}
+		assert.Empty(t, peersWithMismatchedClusterId("cluster-1", peers))
+	})
+
+	t.Run("returns only the peers whose cluster id differs", func(t *testing.T) {
+		mismatch := &Peer{Id: "mismatch", ClusterId: "cluster-2"}
+		peers := map[string]*Peer{
+			"match":    {Id: "match", ClusterId: "cluster-1"},
+			"blank":    {Id: "blank", ClusterId: ""},
+			"mismatch": mismatch,
+		}
+		assert.Equal(t, []*Peer{mismatch}, peersWithMismatchedClusterId("cluster-1", peers))
+	})
+}
+
+// closeRecordingChannel is a channel.Channel that records whether Close was called. Only Close is
+// exercised by RevalidatePeerClusterIds; the embedded nil interface satisfies the rest.
+type closeRecordingChannel struct {
+	channel.Channel
+	closed bool
+}
+
+func (self *closeRecordingChannel) Close() error {
+	self.closed = true
+	return nil
+}
+
+// clusterIdEnv is a mesh Env that reports a fixed cluster id. Only GetClusterId is exercised by
+// RevalidatePeerClusterIds; the embedded nil interface satisfies the rest.
+type clusterIdEnv struct {
+	Env
+	clusterId string
+}
+
+func (self *clusterIdEnv) GetClusterId() string {
+	return self.clusterId
+}
+
+func Test_RevalidatePeerClusterIds_ClosesOnlyMismatchedPeers(t *testing.T) {
+	matchCh := &closeRecordingChannel{}
+	blankCh := &closeRecordingChannel{}
+	mismatchCh := &closeRecordingChannel{}
+
+	m := &impl{
+		env: &clusterIdEnv{clusterId: "cluster-1"},
+		Peers: map[string]*Peer{
+			"match":    {Id: "match", ClusterId: "cluster-1", Channel: matchCh},
+			"blank":    {Id: "blank", ClusterId: "", Channel: blankCh},
+			"mismatch": {Id: "mismatch", ClusterId: "cluster-2", Channel: mismatchCh},
+		},
+	}
+
+	m.RevalidatePeerClusterIds()
+
+	assert.False(t, matchCh.closed, "peer with matching cluster id should not be closed")
+	assert.False(t, blankCh.closed, "peer with an empty cluster id should not be closed")
+	assert.True(t, mismatchCh.closed, "peer with a mismatched cluster id should be closed")
 }
 
 type VersionProviderTest struct {

--- a/controller/raft/raft.go
+++ b/controller/raft/raft.go
@@ -916,6 +916,17 @@ func (self *Controller) Bootstrap() error {
 		logrus.Info("raft already bootstrapped")
 		self.bootstrapped.Store(true)
 	} else {
+		// Already connected to peers means this node belongs to an existing cluster; founding a new
+		// one here would fork a divergent cluster.
+		if peers := self.Mesh.GetPeers(); len(peers) > 0 {
+			addrs := make([]string, 0, len(peers))
+			for addr := range peers {
+				addrs = append(addrs, addr)
+			}
+			return fmt.Errorf("refusing to bootstrap a new cluster: node is already connected to %d cluster peer(s) %v; "+
+				"this node should join the existing cluster (e.g. 'ziti agent cluster add' from a current member), not initialize a new one", len(peers), addrs)
+		}
+
 		if err := self.migrationMgr.ValidateMigrationEnvironment(); err != nil {
 			return err
 		}
@@ -1117,6 +1128,12 @@ type InitClusterIdCmd struct {
 
 func (self *InitClusterIdCmd) Apply(ctx boltz.MutateContext) error {
 	self.raftController.clusterId.Store(self.ClusterId)
+	if mesh := self.raftController.Mesh; mesh != nil {
+		// The local cluster id just changed; drop any peer that connected while this node was blank
+		// (accepted via the empty-id bypass) and now belongs to a different cluster. Done off the
+		// apply path so channel teardown does not stall raft.
+		go mesh.RevalidatePeerClusterIds()
+	}
 	_, err := self.raftController.Fsm.GetDb().GetTimelineId(boltz.TimelineModeForceReset, func() (string, error) {
 		return self.TimelineId, nil
 	})

--- a/controller/raft/raft.go
+++ b/controller/raft/raft.go
@@ -41,7 +41,6 @@ import (
 	"github.com/openziti/foundation/v2/versions"
 	"github.com/openziti/identity"
 	"github.com/openziti/metrics"
-	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/openziti/ziti/v2/common/pb/cmd_pb"
 	"github.com/openziti/ziti/v2/common/pb/ctrl_pb"
 	"github.com/openziti/ziti/v2/controller/apierror"
@@ -53,6 +52,7 @@ import (
 	"github.com/openziti/ziti/v2/controller/model"
 	"github.com/openziti/ziti/v2/controller/peermsg"
 	"github.com/openziti/ziti/v2/controller/raft/mesh"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/sirupsen/logrus"
 	"github.com/teris-io/shortid"
 )
@@ -220,12 +220,8 @@ func (self *Controller) RegisterClusterEventHandler(f func(event ClusterEvent, s
 }
 
 func (self *Controller) InitEnv(env model.Env) error {
+	// The cluster id is loaded earlier, in Init, so it is set before raft and the mesh start.
 	model.RegisterCommand(env, &InitClusterIdCmd{}, &cmd_pb.InitClusterIdCommand{})
-	clusterId, err := db.LoadClusterId(env.GetDb())
-	if err != nil {
-		return err
-	}
-	self.clusterId.Store(clusterId)
 	return nil
 }
 
@@ -649,6 +645,14 @@ func (self *Controller) Init() error {
 	if err = self.Fsm.Init(); err != nil {
 		return fmt.Errorf("failed to init FSM (%w)", err)
 	}
+
+	// Load the cluster id before raft (and the mesh) start, so this node never presents an empty id
+	// that the mesh empty-id bypass would let pair with a different cluster.
+	clusterId, err := db.LoadClusterId(self.Fsm.GetDb())
+	if err != nil {
+		return fmt.Errorf("failed to load cluster id (%w)", err)
+	}
+	self.clusterId.Store(clusterId)
 
 	raftTransport := raft.NewNetworkTransportWithLogger(self.Mesh, 3, 10*time.Second, raftConfig.Logger)
 

--- a/controller/raft/raft.go
+++ b/controller/raft/raft.go
@@ -1120,20 +1120,19 @@ type MigrationManager interface {
 	InitializeRaftFromBoltDb(srcDb string) error
 }
 
+var _ command.CriticalCommand = (*InitClusterIdCmd)(nil)
+
 type InitClusterIdCmd struct {
 	ClusterId      string `json:"clusterId"`
 	TimelineId     string `json:"timelineId"`
 	raftController *Controller
 }
 
+// IsCriticalCommand marks InitClusterIdCmd as base state: it establishes the cluster id, which is
+// not otherwise replayed, so a failed apply must halt rather than advance. Its writes are idempotent.
+func (self *InitClusterIdCmd) IsCriticalCommand() {}
+
 func (self *InitClusterIdCmd) Apply(ctx boltz.MutateContext) error {
-	self.raftController.clusterId.Store(self.ClusterId)
-	if mesh := self.raftController.Mesh; mesh != nil {
-		// The local cluster id just changed; drop any peer that connected while this node was blank
-		// (accepted via the empty-id bypass) and now belongs to a different cluster. Done off the
-		// apply path so channel teardown does not stall raft.
-		go mesh.RevalidatePeerClusterIds()
-	}
 	_, err := self.raftController.Fsm.GetDb().GetTimelineId(boltz.TimelineModeForceReset, func() (string, error) {
 		return self.TimelineId, nil
 	})
@@ -1144,7 +1143,22 @@ func (self *InitClusterIdCmd) Apply(ctx boltz.MutateContext) error {
 	if self.raftController.env.TimelineId() != self.TimelineId {
 		self.raftController.env.InitTimelineId(self.TimelineId)
 	}
-	return db.InitClusterId(self.raftController.Fsm.GetDb(), ctx, self.ClusterId)
+
+	// Persist the cluster id before publishing it in memory. db.InitClusterId commits within this
+	// call, so once it returns successfully the id is durable.
+	if err = db.InitClusterId(self.raftController.Fsm.GetDb(), ctx, self.ClusterId); err != nil {
+		return err
+	}
+
+	// Only after the id is persisted, publish it in memory and revalidate peers, so memory, peer
+	// state, and on-disk state cannot diverge if the write fails. Revalidation drops any peer that
+	// connected while this node was blank (accepted via the empty-id bypass) and now belongs to a
+	// different cluster; it runs off the apply path so channel teardown does not stall raft.
+	self.raftController.clusterId.Store(self.ClusterId)
+	if mesh := self.raftController.Mesh; mesh != nil {
+		go mesh.RevalidatePeerClusterIds()
+	}
+	return nil
 }
 
 func (self *InitClusterIdCmd) Encode() ([]byte, error) {

--- a/controller/raft/raft.go
+++ b/controller/raft/raft.go
@@ -156,6 +156,7 @@ type Controller struct {
 	indexTracker               IndexTracker
 	migrationMgr               MigrationManager
 	clusterStateChangeHandlers concurrenz.CopyOnWriteSlice[func(event ClusterEvent, state ClusterState, leaderId string)]
+	clusterStateChangeLock     sync.Mutex
 	isLeader                   atomic.Bool
 	clusterEvents              chan raft.Observation
 	raftRateLimiter            rate.AdaptiveRateLimitTracker
@@ -213,6 +214,10 @@ func (self *Controller) initErrorMappers() {
 }
 
 func (self *Controller) RegisterClusterEventHandler(f func(event ClusterEvent, state ClusterState, leaderId string)) {
+	// Hold the lock across the leader check and append so a leadership transition cannot slip
+	// between them, which would leave the handler seeing neither the immediate call nor the event.
+	self.clusterStateChangeLock.Lock()
+	defer self.clusterStateChangeLock.Unlock()
 	if self.isLeader.Load() {
 		f(ClusterEventLeadershipGained, newClusterState(true, !self.Mesh.IsReadOnly()), self.env.GetId().Token)
 	}
@@ -682,6 +687,7 @@ func (self *Controller) StartEventGeneration() {
 	self.addEventsHandlers()
 	go self.eventLoop()
 	self.setupPreferredLeaderTransfer()
+	self.setupClusterIdBackfill()
 	self.Mesh.StartPeerDialer(&self.Config.PeerDialer)
 }
 
@@ -779,6 +785,38 @@ func (self *Controller) transferToPreferredLeader() {
 	log.Warn("no preferred leader peers are connected, retaining leadership")
 }
 
+// setupClusterIdBackfill backfills a cluster id on leadership when the cluster has none, letting a
+// cluster migrated on an older build (which came up with no cluster id) self-heal. If a cluster
+// hasn't been bootstrapped yet, this isn't needed
+func (self *Controller) setupClusterIdBackfill() {
+	if self.Raft.LastIndex() == 0 {
+		return
+	}
+	self.RegisterClusterEventHandler(func(evt ClusterEvent, state ClusterState, leaderId string) {
+		if evt == ClusterEventLeadershipGained {
+			go self.backfillClusterId()
+		}
+	})
+}
+
+// backfillClusterId sets a cluster id if this leader finds none; a no-op otherwise, so it is safe to
+// run on every leadership change. The current timeline id is passed through unchanged.
+func (self *Controller) backfillClusterId() {
+	if !self.IsLeader() || self.GetClusterId() != "" {
+		return
+	}
+	clusterId := uuid.NewString()
+	log := pfxlog.Logger().WithField("clusterId", clusterId)
+	log.Info("cluster has no cluster id; backfilling one on leadership acquisition")
+	if err := self.Dispatch(&InitClusterIdCmd{
+		ClusterId:      clusterId,
+		TimelineId:     self.env.TimelineId(),
+		raftController: self,
+	}); err != nil {
+		log.WithError(err).Error("failed to backfill cluster id")
+	}
+}
+
 func (self *Controller) Configure(ctrlConfig *config.RaftConfig, conf *raft.Config) {
 	conf.SnapshotThreshold = uint64(ctrlConfig.SnapshotThreshold)
 	conf.SnapshotInterval = ctrlConfig.SnapshotInterval
@@ -867,6 +905,9 @@ func (self *Controller) processRaftObservation(observation raft.Observation, eve
 	pfxlog.Logger().Tracef("raft observation received: isLeader: %v, isReadWrite: %v", self.isLeader.Load(), eventState.isReadWrite)
 
 	if raftState, ok := observation.Data.(raft.RaftState); ok {
+		// Serialize the leadership swap and dispatch with RegisterClusterEventHandler so a handler
+		// registered during a transition is not missed by both the immediate call and the event.
+		self.clusterStateChangeLock.Lock()
 		if raftState == raft.Leader {
 			if wasLeader := self.isLeader.Swap(true); !wasLeader {
 				self.handleClusterStateChange(ClusterEventLeadershipGained, eventState)
@@ -874,6 +915,7 @@ func (self *Controller) processRaftObservation(observation raft.Observation, eve
 		} else if wasLeader := self.isLeader.Swap(false); wasLeader {
 			self.handleClusterStateChange(ClusterEventLeadershipLost, eventState)
 		}
+		self.clusterStateChangeLock.Unlock()
 	}
 
 	if state, ok := observation.Data.(mesh.ClusterState); ok {
@@ -1144,17 +1186,16 @@ func (self *InitClusterIdCmd) Apply(ctx boltz.MutateContext) error {
 		self.raftController.env.InitTimelineId(self.TimelineId)
 	}
 
-	// Persist the cluster id before publishing it in memory. db.InitClusterId commits within this
-	// call, so once it returns successfully the id is durable.
-	if err = db.InitClusterId(self.raftController.Fsm.GetDb(), ctx, self.ClusterId); err != nil {
+	// Persist before publishing in memory. InitClusterId returns the effective id (an existing id
+	// wins), so a redundant command cannot diverge memory from disk.
+	effectiveClusterId, err := db.InitClusterId(self.raftController.Fsm.GetDb(), ctx, self.ClusterId)
+	if err != nil {
 		return err
 	}
 
-	// Only after the id is persisted, publish it in memory and revalidate peers, so memory, peer
-	// state, and on-disk state cannot diverge if the write fails. Revalidation drops any peer that
-	// connected while this node was blank (accepted via the empty-id bypass) and now belongs to a
-	// different cluster; it runs off the apply path so channel teardown does not stall raft.
-	self.raftController.clusterId.Store(self.ClusterId)
+	// Publish and revalidate only after persisting. Revalidation drops peers from a different
+	// cluster that connected while this node was blank; off the apply path so it does not stall raft.
+	self.raftController.clusterId.Store(effectiveClusterId)
 	if mesh := self.raftController.Mesh; mesh != nil {
 		go mesh.RevalidatePeerClusterIds()
 	}


### PR DESCRIPTION
## What

A set of defensive fixes for HA controller bootstrap, cluster initialization, legacy-db
migration, and mesh connection validation. Individually small and independent; together they
close the paths by which a controller could silently create an empty or divergent raft cluster
instead of joining an existing one, up to and including a split-brain of two independent clusters
sharing a trust domain and mesh.

- `edge init` refuses a clustered config instead of forking an empty single-node cluster.
- The cluster id is loaded before raft and the mesh start, so an initialized node never presents
  or validates an empty id.
- The legacy-db migration source is validated to contain data before it is restored.
- A `db:` setting on an already-initialized clustered controller warns that it is ignored.
- Mesh peers whose cluster id diverges after connecting are dropped, and a blank node already
  connected to peers refuses to self-bootstrap.
- A failed base-state (snapshot restore) command halts the node rather than advancing the raft
  index over incomplete data.

## Why

These are hardening measures against operator-error and edge-case paths (e.g. running an init
command against a node that should join) that could otherwise leave a cluster silently split,
with one node holding the data and others running as empty leaders while all appear connected.

For #4104. One item from that issue (shipping migrated base state via `raft.Raft.Restore` instead
of a replayed log command) is deferred as a larger, compatibility-sensitive change, so the issue
stays open.
