### PR TITLE
Copy terminator peer data and instance secret out of bolt memory

### DIFF
--- a/controller/db/terminator_store.go
+++ b/controller/db/terminator_store.go
@@ -167,7 +167,8 @@ func (store *terminatorStoreImpl) FillEntity(entity *Terminator, bucket *boltz.T
 	entity.Binding = bucket.GetStringOrError(FieldTerminatorBinding)
 	entity.Address = bucket.GetStringWithDefault(FieldTerminatorAddress, "")
 	entity.InstanceId = bucket.GetStringWithDefault(FieldTerminatorInstanceId, "")
-	entity.InstanceSecret = bucket.Get([]byte(FieldTerminatorInstanceSecret))
+	// bbolt values must be copied; the source memory doesn't outlive the transaction.
+	entity.InstanceSecret = append([]byte(nil), bucket.Get([]byte(FieldTerminatorInstanceSecret))...)
 	entity.Cost = uint16(bucket.GetInt32WithDefault(FieldTerminatorCost, 0))
 	entity.Precedence = bucket.GetStringWithDefault(FieldTerminatorPrecedence, xt.Precedences.Default.String())
 	entity.HostId = bucket.GetStringWithDefault(FieldTerminatorHostId, "")
@@ -179,7 +180,8 @@ func (store *terminatorStoreImpl) FillEntity(entity *Terminator, bucket *boltz.T
 		entity.PeerData = make(map[uint32][]byte)
 		iter := data.Cursor()
 		for k, v := iter.First(); k != nil; k, v = iter.Next() {
-			entity.PeerData[binary.LittleEndian.Uint32(k)] = v
+			// bbolt values must be copied; the source memory doesn't outlive the transaction.
+			entity.PeerData[binary.LittleEndian.Uint32(k)] = append([]byte(nil), v...)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #4108.

A terminator's instance secret and peer data were read directly from bbolt-owned memory and kept past the transaction that produced them. bbolt may remap or reuse that memory once the transaction closes or the store grows, so a later read of the retained value could observe corrupted bytes. On the controller this surfaced as memory corruption reachable from the create-circuit response path.

This copies the instance secret and peer-data values out of bbolt memory when a terminator is loaded, so the retained values no longer alias the transaction's backing store.

Backports for the 2.0.x and 1.6.x lines are on the `backport-v2.0.x-bbolt-mem` and `backport-v1.6.x-bbolt-mem` branches.