### PR TITLE
Signal retry on leaderless terminator operations (backport to 2.0.x)

### DIFF
--- a/controller/command/rate_limiter.go
+++ b/controller/command/rate_limiter.go
@@ -438,6 +438,17 @@ func WasRateLimited(err error) bool {
 	return false
 }
 
+// WasLeaderless returns true if the given error indicates that a command could not be dispatched because the
+// cluster currently has no leader. This is a transient condition during membership changes; callers should
+// treat it like rate limiting and signal the requester to retry rather than fail permanently.
+func WasLeaderless(err error) bool {
+	var apiErr *errorz.ApiError
+	if errors.As(err, &apiErr) {
+		return apiErr.AppCode == apierror.ClusterHasNoLeaderCode
+	}
+	return false
+}
+
 // AdaptiveRateLimitTrackerConfig contains configuration values used to create a new AdaptiveRateLimitTracker
 type AdaptiveRateLimitTrackerConfig struct {
 	AdaptiveRateLimiterConfig

--- a/controller/handler_ctrl/remove_terminators.go
+++ b/controller/handler_ctrl/remove_terminators.go
@@ -75,7 +75,9 @@ func (self *removeTerminatorsHandler) handleRemoveTerminators(msg *channel.Messa
 			WithField("terminatorIds", request.TerminatorIds).
 			Info("removed terminators")
 		handler_common.SendSuccess(msg, ch, "")
-	} else if command.WasRateLimited(err) {
+	} else if command.WasRateLimited(err) || command.WasLeaderless(err) {
+		// A leaderless cluster (during a membership change) is transient; signal busy so the router retries
+		// rather than treating the removal as a permanent failure.
 		handler_common.SendServerBusy(msg, ch, "remove.terminators")
 	} else {
 		handler_common.SendFailure(msg, ch, err.Error())

--- a/controller/handler_edge_ctrl/create_terminator_v2.go
+++ b/controller/handler_edge_ctrl/create_terminator_v2.go
@@ -58,11 +58,6 @@ func (self *createTerminatorV2Handler) Label() string {
 }
 
 func (self *createTerminatorV2Handler) HandleReceive(msg *channel.Message, ch channel.Channel) {
-	if self.appEnv.GetCommandDispatcher().IsLeaderless() {
-		pfxlog.ContextLogger(ch.Label()).Error("cluster has no leader, unable to handle create terminator request")
-		return
-	}
-
 	req := &edge_ctrl_pb.CreateTerminatorV2Request{}
 	if err := proto.Unmarshal(msg.Body, req); err != nil {
 		pfxlog.ContextLogger(ch.Label()).WithError(err).Error("could not unmarshal CreateTerminatorV2Request")
@@ -122,6 +117,12 @@ func (self *createTerminatorV2Handler) CreateTerminatorV2(ctx *CreateTerminatorV
 			}, ctx.newChangeContext())
 
 			if err != nil {
+				// A rate-limited or leaderless dispatch is transient; reply busy so the router requeues
+				// promptly instead of treating it as a hard failure.
+				if command.WasRateLimited(err) || command.WasLeaderless(err) {
+					self.returnError(ctx, busyError(err), logger)
+					return
+				}
 				self.returnError(ctx, internalError(err), logger)
 				return
 			}
@@ -160,7 +161,7 @@ func (self *createTerminatorV2Handler) CreateTerminatorV2(ctx *CreateTerminatorV
 					return
 				}
 			} else {
-				if command.WasRateLimited(err) {
+				if command.WasRateLimited(err) || command.WasLeaderless(err) {
 					self.returnError(ctx, busyError(err), logger)
 					return
 				}

--- a/controller/handler_edge_ctrl/create_tunnel_terminator_v2.go
+++ b/controller/handler_edge_ctrl/create_tunnel_terminator_v2.go
@@ -148,7 +148,9 @@ func (self *createTunnelTerminatorV2Handler) CreateTerminator(ctx *createTunnelT
 					return
 				}
 			} else {
-				if command.WasRateLimited(err) {
+				// A rate-limited or leaderless dispatch is transient; reply busy so the router requeues
+				// promptly instead of treating it as a hard failure.
+				if command.WasRateLimited(err) || command.WasLeaderless(err) {
 					self.returnError(ctx, busyError(err), logger)
 					return
 				}


### PR DESCRIPTION
Fixes #4161. Backport of #4160 to release-v2.0.x.

Treats a leaderless dispatch like a rate-limited one, a retriable busy result, at every mutating terminator handler branch (sdk create, ert tunnel create, batch remove), so the router backs off and requeues promptly instead of waiting for its multi-minute recovery scan. Removes the racy up-front leaderless pre-check in favor of classifying the actual dispatch result.

Surfaced by the fablab upgrade test's 3-node cluster-add step.