### PR TITLE
Forward port the 2.0.2 control-plane certificate validation fixes to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,24 @@
 * [Multiple Resolver Addresses for tproxy](#multiple-resolver-addresses-for-tproxy) - `resolver` now accepts a single address or a list of addresses
 * [DNS Upstream Query Modes](#dns-upstream-query-modes) - choose how multiple DNS upstreams are queried: parallel fan-out (default) or serial fail-through
 * [Logging Now Uses slog with an Async Handler](#logging-now-uses-slog-with-an-async-handler) - Logging moves to Go's `log/slog` behind an asynchronous sink; output is unchanged by default, with new flags to tune buffering
+* [Security Advisories](#security-advisories) - Includes the two control-plane certificate validation fixes first released in 2.0.2
+
+## Security Advisories
+
+This release includes the two control-plane certificate and identity validation fixes first released in
+2.0.2 and 1.6.18. Anyone upgrading from 2.0.1 or earlier is picking them up here for the first time. See
+the linked GitHub Security Advisories for full details, impact, and affected versions.
+
+* [GHSA-mrpr-756c-xm47](https://github.com/openziti/ziti/security/advisories/GHSA-mrpr-756c-xm47) (Critical) - Improper peer certificate validation on the controller
+  cluster mesh, router links, and metrics endpoint. TLS peer checks accepted a connection when any presented
+  certificate chained to the trusted CA while taking the peer identity from the leaf certificate, allowing a
+  peer to be admitted under a forged identity without possessing a trusted key. On HA/clustered controllers
+  this allows joining the controller cluster as an arbitrary controller.
+* [GHSA-cc5m-7mhm-xh9f](https://github.com/openziti/ziti/security/advisories/GHSA-cc5m-7mhm-xh9f) (Medium) - Control-channel connections carrying a channel-type header
+  bypassed router certificate and identity verification, allowing an attacker that can reach the controller
+  control port to be admitted as an arbitrary router identity and manipulate that router's fabric terminators,
+  faults, and circuit routing. Impact is limited to router data model metadata (service and identity names) and
+  control-plane manipulation; it does not by itself grant access to the services the network protects.
 
 ## ZAC Bootstrapping CLI
 

--- a/common/cert/verify.go
+++ b/common/cert/verify.go
@@ -1,0 +1,60 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package cert
+
+import (
+	"crypto/x509"
+	"errors"
+	"fmt"
+)
+
+// VerifyLeafCertChain verifies that the presented leaf certificate (certs[0]) chains to a trusted
+// certificate in the given pool, and returns that verified leaf. Only certs[0] is verified: it is the
+// certificate whose private key the TLS handshake proved the peer holds, and it is the certificate a
+// caller derives peer identity from. Any remaining certs[1:] are treated only as candidate
+// intermediates supplied by the peer, never as independent grounds for acceptance - so a peer cannot be
+// admitted by presenting its own leaf alongside some other certificate that happens to chain.
+//
+// roots is the verifying node's full trusted-CA pool (identity.CA()). Every certificate in it is a valid
+// chain terminus, whether a self-signed root or an intermediate distributed as a trust anchor, matching
+// how the node's TLS configuration establishes trust. No extended-key-usage restriction is applied:
+// certificates issued by an external PKI with arbitrary or absent EKUs are accepted as long as the leaf
+// chains to a trusted CA.
+func VerifyLeafCertChain(roots *x509.CertPool, certs []*x509.Certificate) (*x509.Certificate, error) {
+	if roots == nil {
+		return nil, errors.New("no ca pool provided")
+	}
+
+	if len(certs) == 0 {
+		return nil, errors.New("no certificates presented")
+	}
+
+	intermediates := x509.NewCertPool()
+	for _, intermediate := range certs[1:] {
+		intermediates.AddCert(intermediate)
+	}
+
+	if _, err := certs[0].Verify(x509.VerifyOptions{
+		Roots:         roots,
+		Intermediates: intermediates,
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+	}); err != nil {
+		return nil, fmt.Errorf("leaf certificate not trusted: %w", err)
+	}
+
+	return certs[0], nil
+}

--- a/common/cert/verify_test.go
+++ b/common/cert/verify_test.go
@@ -1,0 +1,212 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package cert
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const vTestTrustDomain = "spiffe://verify-test"
+
+type vCertAndKey struct {
+	cert *x509.Certificate
+	key  *ecdsa.PrivateKey
+}
+
+var vSerial int64
+
+func vNextSerial() *big.Int {
+	vSerial++
+	return big.NewInt(vSerial)
+}
+
+func vMkCA(t *testing.T, cn string, parent *vCertAndKey) *vCertAndKey {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber:          vNextSerial(),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+	signParent, signKey := tmpl, key
+	if parent != nil {
+		signParent, signKey = parent.cert, parent.key
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, signParent, &key.PublicKey, signKey)
+	require.NoError(t, err)
+	c, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return &vCertAndKey{cert: c, key: key}
+}
+
+// vMkLeaf builds an end-entity cert. signer==nil yields a leaf that does not chain to any CA. A nil
+// ekus produces a cert with no ExtKeyUsage extension (unrestricted).
+func vMkLeaf(t *testing.T, cn, spiffePath string, ekus []x509.ExtKeyUsage, signer *vCertAndKey) *vCertAndKey {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber: vNextSerial(),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  ekus,
+	}
+	if spiffePath != "" {
+		u, err := url.Parse(vTestTrustDomain + spiffePath)
+		require.NoError(t, err)
+		tmpl.URIs = []*url.URL{u}
+	}
+	signParent, signKey := tmpl, key
+	if signer != nil {
+		signParent, signKey = signer.cert, signer.key
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, signParent, &key.PublicKey, signKey)
+	require.NoError(t, err)
+	c, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return &vCertAndKey{cert: c, key: key}
+}
+
+func vPoolOf(certs ...*x509.Certificate) *x509.CertPool {
+	pool := x509.NewCertPool()
+	for _, c := range certs {
+		pool.AddCert(c)
+	}
+	return pool
+}
+
+// TestVerifyLeafCertChain_RejectsUnchainedLeaf verifies that a leaf which does not itself chain to a
+// trusted CA is rejected even when another presented certificate does chain - i.e. verification is bound
+// to the leaf, not to "some presented certificate verifies".
+func TestVerifyLeafCertChain_RejectsUnchainedLeaf(t *testing.T) {
+	req := require.New(t)
+	root := vMkCA(t, "root", nil)
+	inter := vMkCA(t, "int", root)
+	roots := vPoolOf(root.cert, inter.cert)
+
+	// A trust-anchored cert (chains to the pool) presented as an extra certificate.
+	extra := vMkLeaf(t, "extra", "", []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}, inter)
+	// The leaf itself is self-signed and does NOT chain to the pool.
+	unchained := vMkLeaf(t, "unchained", "/identity/other", []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, nil)
+
+	_, err := VerifyLeafCertChain(roots, []*x509.Certificate{unchained.cert, extra.cert})
+	req.Error(err, "leaf not chaining to the pool must be rejected even alongside a chaining extra cert")
+}
+
+func TestVerifyLeafCertChain_AcceptsLegitLeaf(t *testing.T) {
+	req := require.New(t)
+	root := vMkCA(t, "root", nil)
+	inter := vMkCA(t, "int", root)
+	roots := vPoolOf(root.cert, inter.cert)
+
+	legit := vMkLeaf(t, "legit", "/identity/real", []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, inter)
+	leaf, err := VerifyLeafCertChain(roots, []*x509.Certificate{legit.cert})
+	req.NoError(err)
+	req.Equal(legit.cert, leaf, "returns the verified leaf (certs[0]) for identity use")
+}
+
+func TestVerifyLeafCertChain_AcceptsPeerSuppliedIntermediate(t *testing.T) {
+	req := require.New(t)
+	root := vMkCA(t, "root", nil)
+	inter := vMkCA(t, "int", root)
+	legit := vMkLeaf(t, "legit", "/identity/real", []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, inter)
+
+	// Pool holds ONLY the root; the intermediate must be supplied on the wire (certs[1:]).
+	rootOnly := vPoolOf(root.cert)
+	_, err := VerifyLeafCertChain(rootOnly, []*x509.Certificate{legit.cert})
+	req.Error(err, "without the intermediate anywhere the leaf cannot be verified")
+	_, err = VerifyLeafCertChain(rootOnly, []*x509.Certificate{legit.cert, inter.cert})
+	req.NoError(err, "peer-supplied intermediate lets a valid peer verify")
+}
+
+// TestVerifyLeafCertChain_MultipleRoots covers a trust bundle with more than one self-signed root (as a
+// quickstart deployment produces, concatenating a controller root and a signer root). A leaf chaining to
+// either root must verify.
+func TestVerifyLeafCertChain_MultipleRoots(t *testing.T) {
+	req := require.New(t)
+	ctrlRoot := vMkCA(t, "ctrl-root", nil)
+	signerRoot := vMkCA(t, "signer-root", nil)
+	signerInter := vMkCA(t, "signer-int", signerRoot)
+	roots := vPoolOf(ctrlRoot.cert, signerRoot.cert)
+
+	leaf := vMkLeaf(t, "router", "/identity/r1", []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, signerInter)
+	_, err := VerifyLeafCertChain(roots, []*x509.Certificate{leaf.cert, signerInter.cert})
+	req.NoError(err, "a leaf chaining to one of several trusted roots must verify")
+}
+
+// TestVerifyLeafCertChain_IntermediateAsTrustAnchor covers a self-managed PKI that distributes a
+// (non-self-signed) intermediate as the trust anchor without its root. Every certificate in the pool is
+// a valid chain terminus, so a leaf chaining directly to that intermediate must verify.
+func TestVerifyLeafCertChain_IntermediateAsTrustAnchor(t *testing.T) {
+	req := require.New(t)
+	root := vMkCA(t, "root", nil)
+	inter := vMkCA(t, "int", root)
+	leaf := vMkLeaf(t, "leaf", "/identity/real", []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, inter)
+
+	interAnchored := vPoolOf(inter.cert) // only the intermediate distributed, no self-signed root
+	_, err := VerifyLeafCertChain(interAnchored, []*x509.Certificate{leaf.cert})
+	req.NoError(err, "an intermediate distributed as a trust anchor must be accepted as a chain terminus")
+}
+
+// TestVerifyLeafCertChain_ArbitraryEKU covers external PKIs whose certificates carry arbitrary or absent
+// extended key usages. No EKU restriction is applied, so all of them verify as long as the chain is
+// valid.
+func TestVerifyLeafCertChain_ArbitraryEKU(t *testing.T) {
+	req := require.New(t)
+	root := vMkCA(t, "root", nil)
+	inter := vMkCA(t, "int", root)
+	roots := vPoolOf(root.cert, inter.cert)
+
+	for _, ekus := range [][]x509.ExtKeyUsage{
+		nil,
+		{x509.ExtKeyUsageClientAuth},
+		{x509.ExtKeyUsageServerAuth},
+		{x509.ExtKeyUsageEmailProtection},
+	} {
+		leaf := vMkLeaf(t, "leaf", "/identity/real", ekus, inter)
+		_, err := VerifyLeafCertChain(roots, []*x509.Certificate{leaf.cert})
+		req.NoError(err, "leaf with EKU %v must be accepted", ekus)
+	}
+}
+
+func TestVerifyLeafCertChain_EmptyInputs(t *testing.T) {
+	req := require.New(t)
+	root := vMkCA(t, "root", nil)
+	roots := vPoolOf(root.cert)
+
+	_, err := VerifyLeafCertChain(nil, []*x509.Certificate{root.cert})
+	req.Error(err, "nil pool rejected")
+	_, err = VerifyLeafCertChain(roots, nil)
+	req.Error(err, "no certs rejected")
+}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -545,6 +545,16 @@ func (c *Controller) Run() error {
 		ctrlAcceptors[mesh.ChannelTypeMesh] = channel.AsHelloAcceptor(c.raftController.GetMesh())
 	}
 
+	// Channel types with a dedicated acceptor below validate their own peers; the connect handler
+	// must skip exactly those and validate everything else (which the routing acceptor sends to the
+	// default router control acceptor, including unrecognized types). Set this before the listener
+	// starts accepting connections.
+	separatelyValidatedTypes := map[string]struct{}{}
+	for chType := range ctrlAcceptors {
+		separatelyValidatedTypes[chType] = struct{}{}
+	}
+	c.ctrlConnectHandler.SetSeparatelyValidatedChannelTypes(separatelyValidatedTypes)
+
 	acceptor := &channel.TypeRoutingAcceptor{
 		Acceptors:       ctrlAcceptors,
 		DefaultAcceptor: ctrlAccepter.NewMultiListener(),

--- a/controller/handler_ctrl/connect.go
+++ b/controller/handler_ctrl/connect.go
@@ -19,20 +19,23 @@ package handler_ctrl
 import (
 	"crypto/sha1"
 	"crypto/x509"
-	"errors"
 	"fmt"
 	"time"
 
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/channel/v5"
-	"github.com/openziti/foundation/v2/stringz"
 	"github.com/openziti/identity"
+	"github.com/openziti/ziti/v2/common/cert"
 	"github.com/openziti/ziti/v2/controller/network"
 )
 
 type ConnectHandler struct {
 	identity identity.Identity
 	network  *network.Network
+
+	// separatelyValidatedTypes holds the control-channel type headers that are dispatched to a
+	// separate, self-validating acceptor (currently the raft mesh, when clustering is enabled).
+	separatelyValidatedTypes map[string]struct{}
 }
 
 func NewConnectHandler(identity identity.Identity, network *network.Network) *ConnectHandler {
@@ -42,8 +45,44 @@ func NewConnectHandler(identity identity.Identity, network *network.Network) *Co
 	}
 }
 
+// SetSeparatelyValidatedChannelTypes records the control-channel type headers that are dispatched to a
+// separate, self-validating acceptor (e.g. the raft mesh). Connections carrying one of these types are
+// skipped by HandleConnection; everything else - router control channel types, unrecognized types, and
+// legacy (no type header) connections, all of which the dispatcher routes to the router control
+// acceptor - is validated here. This must be populated before the listener begins accepting.
+func (self *ConnectHandler) SetSeparatelyValidatedChannelTypes(types map[string]struct{}) {
+	self.separatelyValidatedTypes = types
+}
+
+// isSeparatelyValidated reports whether the connection's channel type is handled by a separate,
+// self-validating acceptor and therefore must not be validated as a router control connection here.
+func (self *ConnectHandler) isSeparatelyValidated(hello *channel.Hello) bool {
+	underlayType, found := hello.Headers[channel.TypeHeader]
+	if !found {
+		return false
+	}
+	_, ok := self.separatelyValidatedTypes[string(underlayType)]
+	return ok
+}
+
+// isFirstCtrlConnection reports whether this hello establishes a new channel rather than adding an
+// underlay to an existing grouped channel. A legacy (non-grouped) dial is always a new channel; for a
+// grouped dial only the connection carrying IsFirstGroupConnection is.
+func isFirstCtrlConnection(hello *channel.Hello) bool {
+	headers := channel.Headers(hello.Headers)
+	if grouped, _ := headers.GetBoolHeader(channel.IsGroupedHeader); !grouped {
+		return true
+	}
+	first, _ := headers.GetBoolHeader(channel.IsFirstGroupConnection)
+	return first
+}
+
 func (self *ConnectHandler) HandleConnection(hello *channel.Hello, certificates []*x509.Certificate) error {
-	if _, found := hello.Headers[channel.TypeHeader]; found {
+	// Connections whose channel type is handled by a separate, self-validating acceptor (e.g. the raft
+	// mesh) are validated there, so skip them. Everything else - router control channel types,
+	// unrecognized types, and legacy (no type header) connections - is dispatched to the router control
+	// acceptor and must be validated here.
+	if self.isSeparatelyValidated(hello) {
 		return nil
 	}
 
@@ -51,53 +90,33 @@ func (self *ConnectHandler) HandleConnection(hello *channel.Hello, certificates 
 
 	log := pfxlog.Logger().WithField("routerId", id)
 
-	// verify cert chain
 	if len(certificates) == 0 {
 		return fmt.Errorf("no certificates provided, unable to verify dialer, routerId: %v", id)
 	}
 
-	config := self.identity.ServerTLSConfig()
-
-	opts := x509.VerifyOptions{
-		Roots:         config.RootCAs,
-		Intermediates: x509.NewCertPool(),
-		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+	// Verify the peer's leaf certificate (certificates[0], the certificate whose private key the TLS
+	// handshake proved) chains to the controller CA, and bind the router fingerprint check to that
+	// verified leaf. Matching the enrolled fingerprint against any presented certificate would let a
+	// peer present its own leaf followed by a target router's public certificate and pass without that
+	// router's private key.
+	leaf, err := cert.VerifyLeafCertChain(self.identity.CA(), certificates)
+	if err != nil {
+		return fmt.Errorf("unable to verify dialer, routerId: %v: %w", id, err)
 	}
+	fingerprint := fmt.Sprintf("%x", sha1.Sum(leaf.Raw))
+	log.Debugf("peer leaf certificate fingerprint [%s], common name [%s]", fingerprint, leaf.Subject.CommonName)
 
-	var validFingerPrints []string
-	var errorList []error
-
-	for _, cert := range certificates {
-		if cert.IsCA {
-			opts.Intermediates.AddCert(cert)
-		}
-	}
-
-	for i, cert := range certificates {
-		if !cert.IsCA {
-			if _, err := cert.Verify(opts); err == nil {
-				fingerprint := fmt.Sprintf("%x", sha1.Sum(cert.Raw))
-				validFingerPrints = append(validFingerPrints, fingerprint)
-				log.Debugf("%d): peer certificate fingerprint [%s]", i, fingerprint)
-				log.Debugf("%d): peer common name [%s]", i, cert.Subject.CommonName)
-			} else {
-				errorList = append(errorList, err)
+	// The churn / already-connected guard applies only when establishing a new channel. Additional
+	// underlays of an existing grouped control channel legitimately arrive while the router is already
+	// connected and must not be rejected here.
+	if isFirstCtrlConnection(hello) {
+		if router := self.network.GetConnectedRouter(id); router != nil {
+			if time.Since(router.ConnectTime) < self.network.GetOptions().RouterConnectChurnLimit {
+				log.WithField("routerName", router.Name).Error("router already connected and churn threshold not met")
+				return fmt.Errorf("router already connected id: %s, name: %s", id, router.Name)
 			}
+			log.WithField("routerName", router.Name).Warn("router already connected, but churn threshold met. replacing connection")
 		}
-	}
-
-	if len(validFingerPrints) == 0 && len(errorList) > 0 {
-		return errors.Join(errorList...)
-	}
-
-	log.Debugf("peer has [%d] valid certificates out of [%v] submitted", len(validFingerPrints), len(certificates))
-
-	if router := self.network.GetConnectedRouter(id); router != nil {
-		if time.Since(router.ConnectTime) < self.network.GetOptions().RouterConnectChurnLimit {
-			log.WithField("routerName", router.Name).Error("router already connected and churn threshold not met")
-			return fmt.Errorf("router already connected id: %s, name: %s", id, router.Name)
-		}
-		log.WithField("routerName", router.Name).Warn("router already connected, but churn threshold met. replacing connection")
 	}
 
 	if r, err := self.network.GetRouter(id); err == nil {
@@ -105,9 +124,9 @@ func (self *ConnectHandler) HandleConnection(hello *channel.Hello, certificates 
 			log.Error("router enrollment incomplete")
 			return fmt.Errorf("router enrollment incomplete, routerId: %v", id)
 		}
-		if !stringz.Contains(validFingerPrints, *r.Fingerprint) {
-			log.WithField("fp", *r.Fingerprint).WithField("givenFps", validFingerPrints).Error("router fingerprint mismatch")
-			return fmt.Errorf("incorrect fingerprint/unenrolled router, routerId: %v, given fingerprints: %v", id, validFingerPrints)
+		if fingerprint != *r.Fingerprint {
+			log.WithField("fp", *r.Fingerprint).WithField("givenFp", fingerprint).Error("router fingerprint mismatch")
+			return fmt.Errorf("incorrect fingerprint/unenrolled router, routerId: %v, given fingerprint: %v", id, fingerprint)
 		}
 		if r.Disabled {
 			log.Error("router disabled")

--- a/controller/handler_ctrl/connect_test.go
+++ b/controller/handler_ctrl/connect_test.go
@@ -1,0 +1,178 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package handler_ctrl
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/openziti/channel/v5"
+	"github.com/openziti/identity"
+	"github.com/openziti/ziti/v2/common/ctrlchan"
+	"github.com/stretchr/testify/require"
+)
+
+// meshChannelType mirrors controller/raft/mesh.ChannelTypeMesh without importing that package.
+const meshChannelType = "ctrl.mesh"
+
+func helloWithType(chType string) *channel.Hello {
+	h := channel.Headers{}
+	if chType != "" {
+		h.PutStringHeader(channel.TypeHeader, chType)
+	}
+	return &channel.Hello{Headers: h}
+}
+
+// Test_ConnectHandler_isSeparatelyValidated covers the rule that only channel types dispatched to a
+// dedicated, self-validating acceptor are skipped; every other type - including unrecognized types and
+// the mesh type on a non-clustered controller - routes to the router control acceptor and must be
+// validated here.
+func Test_ConnectHandler_isSeparatelyValidated(t *testing.T) {
+	// Clustered controller: only the mesh type has a dedicated acceptor.
+	clustered := &ConnectHandler{separatelyValidatedTypes: map[string]struct{}{meshChannelType: {}}}
+	require.True(t, clustered.isSeparatelyValidated(helloWithType(meshChannelType)), "mesh is validated by its own acceptor")
+	require.False(t, clustered.isSeparatelyValidated(helloWithType(ctrlchan.ChannelTypeDefault)), "router ctrl type is validated here")
+	require.False(t, clustered.isSeparatelyValidated(helloWithType(ctrlchan.ChannelTypeHighPriority)))
+	require.False(t, clustered.isSeparatelyValidated(helloWithType("bogus")), "unrecognized types route to the router acceptor and must be validated")
+	require.False(t, clustered.isSeparatelyValidated(helloWithType("")), "legacy (no type) connections are validated here")
+
+	// Non-clustered controller: no dedicated acceptors, so even a mesh-typed connection routes to the
+	// router acceptor and must be validated.
+	standalone := &ConnectHandler{separatelyValidatedTypes: map[string]struct{}{}}
+	require.False(t, standalone.isSeparatelyValidated(helloWithType(meshChannelType)), "mesh on a non-clustered controller must be validated")
+	require.False(t, standalone.isSeparatelyValidated(helloWithType(ctrlchan.ChannelTypeDefault)))
+}
+
+func Test_isFirstCtrlConnection(t *testing.T) {
+	// Legacy / non-grouped dial: no grouped header -> treated as a new channel.
+	require.True(t, isFirstCtrlConnection(&channel.Hello{Headers: channel.Headers{}}))
+
+	grouped := channel.Headers{}
+	grouped.PutBoolHeader(channel.IsGroupedHeader, true)
+	grouped.PutBoolHeader(channel.IsFirstGroupConnection, true)
+	require.True(t, isFirstCtrlConnection(&channel.Hello{Headers: grouped}), "grouped first connection")
+
+	additional := channel.Headers{}
+	additional.PutBoolHeader(channel.IsGroupedHeader, true)
+	require.False(t, isFirstCtrlConnection(&channel.Hello{Headers: additional}), "additional underlay (no first flag)")
+
+	notFirst := channel.Headers{}
+	notFirst.PutBoolHeader(channel.IsGroupedHeader, true)
+	notFirst.PutBoolHeader(channel.IsFirstGroupConnection, false)
+	require.False(t, isFirstCtrlConnection(&channel.Hello{Headers: notFirst}), "additional underlay (first=false)")
+}
+
+// caPoolIdentity is a minimal identity.Identity whose only useful method is CA. The certificate
+// verification path of HandleConnection consults nothing else, so the remaining interface methods are
+// left to the embedded nil interface (never called on the paths exercised here).
+type caPoolIdentity struct {
+	identity.Identity
+	roots *x509.CertPool
+}
+
+func (f *caPoolIdentity) CA() *x509.CertPool { return f.roots }
+
+type ctCertAndKey struct {
+	cert *x509.Certificate
+	key  *ecdsa.PrivateKey
+}
+
+var ctSerial int64
+
+func ctMkCert(t *testing.T, cn string, isCA bool, signer *ctCertAndKey) *ctCertAndKey {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	ctSerial++
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(ctSerial),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		BasicConstraintsValid: true,
+	}
+	if isCA {
+		tmpl.IsCA = true
+		tmpl.KeyUsage = x509.KeyUsageCertSign | x509.KeyUsageCRLSign
+	} else {
+		tmpl.KeyUsage = x509.KeyUsageDigitalSignature
+		tmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+	}
+	signParent, signKey := tmpl, key
+	if signer != nil {
+		signParent, signKey = signer.cert, signer.key
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, signParent, &key.PublicKey, signKey)
+	require.NoError(t, err)
+	c, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return &ctCertAndKey{cert: c, key: key}
+}
+
+// Test_ConnectHandler_HandleConnection_RejectsUntrustedLeaf covers the router control-channel
+// verification: a connection dispatched to the router acceptor must present a leaf that chains to the
+// controller CA. In particular, presenting a self-signed leaf followed by a legitimate router's public
+// certificate as filler must be rejected - the check is bound to the leaf, not to "some presented cert
+// chains". These paths fail during certificate verification, before any network state is consulted.
+func Test_ConnectHandler_HandleConnection_RejectsUntrustedLeaf(t *testing.T) {
+	req := require.New(t)
+
+	root := ctMkCert(t, "root", true, nil)
+	inter := ctMkCert(t, "int", true, root)
+	roots := x509.NewCertPool()
+	roots.AddCert(root.cert)
+	roots.AddCert(inter.cert)
+
+	handler := &ConnectHandler{
+		identity:                 &caPoolIdentity{roots: roots},
+		separatelyValidatedTypes: map[string]struct{}{},
+	}
+
+	// A legitimate, CA-chained certificate an attacker could scrape off the wire and present as filler.
+	legit := ctMkCert(t, "legit-router", false, inter)
+	// The attacker's own self-signed leaf - it does not chain to the CA.
+	forged := ctMkCert(t, "forged", false, nil)
+
+	hello := &channel.Hello{IdToken: "router1", Headers: channel.Headers{}}
+
+	req.Error(handler.HandleConnection(hello, nil), "no certificates must be rejected")
+	req.Error(handler.HandleConnection(hello, []*x509.Certificate{forged.cert}),
+		"self-signed leaf that does not chain to the CA must be rejected")
+	req.Error(handler.HandleConnection(hello, []*x509.Certificate{forged.cert, legit.cert}),
+		"self-signed leaf backed by a scraped CA-chained filler cert must be rejected")
+}
+
+// Test_ConnectHandler_HandleConnection_SkipsSeparatelyValidated verifies that connections whose type is
+// handled by a separate acceptor (e.g. the raft mesh on a clustered controller) are not validated here,
+// even when the presented certificate would fail the router control-channel check.
+func Test_ConnectHandler_HandleConnection_SkipsSeparatelyValidated(t *testing.T) {
+	req := require.New(t)
+
+	forged := ctMkCert(t, "forged", false, nil)
+	handler := &ConnectHandler{
+		separatelyValidatedTypes: map[string]struct{}{meshChannelType: {}},
+	}
+
+	req.NoError(handler.HandleConnection(helloWithType(meshChannelType), []*x509.Certificate{forged.cert}),
+		"mesh-typed connection is validated by its own acceptor and must be skipped here")
+}

--- a/controller/raft/mesh/mesh.go
+++ b/controller/raft/mesh/mesh.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/openziti/foundation/v2/concurrenz"
 	"github.com/openziti/foundation/v2/versions"
+	"github.com/openziti/ziti/v2/common/cert"
 	"github.com/openziti/ziti/v2/controller/config"
 	"github.com/openziti/ziti/v2/controller/event"
 
@@ -672,18 +673,13 @@ func (self *impl) checkClusterIds(ch channel.Channel) error {
 }
 
 func (self *impl) checkCerts(ch channel.Channel) error {
-	certs := ch.Underlay().Certificates()
-	if len(certs) == 0 {
-		return errors.New("unable to validate peer connection, no certs presented")
+	// Peer identity is taken from certs[0] via ExtractSpiffeId, so certs[0] is the certificate that must
+	// chain to a trusted CA; VerifyLeafCertChain verifies that leaf specifically against the node's full
+	// trusted-CA pool.
+	if _, err := cert.VerifyLeafCertChain(self.env.GetNodeId().CA(), ch.Underlay().Certificates()); err != nil {
+		return fmt.Errorf("unable to validate peer connection: %w", err)
 	}
-
-	for _, cert := range ch.Underlay().Certificates() {
-		if _, err := self.env.GetNodeId().CaPool().VerifyToRoot(cert); err == nil {
-			return nil
-		}
-	}
-
-	return errors.New("unable to validate peer connection, no certs presented matched the CA for this node")
+	return nil
 }
 
 func (self *impl) GetPeerInfo(address string, timeout time.Duration) (raft.ServerID, raft.ServerAddress, error) {

--- a/controller/raft/mesh/mesh_peer_cert_validation_test.go
+++ b/controller/raft/mesh/mesh_peer_cert_validation_test.go
@@ -1,0 +1,246 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package mesh
+
+// End-to-end validation of the mesh peer certificate check over a real TCP+TLS socket, using the
+// production controller TLS config (identity.ServerTLSConfig). The ctrl listener uses
+// RequireAnyClientCert and does not verify the client chain, so the handshake completes for any
+// presented client leaf; peer admission is enforced afterward by the direction-aware cert-chain check
+// against the node CA pool. Unit-level coverage of the shared check lives in common/cert.
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openziti/identity"
+	"github.com/openziti/ziti/v2/common/cert"
+	"github.com/stretchr/testify/require"
+)
+
+const testTrustDomain = "spiffe://mesh-cert-test"
+
+type certAndKey struct {
+	cert *x509.Certificate
+	key  *ecdsa.PrivateKey
+}
+
+var testSerial int64
+
+func nextTestSerial() *big.Int {
+	testSerial++
+	return big.NewInt(testSerial)
+}
+
+func mkTestKey(t *testing.T) *ecdsa.PrivateKey {
+	t.Helper()
+	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	return k
+}
+
+func signTestCert(t *testing.T, tmpl, parent *x509.Certificate, pub *ecdsa.PublicKey, signerKey *ecdsa.PrivateKey) *x509.Certificate {
+	t.Helper()
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, parent, pub, signerKey)
+	require.NoError(t, err)
+	c, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return c
+}
+
+func mkCA(t *testing.T, cn string, parent *certAndKey) *certAndKey {
+	t.Helper()
+	key := mkTestKey(t)
+	tmpl := &x509.Certificate{
+		SerialNumber:          nextTestSerial(),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+	signParent, signKey := tmpl, key
+	if parent != nil {
+		signParent, signKey = parent.cert, parent.key
+	}
+	return &certAndKey{cert: signTestCert(t, tmpl, signParent, &key.PublicKey, signKey), key: key}
+}
+
+func mkLeafWithKey(t *testing.T, cn, spiffePath string, ekus []x509.ExtKeyUsage, signer *certAndKey, key *ecdsa.PrivateKey) *certAndKey {
+	t.Helper()
+	tmpl := &x509.Certificate{
+		SerialNumber: nextTestSerial(),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  ekus,
+	}
+	if spiffePath != "" {
+		u, err := url.Parse(testTrustDomain + spiffePath)
+		require.NoError(t, err)
+		tmpl.URIs = []*url.URL{u}
+	}
+	signParent, signKey := tmpl, key
+	if signer != nil {
+		signParent, signKey = signer.cert, signer.key
+	}
+	return &certAndKey{cert: signTestCert(t, tmpl, signParent, &key.PublicKey, signKey), key: key}
+}
+
+func mkLeaf(t *testing.T, cn, spiffePath string, ekus []x509.ExtKeyUsage, signer *certAndKey) *certAndKey {
+	return mkLeafWithKey(t, cn, spiffePath, ekus, signer, mkTestKey(t))
+}
+
+func pemOfCerts(t *testing.T, certs ...*x509.Certificate) string {
+	t.Helper()
+	var b strings.Builder
+	for _, c := range certs {
+		require.NoError(t, pem.Encode(&b, &pem.Block{Type: "CERTIFICATE", Bytes: c.Raw}))
+	}
+	return b.String()
+}
+
+func pemOfKey(t *testing.T, key *ecdsa.PrivateKey) string {
+	t.Helper()
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	var b strings.Builder
+	require.NoError(t, pem.Encode(&b, &pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+	return b.String()
+}
+
+// Test_MeshPeerCert_LiveHandshake stands up a real TLS listener with the production node identity,
+// then connects as both a rogue and a legitimate peer. The rogue presents a self-signed identity leaf
+// plus the node's own (scraped) server cert as an extra certificate; the handshake completes, but the
+// mesh check must reject it. The legitimate peer presents a CA-signed client leaf and must be accepted.
+func Test_MeshPeerCert_LiveHandshake(t *testing.T) {
+	req := require.New(t)
+
+	root := mkCA(t, "root", nil)
+	inter := mkCA(t, "int", root)
+
+	// Real node identity: one key backs the client and server certs (LoadIdentity uses the default
+	// key for the server cert when no server_key is configured).
+	nodeKey := mkTestKey(t)
+	clientCert := mkLeafWithKey(t, "node-client", "/controller/real-id",
+		[]x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth}, inter, nodeKey)
+	serverCert := mkLeafWithKey(t, "node-server", "",
+		[]x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}, inter, nodeKey)
+
+	id, err := identity.LoadIdentity(identity.Config{
+		Key:        "pem:" + pemOfKey(t, nodeKey),
+		Cert:       "pem:" + pemOfCerts(t, clientCert.cert, inter.cert),
+		ServerCert: "pem:" + pemOfCerts(t, serverCert.cert, inter.cert),
+		CA:         "pem:" + pemOfCerts(t, root.cert, inter.cert),
+	})
+	req.NoError(err)
+
+	serverCfg := id.ServerTLSConfig()
+	req.NotNil(serverCfg)
+	req.Equal(tls.RequireAnyClientCert, serverCfg.ClientAuth)
+
+	rawLn, err := net.Listen("tcp", "127.0.0.1:0")
+	req.NoError(err)
+	defer func() { _ = rawLn.Close() }()
+	ln := tls.NewListener(rawLn, serverCfg)
+	addr := ln.Addr().String()
+
+	type acceptResult struct {
+		peer []*x509.Certificate
+		err  error
+	}
+	results := make(chan acceptResult, 3)
+	go func() {
+		for i := 0; i < 3; i++ {
+			c, aerr := ln.Accept()
+			if aerr != nil {
+				results <- acceptResult{err: aerr}
+				continue
+			}
+			tc := c.(*tls.Conn)
+			_ = tc.SetDeadline(time.Now().Add(10 * time.Second))
+			if herr := tc.Handshake(); herr != nil {
+				results <- acceptResult{err: herr}
+				_ = tc.Close()
+				continue
+			}
+			results <- acceptResult{peer: tc.ConnectionState().PeerCertificates}
+			_ = tc.Close()
+		}
+	}()
+
+	ca := id.CA()
+
+	// Scrape the node's own server certificate from the listener (a throwaway client cert satisfies
+	// RequireAnyClientCert). This is the "extra" certificate the rogue peer will present.
+	throwaway := mkLeaf(t, "throwaway", "", []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, nil)
+	scrapeConn, err := tls.Dial("tcp", addr, &tls.Config{
+		InsecureSkipVerify: true,
+		Certificates:       []tls.Certificate{{Certificate: [][]byte{throwaway.cert.Raw}, PrivateKey: throwaway.key, Leaf: throwaway.cert}},
+	})
+	req.NoError(err)
+	serverPresented := scrapeConn.ConnectionState().PeerCertificates
+	_ = scrapeConn.Close()
+	req.NotEmpty(serverPresented)
+	extra := serverPresented[0]
+	req.Equal("node-server", extra.Subject.CommonName)
+	<-results
+
+	// The scraped server certificate is server-auth-only, yet it chains to the node CA. Verification is
+	// EKU-agnostic and anchors on the node's full trusted-CA pool, so it is accepted - this is the
+	// certificate an outbound dial would present as its leaf.
+	_, err = cert.VerifyLeafCertChain(ca, serverPresented)
+	req.NoError(err, "a server-auth leaf that chains to the node CA is accepted")
+
+	// Rogue peer: self-signed identity leaf + the scraped extra cert. Handshake completes; the mesh
+	// check must reject it because the identity leaf (certs[0]) does not chain to the CA.
+	rogue := mkLeaf(t, "rogue", "/controller/victim-id", []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, nil)
+	rogueConn, err := tls.Dial("tcp", addr, &tls.Config{
+		InsecureSkipVerify: true,
+		Certificates:       []tls.Certificate{{Certificate: [][]byte{rogue.cert.Raw, extra.Raw}, PrivateKey: rogue.key, Leaf: rogue.cert}},
+	})
+	req.NoError(err, "handshake completes under RequireAnyClientCert even for a self-signed leaf")
+	_ = rogueConn.Close()
+	rogueRes := <-results
+	req.NoError(rogueRes.err)
+	_, err = cert.VerifyLeafCertChain(ca, rogueRes.peer)
+	req.Error(err, "mesh check rejects a self-signed identity leaf backed by a scraped extra cert")
+
+	// Legitimate peer: CA-signed client leaf. Handshake completes and the mesh check accepts it.
+	legitConn, err := tls.Dial("tcp", addr, &tls.Config{
+		InsecureSkipVerify: true,
+		Certificates:       []tls.Certificate{{Certificate: [][]byte{clientCert.cert.Raw, inter.cert.Raw}, PrivateKey: nodeKey, Leaf: clientCert.cert}},
+	})
+	req.NoError(err)
+	_ = legitConn.Close()
+	legitRes := <-results
+	req.NoError(legitRes.err)
+	_, err = cert.VerifyLeafCertChain(ca, legitRes.peer)
+	req.NoError(err, "mesh check accepts a legitimate CA-signed peer leaf")
+}

--- a/controller/webapis/metrics-api.go
+++ b/controller/webapis/metrics-api.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/identity"
@@ -147,8 +148,15 @@ func (metricsApi *MetricsApiHandler) newHandler() http.Handler {
 
 		if nil != metricsApi.scrapeCert {
 			certOk := false
-			for _, r := range r.TLS.PeerCertificates {
-				if bytes.Equal(metricsApi.scrapeCert.Signature, r.Signature) {
+			// Match the pinned scrape cert against the presented LEAF only (PeerCertificates[0], the
+			// cert whose private key the TLS handshake proved) - iterating the whole chain would let a
+			// client present its own leaf plus the public scrape cert as an extra cert and pass. Compare
+			// full DER, not just the signature, and reject a leaf outside its validity window.
+			if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
+				leaf := r.TLS.PeerCertificates[0]
+				now := time.Now()
+				if bytes.Equal(metricsApi.scrapeCert.Raw, leaf.Raw) &&
+					!now.Before(leaf.NotBefore) && !now.After(leaf.NotAfter) {
 					certOk = true
 				}
 			}

--- a/controller/webapis/metrics-api_test.go
+++ b/controller/webapis/metrics-api_test.go
@@ -1,0 +1,103 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package webapis
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+var mSerial int64
+
+func mMkCert(t *testing.T, cn string, notBefore, notAfter time.Time) *x509.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	mSerial++
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(mSerial),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	c, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return c
+}
+
+func mScrapeRequest(peerCerts []*x509.Certificate) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	if peerCerts != nil {
+		r.TLS = &tls.ConnectionState{PeerCertificates: peerCerts}
+	}
+	return r
+}
+
+// Test_MetricsApi_ScrapeCertAuthorization covers the scrape-cert gate on the metrics endpoint. When a
+// scrape cert is pinned, authorization must match the pinned cert against the presented LEAF only
+// (PeerCertificates[0]), compare the full certificate, honor the validity window, and reject requests
+// with no client certificate. Only the rejecting (401) paths are exercised here; they return before the
+// handler consults the network.
+func Test_MetricsApi_ScrapeCertAuthorization(t *testing.T) {
+	now := time.Now()
+	scrapeCert := mMkCert(t, "scrape", now.Add(-time.Hour), now.Add(time.Hour))
+
+	handler := (&MetricsApiHandler{scrapeCert: scrapeCert}).newHandler()
+
+	assertUnauthorized := func(t *testing.T, peerCerts []*x509.Certificate) {
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, mScrapeRequest(peerCerts))
+		require.Equal(t, http.StatusUnauthorized, rec.Code)
+	}
+
+	t.Run("no client certificate", func(t *testing.T) {
+		assertUnauthorized(t, nil)
+	})
+
+	t.Run("presented leaf is not the scrape cert", func(t *testing.T) {
+		other := mMkCert(t, "other", now.Add(-time.Hour), now.Add(time.Hour))
+		assertUnauthorized(t, []*x509.Certificate{other})
+	})
+
+	t.Run("scrape cert presented only as a filler cert, not the leaf", func(t *testing.T) {
+		attacker := mMkCert(t, "attacker", now.Add(-time.Hour), now.Add(time.Hour))
+		// The pinned scrape cert is present in the chain, but the leaf (index 0) is the attacker's.
+		assertUnauthorized(t, []*x509.Certificate{attacker, scrapeCert})
+	})
+
+	t.Run("expired scrape cert presented as the leaf", func(t *testing.T) {
+		expired := mMkCert(t, "expired", now.Add(-2*time.Hour), now.Add(-time.Hour))
+		expiredHandler := (&MetricsApiHandler{scrapeCert: expired}).newHandler()
+		rec := httptest.NewRecorder()
+		expiredHandler.ServeHTTP(rec, mScrapeRequest([]*x509.Certificate{expired}))
+		require.Equal(t, http.StatusUnauthorized, rec.Code, "a leaf outside its validity window must be rejected")
+	})
+}

--- a/router/env/ctrls.go
+++ b/router/env/ctrls.go
@@ -299,6 +299,20 @@ func (self *networkControllers) connectToControllerWithBackoff(detail *ctrl_pb.C
 	}()
 }
 
+// firstUnderlayHeaders returns the hello headers for the initial underlay of a grouped control
+// channel, the only underlay that carries IsFirstGroupConnection. These are deliberately built fresh
+// rather than added to the dialer's base
+// headers: additional underlays reuse the base headers, and an inherited first-connection flag would
+// both spawn a new listener-side group and make each additional underlay look like a new channel to
+// the controller's already-connected guard.
+func firstUnderlayHeaders() channel.Headers {
+	first := channel.Headers{}
+	first.PutBoolHeader(channel.IsGroupedHeader, true)
+	first.PutStringHeader(channel.TypeHeader, ctrlchan.ChannelTypeDefault)
+	first.PutBoolHeader(channel.IsFirstGroupConnection, true)
+	return first
+}
+
 func (self *networkControllers) connectToController(endpoint string, addr transport.Address) error {
 	headers, err := self.dialEnv.GetChannelHeaders()
 	if err != nil {
@@ -322,13 +336,8 @@ func (self *networkControllers) connectToController(endpoint string, addr transp
 		},
 	})
 
-	// Headers for the initial dial only: establish a new grouped channel as its first connection.
-	// These must NOT live on the dialer's base headers, or non-first (constraint/backoff/reconnect)
-	// dials would inherit IsFirstGroupConnection=true and spawn a new listener-side group.
-	firstDialHeaders := channel.Headers{}
-	firstDialHeaders.PutBoolHeader(channel.IsGroupedHeader, true)
-	firstDialHeaders.PutStringHeader(channel.TypeHeader, ctrlchan.ChannelTypeDefault)
-	firstDialHeaders.PutBoolHeader(channel.IsFirstGroupConnection, true)
+	// The initial underlay, and only it, carries IsFirstGroupConnection.
+	firstDialHeaders := firstUnderlayHeaders()
 
 	// Dial initial underlay
 	underlay, err := dialer.CreateWithHeaders(config.Ctrl.Options.ConnectTimeout, firstDialHeaders)

--- a/router/env/ctrls_test.go
+++ b/router/env/ctrls_test.go
@@ -1,0 +1,51 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package env
+
+import (
+	"testing"
+
+	"github.com/openziti/channel/v5"
+	"github.com/openziti/ziti/v2/common/ctrlchan"
+	"github.com/stretchr/testify/require"
+)
+
+// Test_firstUnderlayHeaders verifies that the initial underlay is flagged as the first grouped
+// connection, and that each call yields an independent map. If the flag leaked onto headers shared with
+// additional underlays (e.g. ctrl.high), every additional underlay would look like a new channel and
+// trip the controller's already-connected churn guard.
+func Test_firstUnderlayHeaders(t *testing.T) {
+	req := require.New(t)
+
+	first := firstUnderlayHeaders()
+
+	firstFlag, ok := first.GetBoolHeader(channel.IsFirstGroupConnection)
+	req.True(ok, "initial underlay headers must contain the first-connection flag")
+	req.True(firstFlag)
+
+	grouped, _ := first.GetBoolHeader(channel.IsGroupedHeader)
+	req.True(grouped, "initial underlay must be flagged as grouped")
+	chType, _ := first.GetStringHeader(channel.TypeHeader)
+	req.Equal(ctrlchan.ChannelTypeDefault, chType, "initial underlay must carry the default ctrl channel type")
+
+	// Callers mutate the returned headers, so each call must hand back a distinct map; a shared map
+	// would let the first-connection flag reach underlays that must not carry it.
+	other := firstUnderlayHeaders()
+	delete(other, channel.IsFirstGroupConnection)
+	_, stillSet := first[channel.IsFirstGroupConnection]
+	req.True(stillSet, "each call must return an independent header map")
+}

--- a/router/xlink_transport/connect.go
+++ b/router/xlink_transport/connect.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/openziti/channel/v5"
 	"github.com/openziti/identity"
+	"github.com/openziti/ziti/v2/common/cert"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -33,14 +34,6 @@ type ConnectionHandler struct {
 func (self *ConnectionHandler) HandleConnection(hello *channel.Hello, certificates []*x509.Certificate) error {
 	if len(certificates) == 0 {
 		return errors.New("no certificates provided, unable to verify dialer")
-	}
-
-	config := self.routerId.ServerTLSConfig()
-
-	opts := x509.VerifyOptions{
-		Roots:         config.RootCAs,
-		Intermediates: x509.NewCertPool(),
-		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
 	}
 
 	dialedRouterId, ok := hello.Headers[LinkDialedRouterId]
@@ -54,15 +47,9 @@ func (self *ConnectionHandler) HandleConnection(hello *channel.Hello, certificat
 		}
 	}
 
-	var errorList []error
-
-	for _, cert := range certificates {
-		if _, err := cert.Verify(opts); err == nil {
-			return nil
-		} else {
-			errorList = append(errorList, err)
-		}
+	if _, err := cert.VerifyLeafCertChain(self.routerId.CA(), certificates); err != nil {
+		return fmt.Errorf("unable to verify dialing router: %w", err)
 	}
 
-	return errors.Join(errorList...)
+	return nil
 }

--- a/router/xlink_transport/connect_test.go
+++ b/router/xlink_transport/connect_test.go
@@ -1,0 +1,150 @@
+/*
+	(c) Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package xlink_transport
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/openziti/channel/v5"
+	"github.com/openziti/identity"
+	"github.com/stretchr/testify/require"
+)
+
+// caPoolIdentity is a minimal identity.Identity whose only useful method is CA. The link verification
+// path consults nothing else on the identity, so the remaining interface methods are left to the
+// embedded nil interface (never called on the paths exercised here).
+type caPoolIdentity struct {
+	identity.Identity
+	roots *x509.CertPool
+}
+
+func (f *caPoolIdentity) CA() *x509.CertPool { return f.roots }
+
+func ltPool(certs ...*x509.Certificate) *x509.CertPool {
+	p := x509.NewCertPool()
+	for _, c := range certs {
+		p.AddCert(c)
+	}
+	return p
+}
+
+type ltCertAndKey struct {
+	cert *x509.Certificate
+	key  *ecdsa.PrivateKey
+}
+
+var ltSerial int64
+
+func ltMkCert(t *testing.T, cn string, isCA bool, signer *ltCertAndKey) *ltCertAndKey {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	ltSerial++
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(ltSerial),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		BasicConstraintsValid: true,
+	}
+	if isCA {
+		tmpl.IsCA = true
+		tmpl.KeyUsage = x509.KeyUsageCertSign | x509.KeyUsageCRLSign
+	} else {
+		tmpl.KeyUsage = x509.KeyUsageDigitalSignature
+		tmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+	}
+	signParent, signKey := tmpl, key
+	if signer != nil {
+		signParent, signKey = signer.cert, signer.key
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, signParent, &key.PublicKey, signKey)
+	require.NoError(t, err)
+	c, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return &ltCertAndKey{cert: c, key: key}
+}
+
+func ltHandler(roots *x509.CertPool, token string) *ConnectionHandler {
+	return &ConnectionHandler{routerId: &identity.TokenId{Identity: &caPoolIdentity{roots: roots}, Token: token}}
+}
+
+// Test_ConnectionHandler_RejectsUntrustedDialer covers incoming link verification: the dialing router
+// must present a leaf that chains to the CA. A self-signed leaf, alone or backed by a scraped
+// CA-chained filler certificate, must be rejected - verification is bound to the leaf, not to "some
+// presented certificate chains".
+func Test_ConnectionHandler_RejectsUntrustedDialer(t *testing.T) {
+	req := require.New(t)
+
+	root := ltMkCert(t, "root", true, nil)
+	inter := ltMkCert(t, "int", true, root)
+	roots := ltPool(root.cert, inter.cert)
+	handler := ltHandler(roots, "router1")
+
+	legit := ltMkCert(t, "legit-router", false, inter)
+	forged := ltMkCert(t, "forged", false, nil)
+
+	hello := &channel.Hello{Headers: channel.Headers{}}
+
+	req.Error(handler.HandleConnection(hello, nil), "no certificates must be rejected")
+	req.Error(handler.HandleConnection(hello, []*x509.Certificate{forged.cert}),
+		"self-signed leaf that does not chain to the CA must be rejected")
+	req.Error(handler.HandleConnection(hello, []*x509.Certificate{forged.cert, legit.cert}),
+		"self-signed leaf backed by a scraped CA-chained filler cert must be rejected")
+}
+
+func Test_ConnectionHandler_AcceptsTrustedDialer(t *testing.T) {
+	req := require.New(t)
+
+	root := ltMkCert(t, "root", true, nil)
+	inter := ltMkCert(t, "int", true, root)
+	roots := ltPool(root.cert, inter.cert)
+	handler := ltHandler(roots, "router1")
+
+	legit := ltMkCert(t, "legit-router", false, inter)
+	req.NoError(handler.HandleConnection(&channel.Hello{Headers: channel.Headers{}}, []*x509.Certificate{legit.cert}),
+		"a leaf chaining to the CA must be accepted")
+}
+
+// Test_ConnectionHandler_DialedRouterIdMismatch verifies the dial is rejected when it names a different
+// target router, even if the presented certificate is otherwise valid.
+func Test_ConnectionHandler_DialedRouterIdMismatch(t *testing.T) {
+	req := require.New(t)
+
+	root := ltMkCert(t, "root", true, nil)
+	inter := ltMkCert(t, "int", true, root)
+	roots := ltPool(root.cert, inter.cert)
+	handler := ltHandler(roots, "router1")
+	legit := ltMkCert(t, "legit-router", false, inter)
+
+	mismatch := channel.Headers{}
+	mismatch.PutStringHeader(LinkDialedRouterId, "some-other-router")
+	req.Error(handler.HandleConnection(&channel.Hello{Headers: mismatch}, []*x509.Certificate{legit.cert}),
+		"a link dial meant for a different router must be rejected")
+
+	match := channel.Headers{}
+	match.PutStringHeader(LinkDialedRouterId, "router1")
+	req.NoError(handler.HandleConnection(&channel.Hello{Headers: match}, []*x509.Certificate{legit.cert}),
+		"a matching dialed router id with a trusted cert must be accepted")
+}


### PR DESCRIPTION
The two control-plane certificate validation advisories fixed in 2.0.2 (and 1.6.18) were never forward
ported to main, so `main` still has both vulnerabilities. This brings them over.

- **GHSA-mrpr-756c-xm47** (Critical) - peer certificate validation on the controller cluster mesh, router
  links, and the metrics endpoint accepted a connection when *any* presented certificate chained to the
  trusted CA, while taking peer identity from the leaf. A peer could therefore be admitted under a forged
  identity without holding a trusted key.
- **GHSA-cc5m-7mhm-xh9f** (Medium) - control-channel connections carrying a channel-type header skipped
  router certificate and identity verification entirely, so anything able to reach the controller's control
  port could be admitted as an arbitrary router.

Both fixes centre on a shared `cert.VerifyLeafCertChain` helper that verifies the leaf specifically (the
certificate whose private key the TLS handshake actually proved) and treats the rest of the presented chain
only as candidate intermediates.

Most files are byte-identical to `release-v2.0.x`, but three needed adapting because main has moved on:

- `controller/controller.go` - main uses channel v5's `TypeRoutingAcceptor`, so the "configure the skip set
  before accepting connections" ordering had to be expressed against the new listener construction.
- `router/env/ctrls.go` - main had already independently reached the required invariant (group flags kept off
  the dialer's base headers), so main's version is kept and the extracted helper and its test were adapted to
  match.
- `common/cert/verify.go` - the two advisories were developed on separate branches, and advisory 2 predates a
  rename plus an EKU split that its own later commit removes. Reconciled against 2.0.x's final state rather
  than replaying superseded intermediate steps.

Also verified that no remaining call site on main still uses the old accept-any-chaining-certificate pattern.