### PR TITLE
Serialize router control-channel connect/disconnect, and fix the router's registration races

### DIFF
--- a/common/ctrlchan/channel_test.go
+++ b/common/ctrlchan/channel_test.go
@@ -690,3 +690,81 @@ func TestDialCtrlChannel_ReconnectCycle(t *testing.T) {
 		return len(multiCh.GetUnderlays()) > 0
 	}, 60*time.Second, 50*time.Millisecond, "channel should re-establish underlays after dropping to zero")
 }
+
+// TestReject_BindErrorNotEstablishedOrRxStarted validates the boundary that router-connect rejection
+// relies on: when the ctrl-channel bind handler returns an error (as CtrlAccepter.Bind does when
+// network.ConnectRouter rejects a busy slot), channel.NewChannel returns that error, the MultiListener
+// closes the underlay without registering the channel, and the receive loop never starts. This
+// no-rx / no-register outcome is the contract the fake-CtrlChannel unit tests cannot observe.
+func TestReject_BindErrorNotEstablishedOrRxStarted(t *testing.T) {
+	req := require.New(t)
+
+	listenerAddr := "tcp:127.0.0.1:40010"
+	id := &identity.TokenId{Token: "test-controller"}
+
+	var bindAttempts atomic.Int32
+	var established atomic.Int32
+	var rxFired atomic.Bool
+
+	multiListener := channel.NewMultiListener(
+		func(underlay channel.Underlay, closeCallback func()) (channel.Channel, error) {
+			bindAttempts.Add(1)
+			listenerChannel := NewListenerCtrlChannel()
+			multiConfig := &channel.Config{
+				LogicalName:            "ctrl/" + underlay.ConnectionId(),
+				Options:                channel.DefaultOptions(),
+				Senders:                listenerChannel,
+				MessageSourceProvider:  listenerChannel,
+				UnderlayEventListeners: []channel.UnderlayEventListener{listenerChannel},
+				Constraints:            listenerChannel.GetConstraints(),
+				MinTotalUnderlays:      1,
+				Underlay:               underlay,
+				Binder: channel.MakeBinder(channel.BindHandlerF(func(binding channel.Binding) error {
+					// Would flip if the rx loop ever started for this (rejected) channel.
+					binding.AddReceiveHandlerF(echoContentType, func(*channel.Message, channel.Channel) {
+						rxFired.Store(true)
+					})
+					// Reject, as network.ConnectRouter does for a busy slot.
+					return fmt.Errorf("simulated router connect rejected (busy slot)")
+				})),
+			}
+
+			multiCh, err := channel.NewChannel(multiConfig)
+			if err != nil {
+				// Rejected: NewChannel closed the underlay and never started rx; do not register.
+				return nil, err
+			}
+			established.Add(1)
+			return multiCh, nil
+		},
+		func(underlay channel.Underlay) error {
+			return fmt.Errorf("ungrouped connections not supported")
+		},
+	)
+
+	bindAddr, err := transport.ParseAddress(listenerAddr)
+	req.NoError(err)
+	listenerConfig := channel.ListenerConfig{ConnectOptions: channel.DefaultOptions().ConnectOptions}
+	listener, err := channel.NewClassicListenerWithAcceptor(id, bindAddr, listenerConfig, multiListener)
+	req.NoError(err)
+	defer func() { _ = listener.Close() }()
+
+	headers := channel.Headers{}
+	headers.PutStringHeader(channel.TypeHeader, ChannelTypeDefault)
+	headers.PutBoolHeader(channel.IsGroupedHeader, true)
+	headers.PutBoolHeader(channel.IsFirstGroupConnection, true)
+
+	dialer := channel.NewClassicDialer(channel.DialerConfig{Identity: id, Endpoint: bindAddr})
+	underlay, err := dialer.CreateWithHeaders(5*time.Second, headers)
+	req.NoError(err)
+	defer func() { _ = underlay.Close() }()
+
+	// The dial reaches the listener's bind (the hello is acked before the factory runs).
+	req.Eventually(func() bool { return bindAttempts.Load() >= 1 }, 5*time.Second, 10*time.Millisecond,
+		"listener bind should have run for the dialed connection")
+
+	// The rejected connection is never established, and its receive loop never starts. Give any spurious
+	// rx a moment to (not) happen.
+	req.Never(func() bool { return established.Load() != 0 || rxFired.Load() }, 500*time.Millisecond, 50*time.Millisecond,
+		"a rejected bind must not establish a channel or start its receive loop")
+}

