### PR TITLE
Preserve tags on external JWT signer and transit router create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -484,6 +484,7 @@ today and expand as packages are converted. The global `ziti agent set-log-level
 * github.com/openziti/transport/v2: [v2.0.215 -> v2.0.216](https://github.com/openziti/transport/compare/v2.0.215...v2.0.216)
 * github.com/openziti/xweb/v3: [v3.0.4 -> v3.0.5](https://github.com/openziti/xweb/compare/v3.0.4...v3.0.5)
 * github.com/openziti/ziti/v2: [v2.0.0 -> v2.1.0](https://github.com/openziti/ziti/compare/v2.0.0...v2.1.0)
+    * [Issue #4124](https://github.com/openziti/ziti/issues/4124) - Tags are dropped when creating external JWT signers, transit routers and authenticators
     * [Issue #4193](https://github.com/openziti/ziti/issues/4193) - ER/T terminator create reports "invalid edge router for session" with no router-side error and slow recovery
     * [Issue #4149](https://github.com/openziti/ziti/issues/4149) - upgrading a running 1.x controller/router to 2.x fails to create the service user
     * [Issue #3990](https://github.com/openziti/ziti/issues/3990) - Expose service change subscriptions to external SDKs over protobuf

--- a/controller/internal/routes/authenticator_api_model.go
+++ b/controller/internal/routes/authenticator_api_model.go
@@ -55,7 +55,9 @@ func (factory *AuthenticatorLinkFactoryImpl) Links(entity models.Entity) rest_mo
 
 func MapCreateToAuthenticatorModel(in *rest_model.AuthenticatorCreate) (*model.Authenticator, error) {
 	result := &model.Authenticator{
-		BaseEntity: models.BaseEntity{},
+		BaseEntity: models.BaseEntity{
+			Tags: TagsOrDefault(in.Tags),
+		},
 		Method:     stringz.OrEmpty(in.Method),
 		IdentityId: stringz.OrEmpty(in.IdentityID),
 		SubType:    nil,

--- a/controller/internal/routes/external_jwt_signer_api_model.go
+++ b/controller/internal/routes/external_jwt_signer_api_model.go
@@ -110,7 +110,9 @@ func MapCreateExternalJwtSignerToModelForManagement(signer *rest_model.ExternalJ
 	}
 
 	ret := &model.ExternalJwtSigner{
-		BaseEntity:                    models.BaseEntity{},
+		BaseEntity: models.BaseEntity{
+			Tags: TagsOrDefault(signer.Tags),
+		},
 		Name:                          *signer.Name,
 		Enabled:                       *signer.Enabled,
 		ExternalAuthUrl:               signer.ExternalAuthURL,
@@ -139,11 +141,6 @@ func MapCreateExternalJwtSignerToModelForManagement(signer *rest_model.ExternalJ
 }
 
 func MapUpdateExternalJwtSignerToModelForManagement(id string, signer *rest_model.ExternalJWTSignerUpdate) *model.ExternalJwtSigner {
-	var tags map[string]interface{}
-	if signer.Tags != nil && signer.Tags.SubTags != nil {
-		tags = signer.Tags.SubTags
-	}
-
 	targetToken := string(rest_model.TargetTokenACCESS)
 
 	if signer.TargetToken != nil {
@@ -156,7 +153,7 @@ func MapUpdateExternalJwtSignerToModelForManagement(id string, signer *rest_mode
 	ret := &model.ExternalJwtSigner{
 		BaseEntity: models.BaseEntity{
 			Id:       id,
-			Tags:     tags,
+			Tags:     TagsOrDefault(signer.Tags),
 			IsSystem: false,
 		},
 		Name:                          *signer.Name,
@@ -187,11 +184,6 @@ func MapUpdateExternalJwtSignerToModelForManagement(id string, signer *rest_mode
 }
 
 func MapPatchExternalJwtSignerToModelForManagement(id string, signer *rest_model.ExternalJWTSignerPatch) *model.ExternalJwtSigner {
-	var tags map[string]interface{}
-	if signer.Tags != nil && signer.Tags.SubTags != nil {
-		tags = signer.Tags.SubTags
-	}
-
 	targetToken := string(rest_model.TargetTokenACCESS)
 
 	if signer.TargetToken != nil {
@@ -204,7 +196,7 @@ func MapPatchExternalJwtSignerToModelForManagement(id string, signer *rest_model
 	ret := &model.ExternalJwtSigner{
 		BaseEntity: models.BaseEntity{
 			Id:       id,
-			Tags:     tags,
+			Tags:     TagsOrDefault(signer.Tags),
 			IsSystem: false,
 		},
 		Name:                          stringz.OrEmpty(signer.Name),

--- a/controller/internal/routes/router_api_model.go
+++ b/controller/internal/routes/router_api_model.go
@@ -18,7 +18,9 @@ var TransitRouterLinkFactory = NewBasicLinkFactory(EntityNameTransitRouter)
 
 func MapCreateRouterToModel(router *rest_model.RouterCreate) *model.TransitRouter {
 	ret := &model.TransitRouter{
-		BaseEntity:        models.BaseEntity{},
+		BaseEntity: models.BaseEntity{
+			Tags: TagsOrDefault(router.Tags),
+		},
 		Name:              stringz.OrEmpty(router.Name),
 		Cost:              uint16(Int64OrDefault(router.Cost)),
 		NoTraversal:       BoolOrDefault(router.NoTraversal),

--- a/controller/internal/routes/routes_test.go
+++ b/controller/internal/routes/routes_test.go
@@ -1,0 +1,61 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package routes
+
+import (
+	"testing"
+
+	"github.com/openziti/edge-api/rest_model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTagsOrDefault(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *rest_model.Tags
+		expected map[string]interface{}
+	}{
+		{
+			name:     "nil wrapper yields empty map",
+			input:    nil,
+			expected: map[string]interface{}{},
+		},
+		{
+			name:     "nil sub-tags yields empty map",
+			input:    &rest_model.Tags{},
+			expected: map[string]interface{}{},
+		},
+		{
+			name:     "empty sub-tags yields empty map",
+			input:    &rest_model.Tags{SubTags: rest_model.SubTags{}},
+			expected: map[string]interface{}{},
+		},
+		{
+			name:     "populated sub-tags are passed through",
+			input:    &rest_model.Tags{SubTags: rest_model.SubTags{"managed": "true", "count": 3, "enabled": false}},
+			expected: map[string]interface{}{"managed": "true", "count": 3, "enabled": false},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := TagsOrDefault(test.input)
+			require.NotNil(t, result)
+			require.Equal(t, test.expected, result)
+		})
+	}
+}

--- a/tests/authenticator_test.go
+++ b/tests/authenticator_test.go
@@ -144,6 +144,38 @@ func Test_Authenticators_AdminUsingAdminEndpoints(t *testing.T) {
 		})
 	})
 
+	t.Run("tags can be set on create and retrieved", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		identityId := ctx.AdminManagementSession.requireCreateIdentity(eid.New(), false)
+
+		body := gabs.New()
+		_, _ = body.Set(identityId, "identityId")
+		_, _ = body.Set("updb", "method")
+		_, _ = body.Set(eid.New(), "username")
+		_, _ = body.Set(eid.New(), "password")
+		_, _ = body.Set("true", "tags", "managed")
+		networkId := uuid.NewString()
+		_, _ = body.Set(networkId, "tags", "network-id")
+
+		resp, err := ctx.AdminManagementSession.newAuthenticatedRequestWithBody(body.String()).Post("/authenticators")
+		ctx.Req.NoError(err)
+		standardJsonResponseTests(resp, http.StatusCreated, t)
+
+		createBody, err := gabs.ParseJSON(resp.Body())
+		ctx.Req.NoError(err)
+		authenticatorId, ok := createBody.Path("data.id").Data().(string)
+		ctx.Req.True(ok, "expected authenticator id to be a string")
+
+		detailEnv := &rest_model.DetailAuthenticatorEnvelope{}
+		resp, err = ctx.AdminManagementSession.newAuthenticatedRequest().SetResult(detailEnv).Get("/authenticators/" + authenticatorId)
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body()))
+
+		ctx.Req.NotNil(detailEnv.Data.Tags)
+		ctx.Req.Equal(rest_model.SubTags{"managed": "true", "network-id": networkId}, detailEnv.Data.Tags.SubTags)
+	})
+
 	t.Run("cannot create a updb authenticator for an identity with an existing updb authenticator", func(t *testing.T) {
 		ctx.testContextChanged(t)
 

--- a/tests/external_jwt_signer_test.go
+++ b/tests/external_jwt_signer_test.go
@@ -266,6 +266,43 @@ func Test_ExternalJWTSigner(t *testing.T) {
 		})
 	})
 
+	t.Run("create with tags returns 200 Ok and the tags are persisted", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		jwtSignerCert, _ := newSelfSignedCert("soCommon")
+		jwtSignerCertPem := nfpem.EncodeToString(jwtSignerCert)
+
+		tags := rest_model.SubTags{
+			"managed":    "true",
+			"network-id": uuid.NewString(),
+		}
+
+		jwtSigner := &rest_model.ExternalJWTSignerCreate{
+			CertPem:  &jwtSignerCertPem,
+			Enabled:  ToPtr(true),
+			Name:     ToPtr("Test JWT Signer With Tags"),
+			Kid:      ToPtr(uuid.NewString()),
+			Issuer:   ToPtr(uuid.NewString()),
+			Audience: ToPtr(uuid.NewString()),
+			Tags:     &rest_model.Tags{SubTags: tags},
+		}
+
+		createResponseEnv := &rest_model.CreateEnvelope{}
+
+		resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(jwtSigner).SetResult(createResponseEnv).Post("/external-jwt-signers")
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusCreated, resp.StatusCode(), string(resp.Body()))
+
+		jwtSignerDetailEnv := &rest_model.DetailExternalJWTSignerEnvelope{}
+
+		resp, err = ctx.AdminManagementSession.newAuthenticatedRequest().SetResult(jwtSignerDetailEnv).Get("/external-jwt-signers/" + createResponseEnv.Data.ID)
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body()))
+
+		ctx.Req.NotNil(jwtSignerDetailEnv.Data.Tags)
+		ctx.Req.Equal(tags, jwtSignerDetailEnv.Data.Tags.SubTags)
+	})
+
 	t.Run("create with missing values returns 400 bad request", func(t *testing.T) {
 		ctx.testContextChanged(t)
 
@@ -656,6 +693,76 @@ func Test_ExternalJWTSigner(t *testing.T) {
 					ctx.Req.Equal(*jwtSigner.Kid, *jwtSignerDetail.Kid)
 					ctx.Req.Equal(string(*jwtSigner.TargetToken), string(*jwtSignerDetail.TargetToken))
 				})
+			})
+		})
+
+		t.Run("name only leaves existing tags untouched", func(t *testing.T) {
+			ctx.testContextChanged(t)
+
+			jwtSignerCert, _ := newSelfSignedCert("soCommon patch tags")
+			jwtSignerCertPem := nfpem.EncodeToString(jwtSignerCert)
+
+			tags := rest_model.SubTags{
+				"managed":    "true",
+				"network-id": uuid.NewString(),
+			}
+
+			jwtSigner := &rest_model.ExternalJWTSignerCreate{
+				CertPem:  &jwtSignerCertPem,
+				Enabled:  ToPtr(true),
+				Name:     ToPtr("Test JWT Signer Pre-Patch Tags"),
+				Kid:      ToPtr(uuid.NewString()),
+				Issuer:   ToPtr(uuid.NewString()),
+				Audience: ToPtr(uuid.NewString()),
+				Tags:     &rest_model.Tags{SubTags: tags},
+			}
+
+			createResponseEnv := &rest_model.CreateEnvelope{}
+
+			resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(jwtSigner).SetResult(createResponseEnv).Post("/external-jwt-signers")
+			ctx.Req.NoError(err)
+			ctx.Req.Equal(http.StatusCreated, resp.StatusCode(), string(resp.Body()))
+
+			jwtSignerPatch := &rest_model.ExternalJWTSignerPatch{
+				Name: ToPtr("Test JWT Signer Post-Patch Tags"),
+			}
+
+			resp, err = ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(jwtSignerPatch).Patch("/external-jwt-signers/" + createResponseEnv.Data.ID)
+			ctx.Req.NoError(err)
+			ctx.Req.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body()))
+
+			jwtSignerDetailEnv := &rest_model.DetailExternalJWTSignerEnvelope{}
+
+			resp, err = ctx.AdminManagementSession.newAuthenticatedRequest().SetResult(jwtSignerDetailEnv).Get("/external-jwt-signers/" + createResponseEnv.Data.ID)
+			ctx.Req.NoError(err)
+			ctx.Req.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body()))
+
+			ctx.Req.Equal("Test JWT Signer Post-Patch Tags", *jwtSignerDetailEnv.Data.Name)
+			ctx.Req.NotNil(jwtSignerDetailEnv.Data.Tags)
+			ctx.Req.Equal(tags, jwtSignerDetailEnv.Data.Tags.SubTags)
+
+			t.Run("tags only replaces the tags", func(t *testing.T) {
+				ctx.testContextChanged(t)
+
+				replacementTags := rest_model.SubTags{"managed": "false"}
+
+				jwtSignerPatch := &rest_model.ExternalJWTSignerPatch{
+					Tags: &rest_model.Tags{SubTags: replacementTags},
+				}
+
+				resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(jwtSignerPatch).Patch("/external-jwt-signers/" + createResponseEnv.Data.ID)
+				ctx.Req.NoError(err)
+				ctx.Req.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body()))
+
+				jwtSignerDetailEnv := &rest_model.DetailExternalJWTSignerEnvelope{}
+
+				resp, err = ctx.AdminManagementSession.newAuthenticatedRequest().SetResult(jwtSignerDetailEnv).Get("/external-jwt-signers/" + createResponseEnv.Data.ID)
+				ctx.Req.NoError(err)
+				ctx.Req.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body()))
+
+				ctx.Req.NotNil(jwtSignerDetailEnv.Data.Tags)
+				ctx.Req.Equal(replacementTags, jwtSignerDetailEnv.Data.Tags.SubTags)
+				ctx.Req.Equal("Test JWT Signer Post-Patch Tags", *jwtSignerDetailEnv.Data.Name)
 			})
 		})
 

--- a/tests/transit_router_test.go
+++ b/tests/transit_router_test.go
@@ -154,6 +154,29 @@ func Test_TransitRouters(t *testing.T) {
 		ctx.Req.Equal(listeners, detailResp.Payload.Data.CtrlChanListeners)
 	})
 
+	t.Run("tags can be set on create and retrieved", func(t *testing.T) {
+		ctx.testContextChanged(t)
+		tags := rest_model.SubTags{
+			"managed":    "true",
+			"network-id": eid.New(),
+		}
+
+		createResp, err := mgmtClient.API.Router.CreateRouter(&router.CreateRouterParams{
+			Router: &rest_model.RouterCreate{
+				Name: util.Ptr(eid.New()),
+				Tags: &rest_model.Tags{SubTags: tags},
+			},
+		}, nil)
+		ctx.Req.NoError(err)
+
+		detailResp, err := mgmtClient.API.Router.DetailRouter(&router.DetailRouterParams{
+			ID: createResp.Payload.Data.ID,
+		}, nil)
+		ctx.Req.NoError(err)
+		ctx.Req.NotNil(detailResp.Payload.Data.Tags)
+		ctx.Req.Equal(tags, detailResp.Payload.Data.Tags.SubTags)
+	})
+
 	t.Run("ctrlChanListeners can be updated", func(t *testing.T) {
 		ctx.testContextChanged(t)
 		name := eid.New()


### PR DESCRIPTION
Fixes #4124

Creating an external JWT signer with tags returned 201, but the tags were silently discarded; PUT and PATCH on the same entity persisted them fine. The create mapper built its `BaseEntity` empty and never copied tags out of the request body.

The same bug exists in the transit router create mapper, so both are fixed here. This isn't a 2.0 regression: the ext-jwt-signer case dates back to 2022.

Adds API tests that assert tags round-trip through create for both entity types.