### PR TITLE
[Backport-1.6] Copy retained bbolt values out of transaction memory

### DIFF
--- a/controller/db/eventual_event_store.go
+++ b/controller/db/eventual_event_store.go
@@ -67,7 +67,9 @@ func (store *eventualEventStoreImpl) NewEntity() *EventualEvent {
 func (store *eventualEventStoreImpl) FillEntity(entity *EventualEvent, bucket *boltz.TypedBucket) {
 	entity.LoadBaseValues(bucket)
 	entity.Type = bucket.GetStringOrError(FieldEventualEventType)
-	entity.Data = bucket.Get([]byte(FieldEventualEventData))
+	// bbolt values must be copied; the source memory doesn't outlive the transaction, and the data is
+	// passed to event handlers asynchronously after the read transaction has closed.
+	entity.Data = append([]byte(nil), bucket.Get([]byte(FieldEventualEventData))...)
 }
 
 func (store *eventualEventStoreImpl) PersistEntity(entity *EventualEvent, ctx *boltz.PersistContext) {

--- a/controller/db/terminator_store.go
+++ b/controller/db/terminator_store.go
@@ -166,7 +166,8 @@ func (store *terminatorStoreImpl) FillEntity(entity *Terminator, bucket *boltz.T
 	entity.Binding = bucket.GetStringOrError(FieldTerminatorBinding)
 	entity.Address = bucket.GetStringWithDefault(FieldTerminatorAddress, "")
 	entity.InstanceId = bucket.GetStringWithDefault(FieldTerminatorInstanceId, "")
-	entity.InstanceSecret = bucket.Get([]byte(FieldTerminatorInstanceSecret))
+	// bbolt values must be copied; the source memory doesn't outlive the transaction.
+	entity.InstanceSecret = append([]byte(nil), bucket.Get([]byte(FieldTerminatorInstanceSecret))...)
 	entity.Cost = uint16(bucket.GetInt32WithDefault(FieldTerminatorCost, 0))
 	entity.Precedence = bucket.GetStringWithDefault(FieldTerminatorPrecedence, xt.Precedences.Default.String())
 	entity.HostId = bucket.GetStringWithDefault(FieldTerminatorHostId, "")
@@ -178,7 +179,8 @@ func (store *terminatorStoreImpl) FillEntity(entity *Terminator, bucket *boltz.T
 		entity.PeerData = make(map[uint32][]byte)
 		iter := data.Cursor()
 		for k, v := iter.First(); k != nil; k, v = iter.Next() {
-			entity.PeerData[binary.LittleEndian.Uint32(k)] = v
+			// bbolt values must be copied; the source memory doesn't outlive the transaction.
+			entity.PeerData[binary.LittleEndian.Uint32(k)] = append([]byte(nil), v...)
 		}
 	}
 }


### PR DESCRIPTION
Backport of #4108 to the release-v1.6.x line. Fixes #4111

Copies the values retained from bbolt out of the transaction's memory at load time, in both `terminatorStoreImpl.FillEntity` (peer data + instance secret) and `eventualEventStoreImpl.FillEntity` (event data). bbolt values are only valid within their transaction; retaining them on cached/long-lived objects leaves dangling references into the mmap, which caused a controller SIGSEGV encoding a create-circuit response under terminator churn. See #4108 for details.