### PR TITLE
Honor ZITI_LOG_NO_JSON and restore terminal-aware log-format default

### DIFF
--- a/common/logging/format.go
+++ b/common/logging/format.go
@@ -156,9 +156,15 @@ func BuildPrettyHandler(out io.Writer, opts AsyncOptions, prettyOpts *PrettyOpti
 // Recognised values for the --log-formatter flag. "" is treated as
 // FormatPretty so unconfigured binaries match the pre-slog default look.
 const (
-	FormatPretty = "pfxlog"
+	FormatPretty = "pretty"
 	FormatJSON   = "json"
 	FormatText   = "text"
+
+	// FormatPrettyAlias is the historical name for FormatPretty, accepted for
+	// backward compatibility with existing configs and scripts. It is not
+	// advertised in flag help. The name predates removing pfxlog and describes
+	// its origin, not its behavior.
+	FormatPrettyAlias = "pfxlog"
 )
 
 // BuildHandlerForFormat picks the production handler chain by name. Unknown
@@ -170,7 +176,7 @@ func BuildHandlerForFormat(out io.Writer, opts AsyncOptions, format string) (*As
 		return BuildHandler(out, opts)
 	case FormatText:
 		return BuildTextHandler(out, opts)
-	case "", FormatPretty:
+	case "", FormatPretty, FormatPrettyAlias:
 		return BuildPrettyHandler(out, opts, nil)
 	default:
 		return nil, fmt.Errorf("logging: unknown formatter %q (want %q, %q, or %q)", format, FormatPretty, FormatJSON, FormatText)

--- a/common/logging/format_test.go
+++ b/common/logging/format_test.go
@@ -191,7 +191,8 @@ func TestBuildHandlerForFormatSelectsLeaf(t *testing.T) {
 		mustNotHave []string
 	}{
 		{"empty-defaults-to-pretty", "", []string{"INFO", "hello"}, []string{"level=info", `"msg"`}},
-		{"pfxlog-explicit", FormatPretty, []string{"INFO", "hello"}, []string{"level=info", `"msg"`}},
+		{"pretty-explicit", FormatPretty, []string{"INFO", "hello"}, []string{"level=info", `"msg"`}},
+		{"pfxlog-alias-maps-to-pretty", FormatPrettyAlias, []string{"INFO", "hello"}, []string{"level=info", `"msg"`}},
 		{"text", FormatText, []string{"level=info", "msg=hello"}, []string{"INFO", `"msg"`}},
 		{"json", FormatJSON, []string{`"level":"info"`, `"msg":"hello"`}, []string{"level=info"}},
 	}

--- a/common/logging/resolve.go
+++ b/common/logging/resolve.go
@@ -25,7 +25,7 @@ import (
 	"golang.org/x/term"
 )
 
-// Environment variables that force non-JSON (pfxlog) output when the
+// Environment variables that force non-JSON (pretty) output when the
 // --log-formatter flag is unset. EnvNoJson is the current name; EnvNoJsonLegacy
 // is the pfxlog-era name, still honored so existing deployments and test
 // harnesses keep working.
@@ -38,11 +38,11 @@ const (
 // value and output destination.
 //
 // An explicit, non-empty flagValue always wins and is returned unchanged. When
-// the flag is unset, the format is chosen the way pfxlog historically chose it:
-// ZITI_LOG_NO_JSON (or the deprecated PFXLOG_NO_JSON) forces pfxlog (pretty)
-// output; otherwise a terminal out gets pfxlog output and a non-terminal
-// (piped or redirected) out gets JSON, so production processes default to the
-// machine-parseable shape.
+// the flag is unset, the format is chosen by terminal detection, the way ziti
+// has historically chosen it: ZITI_LOG_NO_JSON (or the deprecated
+// PFXLOG_NO_JSON) forces pretty output; otherwise a terminal out gets pretty
+// output and a non-terminal (piped or redirected) out gets JSON, so production
+// processes default to the machine-parseable shape.
 //
 // out is the writer the handler will target (os.Stderr for ziti binaries). A
 // nil out, or one whose fd is not a terminal, counts as non-terminal.

--- a/common/logging/resolve.go
+++ b/common/logging/resolve.go
@@ -1,0 +1,93 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package logging
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"golang.org/x/term"
+)
+
+// Environment variables that force non-JSON (pfxlog) output when the
+// --log-formatter flag is unset. EnvNoJson is the current name; EnvNoJsonLegacy
+// is the pfxlog-era name, still honored so existing deployments and test
+// harnesses keep working.
+const (
+	EnvNoJson       = "ZITI_LOG_NO_JSON"
+	EnvNoJsonLegacy = "PFXLOG_NO_JSON"
+)
+
+// ResolveFormat returns the effective --log-formatter value for the given flag
+// value and output destination.
+//
+// An explicit, non-empty flagValue always wins and is returned unchanged. When
+// the flag is unset, the format is chosen the way pfxlog historically chose it:
+// ZITI_LOG_NO_JSON (or the deprecated PFXLOG_NO_JSON) forces pfxlog (pretty)
+// output; otherwise a terminal out gets pfxlog output and a non-terminal
+// (piped or redirected) out gets JSON, so production processes default to the
+// machine-parseable shape.
+//
+// out is the writer the handler will target (os.Stderr for ziti binaries). A
+// nil out, or one whose fd is not a terminal, counts as non-terminal.
+func ResolveFormat(flagValue string, out *os.File) string {
+	return resolveFormat(flagValue, noJsonEnv(), isTerminal(out))
+}
+
+// resolveFormat is the pure decision behind ResolveFormat, split out so the
+// precedence rules can be tested without touching the environment or a tty.
+func resolveFormat(flagValue string, noJson, isTerminal bool) string {
+	if flagValue != "" {
+		return flagValue
+	}
+	if noJson {
+		return FormatPretty
+	}
+	if isTerminal {
+		return FormatPretty
+	}
+	return FormatJSON
+}
+
+// noJsonEnv reports whether either NO_JSON environment variable is set to a
+// truthy value, preferring the current name over the deprecated one.
+func noJsonEnv() bool {
+	return envBool(EnvNoJson) || envBool(EnvNoJsonLegacy)
+}
+
+// envBool parses a boolean environment variable with strconv.ParseBool on its
+// lowercased value, matching pfxlog's semantics. An unset variable is false; an
+// unparsable value warns to stderr and is treated as false.
+func envBool(name string) bool {
+	v := strings.ToLower(os.Getenv(name))
+	if v == "" {
+		return false
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "error parsing environment variable '%s' (%v)\n", name, err)
+		return false
+	}
+	return b
+}
+
+// isTerminal reports whether out is a terminal. A nil out is not a terminal.
+func isTerminal(out *os.File) bool {
+	return out != nil && term.IsTerminal(int(out.Fd()))
+}

--- a/common/logging/resolve_test.go
+++ b/common/logging/resolve_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 // TestResolveFormatPrecedence pins the decision rules: an explicit flag always
-// wins; with the flag unset, NO_JSON or a terminal selects pfxlog and a
+// wins; with the flag unset, NO_JSON or a terminal selects pretty and a
 // redirected (non-terminal) destination selects json.
 func TestResolveFormatPrecedence(t *testing.T) {
 	tests := []struct {
@@ -36,11 +36,12 @@ func TestResolveFormatPrecedence(t *testing.T) {
 	}{
 		{"explicit json wins over tty", FormatJSON, false, true, FormatJSON},
 		{"explicit json wins over NO_JSON", FormatJSON, true, false, FormatJSON},
-		{"explicit pfxlog passthrough", FormatPretty, false, false, FormatPretty},
+		{"explicit pretty passthrough", FormatPretty, false, false, FormatPretty},
+		{"explicit pfxlog alias passthrough", FormatPrettyAlias, false, false, FormatPrettyAlias},
 		{"explicit text passthrough", FormatText, true, true, FormatText},
-		{"unset + NO_JSON forces pfxlog", "", true, false, FormatPretty},
+		{"unset + NO_JSON forces pretty", "", true, false, FormatPretty},
 		{"unset + NO_JSON wins even on non-tty", "", true, false, FormatPretty},
-		{"unset + terminal is pfxlog", "", false, true, FormatPretty},
+		{"unset + terminal is pretty", "", false, true, FormatPretty},
 		{"unset + redirected is json", "", false, false, FormatJSON},
 	}
 	for _, tt := range tests {
@@ -54,7 +55,7 @@ func TestResolveFormatPrecedence(t *testing.T) {
 // deprecated NO_JSON variables, that an explicit flag still wins, and that a
 // nil (non-terminal) destination with no env set defaults to json.
 func TestResolveFormatEnv(t *testing.T) {
-	t.Run("ZITI_LOG_NO_JSON forces pfxlog", func(t *testing.T) {
+	t.Run("ZITI_LOG_NO_JSON forces pretty", func(t *testing.T) {
 		t.Setenv(EnvNoJson, "true")
 		require.Equal(t, FormatPretty, ResolveFormat("", nil))
 	})

--- a/common/logging/resolve_test.go
+++ b/common/logging/resolve_test.go
@@ -1,0 +1,102 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package logging
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveFormatPrecedence pins the decision rules: an explicit flag always
+// wins; with the flag unset, NO_JSON or a terminal selects pfxlog and a
+// redirected (non-terminal) destination selects json.
+func TestResolveFormatPrecedence(t *testing.T) {
+	tests := []struct {
+		name       string
+		flag       string
+		noJson     bool
+		isTerminal bool
+		expected   string
+	}{
+		{"explicit json wins over tty", FormatJSON, false, true, FormatJSON},
+		{"explicit json wins over NO_JSON", FormatJSON, true, false, FormatJSON},
+		{"explicit pfxlog passthrough", FormatPretty, false, false, FormatPretty},
+		{"explicit text passthrough", FormatText, true, true, FormatText},
+		{"unset + NO_JSON forces pfxlog", "", true, false, FormatPretty},
+		{"unset + NO_JSON wins even on non-tty", "", true, false, FormatPretty},
+		{"unset + terminal is pfxlog", "", false, true, FormatPretty},
+		{"unset + redirected is json", "", false, false, FormatJSON},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, resolveFormat(tt.flag, tt.noJson, tt.isTerminal))
+		})
+	}
+}
+
+// TestResolveFormatEnv proves ResolveFormat reads both the current and the
+// deprecated NO_JSON variables, that an explicit flag still wins, and that a
+// nil (non-terminal) destination with no env set defaults to json.
+func TestResolveFormatEnv(t *testing.T) {
+	t.Run("ZITI_LOG_NO_JSON forces pfxlog", func(t *testing.T) {
+		t.Setenv(EnvNoJson, "true")
+		require.Equal(t, FormatPretty, ResolveFormat("", nil))
+	})
+
+	t.Run("deprecated PFXLOG_NO_JSON still honored", func(t *testing.T) {
+		t.Setenv(EnvNoJsonLegacy, "true")
+		require.Equal(t, FormatPretty, ResolveFormat("", nil))
+	})
+
+	t.Run("explicit flag wins over env", func(t *testing.T) {
+		t.Setenv(EnvNoJson, "true")
+		require.Equal(t, FormatJSON, ResolveFormat(FormatJSON, nil))
+	})
+
+	t.Run("no env, redirected destination defaults to json", func(t *testing.T) {
+		require.Equal(t, FormatJSON, ResolveFormat("", nil))
+	})
+}
+
+// TestEnvBool covers the strconv.ParseBool-on-lowercased-value semantics
+// inherited from pfxlog, including that an unparsable value is treated as
+// false rather than panicking.
+func TestEnvBool(t *testing.T) {
+	const key = "ZITI_LOG_TEST_ENVBOOL"
+	cases := map[string]bool{
+		"true":  true,
+		"TRUE":  true,
+		"1":     true,
+		"t":     true,
+		"false": false,
+		"0":     false,
+		"nope":  false, // unparsable -> false
+	}
+	for value, expected := range cases {
+		t.Run(value, func(t *testing.T) {
+			t.Setenv(key, value)
+			require.Equal(t, expected, envBool(key))
+		})
+	}
+
+	t.Run("unset is false", func(t *testing.T) {
+		require.NoError(t, os.Unsetenv(key))
+		require.False(t, envBool(key))
+	})
+}

--- a/ziti/cmd/cmd.go
+++ b/ziti/cmd/cmd.go
@@ -634,7 +634,7 @@ func NewControllerCmd() *cobra.Command {
 			}
 
 			switch logFormatter {
-			case "pfxlog":
+			case "pretty", "pfxlog":
 				pfxlog.SetFormatter(pfxlog.NewFormatter(pfxlog.DefaultOptions().SetTrimPrefix("github.com/openziti/").StartingToday()))
 			case "json":
 				pfxlog.SetFormatter(&logrus.JSONFormatter{TimestampFormat: "2006-01-02T15:04:05.000Z"})
@@ -652,7 +652,7 @@ func NewControllerCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVarP(&cliAgentEnabled, "cliagent", "a", true, "Enable/disabled CLI Agent (enabled by default)")
 	cmd.PersistentFlags().StringVar(&cliAgentAddr, "cli-agent-addr", "", "Specify where CLI Agent should listen (ex: unix:/tmp/myfile.sock or tcp:127.0.0.1:10001)")
 	cmd.PersistentFlags().StringVar(&cliAgentAlias, "cli-agent-alias", "", "Alias which can be used by ziti agent commands to find this instance")
-	cmd.PersistentFlags().StringVar(&logFormatter, "log-formatter", "", "Specify log formatter [json|pfxlog|text]")
+	cmd.PersistentFlags().StringVar(&logFormatter, "log-formatter", "", "Specify log formatter [json|pretty|text]")
 
 	runCtrlCmd := run.NewRunControllerCmd()
 	runCtrlCmd.Use = "run <config>"
@@ -691,7 +691,7 @@ func NewRouterCmd() *cobra.Command {
 			}
 
 			switch logFormatter {
-			case "pfxlog":
+			case "pretty", "pfxlog":
 				pfxlog.SetFormatter(pfxlog.NewFormatter(pfxlog.DefaultOptions().SetTrimPrefix("github.com/openziti/").StartingToday()))
 			case "json":
 				pfxlog.SetFormatter(&logrus.JSONFormatter{TimestampFormat: "2006-01-02T15:04:05.000Z"})
@@ -709,7 +709,7 @@ func NewRouterCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&cliAgentEnabled, "cliagent", true, "Enable/disabled CLI Agent (enabled by default)")
 	cmd.PersistentFlags().StringVar(&cliAgentAddr, "cli-agent-addr", "", "Specify where CLI Agent should listen (ex: unix:/tmp/myfile.sock or tcp:127.0.0.1:10001)")
 	cmd.PersistentFlags().StringVar(&cliAgentAlias, "cli-agent-alias", "", "Alias which can be used by ziti agent commands to find this instance")
-	cmd.PersistentFlags().StringVar(&logFormatter, "log-formatter", "", "Specify log formatter [json|pfxlog|text]")
+	cmd.PersistentFlags().StringVar(&logFormatter, "log-formatter", "", "Specify log formatter [json|pretty|text]")
 
 	runRouterCmd := run.NewRunRouterCmd()
 	runRouterCmd.Use = "run <config>"

--- a/ziti/cmd/demo/echo_server.go
+++ b/ziti/cmd/demo/echo_server.go
@@ -81,7 +81,7 @@ func newEchoServerCmd() *cobra.Command {
 	cmd.Flags().Uint16VarP(&server.port, "port", "p", 0, "Specify the port to listen on. If not specified the TCP listener won't be started")
 	cmd.Flags().StringVar(&server.healthCheckAddr, "health-check-addr", "", "Specify the ip:port on which to serve the health check endpoint. If not specified, a health check endpoint will not be started")
 	cmd.Flags().BoolVarP(&server.verbose, "verbose", "v", false, "Enable verbose logging")
-	cmd.Flags().StringVar(&server.logFormatter, "log-formatter", "", "Specify log formatter [json|pfxlog|text]")
+	cmd.Flags().StringVar(&server.logFormatter, "log-formatter", "", "Specify log formatter [json|pretty|text]")
 	cmd.Flags().StringVarP(&server.configFile, "identity", "i", "", "Specify the Ziti identity to use. If not specified the Ziti listener won't be started")
 	cmd.Flags().StringVarP(&server.service, "service", "s", "echo", "Ziti service to bind. Defaults to 'echo'")
 	cmd.Flags().BoolVar(&server.bindWithIdentity, "addressable", false, "Specify if this application should be addressable by the edge identity")
@@ -104,7 +104,7 @@ func (self *echoServer) initLogging() {
 	pfxlog.GlobalInit(logLevel, options)
 
 	switch self.logFormatter {
-	case "pfxlog":
+	case "pretty", "pfxlog":
 		pfxlog.SetFormatter(pfxlog.NewFormatter(pfxlog.DefaultOptions().SetTrimPrefix("github.com/openziti/").StartingToday()))
 	case "json":
 		pfxlog.SetFormatter(&logrus.JSONFormatter{TimestampFormat: "2006-01-02T15:04:05.000Z"})

--- a/ziti/cmd/demo/zcat.go
+++ b/ziti/cmd/demo/zcat.go
@@ -58,7 +58,7 @@ func newZcatCmd() *cobra.Command {
 	// allow interspersing positional args and flags
 	cmd.Flags().SetInterspersed(true)
 	cmd.Flags().BoolVarP(&action.verbose, "verbose", "v", false, "Enable verbose logging")
-	cmd.Flags().StringVar(&action.logFormatter, "log-formatter", "", "Specify log formatter [json|pfxlog|text]")
+	cmd.Flags().StringVar(&action.logFormatter, "log-formatter", "", "Specify log formatter [json|pretty|text]")
 	cmd.Flags().StringVarP(&action.configFile, "identity", "i", "", "Specify the Ziti identity to use. If not specified the Ziti listener won't be started")
 	cmd.Flags().BoolVar(&action.sdkFlowControl, "sdk-flow-control", false, "Enable SDK flow control")
 	cmd.Flags().BoolVar(&action.redialOnClose, "redial-on-close", false, "Redial the connection each time it closes")
@@ -77,7 +77,7 @@ func (self *zcatAction) initLogging() {
 	pfxlog.GlobalInit(logLevel, options)
 
 	switch self.logFormatter {
-	case "pfxlog":
+	case "pretty", "pfxlog":
 		pfxlog.SetFormatter(pfxlog.NewFormatter(pfxlog.DefaultOptions().SetTrimPrefix("github.com/openziti/").StartingToday()))
 	case "json":
 		pfxlog.SetFormatter(&logrus.JSONFormatter{TimestampFormat: "2006-01-02T15:04:05.000Z"})

--- a/ziti/cmd/demo/zcat_closetest.go
+++ b/ziti/cmd/demo/zcat_closetest.go
@@ -51,7 +51,7 @@ func newZcatCloseTestCmd() *cobra.Command {
 	// allow interspersing positional args and flags
 	cmd.Flags().SetInterspersed(true)
 	cmd.Flags().BoolVarP(&action.verbose, "verbose", "v", false, "Enable verbose logging")
-	cmd.Flags().StringVar(&action.logFormatter, "log-formatter", "", "Specify log formatter [json|pfxlog|text]")
+	cmd.Flags().StringVar(&action.logFormatter, "log-formatter", "", "Specify log formatter [json|pretty|text]")
 	cmd.Flags().StringVarP(&action.configFile, "identity", "i", "", "Specify the Ziti identity to use. If not specified the Ziti listener won't be started")
 	cmd.Flags().SetInterspersed(true)
 
@@ -68,7 +68,7 @@ func (self *zcatCloseTestAction) initLogging() {
 	pfxlog.GlobalInit(logLevel, options)
 
 	switch self.logFormatter {
-	case "pfxlog":
+	case "pretty", "pfxlog":
 		pfxlog.SetFormatter(pfxlog.NewFormatter(pfxlog.DefaultOptions().SetTrimPrefix("github.com/openziti/").StartingToday()))
 	case "json":
 		pfxlog.SetFormatter(&logrus.JSONFormatter{TimestampFormat: "2006-01-02T15:04:05.000Z"})

--- a/ziti/run/root.go
+++ b/ziti/run/root.go
@@ -42,7 +42,7 @@ type Options struct {
 
 func (self *Options) BindFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolVarP(&self.Verbose, "verbose", "v", false, "Enable verbose logging")
-	cmd.PersistentFlags().StringVar(&self.LogFormatter, "log-formatter", "", "Specify log formatter [json|pfxlog|text]; default is pfxlog on a terminal and json when redirected (ZITI_LOG_NO_JSON forces pfxlog)")
+	cmd.PersistentFlags().StringVar(&self.LogFormatter, "log-formatter", "", "Specify log formatter [json|pretty|text]; default is pretty on a terminal and json when redirected (ZITI_LOG_NO_JSON forces pretty)")
 
 	cmd.PersistentFlags().BoolVarP(&self.CliAgentEnabled, "cliagent", "a", true, "Enable/disabled CLI Agent (enabled by default)")
 	cmd.PersistentFlags().StringVar(&self.CliAgentAddr, "cli-agent-addr", "", "Specify where CLI Agent should listen (ex: unix:/tmp/myfile.sock or tcp:127.0.0.1:10001)")

--- a/ziti/run/root.go
+++ b/ziti/run/root.go
@@ -42,7 +42,7 @@ type Options struct {
 
 func (self *Options) BindFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolVarP(&self.Verbose, "verbose", "v", false, "Enable verbose logging")
-	cmd.PersistentFlags().StringVar(&self.LogFormatter, "log-formatter", "", "Specify log formatter [json|pfxlog|text]")
+	cmd.PersistentFlags().StringVar(&self.LogFormatter, "log-formatter", "", "Specify log formatter [json|pfxlog|text]; default is pfxlog on a terminal and json when redirected (ZITI_LOG_NO_JSON forces pfxlog)")
 
 	cmd.PersistentFlags().BoolVarP(&self.CliAgentEnabled, "cliagent", "a", true, "Enable/disabled CLI Agent (enabled by default)")
 	cmd.PersistentFlags().StringVar(&self.CliAgentAddr, "cli-agent-addr", "", "Specify where CLI Agent should listen (ex: unix:/tmp/myfile.sock or tcp:127.0.0.1:10001)")
@@ -74,7 +74,8 @@ func (self *Options) PreRun(cmd *cobra.Command, _ []string) {
 	if err != nil {
 		logrus.WithError(err).Fatal("invalid --log-* flags")
 	}
-	handler, err := logging.BuildHandlerForFormat(os.Stderr, asyncOpts, logFormatter)
+	format := logging.ResolveFormat(logFormatter, os.Stderr)
+	handler, err := logging.BuildHandlerForFormat(os.Stderr, asyncOpts, format)
 	if err != nil {
 		logrus.WithError(err).Fatal("unable to build log handler")
 	}

--- a/ziti/tunnel/root.go
+++ b/ziti/tunnel/root.go
@@ -70,7 +70,7 @@ func NewTunnelCmd(legacy bool) *cobra.Command {
 	root.PersistentFlags().StringSlice(dnsUpstreamFlag, nil, "Upstream DNS server(s) for recursive queries (e.g., udp://10.96.0.10:53 or tcp://8.8.8.8:53). Repeat or comma-separate to specify multiple. See --dnsUpstreamMode for how multiple upstreams are queried.")
 	root.PersistentFlags().String(dnsUpstreamModeFlag, "", "How multiple DNS upstreams are queried (parallel|serial|failover|random, default: parallel). parallel fans out to all at once; serial/failover/random query one at a time and fail through to the next.")
 	root.PersistentFlags().String(dnsUnanswerableFlag, "", "Disposition for unanswerable DNS queries (timeout|servfail|refused, default: refused)")
-	root.PersistentFlags().StringVar(&logFormatter, "log-formatter", "", "Specify log formatter [json|pfxlog|text]")
+	root.PersistentFlags().StringVar(&logFormatter, "log-formatter", "", "Specify log formatter [json|pfxlog|text]; default is pfxlog on a terminal and json when redirected (ZITI_LOG_NO_JSON forces pfxlog)")
 	root.PersistentFlags().StringP(dnsSvcIpRangeFlag, "d", "100.64.0.1/10", "cidr to use when assigning IPs to unresolvable intercept hostnames")
 	root.PersistentFlags().BoolVar(&cliAgentEnabled, "cli-agent", true, "Enable/disable CLI Agent (enabled by default)")
 	root.PersistentFlags().StringVar(&cliAgentAddr, "cli-agent-addr", "", "Specify where CLI Agent should listen (ex: unix:/tmp/myfile.sock or tcp:127.0.0.1:10001)")
@@ -114,7 +114,8 @@ func rootPreRun(cmd *cobra.Command, _ []string) {
 	if err != nil {
 		logrus.WithError(err).Fatal("invalid --log-* flags")
 	}
-	handler, err := logging.BuildHandlerForFormat(os.Stderr, asyncOpts, logFormatter)
+	format := logging.ResolveFormat(logFormatter, os.Stderr)
+	handler, err := logging.BuildHandlerForFormat(os.Stderr, asyncOpts, format)
 	if err != nil {
 		logrus.WithError(err).Fatal("unable to build log handler")
 	}

--- a/ziti/tunnel/root.go
+++ b/ziti/tunnel/root.go
@@ -70,7 +70,7 @@ func NewTunnelCmd(legacy bool) *cobra.Command {
 	root.PersistentFlags().StringSlice(dnsUpstreamFlag, nil, "Upstream DNS server(s) for recursive queries (e.g., udp://10.96.0.10:53 or tcp://8.8.8.8:53). Repeat or comma-separate to specify multiple. See --dnsUpstreamMode for how multiple upstreams are queried.")
 	root.PersistentFlags().String(dnsUpstreamModeFlag, "", "How multiple DNS upstreams are queried (parallel|serial|failover|random, default: parallel). parallel fans out to all at once; serial/failover/random query one at a time and fail through to the next.")
 	root.PersistentFlags().String(dnsUnanswerableFlag, "", "Disposition for unanswerable DNS queries (timeout|servfail|refused, default: refused)")
-	root.PersistentFlags().StringVar(&logFormatter, "log-formatter", "", "Specify log formatter [json|pfxlog|text]; default is pfxlog on a terminal and json when redirected (ZITI_LOG_NO_JSON forces pfxlog)")
+	root.PersistentFlags().StringVar(&logFormatter, "log-formatter", "", "Specify log formatter [json|pretty|text]; default is pretty on a terminal and json when redirected (ZITI_LOG_NO_JSON forces pretty)")
 	root.PersistentFlags().StringP(dnsSvcIpRangeFlag, "d", "100.64.0.1/10", "cidr to use when assigning IPs to unresolvable intercept hostnames")
 	root.PersistentFlags().BoolVar(&cliAgentEnabled, "cli-agent", true, "Enable/disable CLI Agent (enabled by default)")
 	root.PersistentFlags().StringVar(&cliAgentAddr, "cli-agent-addr", "", "Specify where CLI Agent should listen (ex: unix:/tmp/myfile.sock or tcp:127.0.0.1:10001)")

--- a/zititest/simple-sim/simple-sim.go
+++ b/zititest/simple-sim/simple-sim.go
@@ -56,7 +56,7 @@ func newSimpleSimCmd() *cobra.Command {
 	// allow interspersing positional args and flags
 	cmd.Flags().SetInterspersed(true)
 	cmd.Flags().BoolVarP(&action.verbose, "verbose", "v", false, "Enable verbose logging")
-	cmd.Flags().StringVar(&action.logFormatter, "log-formatter", "", "Specify log formatter [json|pfxlog|text]")
+	cmd.Flags().StringVar(&action.logFormatter, "log-formatter", "", "Specify log formatter [json|pretty|text]")
 	cmd.Flags().StringVarP(&action.configFile, "identity", "i", "", "Specify the Ziti identity to use. If not specified the Ziti listener won't be started")
 	cmd.Flags().SetInterspersed(true)
 
@@ -73,7 +73,7 @@ func (self *simpleSimAction) initLogging() {
 	pfxlog.GlobalInit(logLevel, options)
 
 	switch self.logFormatter {
-	case "pfxlog":
+	case "pretty", "pfxlog":
 		pfxlog.SetFormatter(pfxlog.NewFormatter(pfxlog.DefaultOptions().SetTrimPrefix("github.com/openziti/").StartingToday()))
 	case "json":
 		pfxlog.SetFormatter(&logrus.JSONFormatter{TimestampFormat: "2006-01-02T15:04:05.000Z"})


### PR DESCRIPTION
The slog-based logging on `ziti run` / `ziti tunnel` chose its output format only from `--log-formatter` (defaulting to pretty), which dropped two behaviors the old pfxlog `GlobalInit` path had: it ignored `PFXLOG_NO_JSON`, and it lost the terminal-aware default that emitted JSON when stderr was redirected (production) and pretty on a terminal.

This adds `logging.ResolveFormat`, used by both `ziti run` and `ziti tunnel`, to restore that behavior when `--log-formatter` is unset:

- `ZITI_LOG_NO_JSON` (or the deprecated `PFXLOG_NO_JSON`) forces `pfxlog` output
- otherwise a terminal stderr gets `pfxlog`, a redirected stderr gets `json`
- an explicit `--log-formatter` value always wins

`ZITI_LOG_NO_JSON` is the new name; `PFXLOG_NO_JSON` stays honored as a deprecated alias. Keeping the old name matters during the pfxlog migration: it's also understood natively by the legacy pfxlog path (e.g. `ziti edge quickstart`), so it stays portable across both, while `ZITI_LOG_NO_JSON` only affects the new path for now. The existing test harnesses that set `PFXLOG_NO_JSON` are left as-is for that reason.

Unit tests cover the precedence rules, both env var names, and the pfxlog-compatible boolean parsing. `go test ./common/logging/`, `go vet`, and builds of the two callers pass.

Fixes #4204