### PR TITLE
Backport.v2.0.x.promote downstreams

### DIFF
--- a/.github/workflows/mattermost-channel-posts.yml
+++ b/.github/workflows/mattermost-channel-posts.yml
@@ -21,9 +21,16 @@ jobs:
   send-notifications:
     runs-on: ubuntu-24.04
     name: POST Webhook with Python
+    # a chat notification must never fail the release: this job's status is reported as success even when the
+    # Mattermost webhook is unreachable, so workflows that gate on the checks for a revision aren't blocked by it
+    continue-on-error: true
+    # the webhook is dialed over the ziti overlay with no client-side connect timeout, so cap the job instead
+    timeout-minutes: 5
     if: github.actor != 'dependabot[bot]'
     steps:
+      # per-step too, so an unreachable webhook in the first post doesn't skip the second
       - uses: openziti/ziti-mattermost-action-py@v1
+        continue-on-error: true
         if: |
           github.repository_owner == 'openziti'
           && ((github.event_name != 'pull_request_review')
@@ -35,6 +42,7 @@ jobs:
           senderUsername: "GitHubZ"
 
       - uses: openziti/ziti-mattermost-action-py@v1
+        continue-on-error: true
         if: |
           github.repository_owner == 'openziti'
           && ((github.event_name != 'pull_request_review')

--- a/.github/workflows/mattermost-webhook.yml
+++ b/.github/workflows/mattermost-webhook.yml
@@ -14,6 +14,9 @@ on:
 jobs:
   mattermost-ziti-nodejs-webhook:
     continue-on-error: true
+    # the webhook is dialed over the ziti overlay with no client-side connect timeout; when the service is down this
+    # job has sat for hours, stalling anything that waits on the checks for a revision
+    timeout-minutes: 5
     runs-on: ubuntu-24.04
     name: POST Webhook with NodeJS
     if: github.repository_owner == 'openziti' && github.actor != 'dependabot[bot]'

--- a/.github/workflows/promote-downstreams.yml
+++ b/.github/workflows/promote-downstreams.yml
@@ -1,15 +1,21 @@
 name: Promote Downstream Releases
 
-on: 
-  # may be triggered manually on a release tag that represents a prerelease to promote it to a release in the downstream package repositories and Docker Hub
+on:
+  # may be triggered manually to promote a release tag to stable in the downstream package repositories and Docker Hub.
+  # Dispatch from the tag itself, or from any branch and set the 'tag' input to the release tag to promote.
   workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to promote, e.g. v2.0.0. Defaults to the ref the run was dispatched from; set this to promote a specific tag when dispatching from a branch.
+        required: false
+        type: string
   # GitHub release is marked stable, i.e., isPrerelease: false
   release:
     types: [released]  # this release event activity type excludes prereleases
 
-# cancel older, redundant runs of same workflow on same branch
+# cancel older, redundant runs of same workflow for the same tag (or dispatched ref)
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.inputs.tag || github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -24,11 +30,14 @@ jobs:
       - name: Validate the Release Tag is a Stable Release Ref
         id: validate
         shell: bash
+        env:
+          # the 'tag' input when dispatched from a branch, otherwise the ref the run fired on (the tag)
+          PROMOTE_REF: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
-          if [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "version=${GITHUB_REF_NAME#v}" | tee -a $GITHUB_OUTPUT
+          if [[ "${PROMOTE_REF}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "version=${PROMOTE_REF#v}" | tee -a $GITHUB_OUTPUT
           else
-            echo "${GITHUB_REF_NAME} is not a semver stable release ref" >&2
+            echo "${PROMOTE_REF} is not a semver stable release ref" >&2
             exit 1
           fi
 
@@ -55,14 +64,15 @@ jobs:
             | sort -V \
             | tail -1
           )
-          CURRENT_VERSION="${GITHUB_REF_NAME}"
-          
+          CURRENT_VERSION="${PROMOTE_REF}"
+
           if [[ "$CURRENT_VERSION" == "$HIGHEST_VERSION" ]]; then
             echo "highest=true" | tee -a $GITHUB_OUTPUT
           else
             echo "highest=false" | tee -a $GITHUB_OUTPUT
           fi
         env:
+          PROMOTE_REF: ${{ github.event.inputs.tag || github.ref_name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   promote_docker:

--- a/.github/workflows/promote-downstreams.yml
+++ b/.github/workflows/promote-downstreams.yml
@@ -13,49 +13,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  wait_for_release:
-    name: Wait for Release Builds to Succeed
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Debug action
-        uses: hmarr/debug-action@v3
-
-      - name: Wait for all checks on this rev
-        uses: lewagon/wait-on-check-action@v1.5.0
-        with:
-          ref: ${{ github.ref_name }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          # seconds between polling the checks api for job statuses
-          wait-interval: 30
-          # confusingly, this means "pause this step until all jobs from all workflows in same run have completed"
-          running-workflow-name: Wait for Release Builds to Succeed
-          # comma-separated list of check names (job.<id>.name) to ignore
-          ignore-checks: SDK Terminator Validation,Fablab HA Smoketest,POST Webhook,Release Quickstart Job,Parse Tag Regex
-
-      - name: Git Checkout
-        if: failure()
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Diagnose Failed "Wait for Release Builds to Succeed"
-        if: failure()
-        shell: bash
-        run: |
-          set -o pipefail
-          set -o xtrace
-
-          COMMIT_SHA=$(git rev-parse ${GITHUB_REF_NAME}^{commit})
-          for STATUS in cancelled failure
-          do
-            gh run list --repo "${GITHUB_REPOSITORY}" --status "${STATUS}" --commit "${COMMIT_SHA}"
-          done
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   # the purpose of this job is to enforce that the Git ref promoted is a semver eligible for stable release, i.e., not having a semver pre-release suffix; the extracted version without the leading 'v' is passed to the docker job as the container image tag
   parse_version:
-    needs: wait_for_release
     name: Parse Tag Regex
     runs-on: ubuntu-24.04
     outputs:

--- a/.github/workflows/promote-downstreams.yml
+++ b/.github/workflows/promote-downstreams.yml
@@ -106,7 +106,9 @@ jobs:
     name: Promote ${{ matrix.package_name }}-${{ matrix.arch.rpm }}.${{ matrix.packager }}
     needs: parse_version
     strategy:
-      fail-fast: true
+      # each copy is independent and idempotent, so let the rest finish and report exactly which one failed instead of
+      # cancelling siblings and leaving an arbitrary subset of the packages promoted
+      fail-fast: false
       matrix:
         package_name:
           - openziti
@@ -130,7 +132,7 @@ jobs:
       ZITI_RPM_PROD_REPO: ${{ vars.ZITI_RPM_PROD_REPO || 'zitipax-openziti-rpm-stable' }}
     steps:
       - name: Configure jFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v5
         env:
           JF_ENV_1: ${{ secrets.ZITI_ARTIFACTORY_CLI_CONFIG_PACKAGE_UPLOAD }}
 

--- a/.github/workflows/publish-linux-packages.yml
+++ b/.github/workflows/publish-linux-packages.yml
@@ -88,7 +88,7 @@ jobs:
           if-no-files-found: error
 
       - name: Configure jFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v5
         env:
           JF_ENV_1: ${{ secrets.ZITI_ARTIFACTORY_CLI_CONFIG_PACKAGE_UPLOAD }}
 


### PR DESCRIPTION
Backport of #4187 to release-v2.0.x, plus two workflow fixes that only ever landed on main.

release-v2.0.x still has the wait-for-all-checks gate in promote-downstreams.yml, and its skip list doesn't match the actual notifier job names (POST Webhook vs POST Webhook with Python/...with NodeJS). A failed chat notification therefore blocks promotion — that's what stopped v2.0.1 from shipping. A release event runs the workflow copy from the release tag, so the fix on main doesn't apply here.

Contents:

  - cherry-pick the gate removal
  - cherry-pick the tag input, so promotion can be re-run for a published tag
  - continue-on-error on the Python notifier, timeout-minutes on both
  - fail-fast: false on the artifactory matrix
  - setup-jfrog-cli v4 → v5