### PR TITLE
Make ER/T terminator create failures diagnosable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -484,6 +484,7 @@ today and expand as packages are converted. The global `ziti agent set-log-level
 * github.com/openziti/transport/v2: [v2.0.215 -> v2.0.216](https://github.com/openziti/transport/compare/v2.0.215...v2.0.216)
 * github.com/openziti/xweb/v3: [v3.0.4 -> v3.0.5](https://github.com/openziti/xweb/compare/v3.0.4...v3.0.5)
 * github.com/openziti/ziti/v2: [v2.0.0 -> v2.1.0](https://github.com/openziti/ziti/compare/v2.0.0...v2.1.0)
+    * [Issue #4193](https://github.com/openziti/ziti/issues/4193) - ER/T terminator create reports "invalid edge router for session" with no router-side error and slow recovery
     * [Issue #4149](https://github.com/openziti/ziti/issues/4149) - upgrading a running 1.x controller/router to 2.x fails to create the service user
     * [Issue #3990](https://github.com/openziti/ziti/issues/3990) - Expose service change subscriptions to external SDKs over protobuf
     * [Issue #4108](https://github.com/openziti/ziti/issues/4108) - Controller retains bbolt-managed memory past transaction (create-circuit response SIGSEGV)
@@ -495,6 +496,8 @@ today and expand as packages are converted. The global `ziti agent set-log-level
     * [Issue #4060](https://github.com/openziti/ziti/issues/4060) - support ext-jwt-signer in ziti verify traffic
     * [Issue #4036](https://github.com/openziti/ziti/issues/4036) - Own the metrics wire format (MetricsMessage) in ziti
     * [Issue #4137](https://github.com/openziti/ziti/issues/4137) - ziti tunnel ignores --dnsSvcIpRange <!-- keep -->
+    * [Issue #3988](https://github.com/openziti/ziti/issues/3988) - Support multiple resolver addresses for tproxy mode <!-- keep -->
+    * [Issue #3972](https://github.com/openziti/ziti/issues/3972) - Support multiple LAN interfaces for tproxy mode <!-- keep -->
     * [Issue #4052](https://github.com/openziti/ziti/issues/4052) - ziti cli cached creds don't use refresh token
     * [Issue #3881](https://github.com/openziti/ziti/issues/3881) - Add Capability for DNSUPSTREAMS to be used in serial
     * [Issue #4035](https://github.com/openziti/ziti/issues/4035) - Controller /metrics endpoint produces duplicate TYPE declarations causing Prometheus to drop samples

--- a/common/ctrl_msg/messages.go
+++ b/common/ctrl_msg/messages.go
@@ -72,6 +72,13 @@ const (
 
 	ResultErrorRateLimited = 1
 
+	// ErrorRetryHintHeader carries an edge.RetryHint on ContentType_ErrorType replies from the
+	// controller, as a companion to the edge-layer ErrorCodeHeader, so a router can reconstruct
+	// the full error for an SDK client instead of guessing the hint. It is an error-reply header,
+	// not part of the CreateCircuitV3 request block below; its value is the next id unused
+	// elsewhere in this block.
+	ErrorRetryHintHeader = 18
+
 	CreateCircuitV3ReqIdentityIdHeader = 15
 	CreateCircuitV3ReqServiceIdHeader  = 16
 	CreateCircuitV3ReqCircuitIdHeader  = 17

--- a/controller/env/sync.go
+++ b/controller/env/sync.go
@@ -50,7 +50,15 @@ const (
 	RouterSyncHelloTimeout RouterSyncStatus = "SYNC_HELLO_TIMEOUT" //sync failed due to a hello timeout.
 	RouterSyncError        RouterSyncStatus = "SYNC_ERROR"         //sync failed due to an unexpected error
 
-	//msg headers
+	// msg headers
+	//
+	// These ids alias the edge namespace's HealthStatus (1013), ErrorCode (1014), and Timestamp
+	// (1015) (see edge_client_pb.HeaderId). Both namespaces share the router-to-controller
+	// channel and are kept apart only by message ContentType: these ride ApiSessionAdded/Updated
+	// messages, the edge ids ride error/health/conn messages. Keep it that way. Do not put an
+	// edge-namespace header on a sync message or a sync header on an edge/error message, or the
+	// two meanings will silently clobber each other. The ranges cannot be moved without breaking
+	// backwards compatibility.
 	SyncStrategyTypeHeader  = 1013
 	SyncStrategyStateHeader = 1014
 	SyncStrategyLastIndex   = 1015

--- a/controller/handler_edge_ctrl/common.go
+++ b/controller/handler_edge_ctrl/common.go
@@ -11,8 +11,8 @@ import (
 	"github.com/openziti/channel/v5"
 	"github.com/openziti/identity"
 	"github.com/openziti/sdk-golang/v2/ziti/edge"
-	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/openziti/ziti/v2/common"
+	"github.com/openziti/ziti/v2/common/ctrl_msg"
 	"github.com/openziti/ziti/v2/common/logcontext"
 	"github.com/openziti/ziti/v2/common/pb/edge_ctrl_pb"
 	"github.com/openziti/ziti/v2/controller/change"
@@ -23,6 +23,7 @@ import (
 	"github.com/openziti/ziti/v2/controller/models"
 	"github.com/openziti/ziti/v2/controller/network"
 	"github.com/openziti/ziti/v2/controller/oidc_auth"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/openziti/ziti/v2/controller/xt"
 	"github.com/sirupsen/logrus"
 )
@@ -67,6 +68,7 @@ func (self *baseRequestHandler) getChannel() channel.Channel {
 func (self *baseRequestHandler) returnError(ctx requestContext, err controllerError) {
 	responseMsg := channel.NewMessage(int32(edge_ctrl_pb.ContentType_ErrorType), []byte(err.Error()))
 	responseMsg.PutUint32Header(edge.ErrorCodeHeader, err.ErrorCode())
+	responseMsg.PutUint32Header(ctrl_msg.ErrorRetryHintHeader, uint32(err.GetRetryHint()))
 	responseMsg.ReplyTo(ctx.GetMessage())
 	logger := pfxlog.
 		ContextLogger(self.ch.Label()).
@@ -355,7 +357,10 @@ func (self *baseSessionRequestContext) checkSessionType(sessionType string) {
 
 func (self *baseSessionRequestContext) verifyIdentityEdgeRouterAccess() {
 	if self.err == nil {
-		self.verifyEdgeRouterAccess(self.session.IdentityId, self.session.ServiceId)
+		self.verifyEdgeRouterAccess(self.session.IdentityId, self.session.ServiceId,
+			func(string, model.EdgeRouterAccess) controllerError {
+				return InvalidEdgeRouterForSessionError{}
+			})
 	}
 }
 
@@ -384,17 +389,36 @@ func (self *baseSessionRequestContext) verifyServiceBindAccess(identityId string
 	}
 }
 
+// verifyRouterEdgeRouterAccess checks that the requesting router may act on the service on its
+// own behalf, as an edge router tunneler does. No edge session is involved, so denials are
+// reported with the missing policy link rather than as a session error.
 func (self *baseSessionRequestContext) verifyRouterEdgeRouterAccess() {
 	if self.err == nil {
-		self.verifyEdgeRouterAccess(self.sourceRouter.Id, self.service.Id)
+		self.verifyEdgeRouterAccess(self.sourceRouter.Id, self.service.Id, self.newEdgeRouterAccessDeniedError)
 	}
 }
 
-func (self *baseSessionRequestContext) verifyEdgeRouterAccess(identityId string, serviceId string) {
+// newEdgeRouterAccessDeniedError builds a denial message naming the policy that would need to be
+// added to permit the identity to reach the service through this edge router.
+func (self *baseSessionRequestContext) newEdgeRouterAccessDeniedError(identityId string, access model.EdgeRouterAccess) controllerError {
+	var reason string
+	if !access.IdentityAllowed && !access.ServiceAllowed {
+		reason = "no edge router policy links the identity to the edge router and no service edge router policy links the service to the edge router"
+	} else if !access.IdentityAllowed {
+		reason = "no edge router policy links the identity to the edge router"
+	} else {
+		reason = "no service edge router policy links the service to the edge router"
+	}
+
+	return edgeRouterAccessDenied(fmt.Sprintf("edge router %s may not be used for service %s by identity %s: %s",
+		self.sourceRouter.Name, self.service.Name, identityId, reason))
+}
+
+func (self *baseSessionRequestContext) verifyEdgeRouterAccess(identityId string, serviceId string, newDeniedError func(identityId string, access model.EdgeRouterAccess) controllerError) {
 	if self.err == nil {
 		// validate edge router
 		erMgr := self.handler.getAppEnv().Managers.EdgeRouter
-		edgeRouterAllowed, err := erMgr.IsAccessToEdgeRouterAllowed(identityId, serviceId, self.sourceRouter.Id)
+		access, err := erMgr.GetEdgeRouterAccess(identityId, serviceId, self.sourceRouter.Id)
 		if err != nil {
 			self.err = internalError(err)
 			logrus.
@@ -406,8 +430,8 @@ func (self *baseSessionRequestContext) verifyEdgeRouterAccess(identityId string,
 			return
 		}
 
-		if !edgeRouterAllowed {
-			self.err = InvalidEdgeRouterForSessionError{}
+		if !access.IsAllowed() {
+			self.err = newDeniedError(identityId, access)
 		}
 	}
 }

--- a/controller/handler_edge_ctrl/create_circuit_v3.go
+++ b/controller/handler_edge_ctrl/create_circuit_v3.go
@@ -182,7 +182,7 @@ func (self *createCircuitV3RequestContext) verifyEdgeRouterAccessForIdentity() {
 	if self.err != nil {
 		return
 	}
-	self.verifyEdgeRouterAccess(self.req.IdentityId, self.service.Id)
+	self.verifyEdgeRouterAccess(self.req.IdentityId, self.service.Id, self.newEdgeRouterAccessDeniedError)
 }
 
 func (self *createCircuitV3RequestContext) newCircuitCreateParms(serviceId string, peerData map[uint32][]byte) model.CreateCircuitParams {

--- a/controller/handler_edge_ctrl/errors.go
+++ b/controller/handler_edge_ctrl/errors.go
@@ -147,6 +147,17 @@ func (InvalidEdgeRouterForSessionError) GetRetryHint() edge.RetryHint {
 	return edge.RetryStartOver
 }
 
+// edgeRouterAccessDenied reports that an edge router is not linked by policy to the identity
+// and/or the service it is trying to act on. It is used where no edge session is involved,
+// such as an edge router tunneler hosting or dialing a service on its own behalf.
+func edgeRouterAccessDenied(msg string) controllerError {
+	return &genericControllerError{
+		Message:   msg,
+		Code:      edge.ErrorCodeAccessDenied,
+		RetryHint: edge.RetryDefault,
+	}
+}
+
 type InvalidServiceError struct{}
 
 func (InvalidServiceError) Error() string {

--- a/controller/handler_edge_ctrl/errors_test.go
+++ b/controller/handler_edge_ctrl/errors_test.go
@@ -19,6 +19,8 @@ package handler_edge_ctrl
 import (
 	"testing"
 
+	"github.com/openziti/sdk-golang/v2/ziti/edge"
+	"github.com/openziti/ziti/v2/controller/model"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -27,4 +29,48 @@ func Test_ErrorsIs(t *testing.T) {
 	err := error(InvalidSessionError{})
 	req := require.New(t)
 	req.True(errors.Is(err, InvalidSessionError{}))
+}
+
+// TestNewEdgeRouterAccessDeniedError checks that the denial names the specific policy that is
+// missing for each way access can be denied, and that all three are reported as access denied.
+func TestNewEdgeRouterAccessDeniedError(t *testing.T) {
+	ctx := &baseSessionRequestContext{
+		sourceRouter: &model.Router{Name: "er1"},
+		service:      &model.EdgeService{Name: "svc1"},
+	}
+
+	tests := []struct {
+		name           string
+		access         model.EdgeRouterAccess
+		expectedReason string
+	}{
+		{
+			name:           "neither policy links",
+			access:         model.EdgeRouterAccess{IdentityAllowed: false, ServiceAllowed: false},
+			expectedReason: "no edge router policy links the identity to the edge router and no service edge router policy links the service to the edge router",
+		},
+		{
+			name:           "only service linked",
+			access:         model.EdgeRouterAccess{IdentityAllowed: false, ServiceAllowed: true},
+			expectedReason: "no edge router policy links the identity to the edge router",
+		},
+		{
+			name:           "only identity linked",
+			access:         model.EdgeRouterAccess{IdentityAllowed: true, ServiceAllowed: false},
+			expectedReason: "no service edge router policy links the service to the edge router",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := require.New(t)
+
+			err := ctx.newEdgeRouterAccessDeniedError("identity1", test.access)
+			req.Equal(edge.ErrorCodeAccessDenied, err.ErrorCode())
+			req.Contains(err.Error(), test.expectedReason)
+			req.Contains(err.Error(), "er1")
+			req.Contains(err.Error(), "svc1")
+			req.Contains(err.Error(), "identity1")
+		})
+	}
 }

--- a/controller/model/edge_router_manager.go
+++ b/controller/model/edge_router_manager.go
@@ -243,19 +243,37 @@ func (self *EdgeRouterManager) ListForIdentityAndService(identityId, serviceId s
 	return list, err
 }
 
-func (self *EdgeRouterManager) IsAccessToEdgeRouterAllowed(identityId, serviceId, edgeRouterId string) (bool, error) {
-	var result bool
+// EdgeRouterAccess reports which of the two policy links required for an identity to
+// reach a service through a given edge router are present. Access requires both.
+type EdgeRouterAccess struct {
+	// IdentityAllowed is true if an edge router policy links the identity to the edge router
+	IdentityAllowed bool
+
+	// ServiceAllowed is true if a service edge router policy links the service to the edge router
+	ServiceAllowed bool
+}
+
+// IsAllowed returns true only if both required policy links are present.
+func (self EdgeRouterAccess) IsAllowed() bool {
+	return self.IdentityAllowed && self.ServiceAllowed
+}
+
+// GetEdgeRouterAccess reports whether the identity and the service are each linked to the
+// given edge router by policy, so a caller can report which policy link is missing.
+func (self *EdgeRouterManager) GetEdgeRouterAccess(identityId, serviceId, edgeRouterId string) (EdgeRouterAccess, error) {
+	var result EdgeRouterAccess
 	err := self.GetDb().View(func(tx *bbolt.Tx) error {
 		identityEdgeRouters := self.env.GetStores().Identity.GetRefCountedLinkCollection(db.EntityTypeRouters)
 		serviceEdgeRouters := self.env.GetStores().Service.GetRefCountedLinkCollection(db.FieldEdgeRouters)
 
 		identityCount := identityEdgeRouters.GetLinkCount(tx, []byte(identityId), []byte(edgeRouterId))
 		serviceCount := serviceEdgeRouters.GetLinkCount(tx, []byte(serviceId), []byte(edgeRouterId))
-		result = identityCount != nil && *identityCount > 0 && serviceCount != nil && *serviceCount > 0
+		result.IdentityAllowed = identityCount != nil && *identityCount > 0
+		result.ServiceAllowed = serviceCount != nil && *serviceCount > 0
 		return nil
 	})
 	if err != nil {
-		return false, err
+		return EdgeRouterAccess{}, err
 	}
 	return result, nil
 }

--- a/controller/model/edge_router_manager_test.go
+++ b/controller/model/edge_router_manager_test.go
@@ -48,6 +48,34 @@ func (ctx *TestContext) testGetEdgeRoutersForServiceAndIdentity(*testing.T) {
 
 }
 
+// TestEdgeRouterAccess uses its own context so that the policies it creates are the only ones
+// in play, letting it assert on each policy link independently.
+func TestEdgeRouterAccess(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Cleanup()
+	ctx.Init()
+
+	edgeRouter := ctx.requireNewEdgeRouter()
+	identity := ctx.requireNewIdentity(false)
+	service := ctx.requireNewService()
+
+	requireAccess := func(identityAllowed, serviceAllowed bool) {
+		access, err := ctx.managers.EdgeRouter.GetEdgeRouterAccess(identity.Id, service.Id, edgeRouter.Id)
+		ctx.NoError(err)
+		ctx.Equal(identityAllowed, access.IdentityAllowed)
+		ctx.Equal(serviceAllowed, access.ServiceAllowed)
+		ctx.Equal(identityAllowed && serviceAllowed, access.IsAllowed())
+	}
+
+	requireAccess(false, false)
+
+	ctx.requireNewEdgeRouterPolicy(ss("#all"), ss("#all"))
+	requireAccess(true, false)
+
+	ctx.requireNewServiceNewEdgeRouterPolicy(ss("#all"), ss("#all"))
+	requireAccess(true, true)
+}
+
 func (ctx *TestContext) isEdgeRouterAccessible(edgeRouterId, identityId, serviceId string) bool {
 	found := false
 	err := ctx.GetDb().View(func(tx *bbolt.Tx) error {
@@ -65,9 +93,9 @@ func (ctx *TestContext) isEdgeRouterAccessible(edgeRouterId, identityId, service
 	})
 	ctx.NoError(err)
 
-	accessAllowed, err := ctx.managers.EdgeRouter.IsAccessToEdgeRouterAllowed(identityId, serviceId, edgeRouterId)
+	access, err := ctx.managers.EdgeRouter.GetEdgeRouterAccess(identityId, serviceId, edgeRouterId)
 	ctx.NoError(err)
-	ctx.Equal(found, accessAllowed)
+	ctx.Equal(found, access.IsAllowed())
 
 	return found
 }

--- a/router/xgress_edge/error.go
+++ b/router/xgress_edge/error.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openziti/channel/v5"
 	sdk "github.com/openziti/sdk-golang/v2/ziti/edge"
+	"github.com/openziti/ziti/v2/common/ctrl_msg"
 	"github.com/openziti/ziti/v2/router/posture"
 	"github.com/openziti/ziti/v2/router/state"
 )
@@ -105,4 +106,20 @@ func NewInvalidApiSessionTokenError(msg string) *EdgeError {
 // NewInvalidApiSessionType creates an EdgeError with the ErrorInvalidApiSessionType" code and the provided message.
 func NewInvalidApiSessionType(msg string) *EdgeError {
 	return &EdgeError{Message: msg, Code: sdk.ErrorCodeInvalidApiSessionType}
+}
+
+// newEdgeErrorFromCtrlError rebuilds a controller error reply as an EdgeError so the code and
+// retry hint reach the SDK, which otherwise sees only the message text and cannot classify the
+// failure. Returns a plain error if the reply carries no code, as older controllers may not.
+func newEdgeErrorFromCtrlError(msg *channel.Message, errMsg string) error {
+	code, found := msg.GetUint32Header(sdk.ErrorCodeHeader)
+	if !found {
+		return errors.New(errMsg)
+	}
+
+	edgeErr := &EdgeError{Message: errMsg, Code: code}
+	if retryHint, found := msg.GetUint32Header(ctrl_msg.ErrorRetryHintHeader); found {
+		edgeErr.RetryHint = sdk.RetryHint(retryHint)
+	}
+	return edgeErr
 }

--- a/router/xgress_edge/error_test.go
+++ b/router/xgress_edge/error_test.go
@@ -1,0 +1,200 @@
+package xgress_edge
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/openziti/channel/v5"
+	"github.com/openziti/sdk-golang/v2/xgress"
+	sdk "github.com/openziti/sdk-golang/v2/ziti/edge"
+	"github.com/openziti/ziti/v2/common/ctrl_msg"
+	"github.com/openziti/ziti/v2/common/ctrlchan"
+	"github.com/openziti/ziti/v2/common/pb/edge_ctrl_pb"
+	"github.com/stretchr/testify/require"
+)
+
+// newCtrlErrorReply builds the reply a controller sends for a denied request, matching what
+// handler_edge_ctrl's returnError puts on the wire.
+func newCtrlErrorReply(msg string, code uint32, retryHint sdk.RetryHint) *channel.Message {
+	result := channel.NewMessage(int32(edge_ctrl_pb.ContentType_ErrorType), []byte(msg))
+	result.PutUint32Header(sdk.ErrorCodeHeader, code)
+	result.PutUint32Header(ctrl_msg.ErrorRetryHintHeader, uint32(retryHint))
+	return result
+}
+
+// TestCtrlErrorReachesSdkAsTypedFailure locks in the full dial-denial path: a controller error
+// reply must survive the hop through the router as a structured error, so the SDK classifies the
+// refusal instead of receiving opaque text.
+func TestCtrlErrorReachesSdkAsTypedFailure(t *testing.T) {
+	tests := []struct {
+		name          string
+		code          uint32
+		retryHint     sdk.RetryHint
+		expectedCause sdk.FailureCause
+	}{
+		{
+			name:          "access denied",
+			code:          sdk.ErrorCodeAccessDenied,
+			retryHint:     sdk.RetryDefault,
+			expectedCause: sdk.CauseAccessDenied,
+		},
+		{
+			name:          "invalid service",
+			code:          sdk.ErrorCodeInvalidService,
+			retryHint:     sdk.RetryNotRetriable,
+			expectedCause: sdk.CauseServiceNotAvailable,
+		},
+		{
+			name:          "invalid session",
+			code:          sdk.ErrorCodeInvalidSession,
+			retryHint:     sdk.RetryStartOver,
+			expectedCause: sdk.CauseSessionInvalid,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := require.New(t)
+
+			ctrlReply := newCtrlErrorReply("denied for a reason", test.code, test.retryHint)
+
+			err := newEdgeErrorFromCtrlError(ctrlReply, string(ctrlReply.Body))
+			edgeErr, ok := err.(*EdgeError)
+			req.True(ok, "controller error with a code must become an EdgeError")
+			req.Equal(test.code, edgeErr.Code)
+			req.Equal(test.retryHint, edgeErr.RetryHint)
+
+			// the router relays it to the sdk on the state-closed reply
+			sdkReply := sdk.NewStateClosedMsg(1, edgeErr.Message)
+			edgeErr.ApplyToMsg(sdkReply)
+
+			connErr := sdk.ConnRefusalError(sdkReply, "svc", "svc-1", "er", "er-1")
+			var typed *sdk.ConnError
+			req.ErrorAs(connErr, &typed)
+			req.Equal(test.expectedCause, typed.Cause)
+		})
+	}
+}
+
+// TestCtrlErrorWithoutCodeStaysPlain covers controllers that predate the error code header. The
+// router must not fabricate a classification the controller never sent.
+func TestCtrlErrorWithoutCodeStaysPlain(t *testing.T) {
+	req := require.New(t)
+
+	ctrlReply := channel.NewMessage(int32(edge_ctrl_pb.ContentType_ErrorType), []byte("no code here"))
+
+	err := newEdgeErrorFromCtrlError(ctrlReply, string(ctrlReply.Body))
+	req.Error(err)
+	req.Equal("no code here", err.Error())
+
+	var edgeErr *EdgeError
+	req.False(errors.As(err, &edgeErr), "must not become an EdgeError without a code")
+}
+
+// TestCtrlErrorWithCodeButNoRetryHint covers controllers that send the error code header but
+// predate the retry hint header. The router must still build a typed EdgeError, defaulting the
+// hint to RetryDefault rather than dropping the code.
+func TestCtrlErrorWithCodeButNoRetryHint(t *testing.T) {
+	req := require.New(t)
+
+	ctrlReply := channel.NewMessage(int32(edge_ctrl_pb.ContentType_ErrorType), []byte("denied, old controller"))
+	ctrlReply.PutUint32Header(sdk.ErrorCodeHeader, sdk.ErrorCodeAccessDenied)
+
+	err := newEdgeErrorFromCtrlError(ctrlReply, string(ctrlReply.Body))
+	edgeErr, ok := err.(*EdgeError)
+	req.True(ok, "controller error with a code must become an EdgeError even without a retry hint")
+	req.Equal(sdk.ErrorCodeAccessDenied, edgeErr.Code)
+	req.Equal(sdk.RetryDefault, edgeErr.RetryHint)
+	req.Equal("denied, old controller", edgeErr.Message)
+}
+
+// replyingSender answers any reply-expecting Sendable with a canned message. That is enough to
+// drive SendForReply, which creates its buffered reply channel before calling Send.
+type replyingSender struct {
+	reply *channel.Message
+	sent  []*channel.Message
+}
+
+func (self *replyingSender) Send(s channel.Sendable) error {
+	self.sent = append(self.sent, s.Msg())
+	if receiver := s.ReplyReceiver(); receiver != nil {
+		receiver.AcceptReply(self.reply)
+	}
+	return nil
+}
+
+func (self *replyingSender) TrySend(s channel.Sendable) (bool, error) {
+	return true, self.Send(s)
+}
+
+// CloseNotify returns nil so the never-ready case is selected against in WaitForReply.
+func (self *replyingSender) CloseNotify() <-chan struct{} {
+	return nil
+}
+
+// fakeCtrlChannel is a ctrlchan.CtrlChannel whose senders all deliver the canned reply.
+type fakeCtrlChannel struct {
+	sender *replyingSender
+}
+
+func (self *fakeCtrlChannel) InitChannel(channel.Channel)           {}
+func (self *fakeCtrlChannel) PeerId() string                        { return "ctrl1" }
+func (self *fakeCtrlChannel) GetChannel() channel.Channel           { return nil }
+func (self *fakeCtrlChannel) GetDefaultSender() channel.Sender      { return self.sender }
+func (self *fakeCtrlChannel) GetHighPrioritySender() channel.Sender { return self.sender }
+func (self *fakeCtrlChannel) GetLowPrioritySender() channel.Sender  { return self.sender }
+func (self *fakeCtrlChannel) IsConnected() bool                     { return true }
+func (self *fakeCtrlChannel) Close() error                          { return nil }
+func (self *fakeCtrlChannel) IsClosed() bool                        { return false }
+
+// newCtrlErrorTestConn builds the minimum needed to call the create-circuit senders. The circuit
+// timeout must be non-zero, or the envelope's context is already expired and it never sends.
+func newCtrlErrorTestConn(reply *channel.Message) (*edgeClientConn, ctrlchan.CtrlChannel) {
+	conn := &edgeClientConn{
+		listener: &listener{
+			options: &Options{Options: xgress.Options{GetCircuitTimeout: time.Second}},
+		},
+	}
+	return conn, &fakeCtrlChannel{sender: &replyingSender{reply: reply}}
+}
+
+// TestV3DialConvertsCtrlError checks that the V3 relay types the controller's denial. The request
+// carries a decoy error code, since both the request and the reply are messages in scope at that
+// call site and reading the wrong one is the mistake this guards against.
+func TestV3DialConvertsCtrlError(t *testing.T) {
+	req := require.New(t)
+
+	reply := newCtrlErrorReply("denied by policy", sdk.ErrorCodeAccessDenied, sdk.RetryDefault)
+	conn, ctrlCh := newCtrlErrorTestConn(reply)
+
+	request := channel.NewMessage(int32(edge_ctrl_pb.ContentType_CreateCircuitV3RequestType), nil)
+	request.PutUint32Header(sdk.ErrorCodeHeader, sdk.ErrorCodeInvalidSession)
+
+	resp, err := conn.sendCreateCircuitV3Msg(request, ctrlCh)
+	req.Nil(resp)
+
+	var edgeErr *EdgeError
+	req.ErrorAs(err, &edgeErr)
+	req.Equal(sdk.ErrorCodeAccessDenied, edgeErr.Code)
+	req.Equal(sdk.RetryDefault, edgeErr.RetryHint)
+	req.Equal("denied by policy", edgeErr.Message)
+}
+
+// TestV1DialConvertsCtrlError checks the same for the V1/V2 relay, which non-OIDC sessions and
+// clients forcing connect-v1 still use.
+func TestV1DialConvertsCtrlError(t *testing.T) {
+	req := require.New(t)
+
+	reply := newCtrlErrorReply("session no longer valid", sdk.ErrorCodeInvalidSession, sdk.RetryStartOver)
+	conn, ctrlCh := newCtrlErrorTestConn(reply)
+
+	resp, err := conn.sendCreateCircuitRequest(&ctrl_msg.CreateCircuitV2Request{}, ctrlCh)
+	req.Nil(resp)
+
+	var edgeErr *EdgeError
+	req.ErrorAs(err, &edgeErr)
+	req.Equal(sdk.ErrorCodeInvalidSession, edgeErr.Code)
+	req.Equal(sdk.RetryStartOver, edgeErr.RetryHint)
+	req.Equal("session no longer valid", edgeErr.Message)
+}

--- a/router/xgress_edge/listener.go
+++ b/router/xgress_edge/listener.go
@@ -1246,7 +1246,7 @@ func (self *edgeClientConn) sendCreateCircuitV3Msg(msg *channel.Message, ctrlCh 
 		if circuitId, found := resp.GetStringHeader(sdkedge.CircuitIdHeader); found {
 			circuitResp = &ctrl_msg.CreateCircuitV2Response{CircuitId: circuitId}
 		}
-		return circuitResp, errors.New(errMsg)
+		return circuitResp, newEdgeErrorFromCtrlError(resp, errMsg)
 	}
 
 	if resp.ContentType != int32(edge_ctrl_pb.ContentType_CreateCircuitV3ResponseType) {
@@ -1291,7 +1291,7 @@ func (self *edgeClientConn) sendCreateCircuitRequest(req *ctrl_msg.CreateCircuit
 		if circuitId, found := msg.GetStringHeader(sdkedge.CircuitIdHeader); found {
 			resp = &ctrl_msg.CreateCircuitV2Response{CircuitId: circuitId}
 		}
-		return resp, errors.New(errMsg)
+		return resp, newEdgeErrorFromCtrlError(msg, errMsg)
 	}
 
 	if msg.ContentType != int32(edge_ctrl_pb.ContentType_CreateCircuitV2ResponseType) {
@@ -1771,15 +1771,32 @@ func (self *edgeClientConn) sendConnectedReply(req *channel.Message, response *c
 // sendStateClosedDenial replies with a state-closed carrying the structured denial (cause code
 // and, for posture denials, the failing check ids), so SDKs can present the failure's cause
 // instead of parsing message text.
-func (self *edgeClientConn) sendStateClosedDenial(edgeErr *EdgeError, req *channel.Message) {
+func (self *edgeClientConn) sendStateClosedDenial(edgeErr *EdgeError, req *channel.Message, headers ...channel.Headers) {
 	connId, _ := req.GetUint32Header(sdkedge.ConnIdHeader)
 	msg := sdkedge.NewStateClosedMsg(connId, edgeErr.Message)
 	msg.ReplyTo(req)
 	edgeErr.ApplyToMsg(msg)
 
+	for _, h := range headers {
+		for k, v := range h {
+			msg.Headers[k] = v
+		}
+	}
+
 	if err := msg.WithTimeout(5 * time.Second).SendAndWaitForWire(self.ch.GetDefaultSender()); err != nil {
 		pfxlog.Logger().WithFields(sdkedge.GetLoggerFields(msg)).WithError(err).Error("failed to send state response")
 	}
+}
+
+// sendStateClosedForDialError replies to a failed dial. When the failure carries a structured
+// error it is passed through so the SDK can classify the refusal rather than parsing text.
+func (self *edgeClientConn) sendStateClosedForDialError(err error, req *channel.Message, headers ...channel.Headers) {
+	var edgeErr *EdgeError
+	if errors.As(err, &edgeErr) {
+		self.sendStateClosedDenial(edgeErr, req, headers...)
+		return
+	}
+	self.sendStateClosedReply(err.Error(), req, headers...)
 }
 
 func (self *edgeClientConn) sendStateClosedReply(message string, req *channel.Message, headers ...channel.Headers) {
@@ -2716,7 +2733,7 @@ func (self *nonXgConnectHandler) FinishConnect(ctx *connectContext, response *ct
 			headers = channel.Headers{}
 			headers.PutStringHeader(sdkedge.CircuitIdHeader, response.CircuitId)
 		}
-		ctx.SdkConn.sendStateClosedReply(err.Error(), ctx.Req, headers)
+		ctx.SdkConn.sendStateClosedForDialError(err, ctx.Req, headers)
 		self.conn.close(false, "failed to dial fabric")
 		return
 	}
@@ -2890,7 +2907,7 @@ func (self *xgEdgeForwarder) FinishConnect(ctx *connectContext, response *ctrl_m
 			headers = channel.Headers{}
 			headers.PutStringHeader(sdkedge.CircuitIdHeader, response.CircuitId)
 		}
-		ctx.SdkConn.sendStateClosedReply(err.Error(), ctx.Req, headers)
+		ctx.SdkConn.sendStateClosedForDialError(err, ctx.Req, headers)
 		return
 	}
 

--- a/router/xgress_edge_tunnel/hosted.go
+++ b/router/xgress_edge_tunnel/hosted.go
@@ -40,6 +40,23 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// establishSettleTime is how long a newly created terminator waits before its first create
+// attempt. Hosting starts as soon as a bind policy grants access, which can be before the
+// edge router and service edge router policies that the controller also requires are in
+// place. Config is usually applied in quick succession, so a short delay lets it settle and
+// avoids a failed create followed by a multi-minute wait for the retry scan.
+//
+// It is intentionally a fixed value rather than a tunable knob: this is a stopgap until edge
+// router and service edge router policy visibility lands in the router data model, at which
+// point the router can tell it is not yet in a valid hosting situation and this delay can be
+// removed entirely.
+const establishSettleTime = 2 * time.Second
+
+// establishSettleCheckInterval is how often the run loop re-checks terminators that are still
+// inside their settle window. It bounds how long past establishSettleTime the first create
+// attempt can be delayed.
+const establishSettleCheckInterval = 500 * time.Millisecond
+
 func newHostedServicesRegistry(env routerEnv.RouterEnv, stateManager state.Manager) *HostedServiceRegistry {
 	result := &HostedServiceRegistry{
 		terminators:  cmap.New[*tunnelTerminator](),
@@ -62,6 +79,11 @@ type HostedServiceRegistry struct {
 	establishSet map[string]*tunnelTerminator
 	deleteSet    map[string]*tunnelTerminator
 	triggerEvalC chan struct{}
+
+	// establishNotify wakes the run loop to re-check terminators still inside their settle
+	// window. It is a shared nudge for the whole establish queue, not per-terminator state, and
+	// is only touched from the run loop.
+	establishNotify <-chan time.Time
 
 	connectedToLeader atomic.Bool
 	started           atomic.Bool
@@ -96,6 +118,7 @@ func (self *HostedServiceRegistry) run() {
 		if self.env.GetCtrlRateLimiter().IsRateLimited() {
 			rateLimitedTick = quickTick.C
 		}
+
 		select {
 		case <-self.env.GetCloseNotify():
 			return
@@ -107,6 +130,8 @@ func (self *HostedServiceRegistry) run() {
 		case <-rateLimitedTick:
 		case <-terminatorIdCacheTicker.C:
 			self.pruneTerminatorIdCache()
+		case <-self.establishNotify:
+			self.establishNotify = nil
 		}
 
 		// events should be quick to handle, so make sure we do all them before we
@@ -165,6 +190,15 @@ func (self *HostedServiceRegistry) evaluateEstablishQueue() {
 
 		if terminator.state.Load() != xgress_common.TerminatorStateEstablishing {
 			dequeue()
+			continue
+		}
+
+		// only delays the first attempt; retries and re-establishes reuse the terminator,
+		// so their createTime is already outside the settle window
+		if settleDeadline := terminator.createTime.Add(establishSettleTime); settleDeadline.After(time.Now()) {
+			if self.establishNotify == nil {
+				self.establishNotify = time.After(establishSettleCheckInterval)
+			}
 			continue
 		}
 
@@ -554,6 +588,15 @@ func (self *HostedServiceRegistry) HandleCreateTerminatorResponse(msg *channel.M
 		if rateLimitCallback := terminator.GetAndClearRateLimitCallback(); rateLimitCallback != nil {
 			rateLimitCallback.Success()
 		}
+
+		// Logged at Warn, not Error: the rejection is recoverable and retried by the periodic
+		// scan, so a persistent misconfiguration (e.g. a missing edge router policy) on an ER/T
+		// hosting many services would otherwise emit an endless per-service Error stream.
+		log.WithField("service", terminator.context.ServiceName()).
+			WithField("result", response.Result.String()).
+			WithField("errorCode", response.ErrorCode).
+			WithField("error", response.Msg).
+			Warn("controller rejected create terminator, will retry on the next scan (in 2-3 minutes)")
 
 		terminator.operationActive.Store(false)
 		return

--- a/router/xgress_edge_tunnel/hosted_test.go
+++ b/router/xgress_edge_tunnel/hosted_test.go
@@ -1,0 +1,168 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package xgress_edge_tunnel
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/openziti/channel/v5"
+	"github.com/openziti/foundation/v2/rate"
+	"github.com/openziti/identity"
+	"github.com/openziti/sdk-golang/v2/ziti"
+	routerEnv "github.com/openziti/ziti/v2/router/env"
+	"github.com/openziti/ziti/v2/router/xgress_common"
+	"github.com/openziti/ziti/v2/tunnel"
+	"github.com/stretchr/testify/require"
+)
+
+// countingCtrlChannel is a channel.Channel that records how many create requests were sent. Only
+// the methods establishTerminator touches are implemented; the rest panic via the nil embedded
+// interface if the test strays onto an unexpected path.
+type countingCtrlChannel struct {
+	channel.Channel
+	sends atomic.Int32
+}
+
+func (self *countingCtrlChannel) Id() string { return "test-ctrl" }
+
+func (self *countingCtrlChannel) TrySend(channel.Sendable) (bool, error) {
+	self.sends.Add(1)
+	return true, nil
+}
+
+// settleTestEnv supplies only the env surface establishTerminator uses: the router id, the model
+// update channel, and a rate limiter that never limits.
+type settleTestEnv struct {
+	routerEnv.RouterEnv
+	ctrlCh *countingCtrlChannel
+}
+
+func (self *settleTestEnv) GetRouterId() *identity.TokenId {
+	return &identity.TokenId{Token: "test-router"}
+}
+
+func (self *settleTestEnv) GetNetworkControllers() routerEnv.NetworkControllers {
+	return &routerEnv.MockNetworkControllers{Channel: self.ctrlCh}
+}
+
+func (self *settleTestEnv) GetCtrlRateLimiter() rate.AdaptiveRateLimitTracker {
+	return rate.NoOpAdaptiveRateLimitTracker{}
+}
+
+// settleTestHostingContext supplies the three accessors establishTerminator reads to build the
+// create request.
+type settleTestHostingContext struct {
+	tunnel.HostingContext
+}
+
+func (settleTestHostingContext) ServiceName() string                { return "test-service" }
+func (settleTestHostingContext) ServiceId() string                  { return "test-service-id" }
+func (settleTestHostingContext) ListenOptions() *ziti.ListenOptions { return &ziti.ListenOptions{} }
+
+func newSettleTestRegistry() (*HostedServiceRegistry, *countingCtrlChannel) {
+	ctrlCh := &countingCtrlChannel{}
+	return &HostedServiceRegistry{
+		establishSet: map[string]*tunnelTerminator{},
+		env:          &settleTestEnv{ctrlCh: ctrlCh},
+	}, ctrlCh
+}
+
+func newSettleTestTerminator(id string, createTime time.Time) *tunnelTerminator {
+	terminator := &tunnelTerminator{
+		id:         id,
+		context:    settleTestHostingContext{},
+		createTime: createTime,
+	}
+	terminator.state.Store(xgress_common.TerminatorStateEstablishing)
+	return terminator
+}
+
+// TestSettleGateHoldsNewTerminator verifies that a terminator still inside its settle window is
+// not sent to the controller, stays queued, and arms the re-check timer.
+func TestSettleGateHoldsNewTerminator(t *testing.T) {
+	req := require.New(t)
+
+	registry, ctrlCh := newSettleTestRegistry()
+	terminator := newSettleTestTerminator("t1", time.Now())
+	registry.establishSet[terminator.id] = terminator
+
+	registry.evaluateEstablishQueue()
+
+	req.Contains(registry.establishSet, terminator.id, "terminator inside its settle window must stay queued")
+	req.Equal(int32(0), ctrlCh.sends.Load(), "no create should be sent inside the settle window")
+	req.NotNil(registry.establishNotify, "a re-check must be scheduled so the terminator is retried after the window")
+}
+
+// TestSettleGateReleasesSettledTerminator verifies that once the settle window has passed the
+// terminator is sent and removed from the queue.
+func TestSettleGateReleasesSettledTerminator(t *testing.T) {
+	req := require.New(t)
+
+	registry, ctrlCh := newSettleTestRegistry()
+	terminator := newSettleTestTerminator("t1", time.Now().Add(-establishSettleTime-time.Second))
+	registry.establishSet[terminator.id] = terminator
+
+	registry.evaluateEstablishQueue()
+
+	req.NotContains(registry.establishSet, terminator.id, "a settled terminator must be dequeued once attempted")
+	req.Equal(int32(1), ctrlCh.sends.Load(), "a settled terminator must be sent to the controller")
+}
+
+// TestSettleGateDoesNotDelayRequeuedTerminator verifies that the delay applies only to a
+// terminator's first attempt. A retry reuses the terminator with its original createTime, so it
+// is already past the window and must be sent again without waiting.
+func TestSettleGateDoesNotDelayRequeuedTerminator(t *testing.T) {
+	req := require.New(t)
+
+	registry, ctrlCh := newSettleTestRegistry()
+	terminator := newSettleTestTerminator("t1", time.Now().Add(-establishSettleTime-time.Second))
+	registry.establishSet[terminator.id] = terminator
+
+	registry.evaluateEstablishQueue()
+	req.Equal(int32(1), ctrlCh.sends.Load())
+
+	// model a controller response that left the terminator establishing: it is requeued with the
+	// same createTime and its in-flight flag cleared.
+	terminator.operationActive.Store(false)
+	registry.establishSet[terminator.id] = terminator
+
+	registry.evaluateEstablishQueue()
+
+	req.Equal(int32(2), ctrlCh.sends.Load(), "a requeued terminator must be retried without a second settle delay")
+	req.NotContains(registry.establishSet, terminator.id)
+}
+
+// TestSettleGateIsPerTerminator verifies the gate is evaluated independently per terminator: a
+// settled terminator is sent even while a newer one is still holding, and neither starves the
+// other.
+func TestSettleGateIsPerTerminator(t *testing.T) {
+	req := require.New(t)
+
+	registry, ctrlCh := newSettleTestRegistry()
+	settled := newSettleTestTerminator("settled", time.Now().Add(-establishSettleTime-time.Second))
+	holding := newSettleTestTerminator("holding", time.Now())
+	registry.establishSet[settled.id] = settled
+	registry.establishSet[holding.id] = holding
+
+	registry.evaluateEstablishQueue()
+
+	req.Equal(int32(1), ctrlCh.sends.Load(), "only the settled terminator should be sent")
+	req.NotContains(registry.establishSet, settled.id, "the settled terminator must be dequeued")
+	req.Contains(registry.establishSet, holding.id, "the holding terminator must remain queued")
+}

--- a/tests/tunneler_data_flow_test.go
+++ b/tests/tunneler_data_flow_test.go
@@ -66,7 +66,11 @@ func Test_TunnelerDataflowTcp(t *testing.T) {
 	l, err := net.Listen("tcp", "localhost:8687")
 	ctx.Req.NoError(err)
 
-	time.Sleep(time.Second)
+	// wait for the tunneler to establish a terminator for the service before dialing, rather than
+	// racing a fixed sleep against the hosting settle delay and establishment round-trip
+	watcher := ctx.AdminManagementSession.newTerminatorWatcher(service.Id, 1)
+	watcher.waitForTerminators(10 * time.Second)
+	watcher.Close()
 
 	errC := make(chan error, 10)
 	go acceptConnections(l, errC)
@@ -195,7 +199,11 @@ func Test_TunnelerDataflowHalfClose(t *testing.T) {
 	l, err := net.Listen("tcp", "localhost:8689")
 	ctx.Req.NoError(err)
 
-	time.Sleep(time.Second)
+	// wait for the tunneler to establish a terminator for the service before dialing, rather than
+	// racing a fixed sleep against the hosting settle delay and establishment round-trip
+	watcher := ctx.AdminManagementSession.newTerminatorWatcher(service.Id, 1)
+	watcher.waitForTerminators(10 * time.Second)
+	watcher.Close()
 
 	errC := make(chan error, 10)
 	go acceptConnectionsHalfClose(l, errC)


### PR DESCRIPTION
Fixes #4193

An ER/T that gains bind access to a service before the edge router policy and service edge
router policy are in place has its terminator create rejected, and the failure is close to
undiagnosable: the controller reports "invalid edge router for session" on a path that has no
session, doesn't say which policy is missing, and the router logs nothing at all.

Requiring the service edge router policy on the hosting side is intentional. The real gap is
that the ER/T has no view of those policies, so it can't tell it isn't in a valid hosting
situation yet. That's expected to be addressed separately by bringing the data into the router
data model. This makes the failure diagnosable and narrows the race in the meantime:

- denials now name the missing policy instead of reusing a session error
- the router logs the controller's rejection instead of discarding the code and message
- a new terminator waits 2s before its first create, so config applied in quick succession
  settles first rather than failing and waiting out the 2-3 minute retry scan

Investigating the error path turned up a second defect, fixed here as well: controller error
codes never reached SDK clients on the dial paths. The router read only the message body from
the controller's error reply and dropped the error code, so `edge.ConnRefusalError` classified
every dial refusal as unknown, making the access-denied, invalid-session, and
invalid-service classifications unreachable. Both dial relays now pass the code and retry hint
through as a structured error.

The changelog's Component Updates and Bug Fixes section was regenerated with `ziti-ci
update-release-notes`. Three existing entries the commit and pull request scan cannot
rediscover are now marked with `<!-- keep -->` so regeneration stops dropping them.
