### PR TITLE
zitilab: typed LogConfig for component log capture

### DIFF
--- a/zititest/models/db-sdk-hosting-test/main.go
+++ b/zititest/models/db-sdk-hosting-test/main.go
@@ -18,8 +18,8 @@ import (
 	"github.com/openziti/fablab/kernel/lib/actions/semaphore"
 	"github.com/openziti/fablab/kernel/lib/binding"
 	"github.com/openziti/fablab/kernel/lib/runlevel/0_infrastructure/aws_ssh_key"
-	"github.com/openziti/fablab/kernel/lib/runlevel/0_infrastructure/semaphore"
-	"github.com/openziti/fablab/kernel/lib/runlevel/0_infrastructure/terraform"
+	semaphore_0 "github.com/openziti/fablab/kernel/lib/runlevel/0_infrastructure/semaphore"
+	terraform_0 "github.com/openziti/fablab/kernel/lib/runlevel/0_infrastructure/terraform"
 	distribution "github.com/openziti/fablab/kernel/lib/runlevel/3_distribution"
 	"github.com/openziti/fablab/kernel/lib/runlevel/3_distribution/rsync"
 	aws_ssh_key2 "github.com/openziti/fablab/kernel/lib/runlevel/6_disposal/aws_ssh_key"
@@ -171,9 +171,9 @@ func (d dbStrategy) CreateIdentityHosts(tx *bbolt.Tx, m *model.Model, builder *z
 			var tunnelType model.ComponentType
 			if TunnelType == "zet" {
 				tunnelType = &zitilab.ZitiEdgeTunnelType{
-					Version:     TargetZitiEdgeTunnelVersion,
-					LogConfig:   "'2;bind.c=6'",
-					ConfigPathF: getConfigPath,
+					Version:      TargetZitiEdgeTunnelVersion,
+					LogVerbosity: "'2;bind.c=6'",
+					ConfigPathF:  getConfigPath,
 				}
 			} else {
 				tunnelType = &zitilab.ZitiTunnelType{

--- a/zititest/zitilab/component_common.go
+++ b/zititest/zitilab/component_common.go
@@ -19,7 +19,6 @@ package zitilab
 import (
 	"fmt"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/openziti/fablab/kernel/model"
@@ -28,9 +27,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// LogStrategy controls how a ziti component's stdout/stderr is written to its
-// log file. Set the "logStrategy" variable (per-component or model-wide) to one
-// of these values; the default is truncate.
+// LogStrategy controls how a ziti component's stdout/stderr is written to its log
+// file. Set it via the component type's LogConfig; the default is truncate.
 type LogStrategy string
 
 const (
@@ -45,25 +43,67 @@ const (
 	// preserves recent history across restarts without growing unbounded. The
 	// log-pipe side runs the component's own binary by default, so a component
 	// pinned to a ziti version that predates "ops log-pipe" must select a newer
-	// binary via the "logPipeBinaryVersion" variable (see resolveLogPipeBinary);
-	// otherwise the pipe breaks and takes the component's stdout down with it.
+	// binary via LogConfig.PipeBinaryVersion; otherwise the pipe breaks and takes
+	// the component's stdout down with it.
 	LogStrategyRotate LogStrategy = "rotate"
 )
 
 const (
-	// defaultLogRotateMaxSizeMb and defaultLogRotateMaxBackups are the rotate
-	// strategy defaults. The per-component log footprint is
-	// maxSizeMb * (maxBackups + 1); on hosts that pack many components onto one
-	// disk (e.g. links-test runs 10 routers per host), set the "logRotateMaxSizeMb"
-	// and "logRotateMaxBackups" variables lower so the total stays well under disk.
-	defaultLogRotateMaxSizeMb  = 50
-	defaultLogRotateMaxBackups = 10
+	// DefaultLogRotateMaxSizeMb and DefaultLogRotateMaxBackups are the rotate
+	// strategy's size bounds, used when a LogConfig leaves them zero. The
+	// per-component log footprint is maxSizeMb * (maxBackups + 1); models that
+	// pack many components onto one disk (e.g. links-test runs 10 routers per
+	// host) should set lower explicit values so the total stays well under disk.
+	DefaultLogRotateMaxSizeMb  = 50
+	DefaultLogRotateMaxBackups = 10
 )
+
+// LogConfig configures how a ziti component's stdout/stderr is captured to its log
+// file. Embed it in a component type (ControllerType, RouterType, ...) to select
+// the strategy declaratively; the zero value means truncate.
+type LogConfig struct {
+	// Strategy selects truncate (default), append, or rotate.
+	Strategy LogStrategy
+
+	// RotateMaxSizeMb and RotateMaxBackups bound the rotate strategy's on-disk
+	// footprint, which is RotateMaxSizeMb * (RotateMaxBackups + 1). Zero uses
+	// DefaultLogRotateMaxSizeMb / DefaultLogRotateMaxBackups.
+	RotateMaxSizeMb  int
+	RotateMaxBackups int
+
+	// PipeBinaryVersion selects the ziti version whose "ops log-pipe" runs the
+	// rotate pipe. Nil uses the component's own binary; a non-nil value selects
+	// that version's binary, with the empty string meaning the current local
+	// build. It exists because a component pinned to a version predating
+	// "ops log-pipe" would otherwise break its stdout piping through a binary
+	// that lacks the command.
+	PipeBinaryVersion *string
+}
+
+// GetLogConfig returns the log configuration, letting a component type expose its
+// embedded LogConfig through the logConfigProvider interface.
+func (l LogConfig) GetLogConfig() LogConfig { return l }
+
+// logConfigProvider is implemented by component types that carry a LogConfig (via
+// embedding), letting the shared start path read a component's log settings off
+// its type.
+type logConfigProvider interface {
+	GetLogConfig() LogConfig
+}
+
+// logConfigOf returns the component's LogConfig, or the zero value (truncate) when
+// its type doesn't carry one.
+func logConfigOf(c *model.Component) LogConfig {
+	if p, ok := c.Type.(logConfigProvider); ok {
+		return p.GetLogConfig()
+	}
+	return LogConfig{}
+}
 
 // resolveLogStrategy returns the component's configured log strategy, defaulting
 // to truncate.
 func resolveLogStrategy(c *model.Component) LogStrategy {
-	switch LogStrategy(strings.ToLower(c.GetStringVariableOr("logStrategy", string(LogStrategyTruncate)))) {
+	switch logConfigOf(c).Strategy {
 	case LogStrategyAppend:
 		return LogStrategyAppend
 	case LogStrategyRotate:
@@ -73,35 +113,25 @@ func resolveLogStrategy(c *model.Component) LogStrategy {
 	}
 }
 
-// logPipeBinaryVersion is the model variable naming the ziti version whose binary
-// runs "ops log-pipe" for the rotate log strategy. When unset, a component uses
-// its own binary; when set it selects the binary for that version, with the empty
-// string meaning the current local build. The override exists because a component
-// can be pinned to a ziti version that predates "ops log-pipe": piping its output
-// through that binary's (nonexistent) log-pipe exits immediately and breaks the
-// component's stdout, so such a model points this at a version that has the
-// command. StageFiles stages the selected binary so switching to rotate never
-// needs the environment rebuilt.
-const logPipeBinaryVersion = "logPipeBinaryVersion"
-
 // resolveLogPipeBinaryVersion returns the configured log-pipe binary version and
-// whether it was set. An unset variable means the component should use its own
-// binary; a set-but-empty value means the current local build. The version is
-// canonicalized the same way component versions are, so "1.2.3" and "v1.2.3"
-// resolve to the same binary and staging op rather than duplicating either.
+// whether it was set. A nil LogConfig.PipeBinaryVersion means the component uses
+// its own binary; a non-nil value selects that version, with the empty string
+// meaning the current local build. The version is canonicalized the same way
+// component versions are, so "1.2.3" and "v1.2.3" resolve to the same binary and
+// staging op rather than duplicating either.
 func resolveLogPipeBinaryVersion(c *model.Component) (version string, set bool) {
-	v, found := c.GetVariable(logPipeBinaryVersion)
-	if !found {
+	v := logConfigOf(c).PipeBinaryVersion
+	if v == nil {
 		return "", false
 	}
-	s, _ := v.(string)
+	s := *v
 	canonicalizeGoAppVersion(&s)
 	return s, true
 }
 
 // resolveLogPipeBinary returns the ziti binary path used to run "ops log-pipe" for
 // the rotate log strategy. It defaults to the component's own binary (binaryPath),
-// but resolves to the logPipeBinaryVersion binary when that variable is set.
+// but resolves to the PipeBinaryVersion binary when that is set.
 func resolveLogPipeBinary(c *model.Component, binaryPath string) string {
 	if version, set := resolveLogPipeBinaryVersion(c); set {
 		return GetZitiBinaryPath(c, version)
@@ -109,12 +139,12 @@ func resolveLogPipeBinary(c *model.Component, binaryPath string) string {
 	return binaryPath
 }
 
-// stageLogPipeBinary stages the binary selected by logPipeBinaryVersion when that
-// variable is set to a version other than the component's own (ownVersion). This
-// ensures the rotate log strategy has a log-pipe-capable binary on the host even
-// when the component itself is pinned to an older version. It stages regardless of
-// the current log strategy, so switching a component to rotate later doesn't
-// require re-staging the environment.
+// stageLogPipeBinary stages the binary selected by LogConfig.PipeBinaryVersion when
+// it is set to a version other than the component's own (ownVersion). This ensures
+// the rotate log strategy has a log-pipe-capable binary on the host even when the
+// component itself is pinned to an older version. It stages regardless of the
+// current log strategy, so switching a component to rotate later doesn't require
+// re-staging the environment.
 func stageLogPipeBinary(r model.Run, c *model.Component, ownVersion string) error {
 	version, set := resolveLogPipeBinaryVersion(c)
 	if !set || version == ownVersion {
@@ -123,35 +153,43 @@ func stageLogPipeBinary(r model.Run, c *model.Component, ownVersion string) erro
 	return stageziti.StageZitiOnce(r, c, version, "")
 }
 
-// resolveLogRotate returns the rotate strategy's max file size (MB) and max
-// number of retained backups for the component, from the "logRotateMaxSizeMb"
-// and "logRotateMaxBackups" variables, defaulting when unset.
+// resolveLogRotate returns the rotate strategy's max file size (MB) and retained
+// backup count for the component, applying the package defaults when the LogConfig
+// leaves them zero.
 func resolveLogRotate(c *model.Component) (maxSizeMb int, maxBackups int) {
-	maxSizeMb = logRotateIntVar(c, "logRotateMaxSizeMb", defaultLogRotateMaxSizeMb)
-	maxBackups = logRotateIntVar(c, "logRotateMaxBackups", defaultLogRotateMaxBackups)
+	cfg := logConfigOf(c)
+	maxSizeMb, maxBackups = cfg.RotateMaxSizeMb, cfg.RotateMaxBackups
+	if maxSizeMb <= 0 {
+		maxSizeMb = DefaultLogRotateMaxSizeMb
+	}
+	if maxBackups <= 0 {
+		maxBackups = DefaultLogRotateMaxBackups
+	}
 	return maxSizeMb, maxBackups
 }
 
-// logRotateIntVar reads an int-valued model variable, tolerating the int and
-// string forms a variable may take, and falls back to def when unset or invalid.
-func logRotateIntVar(c *model.Component, name string, def int) int {
-	v, found := c.GetVariable(name)
-	if !found {
-		return def
+// logRedirect returns the shell redirect fragment that captures a component's
+// stdout/stderr per its log strategy: truncate ("> file"), append (">> file"), or
+// rotate (pipe through "ops log-pipe"). defaultLogPipeBinary is the binary used to
+// run "ops log-pipe" for the rotate strategy unless LogConfig.PipeBinaryVersion
+// selects another; it must be a ziti binary that has the "ops log-pipe" command
+// (the ziti-edge-tunnel binary does not, so ZET passes its staged ziti binary).
+//
+// For rotate, log-pipe's OWN stdout/stderr must go to /dev/null and it must be
+// nohup'd, so it doesn't hold the start command's ssh channel open (which makes a
+// backgrounded start never return) or die on SIGHUP when the channel closes.
+func logRedirect(c *model.Component, logsPath, defaultLogPipeBinary string) string {
+	switch resolveLogStrategy(c) {
+	case LogStrategyRotate:
+		maxSizeMb, maxBackups := resolveLogRotate(c)
+		logPipeBinary := resolveLogPipeBinary(c, defaultLogPipeBinary)
+		return fmt.Sprintf("2>&1 | nohup %s ops log-pipe %s --max-size-mb %d --max-backups %d >/dev/null 2>&1",
+			logPipeBinary, logsPath, maxSizeMb, maxBackups)
+	case LogStrategyAppend:
+		return fmt.Sprintf(">> %s 2>&1", logsPath)
+	default: // truncate
+		return fmt.Sprintf("> %s 2>&1", logsPath)
 	}
-	switch tv := v.(type) {
-	case int:
-		return tv
-	case int64:
-		return int(tv)
-	case float64:
-		return int(tv)
-	case string:
-		if n, err := strconv.Atoi(tv); err == nil {
-			return n
-		}
-	}
-	return def
 }
 
 func getZitiProcessFilter(c *model.Component, zitiType string) func(string) bool {
@@ -181,27 +219,10 @@ func startZitiComponent(c *model.Component, zitiType string, version string, con
 	// Truncating on each start discards pre-restart history, which is often
 	// exactly what's needed to debug a failure, so chaos-heavy models will want
 	// append (survives restarts) or rotate (survives restarts, size-bounded).
-	var logRedirect string
-	switch resolveLogStrategy(c) {
-	case LogStrategyTruncate:
-		logRedirect = fmt.Sprintf("> %s 2>&1", logsPath)
-	case LogStrategyRotate:
-		// Pipe the run process's output into log-pipe for rotation. log-pipe's
-		// OWN stdout/stderr must go to /dev/null (and it must be nohup'd) so it
-		// doesn't hold the start command's ssh channel open (which made the
-		// backgrounded start never return) or die on SIGHUP when the channel
-		// closes. log-pipe runs the component's own binary unless the model
-		// overrides it (needed when the component predates "ops log-pipe").
-		maxSizeMb, maxBackups := resolveLogRotate(c)
-		logPipeBinary := resolveLogPipeBinary(c, binaryPath)
-		logRedirect = fmt.Sprintf("2>&1 | nohup %s ops log-pipe %s --max-size-mb %d --max-backups %d >/dev/null 2>&1",
-			logPipeBinary, logsPath, maxSizeMb, maxBackups)
-	default: // append
-		logRedirect = fmt.Sprintf(">> %s 2>&1", logsPath)
-	}
+	redirect := logRedirect(c, logsPath, binaryPath)
 
 	serviceCmd := fmt.Sprintf("nohup %s %s %s run %s --cli-agent-alias %s --log-formatter json %s %s &",
-		useSudo, binaryPath, zitiType, extraArgs, c.Id, configPath, logRedirect)
+		useSudo, binaryPath, zitiType, extraArgs, c.Id, configPath, redirect)
 
 	if quiet, _ := c.GetBoolVariable("quiet_startup"); !quiet {
 		logrus.Info(serviceCmd)

--- a/zititest/zitilab/component_controller.go
+++ b/zititest/zitilab/component_controller.go
@@ -47,6 +47,7 @@ type ControllerType struct {
 	LocalPath      string
 	DNSNames       []string
 	Debug          bool
+	LogConfig
 }
 
 func (self *ControllerType) Label() string {

--- a/zititest/zitilab/component_router.go
+++ b/zititest/zitilab/component_router.go
@@ -48,6 +48,7 @@ type RouterType struct {
 	Version   string
 	LocalPath string
 	Debug     bool
+	LogConfig
 }
 
 func (self *RouterType) Label() string {

--- a/zititest/zitilab/component_ziti_edge_tunnel.go
+++ b/zititest/zitilab/component_ziti_edge_tunnel.go
@@ -35,13 +35,15 @@ const (
 )
 
 type ZitiEdgeTunnelType struct {
-	Mode           ZitiEdgeTunnelMode
-	Version        string
-	ZitiVersion    string
-	LocalPath      string
-	LogConfig      string
+	Mode        ZitiEdgeTunnelMode
+	Version     string
+	ZitiVersion string
+	LocalPath   string
+	// LogVerbosity is the ziti-edge-tunnel ZITI_LOG spec (e.g. "2;bind.c=6"); empty leaves it unset.
+	LogVerbosity   string
 	VerbosityLevel uint16
 	ConfigPathF    func(c *model.Component) string
+	LogConfig
 }
 
 func (self *ZitiEdgeTunnelType) Label() string {
@@ -90,7 +92,15 @@ func (self *ZitiEdgeTunnelType) StageFiles(r model.Run, c *model.Component) erro
 	if err := stageziti.StageZitiEdgeTunnelOnce(r, c, self.Version, self.LocalPath); err != nil {
 		return err
 	}
-	return stageziti.StageZitiOnce(r, c, self.ZitiVersion, self.LocalPath)
+	// LocalPath is the ziti-edge-tunnel build, not a ziti build, so it must not be reused as the
+	// ziti source: with an empty ZitiVersion that would stage the ZET executable as "ziti" and break
+	// rotation's "ziti ops log-pipe". An empty source resolves ziti from ZITI_PATH/PATH instead.
+	if err := stageziti.StageZitiOnce(r, c, self.ZitiVersion, ""); err != nil {
+		return err
+	}
+	// The rotate log strategy runs "ops log-pipe" from the staged ziti binary (ZitiVersion);
+	// stage a different one when LogConfig.PipeBinaryVersion overrides it.
+	return stageLogPipeBinary(r, c, self.ZitiVersion)
 }
 
 func (self *ZitiEdgeTunnelType) getProcessFilter(c *model.Component) func(string) bool {
@@ -134,8 +144,8 @@ func (self *ZitiEdgeTunnelType) Start(r model.Run, c *model.Component) error {
 	logsPath := fmt.Sprintf("/home/%s/logs/%s.log", user, c.Id)
 
 	env := "ZITI_TIME_FORMAT=utc"
-	if self.LogConfig != "" {
-		env += " ZITI_LOG=" + self.LogConfig
+	if self.LogVerbosity != "" {
+		env += " ZITI_LOG=" + self.LogVerbosity
 	}
 
 	verbosity := ""
@@ -143,11 +153,15 @@ func (self *ZitiEdgeTunnelType) Start(r model.Run, c *model.Component) error {
 		verbosity = fmt.Sprintf("-v %v", self.VerbosityLevel)
 	}
 
+	// ziti-edge-tunnel has no "ops log-pipe" command, so rotation must run it from the ziti
+	// binary staged alongside (ZitiVersion), not from binaryPath (the ziti-edge-tunnel binary).
+	redirect := logRedirect(c, logsPath, GetZitiBinaryPath(c, self.ZitiVersion))
+
 	var serviceCmd string
 	if self.Mode == ZitiEdgeTunnelModeDefault {
-		serviceCmd = fmt.Sprintf("%s sudo -E %s run -i %s %s > %s 2>&1 &", env, binaryPath, configPath, verbosity, logsPath)
+		serviceCmd = fmt.Sprintf("%s sudo -E %s run -i %s %s %s &", env, binaryPath, configPath, verbosity, redirect)
 	} else if self.Mode == ZitiEdgeTunnelModeHost {
-		serviceCmd = fmt.Sprintf("%s %s run-host -i %s %s > %s 2>&1 &", env, binaryPath, configPath, verbosity, logsPath)
+		serviceCmd = fmt.Sprintf("%s %s run-host -i %s %s %s &", env, binaryPath, configPath, verbosity, redirect)
 	} else {
 		return fmt.Errorf("unsupported ziti-edge-tunnel mode: %v", self.Mode)
 	}

--- a/zititest/zitilab/component_ziti_tunnel.go
+++ b/zititest/zitilab/component_ziti_tunnel.go
@@ -61,6 +61,7 @@ type ZitiTunnelType struct {
 	ControlRouterConnections uint8
 	EnableSdkFlowControl     bool
 	Verbose                  bool
+	LogConfig
 }
 
 func (self *ZitiTunnelType) Label() string {
@@ -110,7 +111,12 @@ func (self *ZitiTunnelType) Dump() any {
 }
 
 func (self *ZitiTunnelType) StageFiles(r model.Run, c *model.Component) error {
-	return stageziti.StageZitiOnce(r, c, self.Version, self.LocalPath)
+	if err := stageziti.StageZitiOnce(r, c, self.Version, self.LocalPath); err != nil {
+		return err
+	}
+	// The rotate log strategy runs "ops log-pipe" from the component's ziti binary (Version);
+	// stage a different one when LogConfig.PipeBinaryVersion overrides it.
+	return stageLogPipeBinary(r, c, self.Version)
 }
 
 func (self *ZitiTunnelType) InitializeHost(_ model.Run, c *model.Component) error {
@@ -205,12 +211,19 @@ func (self *ZitiTunnelType) StartIndividual(c *model.Component, idx int) error {
 		verbose = "-v"
 	}
 
-	serviceCmd := fmt.Sprintf("%s %s tunnel %s %s %s --cli-agent-alias %s --log-formatter json -i %s > %s 2>&1 &",
-		useSudo, binaryPath, mode.String(), connectCfg, verbose, c.Id, configPath, logsPath)
+	redirect := logRedirect(c, logsPath, binaryPath)
 
-	value, err := c.Host.ExecLogged(
-		"rm -f "+logsPath,
-		serviceCmd)
+	serviceCmd := fmt.Sprintf("%s %s tunnel %s %s %s --cli-agent-alias %s --log-formatter json -i %s %s &",
+		useSudo, binaryPath, mode.String(), connectCfg, verbose, c.Id, configPath, redirect)
+
+	// Only clear prior history for truncate; append and rotate must preserve it.
+	var cmds []string
+	if resolveLogStrategy(c) == LogStrategyTruncate {
+		cmds = append(cmds, "rm -f "+logsPath)
+	}
+	cmds = append(cmds, serviceCmd)
+
+	value, err := c.Host.ExecLogged(cmds...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Makes a ziti component's log-capture strategy a typed, discoverable field instead of undiscoverable model variables.

Before, setting a component's log strategy (truncate/append/rotate), rotate size bounds, or log-pipe binary version meant calling `PutVariable` with magic string keys that only existed in the source, backed by private default constants you couldn't reference. There was no way to know the feature existed without reading zitilab internals.

This adds a `LogConfig` type embedded in each component type (controller, router, tunnelers) so the settings are declared on the component and surfaced by autocompletion. The log-redirect construction is shared across all start paths so the tunnelers honor the strategy too; the truncate default is byte-identical to prior behavior. `ZitiEdgeTunnelType.LogConfig` (a ZITI_LOG verbosity string) is renamed to `ZitiLog` to free the name.

Test-infra only; no product code changes. Bottom of the sdk-hosting-test / terminator-congestion stack.