### PR TITLE
Fix lock order inversion in ConnectionTracker

### DIFF
--- a/controller/model/connection_tracker_test.go
+++ b/controller/model/connection_tracker_test.go
@@ -1,0 +1,214 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package model
+
+import (
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	cmap "github.com/orcaman/concurrent-map/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openziti/ziti/v2/common/ctrlchan"
+	"github.com/openziti/ziti/v2/controller/event"
+)
+
+// fakeCtrlChannel implements the part of ctrlchan.CtrlChannel that the connection tracker
+// uses. The embedded interface is left nil so that any other method panics rather than
+// quietly returning a zero value.
+type fakeCtrlChannel struct {
+	ctrlchan.CtrlChannel
+	id     string
+	closed atomic.Bool
+}
+
+func (self *fakeCtrlChannel) PeerId() string {
+	return self.id
+}
+
+func (self *fakeCtrlChannel) IsClosed() bool {
+	return self.closed.Load()
+}
+
+func newTestConnectionTracker(t *testing.T) *ConnectionTracker {
+	closeNotify := make(chan struct{})
+	t.Cleanup(func() {
+		close(closeNotify)
+	})
+
+	return &ConnectionTracker{
+		connections:     cmap.New[*identityConnections](),
+		eventDispatcher: event.DispatcherMock{},
+		scanInterval:    time.Millisecond,
+		unknownTimeout:  time.Minute,
+		closeNotify:     closeNotify,
+	}
+}
+
+// TestConnectionTrackerLockOrdering ensures that the scan loop and connect/disconnect
+// handling can run concurrently against the same identities without deadlocking.
+//
+// The tracker uses two locks, the cmap shard lock and the per-identity lock. Acquiring
+// them in opposite orders in different code paths deadlocks permanently, and because the
+// shard lock is then never released, every identity read in the controller blocks behind
+// it.
+func TestConnectionTrackerLockOrdering(t *testing.T) {
+	tracker := newTestConnectionTracker(t)
+
+	// A small identity set keeps the scan loop and the connect/disconnect handling
+	// contending on the same entries and the same cmap shards.
+	identityIds := []string{"identity-1", "identity-2", "identity-3", "identity-4"}
+
+	var stop atomic.Bool
+	var wg sync.WaitGroup
+
+	for _, identityId := range identityIds {
+		wg.Add(1)
+		go func(identityId string) {
+			defer wg.Done()
+			ch := &fakeCtrlChannel{id: "router-1"}
+			for !stop.Load() {
+				// leaves the entry with no routers, making it a candidate for the scan
+				// loop to reap while this goroutine is still touching it
+				tracker.MarkConnected(identityId, ch)
+				tracker.MarkDisconnected(identityId, ch)
+			}
+		}(identityId)
+	}
+
+	// An identity no other goroutine touches, so that the scan loop is the only thing
+	// that could take it offline. Nothing may drop an entry that has a live router
+	// connection, so if the scan loop removes it based on a view taken before the
+	// reconnect, this sees it.
+	var sawUnexpectedState atomic.Bool
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ch := &fakeCtrlChannel{id: "router-2"}
+		for !stop.Load() {
+			tracker.MarkConnected("identity-reconnecting", ch)
+			if tracker.GetIdentityOnlineState("identity-reconnecting") != IdentityStateOnline {
+				sawUnexpectedState.Store(true)
+				return
+			}
+			tracker.MarkDisconnected("identity-reconnecting", ch)
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for !stop.Load() {
+			tracker.ScanForDisconnectedRouters()
+		}
+	}()
+
+	time.AfterFunc(2*time.Second, func() {
+		stop.Store(true)
+	})
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		buf := make([]byte, 4*1024*1024)
+		n := runtime.Stack(buf, true)
+		t.Fatalf("connection tracker deadlocked, goroutine dump follows:\n%s", buf[:n])
+	}
+
+	require.False(t, sawUnexpectedState.Load(),
+		"identity reported as not online while it had a live router connection")
+}
+
+// TestConnectionTrackerReapsDisconnectedIdentities covers the entry removal path that the
+// scan loop uses, since that is where the lock ordering has to be respected.
+func TestConnectionTrackerReapsDisconnectedIdentities(t *testing.T) {
+	req := require.New(t)
+	tracker := newTestConnectionTracker(t)
+
+	ch := &fakeCtrlChannel{id: "router-1"}
+
+	tracker.MarkConnected("identity-1", ch)
+	req.Equal(IdentityStateOnline, tracker.GetIdentityOnlineState("identity-1"))
+
+	tracker.ScanForDisconnectedRouters()
+	req.Equal(1, tracker.connections.Count(), "identity with a connected router should not be reaped")
+
+	tracker.MarkDisconnected("identity-1", ch)
+	req.Equal(IdentityStateOffline, tracker.GetIdentityOnlineState("identity-1"))
+
+	tracker.ScanForDisconnectedRouters()
+	req.Equal(0, tracker.connections.Count(), "identity with no connected routers should be reaped")
+}
+
+// TestConnectionTrackerRemoveIfEmptyRechecksMapValue covers the window between the scan
+// loop deciding an entry is empty and the entry actually being removed. Nothing is locked
+// across that window, so an identity can reconnect inside it and the removal has to
+// notice.
+//
+// The scan loop is driven a step at a time here because that window cannot be held open
+// from outside; removeIfEmpty is exactly the step that runs after the decision.
+func TestConnectionTrackerRemoveIfEmptyRechecksMapValue(t *testing.T) {
+	req := require.New(t)
+	tracker := newTestConnectionTracker(t)
+
+	ch := &fakeCtrlChannel{id: "router-1"}
+
+	tracker.MarkConnected("identity-1", ch)
+	tracker.MarkDisconnected("identity-1", ch)
+
+	// the state the scan loop observes, and acts on, before removing the entry
+	entry, found := tracker.connections.Get("identity-1")
+	req.True(found)
+	entry.RLock()
+	empty := len(entry.routers) == 0
+	entry.RUnlock()
+	req.True(empty, "scan loop would decide to remove this entry")
+
+	// the identity reconnects before the removal runs
+	tracker.MarkConnected("identity-1", ch)
+
+	tracker.removeIfEmpty("identity-1")
+
+	req.Equal(1, tracker.connections.Count(), "reconnected identity should not be removed")
+	req.Equal(IdentityStateOnline, tracker.GetIdentityOnlineState("identity-1"))
+}
+
+// TestConnectionTrackerRemoveIfEmptyRemovesEmptyEntry is the other half of
+// TestConnectionTrackerRemoveIfEmptyRechecksMapValue, so that the recheck cannot be
+// satisfied by simply never removing anything.
+func TestConnectionTrackerRemoveIfEmptyRemovesEmptyEntry(t *testing.T) {
+	req := require.New(t)
+	tracker := newTestConnectionTracker(t)
+
+	ch := &fakeCtrlChannel{id: "router-1"}
+
+	tracker.MarkConnected("identity-1", ch)
+	tracker.MarkDisconnected("identity-1", ch)
+	req.Equal(1, tracker.connections.Count())
+
+	tracker.removeIfEmpty("identity-1")
+	req.Equal(0, tracker.connections.Count())
+}

