### PR TITLE
Guard tunnel dialer against a nil hosted-service registry

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -14,5 +14,5 @@ jobs:
       - name: Run code spelling check
         uses: codespell-project/actions-codespell@v2
         with:
-          ignore_words_list: allos,ans,dne,noe,referr,ssudo,te,tranfer,ue
+          ignore_words_list: actieve,allos,ans,dne,noe,referr,ssudo,te,tranfer,ue
           skip: go.*,zititest/go.*,./controller/storage/zitiql/zitiql_parser.go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Release 1.6.20
+
+## What's New
+
+* Fixes a router panic on routers which aren't hosting tunnel services
+
+## Component Updates and Bug Fixes
+
+* github.com/openziti/ziti: [v1.6.19 -> v1.6.20](https://github.com/openziti/ziti/compare/v1.6.19...v1.6.20)
+    * [Issue #4114](https://github.com/openziti/ziti/issues/4114) - Router panics on ERT-terminator inspect when it hosts no tunnel services (1.6.x)
+
 # Release 1.6.19
 
 ## What's New

--- a/router/xgress_edge_tunnel_v2/dialer.go
+++ b/router/xgress_edge_tunnel_v2/dialer.go
@@ -89,6 +89,11 @@ func (self *tunneler) Dial(params xgress_router.DialParams) (xt.PeerData, error)
 
 func (self *tunneler) Inspect(key string, timeout time.Duration) any {
 	if key == inspect.ErtTerminatorsKey {
+		// hostedServices is only wired when the router has a tunnel listener; a router that hosts no
+		// tunnel services has none to report, so avoid dereferencing a nil registry.
+		if self.hostedServices == nil {
+			return nil
+		}
 		return self.hostedServices.Inspect(timeout)
 	}
 	return nil

--- a/router/xgress_edge_tunnel_v2/dialer.go
+++ b/router/xgress_edge_tunnel_v2/dialer.go
@@ -34,9 +34,13 @@ import (
 
 func (self *tunneler) IsTerminatorValid(id string, destination string) bool {
 	self.WaitForInitialized()
-	terminator, found := self.hostedServices.Get(id)
+	hostedServices := self.hostedServices.Load()
+	if hostedServices == nil {
+		return false
+	}
+	terminator, found := hostedServices.Get(id)
 	if found {
-		self.hostedServices.markEstablished(terminator, "validation message received")
+		hostedServices.markEstablished(terminator, "validation message received")
 	}
 	return found
 }
@@ -49,7 +53,12 @@ func (self *tunneler) Dial(params xgress_router.DialParams) (xt.PeerData, error)
 		WithField("binding", "tunnel").
 		WithField("destination", destination)
 
-	terminator, ok := self.hostedServices.Get(destination)
+	hostedServices := self.hostedServices.Load()
+	if hostedServices == nil {
+		return nil, xgress.InvalidTerminatorError{InnerError: errors.Errorf("router is not hosting tunnel services, terminator for destination %v not found", destination)}
+	}
+
+	terminator, ok := hostedServices.Get(destination)
 	if !ok {
 		return nil, xgress.InvalidTerminatorError{InnerError: errors.Errorf("tunnel terminator for destination %v not found", destination)}
 	}
@@ -89,7 +98,13 @@ func (self *tunneler) Dial(params xgress_router.DialParams) (xt.PeerData, error)
 
 func (self *tunneler) Inspect(key string, timeout time.Duration) any {
 	if key == inspect.ErtTerminatorsKey {
-		return self.hostedServices.Inspect(timeout)
+		// a router that hosts no tunnel services has no terminators to report. An empty result is
+		// returned rather than nil, so callers see a successful inspect with no terminators.
+		hostedServices := self.hostedServices.Load()
+		if hostedServices == nil {
+			return &inspect.ErtTerminatorInspectResult{}
+		}
+		return hostedServices.Inspect(timeout)
 	}
 	return nil
 }

--- a/router/xgress_edge_tunnel_v2/dialer_test.go
+++ b/router/xgress_edge_tunnel_v2/dialer_test.go
@@ -1,0 +1,106 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package xgress_edge_tunnel_v2
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openziti/identity"
+	"github.com/openziti/sdk-golang/xgress"
+	"github.com/openziti/ziti/common/inspect"
+	"github.com/openziti/ziti/common/logcontext"
+	"github.com/stretchr/testify/require"
+)
+
+// A router with no tunnel listener has no hosted service registry, so the dialer entry points must
+// all work without one. Control channel requests for tunnel terminators reach every router, not just
+// those hosting tunnel services.
+func TestTunnelerWithoutHostedServices(t *testing.T) {
+	newUnhostedTunneler := func() *tunneler {
+		result := &tunneler{
+			notifyReconnect: make(chan struct{}, 1),
+			createTime:      time.Now(),
+		}
+		result.initialized.Store(true)
+		return result
+	}
+
+	t.Run("inspect returns an empty result", func(t *testing.T) {
+		req := require.New(t)
+
+		result := newUnhostedTunneler().Inspect(inspect.ErtTerminatorsKey, time.Second)
+		ertResult, ok := result.(*inspect.ErtTerminatorInspectResult)
+		req.True(ok, "expected an ERT terminator inspect result, got %T", result)
+		req.Empty(ertResult.Entries)
+		req.Empty(ertResult.Errors)
+	})
+
+	t.Run("inspect of an unrelated key returns nil", func(t *testing.T) {
+		req := require.New(t)
+		req.Nil(newUnhostedTunneler().Inspect("router-data-model", time.Second))
+	})
+
+	t.Run("terminators are reported invalid", func(t *testing.T) {
+		req := require.New(t)
+		req.False(newUnhostedTunneler().IsTerminatorValid("terminator-id", "hosted:destination"))
+	})
+
+	t.Run("dial fails with an invalid terminator error", func(t *testing.T) {
+		req := require.New(t)
+
+		_, err := newUnhostedTunneler().Dial(&testDialParams{destination: "hosted:destination"})
+		req.Error(err)
+		req.IsType(xgress.InvalidTerminatorError{}, err)
+	})
+}
+
+type testDialParams struct {
+	destination string
+}
+
+func (self *testDialParams) GetCtrlId() string {
+	return "test-ctrl"
+}
+
+func (self *testDialParams) GetDestination() string {
+	return self.destination
+}
+
+func (self *testDialParams) GetCircuitId() *identity.TokenId {
+	return &identity.TokenId{Token: "test-circuit"}
+}
+
+func (self *testDialParams) GetAddress() xgress.Address {
+	return "test-address"
+}
+
+func (self *testDialParams) GetBindHandler() xgress.BindHandler {
+	return nil
+}
+
+func (self *testDialParams) GetLogContext() logcontext.Context {
+	return logcontext.NewContext()
+}
+
+func (self *testDialParams) GetDeadline() time.Time {
+	return time.Now().Add(time.Minute)
+}
+
+func (self *testDialParams) GetCircuitTags() map[string]string {
+	return nil
+}

--- a/router/xgress_edge_tunnel_v2/factory.go
+++ b/router/xgress_edge_tunnel_v2/factory.go
@@ -69,7 +69,6 @@ type Factory struct {
 	tunneler          *tunneler
 	metricsRegistry   metrics.UsageRegistry
 	env               env.RouterEnv
-	hostedServices    *HostedServiceRegistry
 	dialerInitialized atomic.Bool
 }
 
@@ -81,12 +80,17 @@ func (self *Factory) Enabled() bool {
 }
 
 func (self *Factory) BindChannel(binding channel.Binding) error {
-	binding.AddReceiveHandlerF(int32(edge_ctrl_pb.ContentType_CreateTunnelTerminatorResponseV2Type), self.hostedServices.HandleCreateTerminatorResponse)
+	binding.AddReceiveHandlerF(int32(edge_ctrl_pb.ContentType_CreateTunnelTerminatorResponseV2Type), self.HandleCreateTunnelTerminatorResponse)
 	return nil
 }
 
+// HandleCreateTunnelTerminatorResponse routes a create tunnel terminator response to the hosted
+// service registry. Responses are ignored if the router isn't hosting tunnel services, since it
+// can't have requested a terminator.
 func (self *Factory) HandleCreateTunnelTerminatorResponse(msg *channel.Message, ch channel.Channel) {
-	self.hostedServices.HandleCreateTerminatorResponse(msg, ch)
+	if hostedServices := self.tunneler.hostedServices.Load(); hostedServices != nil {
+		hostedServices.HandleCreateTerminatorResponse(msg, ch)
+	}
 }
 
 func (self *Factory) Run(env env.RouterEnv) error {
@@ -123,13 +127,13 @@ func NewFactory(env env.RouterEnv, stateManager state.Manager) *Factory {
 func (self *Factory) CreateListener(optionsData xgress.OptionsData) (xgress_router.Listener, error) {
 	self.env.MarkRouterDataModelRequired()
 
-	self.hostedServices = newHostedServicesRegistry(self.env, self.stateManager)
-	self.tunneler.hostedServices = self.hostedServices
+	hostedServices := newHostedServicesRegistry(self.env, self.stateManager)
+	self.tunneler.hostedServices.Store(hostedServices)
 
 	if fabricProviderFunc := fabricProviderF.Load(); fabricProviderFunc != nil {
-		self.tunneler.fabricProvider = fabricProviderFunc(self.env, self.hostedServices)
+		self.tunneler.fabricProvider = fabricProviderFunc(self.env, hostedServices)
 	} else {
-		self.tunneler.fabricProvider = NewTunnelFabricProvider(self.env, self.hostedServices)
+		self.tunneler.fabricProvider = NewTunnelFabricProvider(self.env, hostedServices)
 	}
 
 	options := &Options{}

--- a/router/xgress_edge_tunnel_v2/tunneler.go
+++ b/router/xgress_edge_tunnel_v2/tunneler.go
@@ -53,8 +53,12 @@ type tunneler struct {
 	interceptor     intercept.Interceptor
 	serviceListener *intercept.ServiceListener
 	fabricProvider  TunnelFabricProvider
-	hostedServices  *HostedServiceRegistry
 	notifyReconnect chan struct{}
+
+	// hostedServices is only populated when the router has a tunnel listener. It's set while the
+	// listener is being created, which can race with control channel requests, so it's accessed
+	// atomically. Callers must handle a nil registry.
+	hostedServices atomic.Pointer[HostedServiceRegistry]
 
 	createTime  time.Time
 	initialized atomic.Bool


### PR DESCRIPTION
Fixes #4114

A router that hosts no tunnel services (no tunnel listener, e.g. an initiator router) has a nil `tunneler.hostedServices`, because it's only wired in `CreateListener`. Control plane requests for tunnel terminators reach every router, not just hosting ones, so several dialer entry points can dereference the nil registry.

The clearest case is an ERT-terminator inspect: `ziti fabric validate router-ert-terminators` inspects every connected router, and a non-hosting router panics (SIGSEGV). Terminator validation and circuit dials hit the same registry, so they're exposed too if the controller still holds a `tunnel` binding terminator for a router that no longer hosts.

This makes all of those paths tolerate a missing registry:

- `Inspect` returns an empty ERT terminator result, so validation reports zero terminators for the router rather than failing it. That also lets the controller flag its own stale terminator records for that router, which a failed result skips.
- `IsTerminatorValid` returns false and `Dial` returns an invalid terminator error.
- create tunnel terminator responses are ignored. These were also registered as a method value on a nil receiver at bind time.

The registry is now stored atomically, since it's set while the listener is being created, which can race with control channel requests.

2.0/main aren't affected: the registry is wired eagerly in `NewFactory` there, with `Start()` split out of the constructor. 1.6.x starts the registry inside its constructor, so wiring it eagerly would put an event loop on every router, hence the guards instead.

Also includes an unrelated CI fix: codespell started flagging the adopter name Actieve in `ADOPTERS.md` as a misspelling of "active", failing the check on every PR. The name is added to the ignore list. `main` and the other release branches need the same change.