--- a/controller/config/config_network.go
+++ b/controller/config/config_network.go
@@ -46,14 +46,22 @@ const (
 )
 
 type NetworkConfig struct {
-	CreateCircuitRetries    uint32
-	CycleSeconds            uint32
-	InitialLinkLatency      time.Duration
-	IntervalAgeThreshold    time.Duration
-	MetricsReportInterval   time.Duration
-	MinRouterCost           uint16
-	PendingLinkTimeout      time.Duration
-	RouteTimeout            time.Duration
+	CreateCircuitRetries  uint32
+	CycleSeconds          uint32
+	InitialLinkLatency    time.Duration
+	IntervalAgeThreshold  time.Duration
+	MetricsReportInterval time.Duration
+	MinRouterCost         uint16
+	PendingLinkTimeout    time.Duration
+	RouteTimeout          time.Duration
+	// RouterConnectChurnLimit is how long an established router control channel is protected from being
+	// displaced by a new connection for the same router. A new connection arriving inside the window is
+	// refused; after it, the established connection is displaced and the router redials into the freed
+	// slot. Zero always allows takeover.
+	//
+	// This is churn policy, not the guarantee that a router has one connection: that is enforced under the
+	// per-router lock in Network.ConnectRouter. Its purpose is to stop a flapping router from repeatedly
+	// tearing down a working channel, since displacement is not free.
 	RouterConnectChurnLimit time.Duration
 	RouterComm              struct {
 		QueueSize  uint32

--- a/controller/handler_ctrl/accept.go
+++ b/controller/handler_ctrl/accept.go
@@ -202,9 +202,16 @@ func (self *CtrlAccepter) Bind(binding channel.Binding) error {
 		binding.AddPeekHandler(self.traceHandler)
 	}
 
-	log.Info("accepted new router connection")
+	if err = self.network.ConnectRouter(r); err != nil {
+		if network.IsConnectRejected(err) {
+			log.Info("router connect rejected; another connection is already current, router will redial")
+		}
+		// Returning the error fails the bind, so NewChannel closes this channel's underlay without
+		// starting rx or registering it. That preserves the rx-gate for a rejected connection.
+		return err
+	}
 
-	self.network.ConnectRouter(r)
+	log.Info("accepted new router connection")
 
 	return nil
 }

--- a/controller/handler_ctrl/accept.go
+++ b/controller/handler_ctrl/accept.go
@@ -17,8 +17,6 @@
 package handler_ctrl
 
 import (
-	"time"
-
 	"github.com/google/uuid"
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/channel/v5"
@@ -108,15 +106,11 @@ func (self *CtrlAccepter) Bind(binding channel.Binding) error {
 	ch := binding.GetChannel()
 
 	log := pfxlog.Logger().WithField("routerId", ch.Id())
-	// Use a new copy of the router instance each time we connect. That way we can tell on disconnect
-	// if we're working with the right connection, in case connects and disconnects happen quickly.
-	// It also means that the channel and connected time fields don't change and we don't have to protect them
-	r, err := self.network.GetReloadedRouter(ch.Id())
+	// A fresh instance per connection, carrying this channel: that is what lets connect and disconnect tell
+	// two connections for one router apart, and keeps them from writing over each other's state.
+	r, err := self.network.NewCtrlChanRouter(ch)
 	if err != nil {
 		return err
-	}
-	if r == nil {
-		return errors.Errorf("no router with id [%v] found, closing connection", ch.Id())
 	}
 
 	var ctrlChanListeners map[string][]string
@@ -186,13 +180,6 @@ func (self *CtrlAccepter) Bind(binding channel.Binding) error {
 		return errors.New("channel provided no headers, not accepting router connection as version info not provided")
 	}
 
-	r.Control = ch.GetSenders().(ctrlchan.CtrlChannel)
-	// Record the channel before the downstream bind handlers run: GetCtrlHandlers builds
-	// handlers (e.g. NewConnectEventsHandler) that dereference the ctrl channel's Channel().
-	// UnderlayAdded fires after this bind handler, so without InitChannel here those derefs
-	// would hit a nil channel.
-	r.Control.InitChannel(ch)
-	r.ConnectTime = time.Now()
 	if err = newBindHandler(self.heartbeatOptions, r, self.network, self.xctrls).BindChannel(binding); err != nil {
 		return errors.Wrap(err, "error binding router")
 	}
@@ -201,9 +188,16 @@ func (self *CtrlAccepter) Bind(binding channel.Binding) error {
 		binding.AddPeekHandler(self.traceHandler)
 	}
 
-	log.Info("accepted new router connection")
+	if err = self.network.ConnectRouter(r); err != nil {
+		if network.IsConnectRejected(err) {
+			log.Info("router connect rejected; another connection is already current, router will redial")
+		}
+		// Returning the error fails the bind, so NewChannel closes this channel's underlay without
+		// starting rx or registering it. That preserves the rx-gate for a rejected connection.
+		return err
+	}
 
-	self.network.ConnectRouter(r)
+	log.Info("accepted new router connection")
 
 	return nil
 }

--- a/controller/handler_ctrl/connect.go
+++ b/controller/handler_ctrl/connect.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openziti/channel/v5"
 	"github.com/openziti/identity"
 	"github.com/openziti/ziti/v2/common/cert"
+	"github.com/openziti/ziti/v2/controller/model"
 	"github.com/openziti/ziti/v2/controller/network"
 )
 
@@ -77,6 +78,20 @@ func isFirstCtrlConnection(hello *channel.Hello) bool {
 	return first
 }
 
+// withinChurnLimit reports whether an established connection is too new to be displaced by a new one.
+//
+// This is admission policy, not the uniqueness guarantee. At most one connection per router is enforced
+// under the per-router lock in Network.ConnectRouter; this runs against the connected map with no lock
+// held, so it can only avoid paying for a bind that would be refused there anyway.
+//
+// Displacing an established connection costs a round trip: the occupant's teardown runs, the connect is
+// refused, and the router redials into the freed slot. A connection that has only just been established
+// is therefore protected for churnLimit, so a flapping router cannot thrash a working channel. A zero
+// limit disables the protection, making every new connection able to displace the current one.
+func withinChurnLimit(connected *model.Router, churnLimit time.Duration) bool {
+	return time.Since(connected.ConnectTime) < churnLimit
+}
+
 func (self *ConnectHandler) HandleConnection(hello *channel.Hello, certificates []*x509.Certificate) error {
 	// Connections whose channel type is handled by a separate, self-validating acceptor (e.g. the raft
 	// mesh) are validated there, so skip them. Everything else - router control channel types,
@@ -111,7 +126,7 @@ func (self *ConnectHandler) HandleConnection(hello *channel.Hello, certificates 
 	// connected and must not be rejected here.
 	if isFirstCtrlConnection(hello) {
 		if router := self.network.GetConnectedRouter(id); router != nil {
-			if time.Since(router.ConnectTime) < self.network.GetOptions().RouterConnectChurnLimit {
+			if withinChurnLimit(router, self.network.GetOptions().RouterConnectChurnLimit) {
 				log.WithField("routerName", router.Name).Error("router already connected and churn threshold not met")
 				return fmt.Errorf("router already connected id: %s, name: %s", id, router.Name)
 			}

--- a/controller/handler_ctrl/connect_test.go
+++ b/controller/handler_ctrl/connect_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/openziti/channel/v5"
 	"github.com/openziti/identity"
 	"github.com/openziti/ziti/v2/common/ctrlchan"
+	"github.com/openziti/ziti/v2/controller/model"
 	"github.com/stretchr/testify/require"
 )
 
@@ -175,4 +176,39 @@ func Test_ConnectHandler_HandleConnection_SkipsSeparatelyValidated(t *testing.T)
 
 	req.NoError(handler.HandleConnection(helloWithType(meshChannelType), []*x509.Certificate{forged.cert}),
 		"mesh-typed connection is validated by its own acceptor and must be skipped here")
+}
+
+// Test_withinChurnLimit pins the admission policy that decides whether an already-connected router's
+// channel may be displaced by a new connection.
+//
+// It is the only thing rate-limiting displacement. Network.ConnectRouter always displaces an occupant it
+// does not recognise, so without this a spurious first-connection hello would tear down a healthy control
+// channel and force the router to redial. Uniqueness itself is guaranteed under the per-router lock in
+// ConnectRouter, not here, so this check exists purely to protect a working connection from churn.
+func Test_withinChurnLimit(t *testing.T) {
+	connectedAt := func(d time.Duration) *model.Router {
+		r := &model.Router{ConnectTime: time.Now().Add(-d)}
+		r.Id = "r1"
+		return r
+	}
+
+	tests := []struct {
+		name       string
+		since      time.Duration
+		churnLimit time.Duration
+		protected  bool
+	}{
+		{"a connection just established is protected", 0, time.Minute, true},
+		{"still protected part way through the window", 30 * time.Second, time.Minute, true},
+		{"displaceable once the window has passed", 2 * time.Minute, time.Minute, false},
+		// A zero limit is a supported setting and means "always allow takeover", which is what the option
+		// existed to make configurable in the first place.
+		{"a zero limit protects nothing", 0, 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.protected, withinChurnLimit(connectedAt(tt.since), tt.churnLimit))
+		})
+	}
 }

--- a/controller/model/router_manager.go
+++ b/controller/model/router_manager.go
@@ -26,7 +26,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/openziti/channel/v5"
 	"github.com/openziti/channel/v5/protobufs"
+	"github.com/openziti/ziti/v2/common/concurrency"
+	"github.com/openziti/ziti/v2/common/ctrlchan"
 	"github.com/openziti/ziti/v2/common/inspect"
 	"github.com/openziti/ziti/v2/common/pb/cmd_pb"
 	"github.com/openziti/ziti/v2/common/pb/ctrl_pb"
@@ -38,9 +41,9 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/michaelquigley/pfxlog"
-	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/openziti/ziti/v2/controller/db"
 	"github.com/openziti/ziti/v2/controller/models"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	cmap "github.com/orcaman/concurrent-map/v2"
 	"github.com/pkg/errors"
 	"go.etcd.io/bbolt"
@@ -79,8 +82,9 @@ func NewRouter(id, name, fingerprint string, cost uint16, noTraversal bool) *Rou
 
 type RouterManager struct {
 	baseEntityManager[*Router, *db.Router]
-	cache     cmap.ConcurrentMap[string, *Router]
-	connected cmap.ConcurrentMap[string, *Router]
+	cache        cmap.ConcurrentMap[string, *Router]
+	connected    cmap.ConcurrentMap[string, *Router]
+	connectLocks *concurrency.StripedIdLocker
 }
 
 func newRouterManager(env Env) *RouterManager {
@@ -89,6 +93,7 @@ func newRouterManager(env Env) *RouterManager {
 		baseEntityManager: newBaseEntityManager[*Router, *db.Router](env, routerStore),
 		cache:             cmap.New[*Router](),
 		connected:         cmap.New[*Router](),
+		connectLocks:      concurrency.NewStripedIdLocker(256),
 	}
 	result.impl = result
 
@@ -115,28 +120,61 @@ func (self *RouterManager) NewModelEntity() *Router {
 	return &Router{}
 }
 
-func (self *RouterManager) MarkConnected(r *Router) {
-	if router, _ := self.connected.Get(r.Id); router != nil {
-		if ch := router.Control; ch != nil {
-			if err := ch.Close(); err != nil {
-				pfxlog.Logger().WithError(err).Error("error closing control channel")
-			}
+// LockConnectFor acquires the per-router connect lock for the given router id and returns the unlock
+// function. It serializes a router's connect and disconnect processing so they cannot interleave. The
+// returned unlock is idempotent, so a caller may both defer it (as a leak-safety net across all exit
+// paths) and call it early (e.g. to release before closing a channel outside the lock) without
+// double-unlocking. The flag is unshared and only ever touched by the goroutine holding the lock, so it
+// needs no synchronization.
+func (self *RouterManager) LockConnectFor(id string) func() {
+	rawUnlock := self.connectLocks.LockFor(id)
+	unlocked := false
+	return func() {
+		if !unlocked {
+			unlocked = true
+			rawUnlock()
 		}
 	}
+}
 
+// MarkConnected publishes r as the current connection for its router id. Callers must serialize with
+// LockConnectFor and must have already ensured the slot is free (ConnectRouter rejects a busy slot rather
+// than taking over here), so this only records the connection; it does not close any prior channel.
+func (self *RouterManager) MarkConnected(r *Router) {
 	r.Connected.Store(true)
 	self.connected.Set(r.Id, r)
 }
 
+// MarkDisconnected gives up r's registration, and does nothing at all if r is not the registration holder.
+//
+// A connection only owns the state on its own instance, so a connection that has already been replaced must
+// not clear it. What makes that worth enforcing rather than assuming is where the connected flag is read:
+// the handler for a router's link reports drops them when it is false, so clearing it for the wrong
+// connection silences a router that is up and reporting, with nothing to correct it.
+//
+// This is all-or-nothing rather than a fix for instances shared between connections. Pointer identity
+// cannot tell two connections apart when they share an instance, so in that case the shared instance is the
+// registration holder and its state is cleared here regardless. Only giving each connection its own
+// instance prevents that.
 func (self *RouterManager) MarkDisconnected(r *Router) {
-	r.Connected.Store(false)
-	self.connected.RemoveCb(r.Id, func(key string, v *Router, exists bool) bool {
+	removed := self.connected.RemoveCb(r.Id, func(key string, v *Router, exists bool) bool {
 		if exists && v != r {
 			pfxlog.Logger().WithField("routerId", r.Id).Info("router not current connect, not clearing from connected map")
 			return false
 		}
-		return exists
+		if !exists {
+			return false
+		}
+		// Under the shard lock so the flag and the map entry change together: the link report path looks the
+		// router up and then reads the flag, and would otherwise see a removed entry still marked connected.
+		r.Connected.Store(false)
+		return true
 	})
+
+	if !removed {
+		return
+	}
+
 	r.routerLinks.Clear()
 }
 
@@ -206,6 +244,44 @@ func (self *RouterManager) Exists(id string) (bool, error) {
 	return exists, err
 }
 
+// NewCtrlChanRouter builds the Router instance representing one control-channel connection, with the
+// channel already recorded on it.
+//
+// The instance is deliberately kept out of the router cache. The connect path writes connection-scoped
+// state onto it (Control, ConnectTime, VersionInfo, Connected, links), and the controller decides which of
+// two racing connections for a router is current by comparing instances. Handing a cached instance to a
+// second connection makes the two indistinguishable: neither the connect path's occupied-slot check nor the
+// disconnect path's currency check can tell them apart, so a connection that dies takes its replacement's
+// registration down with it, and each connection's writes land on the other's state.
+//
+// Read, by contrast, is cache-backed and returns router entity data. Connection state belongs to
+// GetConnected, not to Read.
+func (self *RouterManager) NewCtrlChanRouter(ch channel.Channel) (*Router, error) {
+	r, err := self.readUncached(ch.Id())
+	if err != nil {
+		return nil, err
+	}
+	if r == nil {
+		return nil, fmt.Errorf("no router with id [%v] found", ch.Id())
+	}
+
+	ctrlCh, ok := ch.GetSenders().(ctrlchan.CtrlChannel)
+	if !ok {
+		return nil, fmt.Errorf("control channel for router [%v] has unexpected senders type %T", ch.Id(), ch.GetSenders())
+	}
+
+	r.Control = ctrlCh
+	// Record the channel before any bind handler runs: handlers built for this connection dereference the
+	// ctrl channel's Channel(), and UnderlayAdded does not fire until the bind handler returns.
+	r.Control.InitChannel(ch)
+	r.ConnectTime = time.Now()
+
+	return r, nil
+}
+
+// readUncached reads a router straight from the database, bypassing the cache in both directions: it
+// neither reads a cached instance nor publishes the one it creates. Callers needing an instance they can
+// own get it here.
 func (self *RouterManager) readUncached(id string) (*Router, error) {
 	entity := &Router{}
 	err := self.GetDb().View(func(tx *bbolt.Tx) error {

--- a/controller/model/router_manager.go
+++ b/controller/model/router_manager.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/openziti/channel/v5/protobufs"
+	"github.com/openziti/ziti/v2/common/concurrency"
 	"github.com/openziti/ziti/v2/common/inspect"
 	"github.com/openziti/ziti/v2/common/pb/cmd_pb"
 	"github.com/openziti/ziti/v2/common/pb/ctrl_pb"
@@ -38,9 +39,9 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/michaelquigley/pfxlog"
-	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/openziti/ziti/v2/controller/db"
 	"github.com/openziti/ziti/v2/controller/models"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	cmap "github.com/orcaman/concurrent-map/v2"
 	"github.com/pkg/errors"
 	"go.etcd.io/bbolt"
@@ -79,8 +80,9 @@ func NewRouter(id, name, fingerprint string, cost uint16, noTraversal bool) *Rou
 
 type RouterManager struct {
 	baseEntityManager[*Router, *db.Router]
-	cache     cmap.ConcurrentMap[string, *Router]
-	connected cmap.ConcurrentMap[string, *Router]
+	cache        cmap.ConcurrentMap[string, *Router]
+	connected    cmap.ConcurrentMap[string, *Router]
+	connectLocks *concurrency.StripedIdLocker
 }
 
 func newRouterManager(env Env) *RouterManager {
@@ -89,6 +91,7 @@ func newRouterManager(env Env) *RouterManager {
 		baseEntityManager: newBaseEntityManager[*Router, *db.Router](env, routerStore),
 		cache:             cmap.New[*Router](),
 		connected:         cmap.New[*Router](),
+		connectLocks:      concurrency.NewStripedIdLocker(256),
 	}
 	result.impl = result
 
@@ -115,15 +118,27 @@ func (self *RouterManager) NewModelEntity() *Router {
 	return &Router{}
 }
 
-func (self *RouterManager) MarkConnected(r *Router) {
-	if router, _ := self.connected.Get(r.Id); router != nil {
-		if ch := router.Control; ch != nil {
-			if err := ch.Close(); err != nil {
-				pfxlog.Logger().WithError(err).Error("error closing control channel")
-			}
+// LockConnectFor acquires the per-router connect lock for the given router id and returns the unlock
+// function. It serializes a router's connect and disconnect processing so they cannot interleave. The
+// returned unlock is idempotent, so a caller may both defer it (as a leak-safety net across all exit
+// paths) and call it early (e.g. to release before closing a channel outside the lock) without
+// double-unlocking. The flag is unshared and only ever touched by the goroutine holding the lock, so it
+// needs no synchronization.
+func (self *RouterManager) LockConnectFor(id string) func() {
+	rawUnlock := self.connectLocks.LockFor(id)
+	unlocked := false
+	return func() {
+		if !unlocked {
+			unlocked = true
+			rawUnlock()
 		}
 	}
+}
 
+// MarkConnected publishes r as the current connection for its router id. Callers must serialize with
+// LockConnectFor and must have already ensured the slot is free (ConnectRouter rejects a busy slot rather
+// than taking over here), so this only records the connection; it does not close any prior channel.
+func (self *RouterManager) MarkConnected(r *Router) {
 	r.Connected.Store(true)
 	self.connected.Set(r.Id, r)
 }

--- a/controller/model/router_manager_test.go
+++ b/controller/model/router_manager_test.go
@@ -1,0 +1,83 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package model
+
+import (
+	"testing"
+
+	cmap "github.com/orcaman/concurrent-map/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func newMarkDisconnectedTestManager() *RouterManager {
+	return &RouterManager{connected: cmap.New[*Router]()}
+}
+
+// TestMarkDisconnected_LeavesStateOfNonHolderAlone: a connection owns only the state on its own instance, so
+// one that has already been replaced must not clear it. The connected flag decides whether the controller
+// accepts that router's link reports, so clearing it for the wrong connection silences a router that is up
+// and reporting with nothing to correct it.
+func TestMarkDisconnected_LeavesStateOfNonHolderAlone(t *testing.T) {
+	mgr := newMarkDisconnectedTestManager()
+
+	superseded := NewRouter("r1", "r1", "", 0, false)
+	current := NewRouter("r1", "r1", "", 0, false)
+
+	superseded.Connected.Store(true)
+	superseded.routerLinks.Add(&Link{Id: "l1", DstId: "dst"}, "dst")
+
+	mgr.MarkConnected(current)
+
+	mgr.MarkDisconnected(superseded)
+
+	require.Same(t, current, mgr.GetConnected("r1"), "the registration holder must be left in place")
+	require.True(t, current.Connected.Load(), "the holder's connected flag must not be cleared")
+	require.True(t, superseded.Connected.Load(),
+		"a non-holder's state is not this call's to clear")
+	require.Len(t, superseded.GetLinks(), 1, "a non-holder's links are not this call's to clear")
+}
+
+// TestMarkDisconnected_ClearsStateOfHolder is the ordinary case: the registration holder disconnecting gives
+// up the registration and its per-connection state together.
+func TestMarkDisconnected_ClearsStateOfHolder(t *testing.T) {
+	mgr := newMarkDisconnectedTestManager()
+
+	current := NewRouter("r1", "r1", "", 0, false)
+	current.routerLinks.Add(&Link{Id: "l1", DstId: "dst"}, "dst")
+	mgr.MarkConnected(current)
+	require.True(t, current.Connected.Load())
+
+	mgr.MarkDisconnected(current)
+
+	require.Nil(t, mgr.GetConnected("r1"), "the registration must be given up")
+	require.False(t, current.Connected.Load(), "the holder's connected flag must be cleared")
+	require.Empty(t, current.GetLinks(), "the holder's links must be cleared")
+}
+
+// TestMarkDisconnected_UnregisteredIsANoop: a connection that never registered, or whose registration is
+// already gone, has nothing to give up.
+func TestMarkDisconnected_UnregisteredIsANoop(t *testing.T) {
+	mgr := newMarkDisconnectedTestManager()
+
+	r := NewRouter("r1", "r1", "", 0, false)
+	r.Connected.Store(true)
+
+	mgr.MarkDisconnected(r)
+
+	require.Nil(t, mgr.GetConnected("r1"))
+	require.True(t, r.Connected.Load(), "with no registration to give up there is nothing to clear")
+}

--- a/controller/model/router_model.go
+++ b/controller/model/router_model.go
@@ -48,9 +48,12 @@ type Router struct {
 	// than take their own lock; contention is irrelevant at this scale.
 	mu sync.RWMutex
 
-	Control           ctrlchan.CtrlChannel
-	Connected         atomic.Bool
-	ConnectTime       time.Time
+	Control     ctrlchan.CtrlChannel
+	Connected   atomic.Bool
+	ConnectTime time.Time
+	// VersionInfo is reported in the router's hello and is not persisted, so it is only populated on the
+	// instance built for a control-channel connection. It is nil on an instance loaded from the database.
+	// Read it from GetConnected rather than from whatever instance is to hand.
 	VersionInfo       *versions.VersionInfo
 	routerLinks       RouterLinks
 	Cost              uint16

--- a/controller/network/link_validation_test.go
+++ b/controller/network/link_validation_test.go
@@ -1,0 +1,99 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package network
+
+import (
+	"testing"
+
+	"github.com/openziti/foundation/v2/versions"
+	"github.com/openziti/ziti/v2/common/inspect"
+	"github.com/openziti/ziti/v2/common/pb/mgmt_pb"
+	"github.com/openziti/ziti/v2/controller/model"
+	"github.com/stretchr/testify/require"
+)
+
+// newDbLoadedSrcLink builds a link whose source is a router instance loaded from the database. Such an
+// instance carries no version, since a router's version arrives in its hello and is not persisted.
+func newDbLoadedSrcLink(t *testing.T, srcId string) *model.Link {
+	t.Helper()
+	src := &model.Router{}
+	src.Id = srcId
+	require.Nil(t, src.VersionInfo, "a database-loaded router carries no version")
+
+	return &model.Link{Id: "l1", DstId: "dst", Src: src}
+}
+
+// TestCheckLinkConns_UnknownVersionIsSkipped: with no connected instance there is no way to know what the
+// router reports, so the comparison is skipped rather than failed, matching how a router too old to report
+// conn info is treated.
+func TestCheckLinkConns_UnknownVersionIsSkipped(t *testing.T) {
+	_, network, _ := newConnectTestNetwork(t)
+
+	link := newDbLoadedSrcLink(t, "r1")
+
+	result := &mgmt_pb.RouterLinkDetail{IsValid: true}
+	network.checkLinkConns(link, &inspect.LinkInspectDetail{}, result)
+
+	require.True(t, result.IsValid, "an unknown router version must not make a link invalid")
+	require.Empty(t, result.Messages)
+}
+
+// TestCheckLinkConns_UsesConnectedVersion: the version lives on the connected instance, so reading it off
+// whatever instance the link references reports a link as invalid whenever that instance is one loaded from
+// the database rather than the connected one.
+func TestCheckLinkConns_UsesConnectedVersion(t *testing.T) {
+	_, network, addr := newConnectTestNetwork(t)
+
+	link := newDbLoadedSrcLink(t, "r1")
+
+	connected := model.NewRouterForTest("r1", "", addr, &fakeCtrlChannel{}, 0, false)
+	connected.VersionInfo = &versions.VersionInfo{Version: "v1.0.0"}
+	network.Router.MarkConnected(connected)
+
+	result := &mgmt_pb.RouterLinkDetail{IsValid: true}
+	network.checkLinkConns(link, &inspect.LinkInspectDetail{}, result)
+
+	require.True(t, result.IsValid, "the connected instance's version must be what decides the comparison")
+	require.Empty(t, result.Messages)
+}
+
+// TestCheckLinkConns_ComparesWhenVersionKnown: once the version is known and high enough, the conn info
+// comparison proceeds, so skipping above does not quietly disable the check.
+func TestCheckLinkConns_ComparesWhenVersionKnown(t *testing.T) {
+	_, network, addr := newConnectTestNetwork(t)
+
+	connected := model.NewRouterForTest("r1", "", addr, &fakeCtrlChannel{}, 0, false)
+	connected.VersionInfo = &versions.VersionInfo{Version: "v1.6.6"}
+	network.Router.MarkConnected(connected)
+
+	link := &model.Link{Id: "l1", DstId: "dst", Src: connected}
+
+	// The router reports a connection the controller does not know about, which the comparison must catch.
+	routerLink := &inspect.LinkInspectDetail{
+		Connections: []*inspect.LinkConnection{
+			{Type: "default", Source: "127.0.0.1:1000", Dest: "127.0.0.1:2000"},
+		},
+	}
+
+	result := &mgmt_pb.RouterLinkDetail{IsValid: true}
+	network.checkLinkConns(link, routerLink, result)
+
+	// A conn count mismatch reports a message without marking the link invalid, so the message is what
+	// shows the comparison ran rather than being skipped.
+	require.NotEmpty(t, result.Messages, "a known version must let the conn info comparison run")
+	require.Contains(t, result.Messages[0], "len(ctrlConns)")
+}

--- a/controller/network/main_test.go
+++ b/controller/network/main_test.go
@@ -1,0 +1,35 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package network
+
+import (
+	"os"
+	"testing"
+
+	"github.com/michaelquigley/pfxlog"
+	"github.com/sirupsen/logrus"
+)
+
+// TestMain configures logging once for the whole package, keeping the path-finding perf tests quiet.
+// GlobalInit writes package-level logger state, so calling it from inside a test races any goroutine a
+// previous test left running that logs while shutting down: a TestContext's api-session heartbeat
+// collector, for instance, does a final flush after its close notification, and that flush logs. Doing
+// this before any test starts leaves no concurrent reader to race with.
+func TestMain(m *testing.M) {
+	pfxlog.GlobalInit(logrus.WarnLevel, pfxlog.DefaultOptions())
+	os.Exit(m.Run())
+}

--- a/controller/network/network.go
+++ b/controller/network/network.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/michaelquigley/pfxlog"
+	"github.com/openziti/channel/v5"
 	"github.com/openziti/channel/v5/protobufs"
 	"github.com/openziti/foundation/v2/concurrenz"
 	"github.com/openziti/foundation/v2/debugz"
@@ -265,9 +266,11 @@ func (network *Network) GetConnectedRouter(routerId string) *model.Router {
 	return network.Router.GetConnected(routerId)
 }
 
-func (network *Network) GetReloadedRouter(routerId string) (*model.Router, error) {
-	network.Router.RemoveFromCache(routerId)
-	return network.Router.Read(routerId)
+// NewCtrlChanRouter returns the Router instance representing a new control-channel connection, with the
+// channel recorded on it. Each connection gets its own instance, which is what lets the connect and
+// disconnect paths tell two racing connections for one router apart.
+func (network *Network) NewCtrlChanRouter(ch channel.Channel) (*model.Router, error) {
+	return network.Router.NewCtrlChanRouter(ch)
 }
 
 func (network *Network) GetRouter(routerId string) (*model.Router, error) {
@@ -348,7 +351,47 @@ func (network *Network) ConnectedRouter(id string) bool {
 	return network.Router.IsConnected(id)
 }
 
-func (network *Network) ConnectRouter(r *model.Router) {
+var (
+	// ErrConnectRejected indicates a router connect was rejected because another connection for the same
+	// router is already current. It is returned by ConnectRouter and propagated out of the bind handler so
+	// NewChannel closes the rejected connection's underlay without starting rx or registering it; the
+	// router then redials.
+	ErrConnectRejected = errors.New("router connect rejected: another connection is already current")
+
+	// ErrConnectChannelClosed indicates a router connect was refused because its control channel was
+	// already closed by the time the connect decision was made, so the connection must not be registered.
+	ErrConnectChannelClosed = errors.New("router connect rejected: control channel already closed")
+)
+
+// IsConnectRejected reports whether err is (or wraps) a connect refusal that the router recovers from by
+// redialing, so the accept path can log it at info rather than treating it as a bind failure.
+func IsConnectRejected(err error) bool {
+	return errors.Is(err, ErrConnectRejected) || errors.Is(err, ErrConnectChannelClosed)
+}
+
+// ConnectRouter registers r as the current connection for its router id, serialized per router. If the
+// slot is already held by a different connection it rejects this one (returning ErrConnectRejected) and
+// displaces the occupant so its teardown runs; the router redials into the freed slot. A connection whose
+// channel is already closed is refused outright (ErrConnectChannelClosed) rather than registered. There is
+// at most one connection per router in the connected map at a time.
+func (network *Network) ConnectRouter(r *model.Router) error {
+	unlock := network.Router.LockConnectFor(r.Id)
+	defer unlock() // leak-safety net; idempotent, so the explicit unlocks below are the ones that matter
+
+	if cur := network.Router.GetConnected(r.Id); cur != nil && cur != r {
+		// Displace the occupant outside the lock: the teardown acquires the stripe itself (we have
+		// released it), so there is no reentrant self-deadlock.
+		unlock()
+		network.displaceConnection(cur)
+		return ErrConnectRejected
+	}
+
+	// Its close handler has already run and never fires again, so nothing would remove it from the
+	// connected map and every redial would bounce off a slot that can never be freed.
+	if r.Control == nil || r.Control.IsClosed() {
+		return ErrConnectChannelClosed
+	}
+
 	network.Link.BuildRouterLinks(r)
 	network.Router.MarkConnected(r)
 
@@ -359,7 +402,10 @@ func (network *Network) ConnectRouter(r *model.Router) {
 			go h.RouterConnected(r)
 		}
 	}
+	unlock()
+
 	go network.ValidateTerminators(r)
+	return nil
 }
 
 func (network *Network) ValidateTerminators(r *model.Router) {
@@ -462,7 +508,46 @@ func (n *Network) ValidateRouterErtTerminators(filter string, cb ErtTerminatorVa
 	return int64(len(result.Entities)), evalF, nil
 }
 
+// isCurrentConnection reports whether r is still the router's current, connected connection, by pointer
+// identity against the connected map (mirrors the check in NotifyExistingLink). A stale or superseded
+// connection returns false.
+func (network *Network) isCurrentConnection(r *model.Router) bool {
+	return network.Router.GetConnected(r.Id) == r && r.Connected.Load()
+}
+
+// displaceConnection removes cur, the connection occupying its router's connected slot, so that a redial
+// can take the slot. Closing the channel is not sufficient on its own: if it is already closed, its close
+// handler has already run and will never run again, so nothing would remove cur and every subsequent
+// connect would be rejected against a slot that can never be freed. The teardown is therefore also
+// invoked directly; it is gated on connection currency, so it is a no-op once the close handler has
+// cleared the slot. Must be called with the router's connect stripe released, since the teardown
+// acquires it.
+func (network *Network) displaceConnection(cur *model.Router) {
+	if ch := cur.Control; ch != nil && !ch.IsClosed() {
+		if err := ch.Close(); err != nil {
+			pfxlog.Logger().WithError(err).WithField("routerId", cur.Id).
+				Error("error closing superseded control channel while rejecting connect")
+		}
+	}
+	network.DisconnectRouter(cur)
+}
+
 func (network *Network) DisconnectRouter(r *model.Router) {
+	// Lock-free pre-check: a stale/superseded disconnect (e.g. the old connection after a takeover) has
+	// nothing to tear down and must not touch the live connection's state; bail without blocking.
+	if !network.isCurrentConnection(r) {
+		return
+	}
+
+	unlock := network.Router.LockConnectFor(r.Id)
+	defer unlock()
+
+	// Re-check under the stripe: a newer connection may have taken over between the pre-check and the
+	// lock. The teardown is all-or-nothing and must not run against a superseded connection.
+	if !network.isCurrentConnection(r) {
+		return
+	}
+
 	// Snapshot the router's links before marking it disconnected: MarkDisconnected clears the
 	// router's link set (routerLinks.Clear()), so a later r.GetLinks() would return nothing and
 	// the link-removal/reroute cascade below would be skipped entirely.
@@ -497,23 +582,33 @@ func (network *Network) NotifyExistingLink(srcRouter *model.Router, reportedLink
 		WithField("destRouterId", reportedLink.DestRouterId).
 		WithField("iteration", reportedLink.Iteration)
 
+	// Publish under the stripe DisconnectRouter holds: checking currency and then publishing without it
+	// lets a report recreate a link after the teardown has snapshotted and cleared it. Events go out after
+	// the unlock, since a dispatcher may be slow and this stripe is shared with connect and disconnect.
+	unlock := network.Router.LockConnectFor(srcRouter.Id)
+
 	src := network.Router.GetConnected(srcRouter.Id)
 	if src == nil {
+		unlock()
 		log.Info("ignoring links message processed after router disconnected")
 		return
 	}
 
 	if src != srcRouter || !srcRouter.Connected.Load() {
+		unlock()
 		log.Info("ignoring links message processed from old router connection")
 		return
 	}
 
 	dst := network.Router.GetConnected(reportedLink.DestRouterId)
+	link, created := network.Link.RouterReportedLink(reportedLink, src, dst)
+
+	unlock()
+
 	if dst == nil {
 		network.NotifyLinkIdEvent(reportedLink.Id, event.LinkFromRouterDisconnectedDest)
 	}
 
-	link, created := network.Link.RouterReportedLink(reportedLink, src, dst)
 	if created {
 		network.NotifyLinkEvent(link, event.LinkFromRouterNew)
 		log.Info("router reported link added")
@@ -1553,9 +1648,14 @@ func (network *Network) checkLinkConns(ctrlLink *model.Link, routerLink *inspect
 		})
 	}
 
-	// ensure that conn info is being reported
+	// The version comes from the hello, so only the connected instance has it. Not knowing it means the
+	// comparison cannot be made, which is not a fault of the link.
 	if srcR := ctrlLink.Src; srcR != nil {
-		hasMinVersion, err := srcR.VersionInfo.HasMinimumVersion("v1.6.6")
+		connectedSrc := network.Router.GetConnected(srcR.Id)
+		if connectedSrc == nil || connectedSrc.VersionInfo == nil {
+			return
+		}
+		hasMinVersion, err := connectedSrc.VersionInfo.HasMinimumVersion("v1.6.6")
 		if err != nil {
 			result.IsValid = false
 			result.Messages = append(result.Messages, err.Error())

--- a/controller/network/network.go
+++ b/controller/network/network.go
@@ -347,7 +347,48 @@ func (network *Network) ConnectedRouter(id string) bool {
 	return network.Router.IsConnected(id)
 }
 
-func (network *Network) ConnectRouter(r *model.Router) {
+var (
+	// ErrConnectRejected indicates a router connect was rejected because another connection for the same
+	// router is already current. It is returned by ConnectRouter and propagated out of the bind handler so
+	// NewChannel closes the rejected connection's underlay without starting rx or registering it; the
+	// router then redials.
+	ErrConnectRejected = errors.New("router connect rejected: another connection is already current")
+
+	// ErrConnectChannelClosed indicates a router connect was refused because its control channel was
+	// already closed by the time the connect decision was made, so the connection must not be registered.
+	ErrConnectChannelClosed = errors.New("router connect rejected: control channel already closed")
+)
+
+// IsConnectRejected reports whether err is (or wraps) a connect refusal that the router recovers from by
+// redialing, so the accept path can log it at info rather than treating it as a bind failure.
+func IsConnectRejected(err error) bool {
+	return errors.Is(err, ErrConnectRejected) || errors.Is(err, ErrConnectChannelClosed)
+}
+
+// ConnectRouter registers r as the current connection for its router id, serialized per router. If the
+// slot is already held by a different connection it rejects this one (returning ErrConnectRejected) and
+// displaces the occupant so its teardown runs; the router redials into the freed slot. A connection whose
+// channel is already closed is refused outright (ErrConnectChannelClosed) rather than registered. There is
+// at most one connection per router in the connected map at a time.
+func (network *Network) ConnectRouter(r *model.Router) error {
+	unlock := network.Router.LockConnectFor(r.Id)
+	defer unlock() // leak-safety net; idempotent, so the explicit unlocks below are the ones that matter
+
+	if cur := network.Router.GetConnected(r.Id); cur != nil && cur != r {
+		// Displace the occupant outside the lock: the teardown acquires the stripe itself (we have
+		// released it), so there is no reentrant self-deadlock.
+		unlock()
+		network.displaceConnection(cur)
+		return ErrConnectRejected
+	}
+
+	// Refuse a connection whose channel is already closed rather than registering it. Its close handler
+	// has already run and will never run again, so no disconnect would ever remove it from the connected
+	// map, and reject-if-busy would then bounce every redial off a slot nothing can free.
+	if r.Control == nil || r.Control.IsClosed() {
+		return ErrConnectChannelClosed
+	}
+
 	network.Link.BuildRouterLinks(r)
 	network.Router.MarkConnected(r)
 
@@ -358,7 +399,10 @@ func (network *Network) ConnectRouter(r *model.Router) {
 			go h.RouterConnected(r)
 		}
 	}
+	unlock()
+
 	go network.ValidateTerminators(r)
+	return nil
 }
 
 func (network *Network) ValidateTerminators(r *model.Router) {
@@ -461,7 +505,46 @@ func (n *Network) ValidateRouterErtTerminators(filter string, cb ErtTerminatorVa
 	return int64(len(result.Entities)), evalF, nil
 }
 
+// isCurrentConnection reports whether r is still the router's current, connected connection, by pointer
+// identity against the connected map (mirrors the check in NotifyExistingLink). A stale or superseded
+// connection returns false.
+func (network *Network) isCurrentConnection(r *model.Router) bool {
+	return network.Router.GetConnected(r.Id) == r && r.Connected.Load()
+}
+
+// displaceConnection removes cur, the connection occupying its router's connected slot, so that a redial
+// can take the slot. Closing the channel is not sufficient on its own: if it is already closed, its close
+// handler has already run and will never run again, so nothing would remove cur and every subsequent
+// connect would be rejected against a slot that can never be freed. The teardown is therefore also
+// invoked directly; it is gated on connection currency, so it is a no-op once the close handler has
+// cleared the slot. Must be called with the router's connect stripe released, since the teardown
+// acquires it.
+func (network *Network) displaceConnection(cur *model.Router) {
+	if ch := cur.Control; ch != nil && !ch.IsClosed() {
+		if err := ch.Close(); err != nil {
+			pfxlog.Logger().WithError(err).WithField("routerId", cur.Id).
+				Error("error closing superseded control channel while rejecting connect")
+		}
+	}
+	network.DisconnectRouter(cur)
+}
+
 func (network *Network) DisconnectRouter(r *model.Router) {
+	// Lock-free pre-check: a stale/superseded disconnect (e.g. the old connection after a takeover) has
+	// nothing to tear down and must not touch the live connection's state; bail without blocking.
+	if !network.isCurrentConnection(r) {
+		return
+	}
+
+	unlock := network.Router.LockConnectFor(r.Id)
+	defer unlock()
+
+	// Re-check under the stripe: a newer connection may have taken over between the pre-check and the
+	// lock. The teardown is all-or-nothing and must not run against a superseded connection.
+	if !network.isCurrentConnection(r) {
+		return
+	}
+
 	// 1: remove Links for Router
 	for _, l := range r.GetLinks() {
 		wasConnected := l.CurrentState().Mode == model.Connected

--- a/controller/network/network_path.go
+++ b/controller/network/network_path.go
@@ -144,6 +144,16 @@ func (network *Network) shortestPath(srcR *model.Router, dstR *model.Router) ([]
 		return nil, 0, errors.New("not routable (!srcR||!dstR)")
 	}
 
+	// The graph below is pointer-keyed, so an endpoint held as a different instance of the same router is
+	// not a node in it and the search reports the router unroutable from itself. Callers legitimately hold
+	// other instances: each connection has its own, and the router cache holds a database-loaded one.
+	if connected := network.Router.GetConnected(srcR.Id); connected != nil {
+		srcR = connected
+	}
+	if connected := network.Router.GetConnected(dstR.Id); connected != nil {
+		dstR = connected
+	}
+
 	if srcR == dstR {
 		return []*model.Router{srcR}, 0, nil
 	}

--- a/controller/network/route_perf_test.go
+++ b/controller/network/route_perf_test.go
@@ -22,14 +22,9 @@ import (
 	"testing"
 
 	"github.com/openziti/ziti/v2/controller/model"
-
-	"github.com/michaelquigley/pfxlog"
-	"github.com/sirupsen/logrus"
 )
 
 func TestShortestPathAgainstEstablished(t *testing.T) {
-	pfxlog.GlobalInit(logrus.WarnLevel, pfxlog.DefaultOptions())
-
 	ctx := model.NewTestContext(t)
 	defer ctx.Cleanup()
 
@@ -151,7 +146,6 @@ func TestShortestPathAgainstEstablished(t *testing.T) {
 
 func BenchmarkShortestPathPerfWithRouterChanges(b *testing.B) {
 	b.StopTimer()
-	pfxlog.GlobalInit(logrus.WarnLevel, pfxlog.DefaultOptions())
 
 	ctx := model.NewTestContext(b)
 	defer ctx.Cleanup()
@@ -242,7 +236,6 @@ type expectedRoute struct {
 
 func BenchmarkShortestPathPerf(b *testing.B) {
 	b.StopTimer()
-	pfxlog.GlobalInit(logrus.WarnLevel, pfxlog.DefaultOptions())
 
 	ctx := model.NewTestContext(b)
 	defer ctx.Cleanup()
@@ -314,7 +307,6 @@ func BenchmarkShortestPathPerf(b *testing.B) {
 
 func BenchmarkMoreRealisticShortestPathPerf(b *testing.B) {
 	//b.StopTimer()
-	pfxlog.GlobalInit(logrus.WarnLevel, pfxlog.DefaultOptions())
 
 	ctx := model.NewTestContext(b)
 	defer ctx.Cleanup()

--- a/controller/network/router_connect_test.go
+++ b/controller/network/router_connect_test.go
@@ -1,0 +1,378 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package network
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/openziti/channel/v5"
+	"github.com/openziti/transport/v2"
+	"github.com/openziti/transport/v2/tcp"
+	"github.com/openziti/ziti/v2/common/ctrlchan"
+	"github.com/openziti/ziti/v2/common/pb/ctrl_pb"
+	"github.com/openziti/ziti/v2/controller/change"
+	"github.com/openziti/ziti/v2/controller/model"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeCtrlChannel is a minimal ctrlchan.CtrlChannel double for connect/disconnect lifecycle tests.
+// It embeds the interface (unimplemented methods panic if called), and implements only the close-related
+// methods the reject/kick path exercises. onClose, if set, runs synchronously on the first Close to
+// simulate the real channel close handler firing DisconnectRouter.
+type fakeCtrlChannel struct {
+	ctrlchan.CtrlChannel
+	closed  atomic.Bool
+	onClose func()
+}
+
+func (f *fakeCtrlChannel) Close() error {
+	if f.closed.CompareAndSwap(false, true) && f.onClose != nil {
+		f.onClose()
+	}
+	return nil
+}
+
+func (f *fakeCtrlChannel) IsClosed() bool { return f.closed.Load() }
+
+func (f *fakeCtrlChannel) IsConnected() bool { return !f.closed.Load() }
+
+func newConnectTestNetwork(t *testing.T) (*model.TestContext, *Network, transport.Address) {
+	ctx := model.NewTestContext(t)
+	t.Cleanup(ctx.Cleanup)
+
+	config := newTestConfig(ctx)
+	t.Cleanup(func() { close(config.closeNotify) })
+
+	network, err := NewNetwork(config, ctx)
+	require.NoError(t, err)
+
+	addr, err := tcp.AddressParser{}.Parse("tcp:0.0.0.0:0")
+	require.NoError(t, err)
+
+	return ctx, network, addr
+}
+
+// TestConnectRouter_RejectsAndKicksWhenBusy: a connect into an occupied slot returns ErrConnectRejected,
+// kicks the occupant (whose teardown clears the slot), and a subsequent redial then connects cleanly.
+func TestConnectRouter_RejectsAndKicksWhenBusy(t *testing.T) {
+	_, network, addr := newConnectTestNetwork(t)
+
+	currentCh := &fakeCtrlChannel{}
+	cur := model.NewRouterForTest("r1", "", addr, currentCh, 0, false)
+	// Simulate the real close handler: closing the occupant runs its DisconnectRouter.
+	currentCh.onClose = func() { network.DisconnectRouter(cur) }
+
+	require.NoError(t, network.ConnectRouter(cur))
+	require.Equal(t, cur, network.Router.GetConnected("r1"))
+
+	newCh := &fakeCtrlChannel{}
+	rNew := model.NewRouterForTest("r1", "", addr, newCh, 0, false)
+	err := network.ConnectRouter(rNew)
+	require.ErrorIs(t, err, ErrConnectRejected)
+	require.True(t, IsConnectRejected(err))
+	require.True(t, currentCh.IsClosed(), "occupant should have been kicked")
+	require.Nil(t, network.Router.GetConnected("r1"), "kicked occupant's teardown should clear the slot")
+	require.False(t, rNew.Connected.Load(), "rejected connect must not be registered")
+
+	// Redial into the now-clear slot succeeds.
+	rRedial := model.NewRouterForTest("r1", "", addr, &fakeCtrlChannel{}, 0, false)
+	require.NoError(t, network.ConnectRouter(rRedial))
+	require.Equal(t, rRedial, network.Router.GetConnected("r1"))
+	require.True(t, rRedial.Connected.Load())
+}
+
+// TestConnectRouter_SetsUpWhenClear: a connect into an empty slot registers the router.
+func TestConnectRouter_SetsUpWhenClear(t *testing.T) {
+	_, network, addr := newConnectTestNetwork(t)
+
+	r := model.NewRouterForTest("r1", "", addr, &fakeCtrlChannel{}, 0, false)
+	require.NoError(t, network.ConnectRouter(r))
+	require.Equal(t, r, network.Router.GetConnected("r1"))
+	require.True(t, r.Connected.Load())
+}
+
+// TestDisconnectRouter_IgnoresStaleConnection: a disconnect for a superseded connection must not disturb
+// the current one (the §9 race guard).
+func TestDisconnectRouter_IgnoresStaleConnection(t *testing.T) {
+	_, network, addr := newConnectTestNetwork(t)
+
+	rNew := model.NewRouterForTest("r1", "", addr, &fakeCtrlChannel{}, 0, false)
+	require.NoError(t, network.ConnectRouter(rNew))
+	require.Equal(t, rNew, network.Router.GetConnected("r1"))
+
+	// A stale disconnect for a different (old) instance of the same router id.
+	rOld := model.NewRouterForTest("r1", "", addr, &fakeCtrlChannel{}, 0, false)
+	network.DisconnectRouter(rOld)
+
+	require.Equal(t, rNew, network.Router.GetConnected("r1"), "stale disconnect must not evict the current connection")
+	require.True(t, rNew.Connected.Load())
+}
+
+// TestDisconnectRouter_CurrentTearsDown: a disconnect for the current connection clears it.
+func TestDisconnectRouter_CurrentTearsDown(t *testing.T) {
+	_, network, addr := newConnectTestNetwork(t)
+
+	r := model.NewRouterForTest("r1", "", addr, &fakeCtrlChannel{}, 0, false)
+	require.NoError(t, network.ConnectRouter(r))
+	require.Equal(t, r, network.Router.GetConnected("r1"))
+
+	network.DisconnectRouter(r)
+	require.Nil(t, network.Router.GetConnected("r1"))
+	require.False(t, r.Connected.Load())
+}
+
+// TestReject_DisplacesOccupantThatCannotTearItselfDown is the regression guard against a permanent
+// reject loop. A connection whose channel closes without its close handler running can never remove
+// itself from the connected map, so a reject that merely closed the channel would leave the slot occupied
+// forever and every redial would be rejected against a slot nothing can free. The reject must displace
+// the occupant itself, so the next redial finds the slot clear.
+func TestReject_DisplacesOccupantThatCannotTearItselfDown(t *testing.T) {
+	_, network, addr := newConnectTestNetwork(t)
+
+	// No onClose: the occupant's channel goes closed without any teardown running, modeling both a
+	// channel already closed before the reject and one whose close handler has already run.
+	currentCh := &fakeCtrlChannel{}
+	cur := model.NewRouterForTest("r1", "", addr, currentCh, 0, false)
+	require.NoError(t, network.ConnectRouter(cur))
+	require.Equal(t, cur, network.Router.GetConnected("r1"))
+	currentCh.closed.Store(true)
+
+	rNew := model.NewRouterForTest("r1", "", addr, &fakeCtrlChannel{}, 0, false)
+	require.ErrorIs(t, network.ConnectRouter(rNew), ErrConnectRejected)
+	require.Nil(t, network.Router.GetConnected("r1"), "reject must displace an occupant that cannot tear itself down")
+	require.False(t, cur.Connected.Load())
+	require.False(t, rNew.Connected.Load(), "rejected connect must not be registered")
+
+	// The redial therefore makes progress instead of bouncing off the slot forever.
+	rRedial := model.NewRouterForTest("r1", "", addr, &fakeCtrlChannel{}, 0, false)
+	require.NoError(t, network.ConnectRouter(rRedial))
+	require.Equal(t, rRedial, network.Router.GetConnected("r1"))
+	require.True(t, rRedial.Connected.Load())
+}
+
+// TestConnectRouter_RefusesAlreadyClosedChannel: a connect whose channel is already closed must be
+// refused rather than registered. Registering it would put a connection in the connected map that no
+// disconnect can ever remove, since its close handler has already run, wedging the router out of this
+// controller permanently.
+func TestConnectRouter_RefusesAlreadyClosedChannel(t *testing.T) {
+	_, network, addr := newConnectTestNetwork(t)
+
+	deadCh := &fakeCtrlChannel{}
+	deadCh.closed.Store(true)
+	r := model.NewRouterForTest("r1", "", addr, deadCh, 0, false)
+
+	err := network.ConnectRouter(r)
+	require.ErrorIs(t, err, ErrConnectChannelClosed)
+	require.True(t, IsConnectRejected(err), "an already-closed channel is a refusal the router redials after")
+	require.Nil(t, network.Router.GetConnected("r1"), "a closed connection must not occupy the slot")
+	require.False(t, r.Connected.Load())
+
+	// A subsequent healthy connect is unaffected.
+	rOk := model.NewRouterForTest("r1", "", addr, &fakeCtrlChannel{}, 0, false)
+	require.NoError(t, network.ConnectRouter(rOk))
+	require.Equal(t, rOk, network.Router.GetConnected("r1"))
+}
+
+// TestConnectDisconnectRace exercises concurrent connect/disconnect for one router id under the race
+// detector, asserting the map never ends holding a disconnected router.
+func TestConnectDisconnectRace(t *testing.T) {
+	_, network, addr := newConnectTestNetwork(t)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func(connect bool) {
+			defer wg.Done()
+			if connect {
+				r := model.NewRouterForTest("r1", "", addr, &fakeCtrlChannel{}, 0, false)
+				_ = network.ConnectRouter(r)
+			} else if cur := network.Router.GetConnected("r1"); cur != nil {
+				network.DisconnectRouter(cur)
+			}
+		}(i%2 == 0)
+	}
+	wg.Wait()
+
+	if cur := network.Router.GetConnected("r1"); cur != nil {
+		require.True(t, cur.Connected.Load(), "map must not hold a disconnected router")
+	}
+}
+
+// fakeConnectChannel is a channel.Channel double reporting a fixed router id and a real
+// ListenerCtrlChannel as its senders, which is what the accept path records on the router. It embeds the
+// interface, so any method these tests do not exercise panics rather than returning a zero value.
+type fakeConnectChannel struct {
+	channel.Channel
+	id      string
+	senders channel.Senders
+}
+
+func (f *fakeConnectChannel) Id() string                  { return f.id }
+func (f *fakeConnectChannel) GetSenders() channel.Senders { return f.senders }
+func (f *fakeConnectChannel) SetLogicalName(string)       {}
+
+func newFakeConnectChannel(routerId string) *fakeConnectChannel {
+	return &fakeConnectChannel{id: routerId, senders: ctrlchan.NewListenerCtrlChannel()}
+}
+
+// newPersistedRouter stores a router so the connect path can load it. Create publishes the instance it was
+// given into the router cache, which is the instance a connection must not be handed.
+func newPersistedRouter(t *testing.T, network *Network, addr transport.Address, id string) *model.Router {
+	t.Helper()
+	router := model.NewRouterForTest(id, "", addr, nil, 0, false)
+	require.NoError(t, network.Router.Create(router, change.New()))
+	return router
+}
+
+// TestNewCtrlChanRouter_InstanceIsNotShared is the guard on the assumption every currency check in the
+// connect and disconnect paths rests on: each connection gets its own Router instance. Two connections
+// sharing one instance are indistinguishable to those checks, so a connect into an occupied slot is not
+// rejected and the first connection's teardown dismantles the second's registration, leaving a live
+// control channel whose router is not registered and can never re-register.
+func TestNewCtrlChanRouter_InstanceIsNotShared(t *testing.T) {
+	_, network, addr := newConnectTestNetwork(t)
+
+	cached := newPersistedRouter(t, network, addr, "r1")
+
+	first, err := network.NewCtrlChanRouter(newFakeConnectChannel("r1"))
+	require.NoError(t, err)
+	second, err := network.NewCtrlChanRouter(newFakeConnectChannel("r1"))
+	require.NoError(t, err)
+
+	require.NotSame(t, first, second, "each connection must get its own router instance")
+	require.NotSame(t, cached, first, "a connection must not be handed the cached instance")
+	require.NotSame(t, cached, second, "a connection must not be handed the cached instance")
+
+	// The connection's instance must not become the cached one either, or the next connection would be
+	// handed it.
+	readBack, err := network.Router.Read("r1")
+	require.NoError(t, err)
+	require.NotSame(t, first, readBack, "a connection's instance must stay out of the router cache")
+	require.NotSame(t, second, readBack, "a connection's instance must stay out of the router cache")
+}
+
+// TestNewCtrlChanRouter_ConcurrentConnectsAreNotShared covers the way instances came to be shared: the
+// load was an eviction followed by a read-through read, so two connects racing could both evict and the
+// later read could then hit the instance the earlier one had just published.
+func TestNewCtrlChanRouter_ConcurrentConnectsAreNotShared(t *testing.T) {
+	_, network, addr := newConnectTestNetwork(t)
+	newPersistedRouter(t, network, addr, "r1")
+
+	const connects = 16
+	start := make(chan struct{})
+	results := make([]*model.Router, connects)
+	var wg sync.WaitGroup
+
+	for i := 0; i < connects; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			r, err := network.NewCtrlChanRouter(newFakeConnectChannel("r1"))
+			if err == nil {
+				results[idx] = r
+			}
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+
+	seen := map[*model.Router]int{}
+	for idx, r := range results {
+		require.NotNil(t, r, "connect %d failed to load a router", idx)
+		seen[r]++
+	}
+	require.Len(t, seen, connects, "every concurrent connect must get its own router instance")
+}
+
+// TestNewCtrlChanRouter_RecordsTheChannel: the instance arrives carrying its connection, so no caller has
+// to remember to attach it, and the channel it carries is the one it was built for.
+func TestNewCtrlChanRouter_RecordsTheChannel(t *testing.T) {
+	_, network, addr := newConnectTestNetwork(t)
+	newPersistedRouter(t, network, addr, "r1")
+
+	ch := newFakeConnectChannel("r1")
+	r, err := network.NewCtrlChanRouter(ch)
+	require.NoError(t, err)
+
+	require.NotNil(t, r.Control, "the connection's channel must be recorded")
+	require.Same(t, ch, r.Control.GetChannel(), "the recorded channel must be the one the instance was built for")
+	require.False(t, r.ConnectTime.IsZero(), "connect time must be recorded")
+	require.False(t, r.Connected.Load(), "loading a router must not register it as connected")
+}
+
+// TestNewCtrlChanRouter_UnknownRouter: a channel from a router the controller has no record of is refused
+// rather than yielding an empty instance.
+func TestNewCtrlChanRouter_UnknownRouter(t *testing.T) {
+	_, network, _ := newConnectTestNetwork(t)
+
+	r, err := network.NewCtrlChanRouter(newFakeConnectChannel("nope"))
+	require.Error(t, err)
+	require.Nil(t, r)
+}
+
+// TestNotifyExistingLink_RaceDisconnect is the invariant that link publication and disconnect teardown
+// cannot interleave: once a router is disconnected, no link may remain naming it as its source.
+//
+// Checking currency and then publishing without holding the router's connect stripe is a check-then-act.
+// A report can find the connection current, and by the time it reaches the link manager the teardown has
+// already taken its snapshot of the router's links and cleared them, so the link is recreated after
+// everything that would have removed it has run. It is then invisible to the router (its index was
+// cleared) while still in the controller's link table with a disconnected source, and a reconnect
+// reporting the same iteration can adopt that stale source rather than rebuilding the link.
+//
+// Run under -race, and repeated, since the window is small.
+func TestNotifyExistingLink_RaceDisconnect(t *testing.T) {
+	_, network, addr := newConnectTestNetwork(t)
+
+	// The destination is left unconnected: only the source router's disconnect can recreate a stale link,
+	// so connecting a second router would add the peer-state sync to the race for no extra coverage.
+	for i := 0; i < 200; i++ {
+		r := model.NewRouterForTest("r1", "", addr, &fakeCtrlChannel{}, 0, false)
+		require.NoError(t, network.ConnectRouter(r))
+
+		reported := &ctrl_pb.RouterLinks_RouterLink{
+			Id:           fmt.Sprintf("l-%d", i),
+			DestRouterId: "r2",
+			LinkProtocol: "tls",
+			DialAddress:  "tcp:localhost:1234",
+			Iteration:    1,
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			network.NotifyExistingLink(r, reported)
+		}()
+		go func() {
+			defer wg.Done()
+			network.DisconnectRouter(r)
+		}()
+		wg.Wait()
+
+		require.Nil(t, network.Router.GetConnected("r1"), "the router must be disconnected")
+		for _, l := range network.Link.All() {
+			require.NotEqual(t, "r1", l.Src.Id,
+				"iteration %d: a link published by a router that has been disconnected must not survive", i)
+		}
+	}
+}

--- a/controller/network/router_connect_test.go
+++ b/controller/network/router_connect_test.go
@@ -1,0 +1,212 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package network
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/openziti/transport/v2"
+	"github.com/openziti/transport/v2/tcp"
+	"github.com/openziti/ziti/v2/common/ctrlchan"
+	"github.com/openziti/ziti/v2/controller/model"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeCtrlChannel is a minimal ctrlchan.CtrlChannel double for connect/disconnect lifecycle tests.
+// It embeds the interface (unimplemented methods panic if called), and implements only the close-related
+// methods the reject/kick path exercises. onClose, if set, runs synchronously on the first Close to
+// simulate the real channel close handler firing DisconnectRouter.
+type fakeCtrlChannel struct {
+	ctrlchan.CtrlChannel
+	closed  atomic.Bool
+	onClose func()
+}
+
+func (f *fakeCtrlChannel) Close() error {
+	if f.closed.CompareAndSwap(false, true) && f.onClose != nil {
+		f.onClose()
+	}
+	return nil
+}
+
+func (f *fakeCtrlChannel) IsClosed() bool { return f.closed.Load() }
+
+func (f *fakeCtrlChannel) IsConnected() bool { return !f.closed.Load() }
+
+func newConnectTestNetwork(t *testing.T) (*model.TestContext, *Network, transport.Address) {
+	ctx := model.NewTestContext(t)
+	t.Cleanup(ctx.Cleanup)
+
+	config := newTestConfig(ctx)
+	t.Cleanup(func() { close(config.closeNotify) })
+
+	network, err := NewNetwork(config, ctx)
+	require.NoError(t, err)
+
+	addr, err := tcp.AddressParser{}.Parse("tcp:0.0.0.0:0")
+	require.NoError(t, err)
+
+	return ctx, network, addr
+}
+
+// TestConnectRouter_RejectsAndKicksWhenBusy: a connect into an occupied slot returns ErrConnectRejected,
+// kicks the occupant (whose teardown clears the slot), and a subsequent redial then connects cleanly.
+func TestConnectRouter_RejectsAndKicksWhenBusy(t *testing.T) {
+	_, network, addr := newConnectTestNetwork(t)
+
+	curCh := &fakeCtrlChannel{}
+	cur := model.NewRouterForTest("r1", "", addr, curCh, 0, false)
+	// Simulate the real close handler: closing the occupant runs its DisconnectRouter.
+	curCh.onClose = func() { network.DisconnectRouter(cur) }
+
+	require.NoError(t, network.ConnectRouter(cur))
+	require.Equal(t, cur, network.Router.GetConnected("r1"))
+
+	newCh := &fakeCtrlChannel{}
+	rNew := model.NewRouterForTest("r1", "", addr, newCh, 0, false)
+	err := network.ConnectRouter(rNew)
+	require.ErrorIs(t, err, ErrConnectRejected)
+	require.True(t, IsConnectRejected(err))
+	require.True(t, curCh.IsClosed(), "occupant should have been kicked")
+	require.Nil(t, network.Router.GetConnected("r1"), "kicked occupant's teardown should clear the slot")
+	require.False(t, rNew.Connected.Load(), "rejected connect must not be registered")
+
+	// Redial into the now-clear slot succeeds.
+	rRedial := model.NewRouterForTest("r1", "", addr, &fakeCtrlChannel{}, 0, false)
+	require.NoError(t, network.ConnectRouter(rRedial))
+	require.Equal(t, rRedial, network.Router.GetConnected("r1"))
+	require.True(t, rRedial.Connected.Load())
+}
+
+// TestConnectRouter_SetsUpWhenClear: a connect into an empty slot registers the router.
+func TestConnectRouter_SetsUpWhenClear(t *testing.T) {
+	_, network, addr := newConnectTestNetwork(t)
+
+	r := model.NewRouterForTest("r1", "", addr, &fakeCtrlChannel{}, 0, false)
+	require.NoError(t, network.ConnectRouter(r))
+	require.Equal(t, r, network.Router.GetConnected("r1"))
+	require.True(t, r.Connected.Load())
+}
+
+// TestDisconnectRouter_IgnoresStaleConnection: a disconnect for a superseded connection must not disturb
+// the current one (the §9 race guard).
+func TestDisconnectRouter_IgnoresStaleConnection(t *testing.T) {
+	_, network, addr := newConnectTestNetwork(t)
+
+	rNew := model.NewRouterForTest("r1", "", addr, &fakeCtrlChannel{}, 0, false)
+	require.NoError(t, network.ConnectRouter(rNew))
+	require.Equal(t, rNew, network.Router.GetConnected("r1"))
+
+	// A stale disconnect for a different (old) instance of the same router id.
+	rOld := model.NewRouterForTest("r1", "", addr, &fakeCtrlChannel{}, 0, false)
+	network.DisconnectRouter(rOld)
+
+	require.Equal(t, rNew, network.Router.GetConnected("r1"), "stale disconnect must not evict the current connection")
+	require.True(t, rNew.Connected.Load())
+}
+
+// TestDisconnectRouter_CurrentTearsDown: a disconnect for the current connection clears it.
+func TestDisconnectRouter_CurrentTearsDown(t *testing.T) {
+	_, network, addr := newConnectTestNetwork(t)
+
+	r := model.NewRouterForTest("r1", "", addr, &fakeCtrlChannel{}, 0, false)
+	require.NoError(t, network.ConnectRouter(r))
+	require.Equal(t, r, network.Router.GetConnected("r1"))
+
+	network.DisconnectRouter(r)
+	require.Nil(t, network.Router.GetConnected("r1"))
+	require.False(t, r.Connected.Load())
+}
+
+// TestReject_DisplacesOccupantThatCannotTearItselfDown is the regression guard against a permanent
+// reject loop. A connection whose channel closes without its close handler running can never remove
+// itself from the connected map, so a reject that merely closed the channel would leave the slot occupied
+// forever and every redial would be rejected against a slot nothing can free. The reject must displace
+// the occupant itself, so the next redial finds the slot clear.
+func TestReject_DisplacesOccupantThatCannotTearItselfDown(t *testing.T) {
+	_, network, addr := newConnectTestNetwork(t)
+
+	// No onClose: the occupant's channel goes closed without any teardown running, modeling both a
+	// channel already closed before the reject and one whose close handler has already run.
+	curCh := &fakeCtrlChannel{}
+	cur := model.NewRouterForTest("r1", "", addr, curCh, 0, false)
+	require.NoError(t, network.ConnectRouter(cur))
+	require.Equal(t, cur, network.Router.GetConnected("r1"))
+	curCh.closed.Store(true)
+
+	rNew := model.NewRouterForTest("r1", "", addr, &fakeCtrlChannel{}, 0, false)
+	require.ErrorIs(t, network.ConnectRouter(rNew), ErrConnectRejected)
+	require.Nil(t, network.Router.GetConnected("r1"), "reject must displace an occupant that cannot tear itself down")
+	require.False(t, cur.Connected.Load())
+	require.False(t, rNew.Connected.Load(), "rejected connect must not be registered")
+
+	// The redial therefore makes progress instead of bouncing off the slot forever.
+	rRedial := model.NewRouterForTest("r1", "", addr, &fakeCtrlChannel{}, 0, false)
+	require.NoError(t, network.ConnectRouter(rRedial))
+	require.Equal(t, rRedial, network.Router.GetConnected("r1"))
+	require.True(t, rRedial.Connected.Load())
+}
+
+// TestConnectRouter_RefusesAlreadyClosedChannel: a connect whose channel is already closed must be
+// refused rather than registered. Registering it would put a connection in the connected map that no
+// disconnect can ever remove, since its close handler has already run, wedging the router out of this
+// controller permanently.
+func TestConnectRouter_RefusesAlreadyClosedChannel(t *testing.T) {
+	_, network, addr := newConnectTestNetwork(t)
+
+	deadCh := &fakeCtrlChannel{}
+	deadCh.closed.Store(true)
+	r := model.NewRouterForTest("r1", "", addr, deadCh, 0, false)
+
+	err := network.ConnectRouter(r)
+	require.ErrorIs(t, err, ErrConnectChannelClosed)
+	require.True(t, IsConnectRejected(err), "an already-closed channel is a refusal the router redials after")
+	require.Nil(t, network.Router.GetConnected("r1"), "a closed connection must not occupy the slot")
+	require.False(t, r.Connected.Load())
+
+	// A subsequent healthy connect is unaffected.
+	rOk := model.NewRouterForTest("r1", "", addr, &fakeCtrlChannel{}, 0, false)
+	require.NoError(t, network.ConnectRouter(rOk))
+	require.Equal(t, rOk, network.Router.GetConnected("r1"))
+}
+
+// TestConnectDisconnectRace exercises concurrent connect/disconnect for one router id under the race
+// detector, asserting the map never ends holding a disconnected router.
+func TestConnectDisconnectRace(t *testing.T) {
+	_, network, addr := newConnectTestNetwork(t)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func(connect bool) {
+			defer wg.Done()
+			if connect {
+				r := model.NewRouterForTest("r1", "", addr, &fakeCtrlChannel{}, 0, false)
+				_ = network.ConnectRouter(r)
+			} else if cur := network.Router.GetConnected("r1"); cur != nil {
+				network.DisconnectRouter(cur)
+			}
+		}(i%2 == 0)
+	}
+	wg.Wait()
+
+	if cur := network.Router.GetConnected("r1"); cur != nil {
+		require.True(t, cur.Connected.Load(), "map must not hold a disconnected router")
+	}
+}

--- a/controller/network/router_messaging.go
+++ b/controller/network/router_messaging.go
@@ -209,6 +209,13 @@ func (self *RouterMessaging) syncStates() {
 			continue
 		}
 
+		// Sending on a closed channel fails immediately, so keeping these queued retries as fast as the
+		// event loop spins. Reconnecting resyncs everything, so discard them.
+		if ch := notifyRouter.Control; ch == nil || ch.IsClosed() {
+			delete(self.routerUpdates, k)
+			continue
+		}
+
 		if v.sendInProgress.Load() {
 			continue
 		}
@@ -251,15 +258,15 @@ func (self *RouterMessaging) syncStates() {
 
 		currentStatesVersion := updates.version
 		queueErr := self.routerCommPool.QueueOrError(func() {
-			ch := notifyRouter.Control
-			if ch == nil {
-				return
-			}
-
-			success := true
-			if err := protobufs.MarshalTyped(changes).WithTimeout(time.Second * 1).SendAndWaitForWire(ch.GetDefaultSender()); err != nil {
-				pfxlog.Logger().WithError(err).WithField("routerId", notifyRouter.Id).Error("failed to send peer state changes to router")
-				success = false
+			// The done event must be queued on every path, including a missing channel: it is what clears
+			// sendInProgress, and without it this router's updates would never be attempted again.
+			success := false
+			if ch := notifyRouter.Control; ch != nil {
+				if err := protobufs.MarshalTyped(changes).WithTimeout(time.Second * 1).SendAndWaitForWire(ch.GetDefaultSender()); err != nil {
+					pfxlog.Logger().WithError(err).WithField("routerId", notifyRouter.Id).Error("failed to send peer state changes to router")
+				} else {
+					success = true
+				}
 			}
 
 			self.queueEvent(&routerPeerChangesSendDone{

--- a/controller/network/router_messaging.go
+++ b/controller/network/router_messaging.go
@@ -201,6 +201,14 @@ func (self *RouterMessaging) syncStates() {
 			continue
 		}
 
+		// A closed channel can never carry these changes, and sending on one fails immediately rather than
+		// blocking, so keeping them queued would retry as fast as the event loop spins. Reconnecting syncs
+		// everything, so discard what is pending, as for a router that is already gone from the map.
+		if ch := notifyRouter.Control; ch == nil || ch.IsClosed() {
+			delete(self.routerUpdates, k)
+			continue
+		}
+
 		if v.sendInProgress.Load() {
 			continue
 		}
@@ -243,15 +251,15 @@ func (self *RouterMessaging) syncStates() {
 
 		currentStatesVersion := updates.version
 		queueErr := self.routerCommPool.QueueOrError(func() {
-			ch := notifyRouter.Control
-			if ch == nil {
-				return
-			}
-
-			success := true
-			if err := protobufs.MarshalTyped(changes).WithTimeout(time.Second * 1).SendAndWaitForWire(ch.GetDefaultSender()); err != nil {
-				pfxlog.Logger().WithError(err).WithField("routerId", notifyRouter.Id).Error("failed to send peer state changes to router")
-				success = false
+			// The done event must be queued on every path, including a missing channel: it is what clears
+			// sendInProgress, and without it this router's updates would never be attempted again.
+			success := false
+			if ch := notifyRouter.Control; ch != nil {
+				if err := protobufs.MarshalTyped(changes).WithTimeout(time.Second * 1).SendAndWaitForWire(ch.GetDefaultSender()); err != nil {
+					pfxlog.Logger().WithError(err).WithField("routerId", notifyRouter.Id).Error("failed to send peer state changes to router")
+				} else {
+					success = true
+				}
 			}
 
 			self.queueEvent(&routerPeerChangesSendDone{

--- a/controller/network/router_messaging_test.go
+++ b/controller/network/router_messaging_test.go
@@ -1,0 +1,58 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package network
+
+import (
+	"testing"
+
+	"github.com/openziti/ziti/v2/controller/model"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSyncStates_DiscardsUpdatesForClosedChannel covers the retry behaviour for peer state changes bound
+// for a router whose control channel has closed while it is still in the connected map. Sending on a
+// closed channel fails immediately instead of blocking, and a failed send is retried as soon as the event
+// loop turns, so retaining the updates spins the loop and floods the log. Reconnecting resyncs everything,
+// so the pending changes are discarded instead. Updates for a router with a live channel must still be
+// retained.
+func TestSyncStates_DiscardsUpdatesForClosedChannel(t *testing.T) {
+	ctx, network, addr := newConnectTestNetwork(t)
+
+	// A standalone instance, so syncStates can be driven directly; the Network's own RouterMessaging runs
+	// an event loop goroutine that would race these map accesses.
+	rm := NewRouterMessaging(ctx, network.RouterMessaging.routerCommPool)
+
+	deadCh := &fakeCtrlChannel{}
+	dead := model.NewRouterForTest("r1", "", addr, deadCh, 0, false)
+	network.Router.MarkConnected(dead)
+	// The channel closes without any teardown running, so it stays in the connected map.
+	deadCh.closed.Store(true)
+	rm.routerUpdates["r1"] = &routerUpdates{changedRouters: map[string]struct{}{"other": {}}}
+
+	// A live router with a send already in flight, which syncStates skips without queueing another.
+	liveCh := &fakeCtrlChannel{}
+	live := model.NewRouterForTest("r2", "", addr, liveCh, 0, false)
+	network.Router.MarkConnected(live)
+	liveUpdates := &routerUpdates{changedRouters: map[string]struct{}{"other": {}}}
+	liveUpdates.sendInProgress.Store(true)
+	rm.routerUpdates["r2"] = liveUpdates
+
+	rm.syncStates()
+
+	require.NotContains(t, rm.routerUpdates, "r1", "updates for a closed channel must be discarded, not retried")
+	require.Contains(t, rm.routerUpdates, "r2", "updates for a live channel must be retained")
+}

--- a/controller/sync_strats/rtx.go
+++ b/controller/sync_strats/rtx.go
@@ -360,8 +360,18 @@ type routerTxMap struct {
 	internalMap cmap.ConcurrentMap[string, *RouterSender] //id -> RouterSender
 }
 
+// Add installs routerMessageTxer as the sender for id, stopping any sender it replaces. Stopping the
+// replaced sender here (rather than relying on RouterDisconnected) is required because the broker
+// dispatches the old connection's RouterDisconnected asynchronously: on a reconnect/takeover the new
+// connection's RouterConnected can install its sender before that async cleanup runs, which would
+// otherwise orphan the old sender's goroutine.
 func (m *routerTxMap) Add(id string, routerMessageTxer *RouterSender) {
-	m.internalMap.Set(id, routerMessageTxer)
+	m.internalMap.Upsert(id, routerMessageTxer, func(exists bool, old *RouterSender, newValue *RouterSender) *RouterSender {
+		if exists && old != nil && old != newValue {
+			old.Stop()
+		}
+		return newValue
+	})
 }
 
 func (m *routerTxMap) Get(id string) *RouterSender {

--- a/controller/sync_strats/rtx_add_test.go
+++ b/controller/sync_strats/rtx_add_test.go
@@ -1,0 +1,53 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package sync_strats
+
+import (
+	"testing"
+
+	cmap "github.com/orcaman/concurrent-map/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRouterTxMap_AddStopsReplaced verifies routerTxMap.Add stops the RouterSender it replaces. This is
+// required under reject-if-busy: on a reconnect/takeover the new connection's RouterConnected can Add its
+// sender before the old connection's RouterDisconnected runs (the broker dispatches it asynchronously),
+// so without this the replaced sender's goroutine would be orphaned.
+func TestRouterTxMap_AddStopsReplaced(t *testing.T) {
+	m := &routerTxMap{internalMap: cmap.New[*RouterSender]()}
+
+	old := &RouterSender{closeNotify: make(chan struct{})}
+	old.running.Store(true)
+	m.Add("r1", old)
+
+	newRtx := &RouterSender{closeNotify: make(chan struct{})}
+	newRtx.running.Store(true)
+	m.Add("r1", newRtx)
+
+	require.False(t, old.running.Load(), "replaced sender should be stopped")
+	select {
+	case <-old.closeNotify:
+	default:
+		t.Fatal("replaced sender's closeNotify should be closed")
+	}
+	require.True(t, newRtx.running.Load(), "installed sender should still be running")
+	require.Equal(t, newRtx, m.Get("r1"))
+
+	// Re-adding the same instance must not stop it.
+	m.Add("r1", newRtx)
+	require.True(t, newRtx.running.Load(), "re-adding the same sender must not stop it")
+}

--- a/router/accepter.go
+++ b/router/accepter.go
@@ -81,6 +81,10 @@ func (self *ctrlChannelAcceptor) HandleGroupedUnderlay(underlay channel.Underlay
 		return nil, err
 	}
 
+	// Only now is the channel fully bound: AcceptCtrlChannel registered it in the first bind handler, but
+	// a later one can still refuse it.
+	self.router.ctrls.MarkChannelEstablished()
+
 	self.router.NotifyOfReconnect(listenerCtrlChan)
 	return mc, nil
 }

--- a/router/env/ctrl.go
+++ b/router/env/ctrl.go
@@ -20,6 +20,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/foundation/v2/versions"
 	"github.com/openziti/ziti/v2/common/ctrlchan"
 
@@ -47,7 +48,10 @@ func newNetworkCtrl(ch ctrlchan.CtrlChannel, address string, heartbeatOptions *H
 		address:          address,
 		heartbeatOptions: heartbeatOptions,
 	}
-	result.lastContact.Store(time.Now().UnixMilli())
+	// Seed the response time so a channel is not judged unresponsive before its first heartbeat has had a
+	// chance to be answered.
+	result.lastRx = time.Now().UnixMilli()
+	result.lastContact.Store(result.lastRx)
 	return result
 }
 
@@ -149,6 +153,25 @@ func (self *networkCtrl) CheckHeartBeat() {
 	} else {
 		self.unresponsive.Store(false)
 	}
+
+	// Unresponsive alone only deprioritizes. A channel whose underlays are dead but undetected keeps its
+	// group and dials only additional underlays, which the controller refuses once its side is gone, so
+	// nothing re-establishes the group until the OS abandons the connection minutes later.
+	if timeout := self.heartbeatOptions.CloseUnresponsiveTimeout; timeout > 0 && self.timeSinceLastResponse() > timeout {
+		log := pfxlog.Logger().
+			WithField("address", self.address).
+			WithField("timeSinceLastResponse", self.timeSinceLastResponse())
+		log.Error("no heartbeat response from controller in time, closing control channel")
+		if err := self.ch.Close(); err != nil {
+			log.WithError(err).Error("error closing unresponsive control channel")
+		}
+	}
+}
+
+// timeSinceLastResponse reports how long it has been since the controller last answered a heartbeat. It is
+// only read on the heartbeat goroutine, which is also the only writer of lastRx.
+func (self *networkCtrl) timeSinceLastResponse() time.Duration {
+	return time.Duration(time.Now().UnixMilli()-self.lastRx) * time.Millisecond
 }
 
 func (self *networkCtrl) IsConnected() bool {

--- a/router/env/ctrl_heartbeat_test.go
+++ b/router/env/ctrl_heartbeat_test.go
@@ -1,0 +1,97 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package env
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/openziti/ziti/v2/common/ctrlchan"
+	"github.com/stretchr/testify/require"
+)
+
+// heartbeatTestChannel is a ctrlchan.CtrlChannel double that records Close calls. It embeds the interface,
+// so any method the heartbeat path does not use panics rather than silently returning a zero value.
+type heartbeatTestChannel struct {
+	ctrlchan.CtrlChannel
+	closed atomic.Bool
+}
+
+func (self *heartbeatTestChannel) Close() error {
+	self.closed.Store(true)
+	return nil
+}
+
+func (self *heartbeatTestChannel) IsClosed() bool { return self.closed.Load() }
+
+func (self *heartbeatTestChannel) IsConnected() bool { return !self.closed.Load() }
+
+func newHeartbeatTestCtrl(t *testing.T) (*networkCtrl, *heartbeatTestChannel) {
+	t.Helper()
+	ch := &heartbeatTestChannel{}
+	options := NewDefaultHeartbeatOptions()
+	options.CloseUnresponsiveTimeout = time.Minute
+	options.UnresponsiveAfter = 5 * time.Second
+	return newNetworkCtrl(ch, "tls:localhost:6262", options), ch
+}
+
+// TestCheckHeartBeat_ClosesWhenNoResponse covers the recovery path for a control channel whose peer has
+// stopped answering. Until it is closed, the channel keeps its group and only ever dials additional
+// underlays, which the controller refuses once it has torn its side of the group down, so the router can
+// never re-establish it.
+func TestCheckHeartBeat_ClosesWhenNoResponse(t *testing.T) {
+	ctrl, ch := newHeartbeatTestCtrl(t)
+
+	// A fresh channel is not judged unresponsive before its first heartbeat could be answered.
+	ctrl.CheckHeartBeat()
+	require.False(t, ch.IsClosed(), "a channel that has just connected must not be closed")
+
+	// No response for longer than the timeout.
+	ctrl.lastRx = time.Now().Add(-2 * time.Minute).UnixMilli()
+	ctrl.CheckHeartBeat()
+	require.True(t, ch.IsClosed(), "a channel with no heartbeat response in time must be closed")
+}
+
+// TestCheckHeartBeat_SlowButAnsweringIsNotClosed guards the control channel's preference for staying up:
+// high latency only deprioritizes a controller when choosing between them. Closing a channel that is
+// merely slow would add control-plane downtime, so only a peer that has stopped answering entirely is
+// torn down.
+func TestCheckHeartBeat_SlowButAnsweringIsNotClosed(t *testing.T) {
+	ctrl, ch := newHeartbeatTestCtrl(t)
+
+	// Answering, but slowly enough to count as unresponsive for selection purposes.
+	ctrl.lastRx = time.Now().UnixMilli()
+	ctrl.latency.Store(int64(30 * time.Second))
+
+	ctrl.CheckHeartBeat()
+
+	require.True(t, ctrl.IsUnresponsive(), "high latency should mark the controller unresponsive")
+	require.False(t, ch.IsClosed(), "a channel that is still answering must not be closed")
+}
+
+// TestCheckHeartBeat_ZeroTimeoutDisablesClose: a zero timeout turns the teardown off, for deployments that
+// would rather keep a silent channel than have it recycled.
+func TestCheckHeartBeat_ZeroTimeoutDisablesClose(t *testing.T) {
+	ctrl, ch := newHeartbeatTestCtrl(t)
+	ctrl.heartbeatOptions.CloseUnresponsiveTimeout = 0
+
+	ctrl.lastRx = time.Now().Add(-time.Hour).UnixMilli()
+	ctrl.CheckHeartBeat()
+
+	require.False(t, ch.IsClosed(), "a zero close timeout must disable the teardown")
+}

--- a/router/env/ctrls.go
+++ b/router/env/ctrls.go
@@ -72,6 +72,8 @@ type DialEnv interface {
 }
 
 type NetworkControllers interface {
+	MarkChannelEstablished()
+	EverConnected() bool
 	GetControllerDetails() map[string]*ctrl_pb.CtrlDetail
 	UpdateControllerDetails(controllers []*ctrl_pb.CtrlDetail) bool
 	ConnectToInitialEndpoints(endpoints []string)
@@ -120,6 +122,26 @@ type networkControllers struct {
 	leaderId              concurrenz.AtomicValue[string]
 	ctrlChangeListeners   concurrenz.CopyOnWriteSlice[CtrlEventListener]
 	controllerDetails     concurrenz.AtomicValue[map[string]*ctrl_pb.CtrlDetail]
+	// everConnected records that a control channel was established at some point. It is never cleared, so it
+	// answers whether the router has ever reached a controller rather than whether it is reachable now.
+	everConnected atomic.Bool
+}
+
+// MarkChannelEstablished records that a control channel was fully established. It must be called only
+// once the whole bind has succeeded, not when the registration is created: Add runs in the first of
+// several bind handlers, and a later one can still refuse the channel, at which point it is closed and
+// unregistered. Setting this from Add would mean a router that only ever reached a controller it cannot
+// talk to, an older one lacking a required capability for instance, counted as having connected, and so
+// never failed its startup check and never exited.
+func (self *networkControllers) MarkChannelEstablished() {
+	self.everConnected.Store(true)
+}
+
+// EverConnected reports whether this router has established a control channel to any controller since
+// starting. It stays true once set, so unlike the current controller count it is not affected by a router
+// being momentarily between channels.
+func (self *networkControllers) EverConnected() bool {
+	return self.everConnected.Load()
 }
 
 func (self *networkControllers) ControllersHaveMinVersion(version string) bool {
@@ -430,6 +452,8 @@ func (self *networkControllers) connectToController(endpoint string, addr transp
 
 		return fmt.Errorf("error connecting ctrl (%w)", err)
 	}
+
+	self.MarkChannelEstablished()
 
 	// If there are multiple controllers we may have to catch up the controllers that connected later
 	// with things that have already happened because we had state from other controllers, such as

--- a/router/env/ctrls.go
+++ b/router/env/ctrls.go
@@ -176,9 +176,9 @@ func (self *networkControllers) UpdateControllerDetails(controllers []*ctrl_pb.C
 		}
 	}
 
-	// Start dialing new controllers that aren't already dialing or connected
+	// Start dialing new controllers that aren't already dialing or usably connected
 	for ctrlId, detail := range newIdSet {
-		if !self.idsBeingDialed.Has(ctrlId) && self.ctrls.Get(ctrlId) == nil {
+		if !self.idsBeingDialed.Has(ctrlId) && !isUsable(self.ctrls.Get(ctrlId)) {
 			log.WithField("ctrlId", ctrlId).WithField("endpoints", detail.Endpoints).Info("adding new ctrl")
 			changed = true
 			self.connectToControllerWithBackoff(detail)
@@ -236,8 +236,9 @@ func (self *networkControllers) connectToControllerWithBackoff(detail *ctrl_pb.C
 			return backoff.Permanent(errors.New("controller removed before connection established"))
 		}
 
-		// Already connected by ID
-		if self.ctrls.Get(detail.Id) != nil {
+		// Already connected by id. An unusable registration is not a reason to stop: the dial displaces it,
+		// where treating it as connected would end the retries and leave the router holding nothing.
+		if isUsable(self.ctrls.Get(detail.Id)) {
 			log.Info("already connected to controller, exiting retry")
 			return nil
 		}
@@ -245,7 +246,7 @@ func (self *networkControllers) connectToControllerWithBackoff(detail *ctrl_pb.C
 		// Already connected by address
 		for _, ep := range detail.Endpoints {
 			for _, v := range self.ctrls.AsMap() {
-				if v.Address() == ep.Address {
+				if v.Address() == ep.Address && isUsable(v) {
 					log.WithField("endpoint", ep.Address).Info("already connected to controller by address, exiting retry")
 					return nil
 				}
@@ -279,6 +280,11 @@ func (self *networkControllers) connectToControllerWithBackoff(detail *ctrl_pb.C
 
 		err = self.connectToController(ep.Address, addr)
 		if err != nil {
+			if ctrlId, ok := self.duplicateResolved(err); ok {
+				log.WithField("endpoint", ep.Address).WithField("ctrlId", ctrlId).
+					Info("endpoint reached an already connected controller, exiting retry")
+				return nil
+			}
 			log.WithField("endpoint", ep.Address).WithError(err).Error("unable to connect controller")
 		}
 		return err
@@ -386,21 +392,13 @@ func (self *networkControllers) connectToController(endpoint string, addr transp
 		// it alone would leave Channel() nil during that notification.
 		dialCtrlChan.InitChannel(binding.GetChannel())
 
-		if err = self.Add(endpoint, dialCtrlChan, binding.GetChannel(), underlay); err != nil {
+		ctrl, err := self.Add(endpoint, dialCtrlChan, binding.GetChannel(), underlay)
+		if err != nil {
 			return err
 		}
 
-		binding.AddCloseHandler(channel.CloseHandlerF(func(ch channel.Channel) {
-			ctrl := self.GetNetworkController(id)
-			self.ctrls.Delete(id)
-			if ctrl != nil {
-				self.notifyOfChange(ctrl, ControllerDisconnected)
-			}
-			if detail := self.getControllerDetail(id); detail != nil {
-				time.AfterFunc(time.Second, func() {
-					self.connectToControllerWithBackoff(detail)
-				})
-			}
+		binding.AddCloseHandler(channel.CloseHandlerF(func(channel.Channel) {
+			self.handleChannelClose(id, ctrl, time.Second)
 		}))
 
 		return nil
@@ -449,36 +447,132 @@ func (self *networkControllers) handleRouterDataModelIndexUpdate(m *channel.Mess
 	}
 }
 
-func (self *networkControllers) Add(address string, ctrlCh ctrlchan.CtrlChannel, ch channel.Channel, underlay channel.Underlay) error {
+// Add registers a newly established control channel and returns the entry created for it. The returned
+// entry is the identity a close handler must present to give the registration up again, so callers that
+// wire a close handler have to hold on to it.
+func (self *networkControllers) Add(address string, ctrlCh ctrlchan.CtrlChannel, ch channel.Channel, underlay channel.Underlay) (NetworkController, error) {
 	ctrl := newNetworkCtrl(ctrlCh, address, self.heartbeatOptions)
 
 	if versionValue, found := underlay.Headers()[channel.HelloVersionHeader]; found {
 		if versionInfo, err := versions.StdVersionEncDec.Decode(versionValue); err == nil {
 			ctrl.versionInfo = versionInfo
 		} else {
-			return fmt.Errorf("could not parse version info from controller hello, closing connection (%w)", err)
+			return nil, fmt.Errorf("could not parse version info from controller hello, closing connection (%w)", err)
 		}
 	} else {
-		return errors.New("no version header provided")
+		return nil, errors.New("no version header provided")
 	}
 
-	if existing := self.ctrls.Get(ch.Id()); existing != nil {
-		if !existing.Channel().IsClosed() && existing.IsConnected() {
-			// if an existing channel exists and is connected, reject the duplicate
-			return backoff.Permanent(fmt.Errorf("duplicate channel with id %v", ctrl.Channel().Id()))
-		}
-		// existing channel is closed or disconnected (0 underlays) — close it and accept new one
-		if !existing.Channel().IsClosed() {
-			if closeErr := existing.Channel().Close(); closeErr != nil {
-				pfxlog.Logger().WithError(closeErr).WithField("ch", existing.Channel().Label()).Error("error closing control channel")
-			}
+	log := pfxlog.Logger().
+		WithField("ctrlId", ch.Id()).
+		WithField("ch", ch.Label()).
+		WithField("address", address)
+
+	// Atomic against a concurrent Add for the same controller and against UpdateControllerDetails, which
+	// decides whether to dial from the same state. Two dials do race: initial endpoint dials carry no
+	// controller id, so idsBeingDialed cannot keep them apart.
+	self.lock.Lock()
+
+	existing := self.ctrls.Get(ch.Id())
+	if isUsable(existing) {
+		self.lock.Unlock()
+		return nil, &errDuplicateChannel{ctrlId: ch.Id()}
+	}
+
+	// Hand the registration over before closing what it displaced, so the displaced close handler finds
+	// itself superseded rather than observing an empty registration and racing this dial with a redial.
+	self.ctrls.Put(ch.Id(), ctrl)
+
+	self.lock.Unlock()
+
+	log.Info("controller registered")
+
+	// Closing a channel runs its close handlers on this goroutine, so it must happen outside the lock.
+	if existing != nil && !existing.Channel().IsClosed() {
+		if closeErr := existing.Channel().Close(); closeErr != nil {
+			log.WithError(closeErr).WithField("displacedCh", existing.Channel().Label()).
+				Error("error closing displaced control channel")
 		}
 	}
-	self.ctrls.Put(ch.Id(), ctrl)
 
 	self.notifyOfChange(ctrl, ControllerAdded)
 
-	return nil
+	return ctrl, nil
+}
+
+// errDuplicateChannel reports that a control channel was refused because the controller it reached is
+// already usably connected. It carries the controller's id because a dial started from a bare endpoint has
+// none of its own, so this is the only way the retry loop can learn which controller the endpoint resolved
+// to and stop dialing it.
+type errDuplicateChannel struct {
+	ctrlId string
+}
+
+func (self *errDuplicateChannel) Error() string {
+	return fmt.Sprintf("controller %v is already connected on another channel", self.ctrlId)
+}
+
+// duplicateResolved reports the controller id when err is a refusal by a controller whose registration is
+// still usable, meaning another channel already did what this dial set out to do. A dial that only reaches
+// an endpoint learns the controller's id here and nowhere else, which is why the refusal has to carry it.
+// The registration is rechecked because the channel that won the race may since have died, leaving the
+// dial's work to do after all.
+func (self *networkControllers) duplicateResolved(err error) (string, bool) {
+	var duplicate *errDuplicateChannel
+	if errors.As(err, &duplicate) && isUsable(self.ctrls.Get(duplicate.ctrlId)) {
+		return duplicate.ctrlId, true
+	}
+	return "", false
+}
+
+// isUsable reports whether a controller registration can still carry traffic. A registration whose channel
+// has been closed, or which has lost every underlay, satisfies a presence check while carrying nothing.
+// Every decision about whether the router is connected to a controller has to ask this rather than whether
+// a registration exists, or an entry left behind by a channel that died leaves the router believing it is
+// connected and suppresses the reconnect that would fix it.
+func isUsable(ctrl NetworkController) bool {
+	return ctrl != nil && !ctrl.CtrlChannel().IsClosed() && ctrl.IsConnected()
+}
+
+// removeIfCurrent gives up ctrl's registration for ctrlId, and reports whether it was still the
+// registered entry. Overlapping channels to one controller share its id, so removing by id alone lets a
+// superseded channel's close delete its replacement's registration. Nothing re-registers a channel that
+// is already established, so the surviving channel would stay unreachable through the map and the router
+// would be invisible to that controller until the channel happened to close.
+func (self *networkControllers) removeIfCurrent(ctrlId string, ctrl NetworkController) bool {
+	return self.ctrls.DeleteIf(func(key string, val NetworkController) bool {
+		return key == ctrlId && val == ctrl
+	})
+}
+
+// handleChannelClose releases ctrl's registration and starts reconnecting to the controller. It is a
+// no-op when ctrl is no longer the registered entry, either because a newer channel has taken over or
+// because the controller was removed from the cluster. Reconnects are delayed by redialDelay, which
+// paces a dial the controller rejects outright.
+func (self *networkControllers) handleChannelClose(ctrlId string, ctrl NetworkController, redialDelay time.Duration) {
+	log := pfxlog.Logger().WithField("ctrlId", ctrlId).WithField("ch", ctrl.Channel().Label())
+
+	if !self.removeIfCurrent(ctrlId, ctrl) {
+		log.Info("superseded control channel closed, leaving the current registration in place")
+		return
+	}
+
+	log.Info("control channel closed, controller unregistered")
+	self.notifyOfChange(ctrl, ControllerDisconnected)
+
+	detail := self.getControllerDetail(ctrlId)
+	if detail == nil {
+		log.Info("controller is no longer known, not reconnecting")
+		return
+	}
+
+	if redialDelay > 0 {
+		time.AfterFunc(redialDelay, func() {
+			self.connectToControllerWithBackoff(detail)
+		})
+	} else {
+		self.connectToControllerWithBackoff(detail)
+	}
 }
 
 func (self *networkControllers) AcceptCtrlChannel(address string, ctrlCh ctrlchan.CtrlChannel, binding channel.Binding, underlay channel.Underlay) error {
@@ -488,19 +582,13 @@ func (self *networkControllers) AcceptCtrlChannel(address string, ctrlCh ctrlcha
 	// Record the channel before Add() fires ControllerAdded listeners (see the dial path).
 	ctrlCh.InitChannel(binding.GetChannel())
 
-	if err := self.Add(address, ctrlCh, binding.GetChannel(), underlay); err != nil {
+	ctrl, err := self.Add(address, ctrlCh, binding.GetChannel(), underlay)
+	if err != nil {
 		return err
 	}
 
-	binding.AddCloseHandler(channel.CloseHandlerF(func(ch channel.Channel) {
-		ctrl := self.GetNetworkController(id)
-		self.ctrls.Delete(id)
-		if ctrl != nil {
-			self.notifyOfChange(ctrl, ControllerDisconnected)
-		}
-		if detail := self.getControllerDetail(id); detail != nil {
-			self.connectToControllerWithBackoff(detail)
-		}
+	binding.AddCloseHandler(channel.CloseHandlerF(func(channel.Channel) {
+		self.handleChannelClose(id, ctrl, 0)
 	}))
 
 	return nil

--- a/router/env/ctrls.go
+++ b/router/env/ctrls.go
@@ -381,19 +381,14 @@ func (self *networkControllers) connectToController(endpoint string, addr transp
 
 	// Track connectivity transitions for reconnect/disconnect notifications
 	var wasDisconnected atomic.Bool
-	changeCallback := func(ch *ctrlchan.DialCtrlChannel, oldCount, newCount uint32) {
+	changeCallback := func(ch *ctrlchan.DialCtrlChannel, _, newCount uint32) {
 		multiCh := ch.GetChannel()
 		if multiCh == nil || multiCh.IsClosed() {
 			return
 		}
-		if wasDisconnected.Load() && newCount > 0 {
+		self.notifyOfConnectivityChange(ch.PeerId(), &wasDisconnected, newCount, func() {
 			self.dialEnv.NotifyOfReconnect(ch)
-			wasDisconnected.Store(false)
-		} else if newCount == 0 {
-			if wasDisconnected.CompareAndSwap(false, true) {
-				self.NotifyOfDisconnect(ch.PeerId())
-			}
-		}
+		})
 	}
 
 	dialCtrlChan := ctrlchan.NewDialCtrlChannel(ctrlchan.DialCtrlChannelConfig{
@@ -616,6 +611,29 @@ func (self *networkControllers) AcceptCtrlChannel(address string, ctrlCh ctrlcha
 	}))
 
 	return nil
+}
+
+// notifyOfConnectivityChange reports a control channel losing and regaining its last
+// underlay. A grouped channel survives losing every underlay, so the registration stays
+// and neither Add nor the close handler runs: these notifications are the only thing that
+// tells anything the channel went away and came back.
+//
+// Both halves of the reconnect matter and are easy to confuse. notifyReconnect re-offers
+// the state a controller may have missed while the channel was down, while the
+// ControllerReconnected ctrl event is what listeners keyed on connectivity wait for.
+// Sending only the first leaves those listeners believing the controller is still gone.
+//
+// wasDisconnected belongs to the one channel and is swapped rather than stored, so each
+// edge is reported exactly once however many underlays come or go at the same moment.
+func (self *networkControllers) notifyOfConnectivityChange(ctrlId string, wasDisconnected *atomic.Bool, newCount uint32, notifyReconnect func()) {
+	if newCount > 0 {
+		if wasDisconnected.CompareAndSwap(true, false) {
+			notifyReconnect()
+			self.NotifyOfReconnect(ctrlId)
+		}
+	} else if wasDisconnected.CompareAndSwap(false, true) {
+		self.NotifyOfDisconnect(ctrlId)
+	}
 }
 
 func (self *networkControllers) NotifyOfDisconnect(ctrlId string) {

--- a/router/env/ctrls_mock.go
+++ b/router/env/ctrls_mock.go
@@ -50,6 +50,9 @@ func (m *MockNetworkControllers) UpdateControllerDetails(controllers []*ctrl_pb.
 	return false
 }
 
+func (m *MockNetworkControllers) MarkChannelEstablished() {}
+func (m *MockNetworkControllers) EverConnected() bool     { return true }
+
 func (m *MockNetworkControllers) ConnectToInitialEndpoints(endpoints []string) {
 }
 

--- a/router/env/ctrls_test.go
+++ b/router/env/ctrls_test.go
@@ -413,3 +413,49 @@ func TestAdd_ConcurrentForOneControllerRegistersOne(t *testing.T) {
 		require.Same(t, winner, nc.ctrls.Get("ctrl1"), "the registration must belong to the dial that took it")
 	}
 }
+
+// TestEverConnected_NotSetByRegistrationAlone guards the difference between registering a control channel
+// and having established one. Add runs in the first of several bind handlers, and a later one can still
+// refuse the channel, after which it is closed and unregistered. If registering were enough to count, a
+// router that only ever reached a controller it cannot talk to, an older one lacking a required capability
+// for instance, would pass its startup check and retry forever instead of exiting.
+func TestEverConnected_NotSetByRegistrationAlone(t *testing.T) {
+	nc := newTestNetworkControllers()
+	underlay := newTestUnderlay(t)
+
+	require.False(t, nc.EverConnected(), "a router that has not connected yet must report so")
+
+	ch := &ctrlsTestChannel{id: "ctrl1", label: "first"}
+	ctrl, err := nc.Add("tls:ctrl1:6262", &ctrlsTestCtrlChannel{ch: ch}, ch, underlay)
+	require.NoError(t, err)
+	require.False(t, nc.EverConnected(),
+		"a registration is not an established channel; the bind can still be refused after Add returns")
+
+	// Losing it without the bind ever completing must leave the router still having never connected, so
+	// the startup check can do its job.
+	nc.handleChannelClose("ctrl1", ctrl, 0)
+	require.False(t, nc.EverConnected(), "a channel that was never established must not count as one")
+}
+
+// TestEverConnected_StaysTrueAcrossLosingEveryController is the distinction the startup check depends on.
+// The check fires once, so asking whether a controller is reachable at that instant kills a router that
+// happens to be between control channels, which is routine rather than a failure to start. Asking whether
+// one was ever reached answers the question the check is actually for.
+func TestEverConnected_StaysTrueAcrossLosingEveryController(t *testing.T) {
+	nc := newTestNetworkControllers()
+	underlay := newTestUnderlay(t)
+
+	ch := &ctrlsTestChannel{id: "ctrl1", label: "first"}
+	ctrl, err := nc.Add("tls:ctrl1:6262", &ctrlsTestCtrlChannel{ch: ch}, ch, underlay)
+	require.NoError(t, err)
+
+	// What the dial and accept paths call once the whole bind has succeeded.
+	nc.MarkChannelEstablished()
+	require.True(t, nc.EverConnected())
+
+	// Lose it, leaving no controllers at all, which is what the instant-count check used to trip on.
+	nc.handleChannelClose("ctrl1", ctrl, 0)
+	require.Empty(t, nc.GetAll(), "no controllers should remain")
+	require.True(t, nc.EverConnected(),
+		"having reached a controller once must not be forgotten when the connection is lost")
+}

--- a/router/env/ctrls_test.go
+++ b/router/env/ctrls_test.go
@@ -459,3 +459,88 @@ func TestEverConnected_StaysTrueAcrossLosingEveryController(t *testing.T) {
 	require.True(t, nc.EverConnected(),
 		"having reached a controller once must not be forgotten when the connection is lost")
 }
+
+// TestNotifyOfConnectivityChange_ReconnectReportsBothHalves guards the reconnect half of a
+// grouped control channel losing every underlay and getting one back. The registration
+// survives that, so nothing else reports it: a reconnect that re-offers state without
+// emitting ControllerReconnected leaves every listener keyed on connectivity believing the
+// controller is still gone.
+func TestNotifyOfConnectivityChange_ReconnectReportsBothHalves(t *testing.T) {
+	nc := newTestNetworkControllers()
+	drain := collectCtrlEvents(nc)
+
+	ctrl, _ := newTestNetworkCtrl(nc, "ctrl1", "current")
+	nc.ctrls.Put("ctrl1", ctrl)
+
+	var wasDisconnected atomic.Bool
+	var reconnectNotifications int
+	notifyReconnect := func() { reconnectNotifications++ }
+
+	// Last underlay lost, then one back.
+	nc.notifyOfConnectivityChange("ctrl1", &wasDisconnected, 0, notifyReconnect)
+	nc.notifyOfConnectivityChange("ctrl1", &wasDisconnected, 1, notifyReconnect)
+
+	var events []CtrlEvent
+	require.Eventually(t, func() bool {
+		events = append(events, drain()...)
+		return len(events) >= 2
+	}, time.Second, 10*time.Millisecond, "expected a disconnect and a reconnect event, got %v", events)
+
+	require.Len(t, events, 2)
+	require.Equal(t, ControllerDisconnected, events[0].Type)
+	require.Equal(t, ControllerReconnected, events[1].Type,
+		"regaining an underlay must report the controller as reconnected")
+	require.Same(t, ctrl, events[1].Controller)
+	require.Equal(t, 1, reconnectNotifications, "the reconnect must also re-offer state to the controller")
+}
+
+// TestNotifyOfConnectivityChange_ReportsEachEdgeOnce covers underlays coming and going
+// without connectivity changing. Only the edges are transitions; every other change is
+// noise that listeners must not see as a reconnect.
+func TestNotifyOfConnectivityChange_ReportsEachEdgeOnce(t *testing.T) {
+	nc := newTestNetworkControllers()
+	drain := collectCtrlEvents(nc)
+
+	ctrl, _ := newTestNetworkCtrl(nc, "ctrl1", "current")
+	nc.ctrls.Put("ctrl1", ctrl)
+
+	var wasDisconnected atomic.Bool
+	var reconnectNotifications int
+	notifyReconnect := func() { reconnectNotifications++ }
+
+	// A second underlay arriving and leaving while one remains is not a transition.
+	nc.notifyOfConnectivityChange("ctrl1", &wasDisconnected, 2, notifyReconnect)
+	nc.notifyOfConnectivityChange("ctrl1", &wasDisconnected, 1, notifyReconnect)
+
+	require.Never(t, func() bool { return len(drain()) > 0 }, 100*time.Millisecond, 10*time.Millisecond,
+		"underlay churn that never cost connectivity must not be reported")
+	require.Zero(t, reconnectNotifications)
+
+	// Two reports of the count reaching zero are one disconnect.
+	nc.notifyOfConnectivityChange("ctrl1", &wasDisconnected, 0, notifyReconnect)
+	nc.notifyOfConnectivityChange("ctrl1", &wasDisconnected, 0, notifyReconnect)
+
+	var events []CtrlEvent
+	require.Eventually(t, func() bool {
+		events = append(events, drain()...)
+		return len(events) >= 1
+	}, time.Second, 10*time.Millisecond, "expected a disconnect event")
+
+	// Same for the count coming back.
+	nc.notifyOfConnectivityChange("ctrl1", &wasDisconnected, 1, notifyReconnect)
+	nc.notifyOfConnectivityChange("ctrl1", &wasDisconnected, 2, notifyReconnect)
+
+	require.Eventually(t, func() bool {
+		events = append(events, drain()...)
+		return len(events) >= 2
+	}, time.Second, 10*time.Millisecond, "expected a reconnect event")
+
+	require.Never(t, func() bool {
+		events = append(events, drain()...)
+		return len(events) > 2
+	}, 100*time.Millisecond, 10*time.Millisecond, "each edge must be reported once, got %v", events)
+
+	require.Equal(t, ControllerDisconnected, events[0].Type)
+	require.Equal(t, ControllerReconnected, events[1].Type)
+	require.Equal(t, 1, reconnectNotifications)
+}

--- a/router/env/ctrls_test.go
+++ b/router/env/ctrls_test.go
@@ -17,7 +17,19 @@
 package env
 
 import (
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+
+	"github.com/openziti/foundation/v2/versions"
+	"github.com/openziti/ziti/v2/common/pb/ctrl_pb"
+
+	cmap "github.com/orcaman/concurrent-map/v2"
 
 	"github.com/openziti/channel/v5"
 	"github.com/openziti/ziti/v2/common/ctrlchan"
@@ -48,4 +60,356 @@ func Test_firstUnderlayHeaders(t *testing.T) {
 	delete(other, channel.IsFirstGroupConnection)
 	_, stillSet := first[channel.IsFirstGroupConnection]
 	req.True(stillSet, "each call must return an independent header map")
+}
+
+// ctrlsTestChannel is a channel.Channel double reporting a fixed id and label. It embeds the interface, so
+// any method these tests do not exercise panics rather than silently returning a zero value.
+type ctrlsTestChannel struct {
+	channel.Channel
+	id     string
+	label  string
+	closed atomic.Bool
+	// underlaysLost models a channel that has lost every underlay without having been closed, which is the
+	// state Add treats as displaceable.
+	underlaysLost atomic.Bool
+}
+
+func (self *ctrlsTestChannel) Id() string     { return self.id }
+func (self *ctrlsTestChannel) Label() string  { return self.label }
+func (self *ctrlsTestChannel) IsClosed() bool { return self.closed.Load() }
+func (self *ctrlsTestChannel) Close() error   { self.closed.Store(true); return nil }
+func (self *ctrlsTestChannel) IsConnected() bool {
+	return !self.closed.Load() && !self.underlaysLost.Load()
+}
+
+// ctrlsTestCtrlChannel is a ctrlchan.CtrlChannel double wrapping a ctrlsTestChannel.
+type ctrlsTestCtrlChannel struct {
+	ctrlchan.CtrlChannel
+	ch *ctrlsTestChannel
+}
+
+func (self *ctrlsTestCtrlChannel) GetChannel() channel.Channel { return self.ch }
+func (self *ctrlsTestCtrlChannel) IsClosed() bool              { return self.ch.IsClosed() }
+func (self *ctrlsTestCtrlChannel) IsConnected() bool           { return self.ch.IsConnected() }
+func (self *ctrlsTestCtrlChannel) Close() error                { return self.ch.Close() }
+
+// ctrlsTestUnderlay is a channel.Underlay double supplying only the hello headers Add reads.
+type ctrlsTestUnderlay struct {
+	channel.Underlay
+	headers channel.Headers
+}
+
+func (self *ctrlsTestUnderlay) Headers() map[int32][]byte { return self.headers }
+
+// newTestUnderlay supplies the version header Add requires of a controller hello.
+func newTestUnderlay(t *testing.T) channel.Underlay {
+	t.Helper()
+	encoded, err := versions.StdVersionEncDec.Encode(&versions.VersionInfo{Version: "v1.0.0"})
+	require.NoError(t, err)
+	return &ctrlsTestUnderlay{headers: channel.Headers{channel.HelloVersionHeader: encoded}}
+}
+
+// newTestNetworkControllers builds a networkControllers with no DialEnv. Tests using it must not reach a
+// path that dials, which for these tests means leaving controllerDetails empty so no reconnect is started.
+func newTestNetworkControllers() *networkControllers {
+	return &networkControllers{
+		heartbeatOptions: NewDefaultHeartbeatOptions(),
+		idsBeingDialed:   cmap.New[struct{}](),
+	}
+}
+
+// newTestNetworkCtrl returns a registration and the test channel backing it, so tests can drive the
+// channel into the states the usability check distinguishes.
+func newTestNetworkCtrl(nc *networkControllers, ctrlId string, label string) (*networkCtrl, *ctrlsTestChannel) {
+	ch := &ctrlsTestChannel{id: ctrlId, label: label}
+	return newNetworkCtrl(&ctrlsTestCtrlChannel{ch: ch}, "tls:"+ctrlId+":6262", nc.heartbeatOptions), ch
+}
+
+// collectCtrlEvents registers a listener and returns a function draining the events seen so far. Listeners
+// are notified on their own goroutine, so the buffer carries them back to the test.
+func collectCtrlEvents(nc *networkControllers) func() []CtrlEvent {
+	received := make(chan CtrlEvent, 16)
+	nc.AddChangeListener(CtrlEventListenerFunc(func(event CtrlEvent) {
+		received <- event
+	}))
+
+	return func() []CtrlEvent {
+		var result []CtrlEvent
+		for {
+			select {
+			case e := <-received:
+				result = append(result, e)
+			default:
+				return result
+			}
+		}
+	}
+}
+
+// TestHandleChannelClose_SupersededLeavesCurrentRegistered guards against a router going permanently
+// invisible to a controller. Overlapping channels to one controller share its id, so a close that gives up
+// the registration by id alone can delete the live channel's entry. Nothing re-registers an already
+// established channel, and the reconnect path treats a present entry as connected, so the router would
+// neither notice nor redial.
+func TestHandleChannelClose_SupersededLeavesCurrentRegistered(t *testing.T) {
+	nc := newTestNetworkControllers()
+	drain := collectCtrlEvents(nc)
+
+	superseded, _ := newTestNetworkCtrl(nc, "ctrl1", "old")
+	current, _ := newTestNetworkCtrl(nc, "ctrl1", "current")
+
+	nc.ctrls.Put("ctrl1", current)
+
+	// The superseded channel's close lands after its replacement has registered.
+	nc.handleChannelClose("ctrl1", superseded, 0)
+
+	require.Same(t, current, nc.ctrls.Get("ctrl1"),
+		"a superseded channel's close must not unregister the channel that replaced it")
+
+	require.Never(t, func() bool {
+		return len(drain()) > 0
+	}, 100*time.Millisecond, 10*time.Millisecond,
+		"a superseded channel's close must not report the current channel as disconnected")
+}
+
+// TestHandleChannelClose_CurrentUnregisters covers the ordinary case: the registered channel closing gives
+// up its registration and reports the disconnect.
+func TestHandleChannelClose_CurrentUnregisters(t *testing.T) {
+	nc := newTestNetworkControllers()
+	drain := collectCtrlEvents(nc)
+
+	current, _ := newTestNetworkCtrl(nc, "ctrl1", "current")
+	nc.ctrls.Put("ctrl1", current)
+
+	nc.handleChannelClose("ctrl1", current, 0)
+
+	require.Nil(t, nc.ctrls.Get("ctrl1"), "the registered channel closing must unregister the controller")
+
+	var events []CtrlEvent
+	require.Eventually(t, func() bool {
+		events = append(events, drain()...)
+		return len(events) > 0
+	}, time.Second, 10*time.Millisecond, "expected a controller change event")
+
+	require.Len(t, events, 1)
+	require.Equal(t, ControllerDisconnected, events[0].Type)
+	require.Same(t, current, events[0].Controller)
+}
+
+// TestHandleChannelClose_AlreadyUnregistered: closeAndRemoveById drops the entry before closing the
+// channel, so the close handler that follows must not report a second disconnect.
+func TestHandleChannelClose_AlreadyUnregistered(t *testing.T) {
+	nc := newTestNetworkControllers()
+	drain := collectCtrlEvents(nc)
+
+	current, _ := newTestNetworkCtrl(nc, "ctrl1", "current")
+
+	nc.handleChannelClose("ctrl1", current, 0)
+
+	require.Never(t, func() bool {
+		return len(drain()) > 0
+	}, 100*time.Millisecond, 10*time.Millisecond,
+		"closing a channel that is already unregistered must not report a disconnect")
+}
+
+// TestRemoveIfCurrent_LeavesOtherControllers guards the key comparison: giving up one controller's
+// registration must not touch another's.
+func TestRemoveIfCurrent_LeavesOtherControllers(t *testing.T) {
+	nc := newTestNetworkControllers()
+
+	ctrl1, _ := newTestNetworkCtrl(nc, "ctrl1", "ctrl1")
+	ctrl2, _ := newTestNetworkCtrl(nc, "ctrl2", "ctrl2")
+	nc.ctrls.Put("ctrl1", ctrl1)
+	nc.ctrls.Put("ctrl2", ctrl2)
+
+	require.True(t, nc.removeIfCurrent("ctrl1", ctrl1))
+
+	require.Nil(t, nc.ctrls.Get("ctrl1"))
+	require.Same(t, ctrl2, nc.ctrls.Get("ctrl2"))
+
+	require.False(t, nc.removeIfCurrent("ctrl1", ctrl1), "removing an absent registration must report no match")
+}
+
+// TestIsUsable covers what counts as being connected to a controller. A registration is not evidence of
+// connectivity on its own: the channel behind it may have been closed, or may have lost every underlay
+// without closing, which is the state a control channel is left in when its group dies but nothing detects
+// it.
+func TestIsUsable(t *testing.T) {
+	nc := newTestNetworkControllers()
+
+	require.False(t, isUsable(nil), "an absent registration is not usable")
+
+	healthy, _ := newTestNetworkCtrl(nc, "ctrl1", "healthy")
+	require.True(t, isUsable(healthy))
+
+	closed, closedCh := newTestNetworkCtrl(nc, "ctrl2", "closed")
+	closedCh.closed.Store(true)
+	require.False(t, isUsable(closed), "a registration whose channel is closed is not usable")
+
+	underlayless, underlaylessCh := newTestNetworkCtrl(nc, "ctrl3", "no-underlays")
+	underlaylessCh.underlaysLost.Store(true)
+	require.False(t, isUsable(underlayless), "a registration with no underlays left is not usable")
+}
+
+// TestUpdateControllerDetails_ReconnectsWhenRegistrationUnusable: a registration left behind by a channel
+// that died must not suppress the reconnect. Treating presence as connectivity is what leaves a router
+// permanently invisible to a controller, since nothing else in this path would notice.
+func TestUpdateControllerDetails_ReconnectsWhenRegistrationUnusable(t *testing.T) {
+	nc := newTestNetworkControllers()
+
+	stale, staleCh := newTestNetworkCtrl(nc, "ctrl1", "stale")
+	staleCh.underlaysLost.Store(true)
+	nc.ctrls.Put("ctrl1", stale)
+
+	// The detail carries no endpoints, so the reconnect gives up before reaching the network.
+	require.True(t, nc.UpdateControllerDetails([]*ctrl_pb.CtrlDetail{{Id: "ctrl1"}}),
+		"an unusable registration must not suppress the reconnect")
+}
+
+// TestUpdateControllerDetails_LeavesUsableRegistrationAlone is the other half: a working channel must not
+// be redialed on every controller detail update.
+func TestUpdateControllerDetails_LeavesUsableRegistrationAlone(t *testing.T) {
+	nc := newTestNetworkControllers()
+
+	current, _ := newTestNetworkCtrl(nc, "ctrl1", "current")
+	nc.ctrls.Put("ctrl1", current)
+
+	require.False(t, nc.UpdateControllerDetails([]*ctrl_pb.CtrlDetail{{Id: "ctrl1"}}),
+		"a usable registration must not be redialed")
+	require.Same(t, current, nc.ctrls.Get("ctrl1"))
+}
+
+// TestAdd_RejectsDuplicateOfUsableChannel: one usable channel per controller. The duplicate is refused and
+// the established channel is left alone.
+func TestAdd_RejectsDuplicateOfUsableChannel(t *testing.T) {
+	nc := newTestNetworkControllers()
+	underlay := newTestUnderlay(t)
+
+	established := &ctrlsTestChannel{id: "ctrl1", label: "established"}
+	first, err := nc.Add("tls:ctrl1:6262", &ctrlsTestCtrlChannel{ch: established}, established, underlay)
+	require.NoError(t, err)
+
+	duplicate := &ctrlsTestChannel{id: "ctrl1", label: "duplicate"}
+	second, err := nc.Add("tls:ctrl1:6262", &ctrlsTestCtrlChannel{ch: duplicate}, duplicate, underlay)
+	require.Error(t, err)
+	require.Nil(t, second)
+
+	require.Same(t, first, nc.ctrls.Get("ctrl1"), "the established channel must keep its registration")
+	require.False(t, established.IsClosed(), "the established channel must not be closed to admit a duplicate")
+}
+
+// TestAdd_DuplicateErrorIsRetryable: losing a dial race is an ordinary race, not a permanent condition. A
+// permanent refusal ends the retry loop for that controller for the life of the process, so if the winner
+// later turns out to be unusable there is nothing left to redial.
+func TestAdd_DuplicateErrorIsRetryable(t *testing.T) {
+	nc := newTestNetworkControllers()
+	underlay := newTestUnderlay(t)
+
+	established := &ctrlsTestChannel{id: "ctrl1", label: "established"}
+	_, err := nc.Add("tls:ctrl1:6262", &ctrlsTestCtrlChannel{ch: established}, established, underlay)
+	require.NoError(t, err)
+
+	duplicate := &ctrlsTestChannel{id: "ctrl1", label: "duplicate"}
+	_, err = nc.Add("tls:ctrl1:6262", &ctrlsTestCtrlChannel{ch: duplicate}, duplicate, underlay)
+	require.Error(t, err)
+
+	var permanent *backoff.PermanentError
+	require.False(t, errors.As(err, &permanent), "a lost dial race must not stop the retry loop")
+
+	var dup *errDuplicateChannel
+	require.True(t, errors.As(err, &dup), "the refusal must identify itself as a duplicate")
+	require.Equal(t, "ctrl1", dup.ctrlId,
+		"the refusal must carry the controller id, which a dial started from a bare endpoint has no other way to learn")
+}
+
+// TestDuplicateResolved covers how the retry loop reacts to losing a race. The id checks at the top of a
+// retry cannot help a dial started from a bare endpoint, since it has no controller id to check with, so
+// the refusal itself is what ends the retries.
+func TestDuplicateResolved(t *testing.T) {
+	nc := newTestNetworkControllers()
+
+	winner, winnerCh := newTestNetworkCtrl(nc, "ctrl1", "winner")
+	nc.ctrls.Put("ctrl1", winner)
+
+	// Wrapped the way connectToController wraps a dial failure.
+	refusal := fmt.Errorf("error connecting ctrl (%w)", &errDuplicateChannel{ctrlId: "ctrl1"})
+
+	ctrlId, ok := nc.duplicateResolved(refusal)
+	require.True(t, ok, "a refusal by a usably connected controller leaves this dial nothing to do")
+	require.Equal(t, "ctrl1", ctrlId)
+
+	// The channel that won the race then dies, so the work is this dial's after all.
+	winnerCh.closed.Store(true)
+	_, ok = nc.duplicateResolved(refusal)
+	require.False(t, ok, "a refusal by a controller that is no longer usable must not end the retries")
+
+	_, ok = nc.duplicateResolved(errors.New("connection refused"))
+	require.False(t, ok, "an unrelated failure must not be read as a lost race")
+}
+
+// TestAdd_DisplacesUnusableChannel: a registration whose channel has no underlays left is not a reason to
+// refuse a new one. The new channel takes the registration over and the old one is closed.
+func TestAdd_DisplacesUnusableChannel(t *testing.T) {
+	nc := newTestNetworkControllers()
+	underlay := newTestUnderlay(t)
+
+	stale := &ctrlsTestChannel{id: "ctrl1", label: "stale"}
+	staleCtrl, err := nc.Add("tls:ctrl1:6262", &ctrlsTestCtrlChannel{ch: stale}, stale, underlay)
+	require.NoError(t, err)
+
+	// Simulate the channel losing its underlays without having been closed.
+	stale.underlaysLost.Store(true)
+
+	replacement := &ctrlsTestChannel{id: "ctrl1", label: "replacement"}
+	replacementCtrl, err := nc.Add("tls:ctrl1:6262", &ctrlsTestCtrlChannel{ch: replacement}, replacement, underlay)
+	require.NoError(t, err)
+	require.NotSame(t, staleCtrl, replacementCtrl)
+
+	require.Same(t, replacementCtrl, nc.ctrls.Get("ctrl1"), "the new channel must hold the registration")
+	require.True(t, stale.IsClosed(), "the displaced channel must be closed")
+}
+
+// TestAdd_ConcurrentForOneControllerRegistersOne is the check-then-put race. Initial endpoint dials carry
+// no controller id, so idsBeingDialed cannot keep two dials to one controller apart; without the
+// registration decision being atomic, both see no entry, both register, and whichever loses is left with a
+// live channel that nothing tracks or reconnects.
+func TestAdd_ConcurrentForOneControllerRegistersOne(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		nc := newTestNetworkControllers()
+		underlay := newTestUnderlay(t)
+
+		const dials = 8
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		var registered atomic.Int32
+		results := make([]NetworkController, dials)
+
+		for j := 0; j < dials; j++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				ch := &ctrlsTestChannel{id: "ctrl1", label: fmt.Sprintf("dial-%d", idx)}
+				<-start
+				ctrl, err := nc.Add("tls:ctrl1:6262", &ctrlsTestCtrlChannel{ch: ch}, ch, underlay)
+				if err == nil {
+					results[idx] = ctrl
+					registered.Add(1)
+				}
+			}(j)
+		}
+
+		close(start)
+		wg.Wait()
+
+		require.Equal(t, int32(1), registered.Load(),
+			"exactly one concurrent dial to a controller may take the registration")
+
+		var winner NetworkController
+		for _, ctrl := range results {
+			if ctrl != nil {
+				winner = ctrl
+			}
+		}
+		require.Same(t, winner, nc.ctrls.Get("ctrl1"), "the registration must belong to the dial that took it")
+	}
 }

--- a/router/link/link_registry.go
+++ b/router/link/link_registry.go
@@ -51,14 +51,16 @@ type Env interface {
 
 func NewLinkRegistry(routerEnv Env) xlink.Registry {
 	result := &linkRegistryImpl{
-		linkMap:        map[string]xlink.Xlink{},
-		linkByIdMap:    map[string]xlink.Xlink{},
-		ctrls:          routerEnv.GetNetworkControllers(),
-		events:         make(chan event, 16),
-		env:            routerEnv,
-		destinations:   map[string]*linkDest{},
-		linkStateQueue: &linkStateHeap{},
-		triggerNotifyC: make(chan struct{}, 1),
+		linkMap:                map[string]xlink.Xlink{},
+		linkByIdMap:            map[string]xlink.Xlink{},
+		ctrls:                  routerEnv.GetNetworkControllers(),
+		events:                 make(chan event, 16),
+		env:                    routerEnv,
+		destinations:           map[string]*linkDest{},
+		linkStateQueue:         &linkStateHeap{},
+		triggerNotifyC:         make(chan struct{}, 1),
+		fullRefreshSendTimeout: fullRefreshSendTimeout,
+		fullRefreshRetryDelay:  fullRefreshRetryDelay,
 	}
 
 	go result.run()
@@ -74,12 +76,17 @@ type linkRegistryImpl struct {
 	sync.Mutex
 	ctrls env.NetworkControllers
 
-	env              Env
-	destinations     map[string]*linkDest
-	linkStateQueue   *linkStateHeap
-	events           chan event
-	triggerNotifyC   chan struct{}
-	notifyInProgress atomic.Bool
+	env          Env
+	destinations map[string]*linkDest
+	// fullRefreshSendTimeout and fullRefreshRetryDelay bound and pace the reconnect announcement. Fields so
+	// tests can reach the timeout, which is the only way to tell a message that was queued and then discarded
+	// from one that reached the wire.
+	fullRefreshSendTimeout time.Duration
+	fullRefreshRetryDelay  time.Duration
+	linkStateQueue         *linkStateHeap
+	events                 chan event
+	triggerNotifyC         chan struct{}
+	notifyInProgress       atomic.Bool
 }
 
 func (self *linkRegistryImpl) runGcLinkMetricsLoop() {
@@ -383,7 +390,49 @@ func (self *linkRegistryImpl) Iter() <-chan xlink.Xlink {
 	return result
 }
 
+const (
+	// fullRefreshSendTimeout bounds one attempt at the reconnect announcement. The registry lock is held for
+	// the attempt, so this is also how long link accept and dial-succeeded can stall.
+	fullRefreshSendTimeout = 5 * time.Second
+
+	// fullRefreshSendAttempts bounds the retries. A router announces its full link set once per reconnect and
+	// nothing re-asks, so an announcement that never lands leaves the controller unable to route over those
+	// links and unable to prune the ones it should have dropped.
+	fullRefreshSendAttempts = 3
+
+	fullRefreshRetryDelay = time.Second
+)
+
 func (self *linkRegistryImpl) NotifyOfReconnect(ch channel.Channel) {
+	// Retried here rather than by clearing the announced marks and letting the periodic path pick it up: that
+	// path sends without FullRefresh, so the controller cannot prune, and it sends nothing at all when there
+	// are no established links, which is exactly when stale controller state most needs clearing.
+	//
+	// Called on its own goroutine (Router.NotifyOfReconnect), so waiting between attempts blocks nothing.
+	for attempt := 1; attempt <= fullRefreshSendAttempts; attempt++ {
+		if self.sendFullRefresh(ch) {
+			return
+		}
+
+		if ch.IsClosed() {
+			return // whatever replaces this channel announces again
+		}
+
+		if attempt < fullRefreshSendAttempts {
+			select {
+			case <-time.After(self.fullRefreshRetryDelay):
+			case <-self.env.GetCloseNotify():
+				return
+			}
+		}
+	}
+
+	pfxlog.Logger().WithField("ctrlId", ch.Id()).
+		Error("gave up announcing link states after reconnect; this controller cannot route over or prune this router's links until it reconnects")
+}
+
+// sendFullRefresh announces every dialed link to one controller, reporting whether the announcement got out.
+func (self *linkRegistryImpl) sendFullRefresh(ch channel.Channel) bool {
 	self.Lock()
 	defer self.Unlock()
 
@@ -415,13 +464,19 @@ func (self *linkRegistryImpl) NotifyOfReconnect(ch channel.Channel) {
 		}
 	}
 
-	if err := protobufs.MarshalTyped(routerLinks).Send(ch); err != nil {
-		logrus.WithError(err).Error("failed to send router links on reconnect")
-	} else {
-		for _, f := range onComplete {
-			f()
-		}
+	// SendAndWaitForWire, not Send: Send returns once the message is queued, and the deadline stays live, so
+	// the tx loop discards it if the queue drains too slowly. Nothing is told, since a plain send's listener
+	// ignores the error, and this would report success and mark the links synchronized for an announcement
+	// that never left. Matches how the periodic path sends.
+	if err := protobufs.MarshalTyped(routerLinks).WithTimeout(self.fullRefreshSendTimeout).SendAndWaitForWire(ch); err != nil {
+		logrus.WithError(err).WithField("ctrlId", ch.Id()).Error("failed to send router links on reconnect")
+		return false
 	}
+
+	for _, f := range onComplete {
+		f()
+	}
+	return true
 }
 
 func (self *linkRegistryImpl) GetTraceDecoders() []channel.TraceMessageDecoder {

--- a/router/link/link_registry_test.go
+++ b/router/link/link_registry_test.go
@@ -18,7 +18,9 @@ package link
 
 import (
 	"fmt"
+	"math"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -35,6 +37,7 @@ import (
 	"github.com/openziti/ziti/v2/controller/idgen"
 	"github.com/openziti/ziti/v2/router/env"
 	"github.com/openziti/ziti/v2/router/xlink"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -505,4 +508,126 @@ func Test_LinkRegistry_RescanIsNoopWhenNoMatches(t *testing.T) {
 	// Probe again; the rescan probe ordered after the rescan event must
 	// observe no matches (groups didn't intersect).
 	req.Equal(0, destLinkCount(reg, destId), "rescan should not produce matches when groups don't intersect")
+}
+
+// flakySendChannel is a channel.Channel double whose sends fail a set number of times before succeeding. It
+// embeds the interface, so any method these tests do not exercise panics rather than returning a zero value.
+type flakySendChannel struct {
+	channel.Channel
+	failures    int
+	sends       atomic.Int32
+	closed      atomic.Bool
+	closeNotify chan struct{}
+}
+
+func newFlakySendChannel(failures int) *flakySendChannel {
+	return &flakySendChannel{failures: failures, closeNotify: make(chan struct{})}
+}
+
+func (self *flakySendChannel) Id() string     { return "ctrl1" }
+func (self *flakySendChannel) Label() string  { return "ctrl1" }
+func (self *flakySendChannel) IsClosed() bool { return self.closed.Load() }
+
+func (self *flakySendChannel) CloseNotify() <-chan struct{} { return self.closeNotify }
+
+func (self *flakySendChannel) Send(s channel.Sendable) error {
+	if int(self.sends.Add(1)) <= self.failures {
+		return errors.New("timeout waiting for space in send queue")
+	}
+	// What the tx loop does once the message is actually written.
+	s.SendListener().NotifyAfterWrite()
+	return nil
+}
+
+// newReconnectTestRegistry builds a registry with no links and no event loop. An empty link set is a case
+// worth covering rather than avoiding: the reconnect announcement is the only message that prunes, so a
+// router with nothing to report still has to send one to clear stale controller state.
+func newReconnectTestRegistry(t *testing.T) (*linkRegistryImpl, *testEnv) {
+	t.Helper()
+	routerEnv := newTestEnv()
+	t.Cleanup(func() { close(routerEnv.closeNotify) })
+
+	return &linkRegistryImpl{
+		env:            routerEnv,
+		ctrls:          routerEnv.ctrls,
+		destinations:   map[string]*linkDest{},
+		linkMap:        map[string]xlink.Xlink{},
+		triggerNotifyC: make(chan struct{}, 1),
+		// Production's pacing is not this test's concern; the timeout has to stay reachable, though, since it
+		// is what distinguishes a discarded message from a delivered one.
+		fullRefreshSendTimeout: 20 * time.Millisecond,
+		fullRefreshRetryDelay:  0,
+	}, routerEnv
+}
+
+// Test_NotifyOfReconnect_RetriesUntilTheAnnouncementLands covers the retry. A router announces its full link
+// set once per controller reconnect and nothing re-asks, so an announcement lost to send-queue back-pressure
+// leaves that controller unable to route over the router's links, and unable to prune the ones it should have
+// dropped, until the next reconnect.
+func Test_NotifyOfReconnect_RetriesUntilTheAnnouncementLands(t *testing.T) {
+	reg, _ := newReconnectTestRegistry(t)
+	ch := newFlakySendChannel(2)
+
+	reg.NotifyOfReconnect(ch)
+
+	require.Equal(t, int32(3), ch.sends.Load(),
+		"the announcement should have been retried until it reached the wire")
+}
+
+// Test_NotifyOfReconnect_GivesUpAfterItsAttempts: the retry is bounded, so a channel that never drains does
+// not hold a goroutine indefinitely.
+func Test_NotifyOfReconnect_GivesUpAfterItsAttempts(t *testing.T) {
+	reg, _ := newReconnectTestRegistry(t)
+	ch := newFlakySendChannel(math.MaxInt32)
+
+	reg.NotifyOfReconnect(ch)
+
+	require.Equal(t, int32(fullRefreshSendAttempts), ch.sends.Load(),
+		"the retry must stop after its attempts rather than looping")
+}
+
+// Test_NotifyOfReconnect_StopsWhenTheChannelCloses: a closed channel cannot be re-announced to, and whatever
+// replaces it announces again, so retrying against it only delays the goroutine's exit.
+func Test_NotifyOfReconnect_StopsWhenTheChannelCloses(t *testing.T) {
+	reg, _ := newReconnectTestRegistry(t)
+	ch := newFlakySendChannel(math.MaxInt32)
+	ch.closed.Store(true)
+
+	reg.NotifyOfReconnect(ch)
+
+	require.Equal(t, int32(1), ch.sends.Load(),
+		"a closed channel should be abandoned after the first failure, not retried")
+}
+
+// acceptThenDiscardChannel models what a real channel does to a message queued behind a backlog: the send is
+// accepted, and the message is dropped when its deadline expires before the queue drains. Nothing calls back,
+// because a plain send's listener ignores the error.
+type acceptThenDiscardChannel struct {
+	channel.Channel
+	sends       atomic.Int32
+	closeNotify chan struct{}
+}
+
+func (self *acceptThenDiscardChannel) Id() string                   { return "ctrl1" }
+func (self *acceptThenDiscardChannel) Label() string                { return "ctrl1" }
+func (self *acceptThenDiscardChannel) IsClosed() bool               { return false }
+func (self *acceptThenDiscardChannel) CloseNotify() <-chan struct{} { return self.closeNotify }
+
+func (self *acceptThenDiscardChannel) Send(channel.Sendable) error {
+	self.sends.Add(1)
+	return nil // queued, and never written
+}
+
+// Test_NotifyOfReconnect_TreatsADiscardedAnnouncementAsFailure is the guard on how the announcement is sent.
+// A plain Send returns once the message is queued, and the deadline stays live afterwards, so the tx loop can
+// drop it with nobody told: a plain send's listener ignores the error. Reporting that as success marks the
+// links announced and leaves the controller permanently without them.
+func Test_NotifyOfReconnect_TreatsADiscardedAnnouncementAsFailure(t *testing.T) {
+	reg, _ := newReconnectTestRegistry(t)
+	ch := &acceptThenDiscardChannel{closeNotify: make(chan struct{})}
+
+	reg.NotifyOfReconnect(ch)
+
+	require.Equal(t, int32(fullRefreshSendAttempts), ch.sends.Load(),
+		"an announcement accepted into the queue but never written must count as a failure and be retried")
 }

--- a/router/router.go
+++ b/router/router.go
@@ -980,12 +980,26 @@ func (self *Router) startControlPlane() error {
 
 	if self.config.Ctrl.StartupTimeout > 0 {
 		time.AfterFunc(self.config.Ctrl.StartupTimeout, func() {
-			if !self.isShutdown.Load() && len(self.ctrls.GetAll()) == 0 {
-				if os.Getenv("STACKDUMP_ON_FAILED_STARTUP") == "true" {
-					debugz.DumpStack()
-				}
-				pfxlog.Logger().Fatal("unable to connect to any controllers before timeout")
+			if self.isShutdown.Load() {
+				return
 			}
+
+			log := pfxlog.Logger().
+				WithField("startupTimeout", self.config.Ctrl.StartupTimeout).
+				WithField("everConnected", self.ctrls.EverConnected()).
+				WithField("connectedCount", len(self.ctrls.GetAll()))
+
+			// This fires once, so sampling the current count kills a router that happens to be between
+			// control channels when it lands, which is routine rather than a failure to start.
+			if self.ctrls.EverConnected() {
+				log.Info("startup connection check passed")
+				return
+			}
+
+			if os.Getenv("STACKDUMP_ON_FAILED_STARTUP") == "true" {
+				debugz.DumpStack()
+			}
+			log.Fatal("unable to connect to any controllers before timeout")
 		})
 	}
 

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -51,6 +51,9 @@ func (m *mockNetworkControllers) UpdateControllerDetails(controllers []*ctrl_pb.
 	return changed
 }
 
+func (m *mockNetworkControllers) MarkChannelEstablished() {}
+func (m *mockNetworkControllers) EverConnected() bool     { return true }
+
 func (m *mockNetworkControllers) ConnectToInitialEndpoints(endpoints []string) {
 	for _, ep := range endpoints {
 		m.endpoints[ep] = struct{}{}


### PR DESCRIPTION
Fixes #4196
Fixes #4247
Fixes #4248

Four commits, all on the same theme: exactly one connection per router should own the state that
describes it, on both sides of the control channel. Two on the controller side, two on the router.

## Controller: connect/disconnect currency (#4196)

Under control-channel churn, a stale or racing disconnect for a router could clobber a newer connection for the same router — the old channel's late-detected disconnect de-registered the router the new connection had just registered and tore down its links. Channel v5's distinct-per-reconnect connection ids turned a formerly-coupled reconnect into a genuine connect-vs-disconnect race.

This serializes a router's connect and disconnect on a per-router striped lock and keeps at most one connection per router in the connected map. A connect into an occupied slot is rejected (its bind fails, so no rx starts and it is not registered) while the occupant is kicked closed; the router then redials into the freed slot (its existing 1s reconnect pause covers the gap). The entire `DisconnectRouter` teardown is now gated by connection currency, so a stale/superseded disconnect can no longer tear down the live connection.

That currency check compares router instances, which only works if two connections get two instances.
They did not: the connect path evicted the router cache and read back through it, so two connects could
both evict and the second be handed what the first had just published. A shared instance makes the
connections indistinguishable, so the occupied-slot check never fires and either channel's death takes
the other's registration with it. `NewCtrlChanRouter` now loads an instance through `readUncached`,
which neither reads from nor writes to the cache. `MarkDisconnected` is guarded the same way, since it
was clearing the connected flag unconditionally, and that flag is what decides whether the controller
accepts a router's link reports.

## Router: single-owner registration (#4196)

The same question on the router side: which channel owns the registration for a controller. Overlapping
channels to one controller share its id, so four things went wrong, each found by fixing the one before.

A close handler removed the registration by id alone and could delete its replacement's entry, after
which nothing re-registers and a present entry reads as connected, so the router never redialed and
stayed invisible to that controller. The check-then-register in `Add` was not atomic, and initial
endpoint dials carry no controller id, so two dials could both register. A registration whose channel
was closed or had lost every underlay still satisfied a presence check, suppressing the reconnect that
would have fixed it. And refusing a duplicate was a permanent backoff error, ending retries for that
controller for the life of the process even if the winner later died.

## Router: close an unresponsive control channel (#4247)

The controller closes a channel when the router stops answering heartbeats; the router did not do the
reverse. A channel with dead-but-undetected underlays keeps its group, so the router dials only
additional underlays, which the controller refuses once its side of the group is gone. Nothing
re-establishes it until the OS abandons the socket, roughly fifteen minutes. Being unresponsive stays a
selection signal for the merely-slow case, and a zero timeout disables the teardown.

## Router: startup check (#4248)

The startup check sampled the current controller count at the single instant its one-shot timer landed,
so a router momentarily between channels was killed as having failed to start. Raising the timeout only
moves the instant. It now fails on whether a controller was ever reached, which preserves the intent
that a router which can never reach one still exits.

## Notes

### Behaviour change to `routerConnectChurnLimit`

Past the churn window, an arriving connection no longer takes over directly. `ConnectRouter` refuses it and
displaces the established connection, so the router redials into the freed slot. Same end state, one extra
round trip, and nothing unvetted gets registered on the way: refusing means the bind fails, so no rx starts.

The option is not deprecated, but its role narrowed. It used to be the only thing keeping two connections for
one router out of the connected map; that is now enforced under the per-router lock, where the decision is
atomic. What remains, and what it is now solely responsible for, is rate-limiting displacement: `ConnectRouter`
always displaces an occupant it does not recognise, so without the limit a spurious first-connection hello
would tear down a healthy channel. The field now carries a godoc saying that, and has tests, which it did not
before.

It is also the upper bound on recovering a stale registration when heartbeats do not fire: inside the window a
new connection is refused before the displacement logic is reached. The heartbeat close added here (#4247)
clears a dead registration in ~30s, below the 1m default, so that is the usual path.


Gossip-agnostic and built on `main`. `DisconnectRouter` merges with #4079's reroute ordering from main
rather than replacing it: the currency guard wraps the teardown, and inside it the link snapshot and
`MarkDisconnected` keep main's order, since reroute must not path through the router being removed.

The link table work that was originally on this branch has been extracted to #4249, which is stacked on
this one. The gossip-links branch will rebase on top of that.

Circuit rerouting on control-channel disconnect is intentionally left at parity with `main` (tracked separately for the SDK-rerouting effort).

Tests: reject/kick, stale-disconnect currency, closing-occupant liveness, and a `-race` fuzz at the model/network level; a `RouterSender` replace-stop test; and a ctrl-channel integration test asserting a rejected bind starts no rx and registers no channel. On the router side: concurrent dials yielding one registration, a superseded close leaving the current registration alone, a usable channel neither displaced nor closed, a silent controller's channel closed while a slow but answering one is not, and reaching a controller once surviving the loss of every controller.

