### PR TITLE
Accept legacy sessions and signal recovery for invalid service tokens

### DIFF
--- a/common/oidc_tokens.go
+++ b/common/oidc_tokens.go
@@ -209,6 +209,26 @@ func (c *ServiceAccessClaims) HasAudience(targetAud string) bool {
 	return false
 }
 
+// InvalidTokenError indicates a token was rejected because of the token itself (bad signature or
+// parse, expiry, unexpected claims/audience/type, a mismatched api session, or revocation) rather
+// than an infrastructure failure (e.g. a datastore read) encountered while validating it. Callers
+// use it to distinguish a client that should discard and re-create its session from a transient
+// controller failure that must not invalidate otherwise-valid client state.
+type InvalidTokenError struct {
+	Err error
+}
+
+func (e *InvalidTokenError) Error() string {
+	if e.Err == nil {
+		return "invalid token"
+	}
+	return e.Err.Error()
+}
+
+func (e *InvalidTokenError) Unwrap() error {
+	return e.Err
+}
+
 type AccessClaims struct {
 	oidc.AccessTokenClaims
 	CustomClaims

--- a/controller/env/appenv.go
+++ b/controller/env/appenv.go
@@ -254,19 +254,19 @@ func (ae *AppEnv) ValidateServiceAccessToken(token string, apiSessionId *string)
 	parsedToken, err := jwt.ParseWithClaims(token, serviceAccessClaims, ae.JwtSignerKeyFunc)
 
 	if err != nil {
-		return nil, err
+		return nil, &common.InvalidTokenError{Err: err}
 	}
 
 	if !parsedToken.Valid {
-		return nil, errors.New("service access token is invalid")
+		return nil, &common.InvalidTokenError{Err: errors.New("service access token is invalid")}
 	}
 
 	if !serviceAccessClaims.HasAudience(common.ClaimAudienceOpenZiti) && !serviceAccessClaims.HasAudience(common.ClaimLegacyNative) {
-		return nil, fmt.Errorf("invalid audience, expected an instance of %s or %s, got %v", common.ClaimAudienceOpenZiti, common.ClaimLegacyNative, serviceAccessClaims.Audience)
+		return nil, &common.InvalidTokenError{Err: fmt.Errorf("invalid audience, expected an instance of %s or %s, got %v", common.ClaimAudienceOpenZiti, common.ClaimLegacyNative, serviceAccessClaims.Audience)}
 	}
 
 	if serviceAccessClaims.TokenType != common.TokenTypeServiceAccess {
-		return nil, fmt.Errorf("invalid token type, expected %s, got %s", common.TokenTypeServiceAccess, serviceAccessClaims.Type)
+		return nil, &common.InvalidTokenError{Err: fmt.Errorf("invalid token type, expected %s, got %s", common.TokenTypeServiceAccess, serviceAccessClaims.Type)}
 	}
 
 	if apiSessionId != nil {
@@ -275,10 +275,12 @@ func (ae *AppEnv) ValidateServiceAccessToken(token string, apiSessionId *string)
 		}
 
 		if serviceAccessClaims.ApiSessionId != *apiSessionId {
-			return nil, fmt.Errorf("invalid api session id, expected %s, got %s", *apiSessionId, serviceAccessClaims.ApiSessionId)
+			return nil, &common.InvalidTokenError{Err: fmt.Errorf("invalid api session id, expected %s, got %s", *apiSessionId, serviceAccessClaims.ApiSessionId)}
 		}
 	}
 
+	// Revocation.Read failures below are infrastructure errors and are returned raw (not wrapped as
+	// InvalidTokenError), so a transient datastore failure does not make callers discard valid sessions.
 	tokenRevocation, err := ae.GetManagers().Revocation.Read(serviceAccessClaims.ID)
 
 	if err != nil && !boltz.IsErrNotFoundErr(err) {
@@ -286,7 +288,7 @@ func (ae *AppEnv) ValidateServiceAccessToken(token string, apiSessionId *string)
 	}
 
 	if tokenRevocation != nil {
-		return nil, errors.New("service access token has been revoked by id")
+		return nil, &common.InvalidTokenError{Err: errors.New("service access token has been revoked by id")}
 	}
 
 	revocation, err := ae.GetManagers().Revocation.Read(serviceAccessClaims.IdentityId)
@@ -296,7 +298,7 @@ func (ae *AppEnv) ValidateServiceAccessToken(token string, apiSessionId *string)
 	}
 
 	if revocation != nil && revocation.CreatedAt.After(serviceAccessClaims.IssuedAt.Time) {
-		return nil, errors.New("service access token has been revoked by identity")
+		return nil, &common.InvalidTokenError{Err: errors.New("service access token has been revoked by identity")}
 	}
 
 	return serviceAccessClaims, nil