--- a/controller/model/identity_manager.go
+++ b/controller/model/identity_manager.go
@@ -1099,6 +1099,14 @@ const (
 	IdentityStateUnknown IdentityOnlineState = 2
 )
 
+// identityConnections tracks which routers an identity is currently connected to, along
+// with the last connectivity state reported for it.
+//
+// Two locks protect the connection tracker: the shard lock inside the ConcurrentMap of
+// these, and the lock on each of these. They must always be acquired in that order,
+// shard lock first. The cmap Upsert and RemoveCb callbacks run with the shard lock held,
+// so taking this lock inside one of them is fine; taking the shard lock while already
+// holding this one is not, and will deadlock.
 type identityConnections struct {
 	sync.RWMutex
 	routers           map[string]ctrlchan.CtrlChannel
@@ -1191,17 +1199,34 @@ func (self *ConnectionTracker) ScanForDisconnectedRouters() {
 			}
 		}
 
-		entry.Val.Lock()
-		if len(entry.Val.routers) == 0 {
-			self.connections.RemoveCb(entry.Key, func(key string, v *identityConnections, exists bool) bool {
-				if v != nil {
-					return len(v.routers) == 0
-				}
-				return true
-			})
+		// This check is only a filter, so that we don't take the shard write lock for
+		// every identity on every scan. The entry lock must be released before calling
+		// removeIfEmpty, which takes the shard lock.
+		entry.Val.RLock()
+		empty := len(entry.Val.routers) == 0
+		entry.Val.RUnlock()
+
+		if empty {
+			self.removeIfEmpty(entry.Key)
 		}
-		entry.Val.Unlock()
 	}
+}
+
+// removeIfEmpty drops an identity's connection entry if it has no router connections.
+// The identity may have reconnected since the caller decided the entry was empty, so the
+// value currently in the map is what decides, not whatever the caller was looking at.
+//
+// This takes the shard lock, so it must not be called while holding an
+// identityConnections lock. See identityConnections for the lock ordering rules.
+func (self *ConnectionTracker) removeIfEmpty(identityId string) {
+	self.connections.RemoveCb(identityId, func(key string, v *identityConnections, exists bool) bool {
+		if v == nil {
+			return true
+		}
+		v.RLock()
+		defer v.RUnlock()
+		return len(v.routers) == 0
+	})
 }
 
 func (self *ConnectionTracker) MarkConnected(identityId string, ch ctrlchan.CtrlChannel) {


### PR DESCRIPTION
Fixes #4206

`ConnectionTracker` acquires the cmap shard lock and the per-identity
`identityConnections` lock in opposite orders. `ScanForDisconnectedRouters` holds the
value lock while calling `RemoveCb`, which needs the shard lock, whereas
`MarkConnected`/`MarkDisconnected` hold the shard lock inside the cmap `Upsert` callback
while taking the value lock. Racing on the same identity deadlocks permanently.

Because the shard lock is then never released, the failure escalates well past the
tracker: every identity read blocks in `GetIdentityOnlineState`, those reads run inside
bbolt read transactions, the leaked read transactions eventually block a database grow,
and the controller stops serving entirely. #4206 has the full chain.

This establishes a single lock order, shard lock then value lock, by releasing the value
lock before `RemoveCb` and taking it inside the callback instead. That also fixes an
unsynchronized read of the router map in the old callback.

The new `TestConnectionTrackerLockOrdering` deadlocks reliably without the fix and passes
with it.

Backports are tracked in #4207 (2.0) and #4208 (1.6). A follow-up will reduce the entry
churn in `SyncAllFromRouter` that makes this race easy to hit.
