### PR TITLE
allow upgrading from 1.6 when service is already running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -405,6 +405,7 @@ today and expand as packages are converted. The global `ziti agent set-log-level
 * github.com/openziti/secretstream: [v0.1.49 -> v0.1.51](https://github.com/openziti/secretstream/compare/v0.1.49...v0.1.51)
 * github.com/openziti/transport/v2: [v2.0.215 -> v2.0.216](https://github.com/openziti/transport/compare/v2.0.215...v2.0.216)
 * github.com/openziti/ziti/v2: [v2.0.0 -> v2.1.0](https://github.com/openziti/ziti/compare/v2.0.0...v2.1.0)
+    * [Issue #4149](https://github.com/openziti/ziti/issues/4149) - Upgrading a running 1.x controller/router to 2.x fails to create the service user
     * [Issue #3910](https://github.com/openziti/ziti/issues/3910) - Install slog and route agent log-level callbacks through common/logging
     * [Issue #3927](https://github.com/openziti/ziti/issues/3927) - Router does not enforce api-session or identity revocations on live connections; revoked OIDC sessions keep dialing/hosting until access-token expiry
     * [Issue #3906](https://github.com/openziti/ziti/issues/3906) - Add named-logger registry, logrus bridge, and pfxlog-shape JSON

--- a/dist/dist-packages/linux/dangerous.upgrade.linux.test.bash
+++ b/dist/dist-packages/linux/dangerous.upgrade.linux.test.bash
@@ -263,6 +263,11 @@ _rtr_svc_env_md5="$(md5sum /opt/openziti/etc/router/service.env | awk '{print $1
 # and the admin's original bootstrap answers in bootstrap.env are preserved.
 upgrade_local_debs "${TMPDIR}"
 
+# postinstall must bring the services back itself; check before our own
+# explicit restarts below so a failed restart isn't masked.
+wait_for_service ziti-controller.service 30
+wait_for_service ziti-router.service 20
+
 # ============================================================
 # Phase 5: Verify migration
 # ============================================================

--- a/dist/dist-packages/linux/dangerous.upgrade.linux.test.bash
+++ b/dist/dist-packages/linux/dangerous.upgrade.linux.test.bash
@@ -244,9 +244,8 @@ log_section "Phase 3: Create test state"
 "${ZITI_BIN}" edge create service upgrade-test-svc --role-attributes 'upgrade-test'
 "${ZITI_BIN}" edge create service-edge-router-policy upgrade-test-serp --service-roles '#upgrade-test' --edge-router-roles '#all'
 
-# Stop services before upgrade (simulate how dpkg postinstall will find them)
-stop_service ziti-router.service
-stop_service ziti-controller.service
+# Leave both services running through the upgrade: apt/dnf do not stop the
+# service, so postinstall must handle a live v1 DynamicUser service.
 
 # ============================================================
 # Phase 4: Build and install v2 packages (triggers postinstall migration)
@@ -271,6 +270,8 @@ log_section "Phase 5: Verify migration"
 
 verify_state_dir ziti-controller ziti-controller ziti-controller
 verify_state_dir ziti-router ziti-router ziti-router
+verify_service_user ziti-controller
+verify_service_user ziti-router
 verify_symlink_resolved ziti-controller
 verify_symlink_resolved ziti-router
 

--- a/dist/dist-packages/linux/deployments-test-lib.bash
+++ b/dist/dist-packages/linux/deployments-test-lib.bash
@@ -298,6 +298,19 @@ verify_state_dir() {
   fi
 }
 
+# Assert the persistent service account exists in the files database, not
+# merely as a transient nss-systemd (DynamicUser) entry.
+# verify_service_user <user>
+verify_service_user() {
+  local _user="$1"
+  if getent -s files passwd "${_user}" >/dev/null 2>&1; then
+    log_pass "service user ${_user} exists in files database"
+  else
+    log_fail "service user ${_user} missing from files database"
+    return 1
+  fi
+}
+
 # Assert that the state directory is NOT a symlink (post-migration)
 verify_symlink_resolved() {
   local _svc="$1"

--- a/dist/dist-packages/linux/openziti-controller/postinstall.bash
+++ b/dist/dist-packages/linux/openziti-controller/postinstall.bash
@@ -15,10 +15,17 @@ install() {
 }
 
 upgrade() {
-  createUser
   # systemd needs to re-read the unit file before any systemctl calls,
   # otherwise commands in migrateDynamicUser trigger a stale-unit warning
   systemctl daemon-reload
+  # While a v1 DynamicUser=yes service is active, nss-systemd resolves a
+  # transient user of this name, so createUser would skip and leave no
+  # persistent account. Stop it first.
+  if detectDynamicUserState && systemctl is-active --quiet "${SVC_USER}.service" 2>/dev/null; then
+    systemctl stop "${SVC_USER}.service" || true
+    _MIGRATION_STOPPED_SERVICE=true
+  fi
+  createUser
   migrateDynamicUser
   commonActions
   # If migration stopped the service, restart it now that the unit file and

--- a/dist/dist-packages/linux/openziti-controller/postinstall.bash
+++ b/dist/dist-packages/linux/openziti-controller/postinstall.bash
@@ -23,6 +23,12 @@ upgrade() {
   # persistent account. Stop it first.
   if detectDynamicUserState && systemctl is-active --quiet "${SVC_USER}.service" 2>/dev/null; then
     systemctl stop "${SVC_USER}.service" || true
+    # createUser + migration below assume the transient DynamicUser is gone;
+    # if it's somehow still up, bail rather than migrate live state.
+    if systemctl is-active --quiet "${SVC_USER}.service" 2>/dev/null; then
+      echo "ERROR: could not stop ${SVC_USER}.service; aborting upgrade" >&2
+      exit 1
+    fi
     _MIGRATION_STOPPED_SERVICE=true
   fi
   createUser

--- a/dist/dist-packages/linux/openziti-router/postinstall.bash
+++ b/dist/dist-packages/linux/openziti-router/postinstall.bash
@@ -15,10 +15,17 @@ install() {
 }
 
 upgrade() {
-  createUser
   # systemd needs to re-read the unit file before any systemctl calls,
   # otherwise commands in migrateDynamicUser trigger a stale-unit warning
   systemctl daemon-reload
+  # While a v1 DynamicUser=yes service is active, nss-systemd resolves a
+  # transient user of this name, so createUser would skip and leave no
+  # persistent account. Stop it first.
+  if detectDynamicUserState && systemctl is-active --quiet "${SVC_USER}.service" 2>/dev/null; then
+    systemctl stop "${SVC_USER}.service" || true
+    _MIGRATION_STOPPED_SERVICE=true
+  fi
+  createUser
   migrateDynamicUser
   commonActions
   # If migration stopped the service, restart it now that the unit file and

--- a/dist/dist-packages/linux/openziti-router/postinstall.bash
+++ b/dist/dist-packages/linux/openziti-router/postinstall.bash
@@ -23,6 +23,12 @@ upgrade() {
   # persistent account. Stop it first.
   if detectDynamicUserState && systemctl is-active --quiet "${SVC_USER}.service" 2>/dev/null; then
     systemctl stop "${SVC_USER}.service" || true
+    # createUser + migration below assume the transient DynamicUser is gone;
+    # if it's somehow still up, bail rather than migrate live state.
+    if systemctl is-active --quiet "${SVC_USER}.service" 2>/dev/null; then
+      echo "ERROR: could not stop ${SVC_USER}.service; aborting upgrade" >&2
+      exit 1
+    fi
     _MIGRATION_STOPPED_SERVICE=true
   fi
   createUser


### PR DESCRIPTION
closes #4149 

see https://openziti.discourse.group/t/ziti-controller-update-to-2-breaks-service/5937/12 for more context. upgrading a running process would fail from 1.6 to 2.0 due to changes we made. the tests would stop the service before upgrading which allowed the bug to creep through