--- a/controller/handler_edge_ctrl/common.go
+++ b/controller/handler_edge_ctrl/common.go
@@ -11,7 +11,6 @@ import (
 	"github.com/openziti/channel/v5"
 	"github.com/openziti/identity"
 	"github.com/openziti/sdk-golang/v2/ziti/edge"
-	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/openziti/ziti/v2/common"
 	"github.com/openziti/ziti/v2/common/logcontext"
 	"github.com/openziti/ziti/v2/common/pb/edge_ctrl_pb"
@@ -23,6 +22,7 @@ import (
 	"github.com/openziti/ziti/v2/controller/models"
 	"github.com/openziti/ziti/v2/controller/network"
 	"github.com/openziti/ziti/v2/controller/oidc_auth"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/openziti/ziti/v2/controller/xt"
 	"github.com/sirupsen/logrus"
 )
@@ -314,10 +314,49 @@ func (self *baseSessionRequestContext) loadFromBolt(sessionToken string, apiSess
 		return
 	}
 
+	if !strings.HasPrefix(sessionToken, oidc_auth.JwtTokenPrefix) {
+		self.session, err = self.handler.getAppEnv().Managers.Session.ReadByToken(sessionToken)
+
+		if err != nil {
+			if boltz.IsErrNotFoundErr(err) {
+				self.err = InvalidSessionError{}
+			} else {
+				self.err = internalError(err)
+			}
+			logrus.
+				WithField("operation", self.handler.Label()).
+				WithError(self.err).Errorf("invalid session")
+			return
+		}
+
+		if self.session.ApiSessionId != self.apiSession.Id {
+			self.err = InvalidSessionError{}
+			logrus.
+				WithField("operation", self.handler.Label()).
+				WithField("sessionId", self.session.Id).
+				WithField("sessionApiSessionId", self.session.ApiSessionId).
+				WithField("apiSessionId", self.apiSession.Id).
+				WithError(self.err).Error("session does not belong to api session")
+		}
+		return
+	}
+
 	serviceAccessClaims, err := self.env.ValidateServiceAccessToken(sessionToken, &self.apiSession.Id)
 
 	if err != nil {
-		self.err = internalError(err)
+		// A token-level failure (bad/expired/mismatched/revoked token) means the client should discard
+		// and re-create its session, so return InvalidSession. An infrastructure failure (e.g. a
+		// revocation datastore read) must stay an internalError, otherwise a transient controller fault
+		// would make clients discard valid sessions and trigger a reauthentication storm.
+		var invalidToken *common.InvalidTokenError
+		if errors.As(err, &invalidToken) {
+			self.err = InvalidSessionError{}
+			logrus.
+				WithField("operation", self.handler.Label()).
+				WithError(err).Error("service access token invalid; treating as invalid session")
+		} else {
+			self.err = internalError(err)
+		}
 		return
 	}
 

--- a/controller/handler_edge_ctrl/common_test.go
+++ b/controller/handler_edge_ctrl/common_test.go
@@ -1,0 +1,156 @@
+package handler_edge_ctrl
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/openziti/channel/v5"
+	"github.com/openziti/ziti/v2/controller/change"
+	"github.com/openziti/ziti/v2/controller/db"
+	"github.com/openziti/ziti/v2/controller/env"
+	"github.com/openziti/ziti/v2/controller/model"
+	"github.com/openziti/ziti/v2/controller/network"
+	"github.com/stretchr/testify/require"
+)
+
+type legacySessionTestHandler struct {
+	appEnv *env.AppEnv
+}
+
+func (self *legacySessionTestHandler) getAppEnv() *env.AppEnv {
+	return self.appEnv
+}
+
+func (*legacySessionTestHandler) getNetwork() *network.Network {
+	return nil
+}
+
+func (*legacySessionTestHandler) getChannel() channel.Channel {
+	return nil
+}
+
+func (*legacySessionTestHandler) Label() string {
+	return "legacy-session-test"
+}
+
+func newLegacySessionTestEntities(t *testing.T, testCtx *model.TestContext) (*model.Managers, *model.Identity, *model.EdgeService) {
+	managers := testCtx.GetManagers()
+	identity := &model.Identity{
+		Name:           uuid.NewString(),
+		IdentityTypeId: db.DefaultIdentityType,
+	}
+	require.NoError(t, managers.Identity.Create(identity, change.New()))
+
+	service := &model.EdgeService{Name: uuid.NewString()}
+	require.NoError(t, managers.EdgeService.Create(service, change.New()))
+
+	edgeRouter := &model.EdgeRouter{Name: uuid.NewString()}
+	require.NoError(t, managers.EdgeRouter.Create(edgeRouter, change.New()))
+
+	servicePolicy := &model.ServicePolicy{
+		Name:          uuid.NewString(),
+		Semantic:      db.SemanticAllOf,
+		IdentityRoles: []string{"#all"},
+		ServiceRoles:  []string{"#all"},
+		PolicyType:    db.PolicyTypeDialName,
+	}
+	require.NoError(t, managers.ServicePolicy.Create(servicePolicy, change.New()))
+
+	edgeRouterPolicy := &model.EdgeRouterPolicy{
+		Name:            uuid.NewString(),
+		Semantic:        db.SemanticAllOf,
+		IdentityRoles:   []string{"#all"},
+		EdgeRouterRoles: []string{"#all"},
+	}
+	require.NoError(t, managers.EdgeRouterPolicy.Create(edgeRouterPolicy, change.New()))
+
+	serviceEdgeRouterPolicy := &model.ServiceEdgeRouterPolicy{
+		Name:            uuid.NewString(),
+		Semantic:        db.SemanticAllOf,
+		ServiceRoles:    []string{"#all"},
+		EdgeRouterRoles: []string{"#all"},
+	}
+	require.NoError(t, managers.ServiceEdgeRouterPolicy.Create(serviceEdgeRouterPolicy, change.New()))
+
+	return managers, identity, service
+}
+
+func TestLoadFromBoltSupportsOpaqueServiceSessionTokens(t *testing.T) {
+	testCtx := model.NewTestContext(t)
+	defer testCtx.Cleanup()
+	testCtx.Init()
+
+	managers, identity, service := newLegacySessionTestEntities(t, testCtx)
+
+	apiSession := &model.ApiSession{
+		Token:          uuid.NewString(),
+		IdentityId:     identity.Id,
+		Identity:       identity,
+		LastActivityAt: time.Now(),
+	}
+	_, err := managers.ApiSession.Create(nil, apiSession, nil)
+	require.NoError(t, err)
+
+	legacySession := &model.Session{
+		Token:        uuid.NewString(),
+		IdentityId:   identity.Id,
+		ApiSessionId: apiSession.Id,
+		ServiceId:    service.Id,
+		Type:         db.SessionTypeDial,
+	}
+	_, err = managers.Session.Create(legacySession, change.New())
+	require.NoError(t, err)
+
+	handler := &legacySessionTestHandler{
+		appEnv: &env.AppEnv{Managers: managers},
+	}
+	requestCtx := &baseSessionRequestContext{handler: handler}
+
+	requestCtx.loadFromBolt(legacySession.Token, apiSession.Token)
+
+	require.NoError(t, requestCtx.err)
+	require.Equal(t, legacySession.Id, requestCtx.session.Id)
+	require.Equal(t, apiSession.Id, requestCtx.apiSession.Id)
+}
+
+func TestLoadFromBoltRejectsOpaqueServiceSessionForDifferentApiSession(t *testing.T) {
+	testCtx := model.NewTestContext(t)
+	defer testCtx.Cleanup()
+	testCtx.Init()
+
+	managers, identity, service := newLegacySessionTestEntities(t, testCtx)
+
+	newApiSession := func() *model.ApiSession {
+		apiSession := &model.ApiSession{
+			Token:          uuid.NewString(),
+			IdentityId:     identity.Id,
+			Identity:       identity,
+			LastActivityAt: time.Now(),
+		}
+		_, err := managers.ApiSession.Create(nil, apiSession, nil)
+		require.NoError(t, err)
+		return apiSession
+	}
+
+	ownerApiSession := newApiSession()
+	otherApiSession := newApiSession()
+	legacySession := &model.Session{
+		Token:        uuid.NewString(),
+		IdentityId:   identity.Id,
+		ApiSessionId: ownerApiSession.Id,
+		ServiceId:    service.Id,
+		Type:         db.SessionTypeDial,
+	}
+	_, err := managers.Session.Create(legacySession, change.New())
+	require.NoError(t, err)
+
+	handler := &legacySessionTestHandler{
+		appEnv: &env.AppEnv{Managers: managers},
+	}
+	requestCtx := &baseSessionRequestContext{handler: handler}
+
+	requestCtx.loadFromBolt(legacySession.Token, otherApiSession.Token)
+
+	require.IsType(t, InvalidSessionError{}, requestCtx.err)
+}


### PR DESCRIPTION
Fixes #4145

The router-facing `loadFromBolt` only handled JWT service-access tokens, so a legacy client whose session predates a controller upgrade failed `create.circuit`/`create.terminator` with a generic `internalError` (`token is malformed`) — its existing durable session was rejected, and the generic error gave the SDK no signal to re-create, so the client wedged.

- **Accept legacy sessions:** a non-JWT session token is now looked up via `Session.ReadByToken` (with an api-session ownership check) instead of being parsed as a JWT, so a legacy client's existing session keeps working across the upgrade.
- **Recoverable vs infrastructure errors:** token-validation failures (malformed/expired/bad claims/mismatched/revoked) map to `InvalidSessionError` (`RetryStartOver` -> re-create); revocation-store/datastore failures stay `internalError` so a transient fault doesn't trigger a client reauth storm. New typed `common.InvalidTokenError` distinguishes them.

Authorization is unchanged — the accepted legacy session still flows through `verifyEdgeRouterAccess`/policy checks. Backport to release-v2.0.x tracked in #4146.