### PR TITLE
Copy retained bbolt values out of transaction memory

### DIFF
--- a/controller/db/eventual_event_store.go
+++ b/controller/db/eventual_event_store.go
@@ -67,7 +67,9 @@ func (store *eventualEventStoreImpl) NewEntity() *EventualEvent {
 func (store *eventualEventStoreImpl) FillEntity(entity *EventualEvent, bucket *boltz.TypedBucket) {
 	entity.LoadBaseValues(bucket)
 	entity.Type = bucket.GetStringOrError(FieldEventualEventType)
-	entity.Data = bucket.Get([]byte(FieldEventualEventData))
+	// bbolt values must be copied; the source memory doesn't outlive the transaction, and the data is
+	// passed to event handlers asynchronously after the read transaction has closed.
+	entity.Data = append([]byte(nil), bucket.Get([]byte(FieldEventualEventData))...)
 }
 
 func (store *eventualEventStoreImpl) PersistEntity(entity *EventualEvent, ctx *boltz.PersistContext) {

--- a/controller/db/terminator_store.go
+++ b/controller/db/terminator_store.go
@@ -167,7 +167,8 @@ func (store *terminatorStoreImpl) FillEntity(entity *Terminator, bucket *boltz.T
 	entity.Binding = bucket.GetStringOrError(FieldTerminatorBinding)
 	entity.Address = bucket.GetStringWithDefault(FieldTerminatorAddress, "")
 	entity.InstanceId = bucket.GetStringWithDefault(FieldTerminatorInstanceId, "")
-	entity.InstanceSecret = bucket.Get([]byte(FieldTerminatorInstanceSecret))
+	// bbolt values must be copied; the source memory doesn't outlive the transaction.
+	entity.InstanceSecret = append([]byte(nil), bucket.Get([]byte(FieldTerminatorInstanceSecret))...)
 	entity.Cost = uint16(bucket.GetInt32WithDefault(FieldTerminatorCost, 0))
 	entity.Precedence = bucket.GetStringWithDefault(FieldTerminatorPrecedence, xt.Precedences.Default.String())
 	entity.HostId = bucket.GetStringWithDefault(FieldTerminatorHostId, "")
@@ -179,7 +180,8 @@ func (store *terminatorStoreImpl) FillEntity(entity *Terminator, bucket *boltz.T
 		entity.PeerData = make(map[uint32][]byte)
 		iter := data.Cursor()
 		for k, v := iter.First(); k != nil; k, v = iter.Next() {
-			entity.PeerData[binary.LittleEndian.Uint32(k)] = v
+			// bbolt values must be copied; the source memory doesn't outlive the transaction.
+			entity.PeerData[binary.LittleEndian.Uint32(k)] = append([]byte(nil), v...)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #4108

The controller retained byte slices returned by bbolt past the transaction that produced them. bbolt values are only valid for the life of the transaction; once the tx closes the pages can be reused, and a database-file growth remaps the mmap to a new base address, leaving cached slices dangling.

Two sites retained raw bbolt memory:

- `terminatorStoreImpl.FillEntity`: `PeerData` entries and `InstanceSecret`. The terminator is cached and read on every circuit creation, so a later create-circuit response memmoves from a stale peer-data slice and can SIGSEGV. The window widens under terminator churn (e.g. a rolling upgrade). This is the observed crash.
- `eventualEventStoreImpl.FillEntity`: `Data`. Events are loaded in one `View` transaction and handed to listeners asynchronously after it closes, with the DB mutated in between, so the retained slice can dangle.

Both are fixed by copying the values out of the bolt-managed memory at load time.
