### PR TITLE
[Backport-2.0] Reject terminator removals from a router that does not own them

### DIFF
--- a/controller/handler_ctrl/base.go
+++ b/controller/handler_ctrl/base.go
@@ -17,10 +17,12 @@
 package handler_ctrl
 
 import (
+	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/channel/v4"
 	"github.com/openziti/ziti/v2/controller/change"
 	"github.com/openziti/ziti/v2/controller/model"
 	"github.com/openziti/ziti/v2/controller/network"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
 )
 
 type baseHandler struct {
@@ -30,4 +32,49 @@ type baseHandler struct {
 
 func (self *baseHandler) newChangeContext(ch channel.Channel, method string) *change.Context {
 	return change.NewControlChannelChange(self.router.Id, self.router.Name, method, ch)
+}
+
+// lookupTerminatorOwner returns the id of the router that owns terminator id and whether the
+// terminator currently exists. A not-found terminator returns ("", false, nil); other read errors
+// are returned so the caller can default to keeping the id rather than acting on incomplete state.
+func (self *baseHandler) lookupTerminatorOwner(id string) (routerId string, present bool, err error) {
+	terminator, err := self.network.Terminator.Read(id)
+	if err != nil {
+		if boltz.IsErrNotFoundErr(err) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	return terminator.Router, true, nil
+}
+
+// selectOwnedTerminators returns the terminator ids from a remove request that this router may
+// remove, dropping (and logging) any whose terminator is owned by a different router, so a router
+// can only remove terminators it owns. Absent ids are kept so a delete racing a not-yet-applied
+// create is still ordered after it.
+func (self *baseHandler) selectOwnedTerminators(ids []string) []string {
+	kept, rejected := filterOwnedTerminators(ids, self.router.Id, self.lookupTerminatorOwner)
+	if rejected > 0 {
+		pfxlog.Logger().
+			WithField("routerId", self.router.Id).
+			WithField("rejected", rejected).
+			Warn("router attempted to remove terminators it does not own; rejected")
+	}
+	return kept
+}
+
+// filterOwnedTerminators returns the ids owned by requestingRouterId (or not currently present),
+// dropping ids whose terminator resolves to a different router; rejected counts those drops. A
+// lookup error keeps the id, so an unresolved owner is not treated as an ownership violation.
+func filterOwnedTerminators(ids []string, requestingRouterId string, lookup func(string) (routerId string, present bool, err error)) (kept []string, rejected int) {
+	kept = make([]string, 0, len(ids))
+	for _, id := range ids {
+		routerId, present, err := lookup(id)
+		if err == nil && present && routerId != requestingRouterId {
+			rejected++
+			continue
+		}
+		kept = append(kept, id)
+	}
+	return kept, rejected
 }

--- a/controller/handler_ctrl/base_test.go
+++ b/controller/handler_ctrl/base_test.go
@@ -1,0 +1,71 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package handler_ctrl
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_filterOwnedTerminators(t *testing.T) {
+	const me = "router-me"
+
+	// mine: present, owned by the requesting router; other: present, owned by a different router;
+	// gone: not present; err: lookup fails.
+	lookup := func(id string) (string, bool, error) {
+		switch id {
+		case "mine":
+			return me, true, nil
+		case "other":
+			return "router-other", true, nil
+		case "err":
+			return "", false, errors.New("boom")
+		default: // "gone" and anything else
+			return "", false, nil
+		}
+	}
+
+	t.Run("keeps owned and absent ids", func(t *testing.T) {
+		req := require.New(t)
+		kept, rejected := filterOwnedTerminators([]string{"mine", "gone"}, me, lookup)
+		req.Equal([]string{"mine", "gone"}, kept)
+		req.Zero(rejected)
+	})
+
+	t.Run("rejects ids owned by another router", func(t *testing.T) {
+		req := require.New(t)
+		kept, rejected := filterOwnedTerminators([]string{"other", "mine"}, me, lookup)
+		req.Equal([]string{"mine"}, kept, "a router may only remove terminators it owns")
+		req.Equal(1, rejected)
+	})
+
+	t.Run("a lookup error keeps the id", func(t *testing.T) {
+		req := require.New(t)
+		kept, rejected := filterOwnedTerminators([]string{"err"}, me, lookup)
+		req.Equal([]string{"err"}, kept, "an unresolved owner must not be treated as an ownership violation")
+		req.Zero(rejected)
+	})
+
+	t.Run("mixes kept and rejected", func(t *testing.T) {
+		req := require.New(t)
+		kept, rejected := filterOwnedTerminators([]string{"mine", "other", "gone", "err"}, me, lookup)
+		req.Equal([]string{"mine", "gone", "err"}, kept)
+		req.Equal(1, rejected)
+	})
+}

--- a/controller/handler_ctrl/remove_terminators.go
+++ b/controller/handler_ctrl/remove_terminators.go
@@ -59,20 +59,25 @@ func (self *removeTerminatorsHandler) HandleReceive(msg *channel.Message, ch cha
 func (self *removeTerminatorsHandler) handleRemoveTerminators(msg *channel.Message, ch channel.Channel, request *ctrl_pb.RemoveTerminatorsRequest) {
 	log := pfxlog.ContextLogger(ch.Label())
 
-	// Don't pre-filter by IsEntityPresent here. The create for a terminator may be
-	// in-flight in raft but not yet applied to the DB. If we skip it here, the create
-	// will apply after we return success, leaving an orphan. By sending all IDs through
-	// raft, the delete will be ordered after the create and ApplyDeleteBatch will handle
-	// non-existent IDs gracefully.
 	if len(request.TerminatorIds) == 0 {
 		handler_common.SendSuccess(msg, ch, "")
 		return
 	}
 
-	if err := self.network.Terminator.DeleteBatch(request.TerminatorIds, self.newChangeContext(ch, "fabric.remove.terminators.batch")); err == nil {
+	// Drop ids this router doesn't own, so it can't remove another router's terminators. Absent ids
+	// are kept (not pre-filtered by presence): the create for a terminator may be in-flight in raft
+	// but not yet applied to the DB, so sending it through raft orders the delete after the create,
+	// and ApplyDeleteBatch handles non-existent ids gracefully.
+	toDelete := self.selectOwnedTerminators(request.TerminatorIds)
+	if len(toDelete) == 0 {
+		handler_common.SendSuccess(msg, ch, "")
+		return
+	}
+
+	if err := self.network.Terminator.DeleteBatch(toDelete, self.newChangeContext(ch, "fabric.remove.terminators.batch")); err == nil {
 		log.
 			WithField("routerId", ch.Id()).
-			WithField("terminatorIds", request.TerminatorIds).
+			WithField("terminatorIds", toDelete).
 			Info("removed terminators")
 		handler_common.SendSuccess(msg, ch, "")
 	} else if command.WasRateLimited(err) {


### PR DESCRIPTION
Fixes #4166 · Backport of #4165. Adds the router-ownership check to the fabric RemoveTerminators handler (2.0 has no RemoveTerminatorsV2).