### PR TITLE
fix(dist): restart controller after live leaf-cert renewal

### DIFF
--- a/dist/dist-packages/linux/openziti-controller/bootstrap.bash
+++ b/dist/dist-packages/linux/openziti-controller/bootstrap.bash
@@ -840,6 +840,17 @@ WorkingDirectory=${ZITI_HOME}
 # Leaf certs valid 365 days; timer fires monthly.
 ExecStart=/usr/bin/bash -c '${_renew_server}'
 ExecStart=/usr/bin/bash -c '${_renew_client}'
+
+# The running controller hot-reloads the renewed cert files (identity
+# WatchFiles) and begins signing JWTs with the new cert's kid, but the new
+# cert is never re-announced to raft peers or edge routers -- they only learn
+# a controller's cert when its cluster connection is (re)established. Without
+# a restart, routers reject every newly signed token with "public key not
+# found" until the controller is restarted, breaking all dials/binds in HA
+# deployments. Restart after renewal so the cluster propagates the new signer.
+# The '+' prefix runs this step with full privileges (the unit runs as
+# ${_svc_user}); try-restart only restarts the controller if it is running.
+ExecStartPost=+systemctl try-restart ziti-controller.service
 UNIT
 
   cat > "${_timer_unit}" <<UNIT


### PR DESCRIPTION
## Summary

Packaging-level fix for #4116: the systemd deployment's `ziti-controller-cert-renewal.service` (installed and default-enabled by `bootstrap.bash`, fires monthly) regenerates the controller's leaf certs **while the controller is running**. The controller hot-reloads them (identity `WatchFiles`, `controller/config/config.go:277`) and starts signing JWTs with the new cert's `kid` (`GetRootTlsJwtSigner()` rebuilds from the live cert per call), but nothing re-announces the new cert to raft peers or edge routers — they only learn a controller's cert when its cluster connection is (re)established (`UpdateControllerState` / `UpdateSelfOnNewLeader` → Controller store → RDM → router `pubKeyLookup`). Every newly signed token is then rejected with `public key not found` until the controller restarts. In our 3-node production HA cluster this took the whole overlay down (details, full code walk, and log evidence in #4116).

This PR adds one directive to the generated renewal unit:

```
ExecStartPost=+systemctl try-restart ziti-controller.service
```

so renewal is immediately followed by the exact action that propagates the new signer through the existing reconnect path.

Notes on the specifics:

- `try-restart` only restarts the controller if it is currently running (won't start a stopped/disabled controller).
- The `+` prefix runs this single step with full privileges; the unit itself runs as the service user, which cannot call `systemctl`.
- The timer's existing `RandomizedDelaySec=1w` staggers nodes across the first week of the month, so HA clusters restart one node at a time with high probability — same rolling pattern as the documented recovery.
- The Docker/container path is unaffected (renewal there happens at container start, before the process is up), so `entrypoint.bash` needs no change.

The deeper runtime fix (re-announce the signer on identity reload; `InstantStrategy.AddPublicKey` looks purpose-built for it but is currently uncalled) is discussed in #4116 — I'm happy to work on that separately with maintainer guidance. This packaging change is intentionally minimal so it can be considered for backport to `release-v2.0.x` alongside #4099, since every stock v2.0.0 HA systemd deployment currently self-breaks within its first monthly renewal window.

## Testing

- `bash -n` passes on the modified `bootstrap.bash`.
- Rendered the generated unit with the template variables substituted and verified the output is a valid unit (directives + comments only; no shell-expansion surprises in the heredoc).
- Production validation of the approach: on our v2.0.0 cluster, restarting a renewed controller is precisely what restored token verification (leader rewrote the controller record from the reconnect, routers received the new key via the RDM, `public key not found` stopped immediately).
- Not run: the `dangerous.install.linux.test.bash` deployment test (requires a disposable Linux host); happy to run it if maintainers want it exercised on this change.

Fixes nothing silently: without this, the failure mode is a cluster-wide auth outage whose log flood (~20k lines/min/router in our incident) also fills disks and degrades raft — see #4116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
