### PR TITLE
Filter service policies by string type in enforcer/list queries (backport to 2.0.x)

### DIFF
--- a/controller/db/service_policy_store_test.go
+++ b/controller/db/service_policy_store_test.go
@@ -24,6 +24,35 @@ func Test_ServicePolicyStore(t *testing.T) {
 	t.Run("test service policy evaluation", ctx.testServicePolicyRoleEvaluation)
 	t.Run("test update/delete referenced entities", ctx.testServicePolicyUpdateDeleteRefs)
 	t.Run("test filter service policies by type name", ctx.testServicePolicyFilterByTypeName)
+	t.Run("test service policy enforcer type query", ctx.testServicePolicyEnforcerTypeQuery)
+}
+
+// testServicePolicyEnforcerTypeQuery guards the predicate the ServicePolicyEnforcer uses to decide
+// whether a session's identity still has a covering policy. The policy type symbol is string-mapped
+// ("Dial"/"Bind"), so the predicate must filter on the string form; filtering on the numeric id
+// (type = 1) matches nothing against the string symbol, which previously made the enforcer delete
+// valid legacy sessions on startup.
+func (ctx *TestContext) testServicePolicyEnforcerTypeQuery(_ *testing.T) {
+	ctx.CleanupAll()
+
+	dialer := ctx.RequireNewIdentity(eid.New(), false)
+	service := newEdgeService(eid.New())
+	boltztest.RequireCreate(ctx, service)
+	ctx.requireNewServicePolicy(PolicyTypeDial, ss(entityRef(dialer.Id)), ss(entityRef(service.Id)))
+
+	ctx.NoError(ctx.GetDb().View(func(tx *bbolt.Tx) error {
+		matched, _, err := ctx.stores.Identity.QueryIds(tx, fmt.Sprintf(
+			`id = "%v" and not isEmpty(from servicePolicies where type = "%v" and anyOf(services) = "%v")`,
+			dialer.Id, PolicyTypeDial.String(), service.Id))
+		ctx.NoError(err)
+		ctx.Contains(matched, dialer.Id, "string policy-type predicate must match the covering Dial policy")
+
+		numeric, _, _ := ctx.stores.Identity.QueryIds(tx, fmt.Sprintf(
+			`id = "%v" and not isEmpty(from servicePolicies where type = %v and anyOf(services) = "%v")`,
+			dialer.Id, PolicyTypeDial.Id(), service.Id))
+		ctx.NotContains(numeric, dialer.Id, "numeric policy-type predicate must not match the string-mapped symbol")
+		return nil
+	}))
 }
 
 func newServicePolicy(name string) *ServicePolicy {

--- a/controller/internal/policy/service_policy_enforcer.go
+++ b/controller/internal/policy/service_policy_enforcer.go
@@ -153,7 +153,7 @@ func (enforcer *ServicePolicyEnforcer) Run() error {
 			if session.Type == db.SessionTypeBind {
 				policyType = db.PolicyTypeBind
 			}
-			query := fmt.Sprintf(`id = "%v" and not isEmpty(from servicePolicies where type = %v and anyOf(services) = "%v")`, identity.Id, policyType.Id(), session.ServiceId)
+			query := fmt.Sprintf(`id = "%v" and not isEmpty(from servicePolicies where type = "%v" and anyOf(services) = "%v")`, identity.Id, policyType.String(), session.ServiceId)
 			_, count, err := enforcer.appEnv.GetStores().Identity.QueryIds(tx, query)
 			if err != nil {
 				return err

--- a/controller/internal/routes/identity_router.go
+++ b/controller/internal/routes/identity_router.go
@@ -327,11 +327,11 @@ func (r *IdentityRouter) listServices(ae *env.AppEnv, rc *response.RequestContex
 	typeFilter := ""
 	if params.PolicyType != nil {
 		if strings.EqualFold(*params.PolicyType, db.PolicyTypeBind.String()) {
-			typeFilter = fmt.Sprintf(` and type = %d`, db.PolicyTypeBind.Id())
+			typeFilter = fmt.Sprintf(` and type = "%s"`, db.PolicyTypeBind.String())
 		}
 
 		if strings.EqualFold(*params.PolicyType, db.PolicyTypeDial.String()) {
-			typeFilter = fmt.Sprintf(` and type = %d`, db.PolicyTypeDial.Id())
+			typeFilter = fmt.Sprintf(` and type = "%s"`, db.PolicyTypeDial.String())
 		}
 	}
 

--- a/controller/internal/routes/service_router.go
+++ b/controller/internal/routes/service_router.go
@@ -386,11 +386,11 @@ func (r *ServiceRouter) listIdentities(ae *env.AppEnv, rc *response.RequestConte
 	typeFilter := ""
 	if params.PolicyType != nil {
 		if strings.EqualFold(*params.PolicyType, db.PolicyTypeBind.String()) {
-			typeFilter = fmt.Sprintf(` and type = %d`, db.PolicyTypeBind.Id())
+			typeFilter = fmt.Sprintf(` and type = "%s"`, db.PolicyTypeBind.String())
 		}
 
 		if strings.EqualFold(*params.PolicyType, db.PolicyTypeDial.String()) {
-			typeFilter = fmt.Sprintf(` and type = %d`, db.PolicyTypeDial.Id())
+			typeFilter = fmt.Sprintf(` and type = "%s"`, db.PolicyTypeDial.String())
 		}
 	}
 


### PR DESCRIPTION
Backport of #4143 to `release-v2.0.x`. Fixes #4142.

Cherry-pick of the fix for #4141. The string-symbol change (9ac9a4f17) that broke the numeric `type =` queries is present on release-v2.0.x, so the enforcer deletes valid non-admin legacy edge sessions on each controller start there too. Fixes the enforcer + the two list filters to query `type = "Dial"/"Bind"`, and adds the db regression test. Not applicable to release-v1.6.x (type symbol is still int).