### PR TITLE
Reject terminator removals from a router that does not own them

### DIFF
--- a/controller/handler_ctrl/base.go
+++ b/controller/handler_ctrl/base.go
@@ -17,10 +17,12 @@
 package handler_ctrl
 
 import (
+	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/channel/v5"
 	"github.com/openziti/ziti/v2/controller/change"
 	"github.com/openziti/ziti/v2/controller/model"
 	"github.com/openziti/ziti/v2/controller/network"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
 )
 
 type baseHandler struct {
@@ -30,4 +32,85 @@ type baseHandler struct {
 
 func (self *baseHandler) newChangeContext(ch channel.Channel, method string) *change.Context {
 	return change.NewControlChannelChange(self.router.Id, self.router.Name, method, ch)
+}
+
+// lookupTerminatorOwner returns the id of the router that owns terminator id and whether the
+// terminator currently exists. A not-found terminator returns ("", false, nil); other read errors
+// are returned so the caller can default to keeping the id rather than acting on incomplete state.
+func (self *baseHandler) lookupTerminatorOwner(id string) (routerId string, present bool, err error) {
+	terminator, err := self.network.Terminator.Read(id)
+	if err != nil {
+		if boltz.IsErrNotFoundErr(err) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	return terminator.Router, true, nil
+}
+
+// selectRemovableTerminators returns the terminator ids from a remove request that should be sent
+// through the ordered delete. It drops ids whose terminator is owned by a different router, so a
+// router can only remove terminators it owns, and (on the leader) confirmed-created ids that are
+// already gone, so a storm of no-op retries doesn't consume the raft rate limiter. createConfirmed
+// may be nil when the request carries no confirmation, in which case no id is treated as confirmed.
+func (self *baseHandler) selectRemovableTerminators(ids []string, createConfirmed []bool) []string {
+	kept, rejected, skipped := filterRemovableTerminators(
+		ids,
+		createConfirmed,
+		self.router.Id,
+		self.network.Dispatcher.IsLeader(),
+		self.lookupTerminatorOwner,
+	)
+
+	if rejected > 0 {
+		pfxlog.Logger().
+			WithField("routerId", self.router.Id).
+			WithField("rejected", rejected).
+			Warn("router attempted to remove terminators it does not own; rejected")
+	}
+
+	if skipped > 0 {
+		pfxlog.Logger().
+			WithField("routerId", self.router.Id).
+			WithField("skipped", skipped).
+			WithField("remaining", len(kept)).
+			Debug("leader fast-path skipped confirmed already-removed terminators")
+	}
+
+	return kept
+}
+
+// filterRemovableTerminators selects which requested terminator ids to send through the ordered
+// (raft) delete for a remove request from requestingRouterId, using lookup to resolve each id's
+// owning router and whether it exists. It drops:
+//   - rejected: ids whose terminator exists but is owned by a different router; a router may only
+//     remove terminators it owns.
+//   - skipped: on the leader, ids the router confirmed it created (createConfirmed, index-aligned
+//     with ids) that no longer exist; those deletes are confirmed no-ops.
+//
+// Absent, unconfirmed ids are kept, so a delete racing a not-yet-applied create is still ordered
+// after it. A lookup error keeps the id (safe default). Off the leader nothing is skipped as a
+// no-op, since a lagging follower can't prove an id is gone, but ownership is still enforced for ids
+// that resolve to a different router.
+func filterRemovableTerminators(ids []string, createConfirmed []bool, requestingRouterId string, isLeader bool, lookup func(string) (routerId string, present bool, err error)) (kept []string, rejected int, skipped int) {
+	kept = make([]string, 0, len(ids))
+	for i, id := range ids {
+		routerId, present, err := lookup(id)
+
+		if err == nil && present && routerId != requestingRouterId {
+			rejected++
+			continue
+		}
+
+		if isLeader && err == nil && !present {
+			if i < len(createConfirmed) && createConfirmed[i] {
+				skipped++
+				continue
+			}
+		}
+
+		kept = append(kept, id)
+	}
+
+	return kept, rejected, skipped
 }

--- a/controller/handler_ctrl/remove_terminators.go
+++ b/controller/handler_ctrl/remove_terminators.go
@@ -59,20 +59,25 @@ func (self *removeTerminatorsHandler) HandleReceive(msg *channel.Message, ch cha
 func (self *removeTerminatorsHandler) handleRemoveTerminators(msg *channel.Message, ch channel.Channel, request *ctrl_pb.RemoveTerminatorsRequest) {
 	log := pfxlog.ContextLogger(ch.Label())
 
-	// Don't pre-filter by IsEntityPresent here. The create for a terminator may be
-	// in-flight in raft but not yet applied to the DB. If we skip it here, the create
-	// will apply after we return success, leaving an orphan. By sending all IDs through
-	// raft, the delete will be ordered after the create and ApplyDeleteBatch will handle
-	// non-existent IDs gracefully.
 	if len(request.TerminatorIds) == 0 {
 		handler_common.SendSuccess(msg, ch, "")
 		return
 	}
 
-	if err := self.network.Terminator.DeleteBatch(request.TerminatorIds, self.newChangeContext(ch, "fabric.remove.terminators.batch")); err == nil {
+	// Drop ids this router doesn't own, so it can't remove another router's terminators. Absent ids
+	// are kept (not pre-filtered by presence): the create for a terminator may be in-flight in raft
+	// but not yet applied to the DB, so sending it through raft orders the delete after the create,
+	// and ApplyDeleteBatch handles non-existent ids gracefully.
+	toDelete := self.selectRemovableTerminators(request.TerminatorIds, nil)
+	if len(toDelete) == 0 {
+		handler_common.SendSuccess(msg, ch, "")
+		return
+	}
+
+	if err := self.network.Terminator.DeleteBatch(toDelete, self.newChangeContext(ch, "fabric.remove.terminators.batch")); err == nil {
 		log.
 			WithField("routerId", ch.Id()).
-			WithField("terminatorIds", request.TerminatorIds).
+			WithField("terminatorIds", toDelete).
 			Info("removed terminators")
 		handler_common.SendSuccess(msg, ch, "")
 	} else if command.WasRateLimited(err) {

--- a/controller/handler_ctrl/remove_terminators_v2.go
+++ b/controller/handler_ctrl/remove_terminators_v2.go
@@ -65,9 +65,10 @@ func (self *removeTerminatorsV2Handler) handleRemoveTerminators(ch channel.Chann
 
 	response := &ctrl_pb.RemoveTerminatorsV2Response{RequestId: request.RequestId}
 
-	toDelete := self.filterConfirmedAbsent(request)
+	toDelete := self.selectRemovableTerminators(request.TerminatorIds, request.CreateConfirmed)
 
-	// Everything was a confirmed no-op (already gone), so there's nothing to order through raft.
+	// Everything was either not owned by this router or a confirmed no-op (already gone), so there's
+	// nothing to order through raft.
 	if len(toDelete) == 0 {
 		response.Success = true
 		self.sendResponse(ch, response)
@@ -92,57 +93,6 @@ func (self *removeTerminatorsV2Handler) handleRemoveTerminators(ch channel.Chann
 	}
 
 	self.sendResponse(ch, response)
-}
-
-// filterConfirmedAbsent returns the terminator ids that must go through the ordered (raft) delete.
-// On the leader, where the applied state is current, it drops ids the router confirmed were created
-// (createConfirmed) but that no longer exist: those deletes are confirmed no-ops, so skipping them
-// keeps a storm of no-op retries from consuming the raft/command rate limiter. Ids that still exist,
-// or whose create the router did not confirm, are kept: an unconfirmed create may be committed but
-// not yet applied, so an absent id doesn't prove it's gone, and sending it through raft orders the
-// delete after any such create (ApplyDeleteBatch handles non-existent ids gracefully). Off the leader
-// every id is kept, since a lagging follower can't prove an id is gone.
-func (self *removeTerminatorsV2Handler) filterConfirmedAbsent(request *ctrl_pb.RemoveTerminatorsV2Request) []string {
-	kept, skipped := filterConfirmedAbsentTerminators(
-		request.TerminatorIds,
-		request.CreateConfirmed,
-		self.network.Dispatcher.IsLeader(),
-		self.network.Terminator.IsEntityPresent,
-	)
-
-	if skipped > 0 {
-		pfxlog.Logger().
-			WithField("requestId", request.RequestId).
-			WithField("skipped", skipped).
-			WithField("remaining", len(kept)).
-			Debug("leader fast-path skipped confirmed already-removed terminators")
-	}
-
-	return kept
-}
-
-// filterConfirmedAbsentTerminators implements the leader fast-path filter for filterConfirmedAbsent,
-// factored out so it can be unit tested without a live network. See filterConfirmedAbsent for the
-// rationale. createConfirmed is index-aligned with ids; a missing entry counts as false. isPresent is
-// only consulted for confirmed ids, and an error from it keeps the id (safe default).
-func filterConfirmedAbsentTerminators(ids []string, createConfirmed []bool, isLeader bool, isPresent func(string) (bool, error)) (kept []string, skipped int) {
-	if !isLeader {
-		return ids, 0
-	}
-
-	kept = make([]string, 0, len(ids))
-	for i, id := range ids {
-		confirmed := i < len(createConfirmed) && createConfirmed[i]
-		if confirmed {
-			if present, err := isPresent(id); err == nil && !present {
-				skipped++
-				continue
-			}
-		}
-		kept = append(kept, id)
-	}
-
-	return kept, skipped
 }
 
 func (self *removeTerminatorsV2Handler) sendResponse(ch channel.Channel, response *ctrl_pb.RemoveTerminatorsV2Response) {

--- a/controller/handler_ctrl/remove_terminators_v2_test.go
+++ b/controller/handler_ctrl/remove_terminators_v2_test.go
@@ -23,65 +23,104 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_filterConfirmedAbsentTerminators(t *testing.T) {
-	present := map[string]bool{"exists": true, "gone": false}
-	isPresent := func(id string) (bool, error) {
-		if id == "err" {
-			return false, errors.New("boom")
+func Test_filterRemovableTerminators(t *testing.T) {
+	const me = "router-me"
+
+	// mine: present, owned by the requesting router; other: present, owned by a different router;
+	// gone: not present; err: lookup fails.
+	lookup := func(id string) (string, bool, error) {
+		switch id {
+		case "mine":
+			return me, true, nil
+		case "other":
+			return "router-other", true, nil
+		case "err":
+			return "", false, errors.New("boom")
+		default: // "gone" and anything else
+			return "", false, nil
 		}
-		return present[id], nil
 	}
 
-	t.Run("off the leader keeps every id", func(t *testing.T) {
+	t.Run("off the leader keeps owned and absent ids", func(t *testing.T) {
 		req := require.New(t)
-		kept, skipped := filterConfirmedAbsentTerminators([]string{"gone", "exists"}, []bool{true, true}, false, isPresent)
-		req.Equal([]string{"gone", "exists"}, kept)
+		kept, rejected, skipped := filterRemovableTerminators([]string{"gone", "mine"}, []bool{true, true}, me, false, lookup)
+		req.Equal([]string{"gone", "mine"}, kept)
+		req.Zero(rejected)
+		req.Zero(skipped, "off the leader nothing is skipped as a no-op")
+	})
+
+	t.Run("rejects ids owned by another router", func(t *testing.T) {
+		req := require.New(t)
+		kept, rejected, skipped := filterRemovableTerminators([]string{"other", "mine"}, nil, me, true, lookup)
+		req.Equal([]string{"mine"}, kept, "a router may only remove terminators it owns")
+		req.Equal(1, rejected)
+		req.Zero(skipped)
+	})
+
+	t.Run("rejects another router's id even when confirmed on the leader", func(t *testing.T) {
+		req := require.New(t)
+		kept, rejected, skipped := filterRemovableTerminators([]string{"other"}, []bool{true}, me, true, lookup)
+		req.Empty(kept)
+		req.Equal(1, rejected)
 		req.Zero(skipped)
 	})
 
 	t.Run("leader skips confirmed and absent", func(t *testing.T) {
 		req := require.New(t)
-		kept, skipped := filterConfirmedAbsentTerminators([]string{"gone"}, []bool{true}, true, isPresent)
+		kept, rejected, skipped := filterRemovableTerminators([]string{"gone"}, []bool{true}, me, true, lookup)
 		req.Empty(kept, "a confirmed, already-removed terminator must be skipped")
+		req.Zero(rejected)
 		req.Equal(1, skipped)
 	})
 
 	t.Run("leader keeps confirmed but still present", func(t *testing.T) {
 		req := require.New(t)
-		kept, skipped := filterConfirmedAbsentTerminators([]string{"exists"}, []bool{true}, true, isPresent)
-		req.Equal([]string{"exists"}, kept, "a terminator that still exists must go through the ordered delete")
+		kept, rejected, skipped := filterRemovableTerminators([]string{"mine"}, []bool{true}, me, true, lookup)
+		req.Equal([]string{"mine"}, kept, "a terminator that still exists must go through the ordered delete")
+		req.Zero(rejected)
 		req.Zero(skipped)
 	})
 
 	t.Run("leader keeps unconfirmed even when absent", func(t *testing.T) {
 		req := require.New(t)
-		kept, skipped := filterConfirmedAbsentTerminators([]string{"gone"}, []bool{false}, true, isPresent)
+		kept, _, skipped := filterRemovableTerminators([]string{"gone"}, []bool{false}, me, true, lookup)
 		req.Equal([]string{"gone"}, kept, "an unconfirmed create may be committed but not yet applied, so it must not be skipped")
+		req.Zero(skipped)
+	})
+
+	t.Run("nil createConfirmed treats every id as unconfirmed", func(t *testing.T) {
+		req := require.New(t)
+		// The v1 request carries no confirmation, so absent ids are kept (ownership still applies).
+		kept, rejected, skipped := filterRemovableTerminators([]string{"gone", "other", "mine"}, nil, me, true, lookup)
+		req.Equal([]string{"gone", "mine"}, kept)
+		req.Equal(1, rejected)
 		req.Zero(skipped)
 	})
 
 	t.Run("leader treats a missing createConfirmed entry as false", func(t *testing.T) {
 		req := require.New(t)
 		// createConfirmed shorter than ids (e.g. an older router) -> the uncovered id is unconfirmed
-		kept, skipped := filterConfirmedAbsentTerminators([]string{"gone", "gone"}, []bool{true}, true, isPresent)
+		kept, _, skipped := filterRemovableTerminators([]string{"gone", "gone"}, []bool{true}, me, true, lookup)
 		req.Equal([]string{"gone"}, kept, "the id without a createConfirmed entry must be kept")
 		req.Equal(1, skipped)
 	})
 
-	t.Run("leader keeps a confirmed id when the presence check errors", func(t *testing.T) {
+	t.Run("a lookup error keeps the id", func(t *testing.T) {
 		req := require.New(t)
-		kept, skipped := filterConfirmedAbsentTerminators([]string{"err"}, []bool{true}, true, isPresent)
-		req.Equal([]string{"err"}, kept, "a presence-check error must fall back to keeping the id")
+		kept, rejected, skipped := filterRemovableTerminators([]string{"err"}, []bool{true}, me, true, lookup)
+		req.Equal([]string{"err"}, kept, "a lookup error must fall back to keeping the id")
+		req.Zero(rejected, "an unresolved owner must not be treated as an ownership violation")
 		req.Zero(skipped)
 	})
 
-	t.Run("leader mixes kept and skipped correctly", func(t *testing.T) {
+	t.Run("leader mixes kept, rejected and skipped correctly", func(t *testing.T) {
 		req := require.New(t)
-		kept, skipped := filterConfirmedAbsentTerminators(
-			[]string{"gone", "exists", "gone", "err"},
-			[]bool{true, true, false, true},
-			true, isPresent)
-		req.Equal([]string{"exists", "gone", "err"}, kept)
+		kept, rejected, skipped := filterRemovableTerminators(
+			[]string{"gone", "mine", "other", "gone", "err"},
+			[]bool{true, true, true, false, true},
+			me, true, lookup)
+		req.Equal([]string{"mine", "gone", "err"}, kept)
+		req.Equal(1, rejected)
 		req.Equal(1, skipped)
 	})
 }


### PR DESCRIPTION
Fixes #4165. Both fabric remove handlers (V1 + V2) reject terminator ids owned by another router; the edge path already enforces this via verifyTerminator. Stacked on the terminator-congestion work (V2 lives there); v1 half backported in #4166.