### PR TITLE
Signal congestion on terminator establish/remove timeouts

### DIFF
--- a/router/xgress_edge/fabric.go
+++ b/router/xgress_edge/fabric.go
@@ -235,10 +235,33 @@ func (self *edgeTerminator) newConnection(connId uint32) (*edgeXgressConn, error
 	return result, nil
 }
 
-func (self *edgeTerminator) SetRateLimitCallback(control rate.RateLimitControl) {
+// replaceRateLimitCallback stores control as the rate-limit control for a new establishment attempt.
+// If a control from a prior attempt is still outstanding, that attempt exceeded establishmentTimeout
+// without completing, so its control is resolved with Backoff (signaling congestion and reclaiming its
+// slot) rather than being orphaned and left for the limiter's internal timeout to clean up.
+func (self *edgeTerminator) replaceRateLimitCallback(control rate.RateLimitControl) {
 	self.lock.Lock()
-	defer self.lock.Unlock()
+	previous := self.rateLimitCallback
 	self.rateLimitCallback = control
+	self.lock.Unlock()
+
+	if previous != nil {
+		previous.Backoff()
+	}
+}
+
+// resolveRateLimitCallback resolves the terminator's outstanding rate-limit control based on how long
+// establishment took. An establishment that completed within establishmentTimeout reports Success,
+// growing the limiter window; one that took at least establishmentTimeout reports Backoff, signaling
+// congestion so the window shrinks. It is a no-op if no control is outstanding.
+func (self *edgeTerminator) resolveRateLimitCallback(latency time.Duration) {
+	if control := self.GetAndClearRateLimitCallback(); control != nil {
+		if latency >= establishmentTimeout {
+			control.Backoff()
+		} else {
+			control.Success()
+		}
+	}
 }
 
 func (self *edgeTerminator) GetAndClearRateLimitCallback() rate.RateLimitControl {

--- a/router/xgress_edge/hosted.go
+++ b/router/xgress_edge/hosted.go
@@ -41,6 +41,11 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// establishmentTimeout is how long a terminator establishment may take before the router treats it
+// as congestion instead of success. Gates the rate-limit signal, the re-send of stalled attempts,
+// and the post-establish inspect. Kept above normal latency so a healthy system won't trip it.
+const establishmentTimeout = 30 * time.Second
+
 func newHostedServicesRegistry(env routerEnv.RouterEnv, stateManager state.Manager) *hostedServiceRegistry {
 	result := &hostedServiceRegistry{
 		terminators:          cmap.New[*edgeTerminator](),
@@ -164,7 +169,7 @@ func (self *hostedServiceRegistry) evaluateEstablishQueue() {
 			return
 		}
 
-		if !terminator.operationActive.CompareAndSwap(false, true) && time.Since(terminator.lastAttempt) < 30*time.Second {
+		if !terminator.operationActive.CompareAndSwap(false, true) && time.Since(terminator.lastAttempt) < establishmentTimeout {
 			rateLimitCtrl.Failed()
 			continue
 		}
@@ -172,7 +177,10 @@ func (self *hostedServiceRegistry) evaluateEstablishQueue() {
 		log.Info("queuing terminator to send create")
 
 		dequeue()
-		terminator.SetRateLimitCallback(rateLimitCtrl)
+		// A re-attempt here means the previous attempt exceeded establishmentTimeout without
+		// completing. Resolve its outstanding rate-limit control with Backoff so the stall is
+		// signaled as congestion and its slot is reclaimed, rather than orphaning it.
+		terminator.replaceRateLimitCallback(rateLimitCtrl)
 		terminator.lastAttempt = time.Now()
 
 		if err = self.establishTerminator(terminator); err != nil {
@@ -204,7 +212,7 @@ func (self *hostedServiceRegistry) evaluateDeleteQueue() {
 		}
 
 		if terminator.operationActive.Load() {
-			if time.Since(terminator.lastAttempt) > 30*time.Second {
+			if time.Since(terminator.lastAttempt) > establishmentTimeout {
 				terminator.operationActive.Store(false)
 			} else {
 				continue
@@ -255,7 +263,10 @@ func (self *hostedServiceRegistry) RemoveTerminatorsRateLimited(terminators []*e
 		}
 
 		if err := self.RemoveTerminators(terminatorIds); err != nil {
-			if command.WasRateLimited(err) {
+			// A rate-limit rejection or a send timeout both mean the controller couldn't keep up, so
+			// signal congestion with Backoff to shrink the window. Other errors (no controller, busy
+			// channel) are local and shouldn't move the window, so they report Failed.
+			if command.WasRateLimited(err) || channel.IsTimeout(err) {
 				rateLimitCtrl.Backoff()
 			} else {
 				rateLimitCtrl.Failed()
@@ -1310,9 +1321,12 @@ func (self *markEstablishedEvent) handle(registry *hostedServiceRegistry) {
 		WithField("lifetime", time.Since(self.terminator.createTime)).
 		WithField("connId", self.terminator.MsgChannel.Id())
 
-	if rateLimitCallback := self.terminator.GetAndClearRateLimitCallback(); rateLimitCallback != nil {
-		rateLimitCallback.Success()
-	}
+	// Time this attempt (lastAttempt), not the terminator's lifetime (createTime):
+	// a reconnect re-creates a long-lived terminator without resetting createTime,
+	// so createTime would flag every reconnect as slow and back off during recovery.
+	establishmentLatency := time.Since(self.terminator.lastAttempt)
+
+	self.terminator.resolveRateLimitCallback(establishmentLatency)
 
 	if !self.terminator.updateState(xgress_common.TerminatorStateEstablishing, xgress_common.TerminatorStateEstablished, self.reason) {
 		log.Info("received additional terminator created notification")
@@ -1321,8 +1335,8 @@ func (self *markEstablishedEvent) handle(registry *hostedServiceRegistry) {
 		// If establishment took a long time, the SDK may have timed out waiting for BindSuccess
 		// and closed the listener. The initial post-create inspect (sent right after bind) would
 		// have confirmed validity before the timeout. Re-inspect to catch this case.
-		if self.terminator.supportsInspect && time.Since(self.terminator.createTime) > 30*time.Second {
-			log.Info("establishment took >30s, queuing post-establish inspect")
+		if self.terminator.supportsInspect && establishmentLatency >= establishmentTimeout {
+			log.WithField("threshold", establishmentTimeout).Info("establishment exceeded threshold, queuing post-establish inspect")
 			registry.postCreateInspectSet[self.terminator.terminatorId] = &pendingPostCreateInspect{
 				terminator:  self.terminator,
 				requestSeqs: map[int32]struct{}{},

--- a/router/xgress_edge/hosted_test.go
+++ b/router/xgress_edge/hosted_test.go
@@ -1,0 +1,112 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package xgress_edge
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// stubRateLimitControl is a rate.RateLimitControl that records how each outcome was signaled, so
+// tests can assert the router classified an establishment as a success or a backoff.
+type stubRateLimitControl struct {
+	success int
+	backoff int
+	failed  int
+}
+
+func (self *stubRateLimitControl) Success() { self.success++ }
+func (self *stubRateLimitControl) Backoff() { self.backoff++ }
+func (self *stubRateLimitControl) Failed()  { self.failed++ }
+
+func Test_edgeTerminator_rateLimitSignaling(t *testing.T) {
+	t.Run("establishment under threshold reports success", func(t *testing.T) {
+		req := require.New(t)
+
+		ctrl := &stubRateLimitControl{}
+		term := &edgeTerminator{}
+		term.replaceRateLimitCallback(ctrl)
+		req.Equal(0, ctrl.backoff, "storing a control with no prior attempt must not signal backoff")
+
+		term.resolveRateLimitCallback(establishmentTimeout - time.Second)
+
+		req.Equal(1, ctrl.success)
+		req.Equal(0, ctrl.backoff)
+		req.Equal(0, ctrl.failed)
+		req.Nil(term.GetAndClearRateLimitCallback(), "control must be cleared once resolved")
+	})
+
+	t.Run("establishment at or over threshold reports backoff", func(t *testing.T) {
+		req := require.New(t)
+
+		ctrl := &stubRateLimitControl{}
+		term := &edgeTerminator{}
+		term.replaceRateLimitCallback(ctrl)
+
+		term.resolveRateLimitCallback(establishmentTimeout)
+
+		req.Equal(0, ctrl.success)
+		req.Equal(1, ctrl.backoff)
+		req.Equal(0, ctrl.failed)
+		req.Nil(term.GetAndClearRateLimitCallback(), "control must be cleared once resolved")
+	})
+
+	t.Run("well over threshold reports backoff", func(t *testing.T) {
+		req := require.New(t)
+
+		ctrl := &stubRateLimitControl{}
+		term := &edgeTerminator{}
+		term.replaceRateLimitCallback(ctrl)
+
+		term.resolveRateLimitCallback(2 * establishmentTimeout)
+
+		req.Equal(0, ctrl.success)
+		req.Equal(1, ctrl.backoff)
+	})
+
+	t.Run("resolving with no outstanding control is a no-op", func(t *testing.T) {
+		req := require.New(t)
+
+		term := &edgeTerminator{}
+		req.NotPanics(func() {
+			term.resolveRateLimitCallback(time.Hour)
+		})
+	})
+
+	t.Run("re-send resolves the prior control with backoff instead of orphaning it", func(t *testing.T) {
+		req := require.New(t)
+
+		prior := &stubRateLimitControl{}
+		term := &edgeTerminator{}
+		term.replaceRateLimitCallback(prior)
+		req.Equal(0, prior.backoff)
+
+		// A 30s re-send acquires a fresh control and supersedes the prior attempt's control.
+		next := &stubRateLimitControl{}
+		term.replaceRateLimitCallback(next)
+
+		req.Equal(1, prior.backoff, "the superseded control must be resolved with backoff, not orphaned")
+		req.Equal(0, prior.success)
+		req.Equal(0, next.backoff, "the new control is still outstanding and must not be resolved yet")
+
+		got := term.GetAndClearRateLimitCallback()
+		req.NotNil(got)
+		req.Same(next, got.(*stubRateLimitControl), "the new control must be the one now stored")
+	})
+}


### PR DESCRIPTION
Under controller slowness the router mis-signals congestion on terminator establish/remove timeouts (neutral/success instead of backoff), so the adaptive window doesn't shrink and a transient stall can become self-reinforcing. Resolves the rate-limit control with Backoff on timeout for the establish and synchronous remove paths, and stops orphaning a superseded attempt's control.

Router-side; intended for backport to release-v2.0.x.

Stacked on the sdk-hosting-test PR.

Fixes #4155