### PR TITLE
fixes openziti/ziti#4222 report isCertExtendable correctly for OIDC cert auth

### DIFF
--- a/controller/oidc_auth/storage.go
+++ b/controller/oidc_auth/storage.go
@@ -455,7 +455,6 @@ func (s *HybridStorage) Authenticate(authCtx model.AuthContext, id string, confi
 
 		if certAuth != nil {
 			authRequest.IsCertExtendable = certAuth.IsIssuedByNetwork
-			authRequest.IsCertExtendable = true
 			authRequest.IsCertKeyRollRequested = certAuth.IsKeyRollRequested
 			authRequest.ImproperClientCertChain = result.ImproperClientCertChain()
 		}

--- a/tests/ca_test.go
+++ b/tests/ca_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Jeffail/gabs"
 	"github.com/openziti/edge-api/rest_model"
+	edge_apis "github.com/openziti/sdk-golang/v2/edge-apis"
 	"github.com/openziti/ziti/v2/common/eid"
 	"github.com/openziti/ziti/v2/controller/model"
 )
@@ -265,6 +266,38 @@ func Test_CA(t *testing.T) {
 			ctx.Req.NotNil(enrolledSession.AuthResponse)
 			ctx.Req.NotNil(enrolledSession.AuthResponse.IsCertExtendable)
 			ctx.Req.False(*enrolledSession.AuthResponse.IsCertExtendable, "expected isCertExtendable on 3rd party CA certificate authentication to be false")
+		})
+
+		t.Run("oidc auth from CA should not be extendable", func(t *testing.T) {
+			ctx.testContextChanged(t)
+
+			certCreds := edge_apis.NewCertCredentials(clientAuthenticator.certs, clientAuthenticator.key)
+			certCreds.CaPool = ctx.ControllerCaPool()
+
+			clientHelper := ctx.NewEdgeClientApi(nil)
+
+			t.Run("access token reports the certificate as not extendable", func(t *testing.T) {
+				ctx.testContextChanged(t)
+
+				_, accessClaims, err := clientHelper.OidcAccessToken(certCreds)
+				ctx.Req.NoError(err)
+				ctx.Req.False(accessClaims.IsCertExtendable, "expected the z_ice claim on 3rd party CA certificate OIDC authentication to be false")
+			})
+
+			t.Run("current api session reports the certificate as not extendable", func(t *testing.T) {
+				ctx.testContextChanged(t)
+
+				clientHelper.SetUseOidc(true)
+
+				apiSession, err := clientHelper.Authenticate(certCreds, nil)
+				ctx.Req.NoError(err)
+				ctx.Req.NotNil(apiSession)
+
+				currentSession, err := clientHelper.GetCurrentApiSessionDetail()
+				ctx.Req.NoError(err)
+				ctx.Req.NotNil(currentSession.IsCertExtendable)
+				ctx.Req.False(*currentSession.IsCertExtendable, "expected isCertExtendable on 3rd party CA certificate OIDC authentication to be false")
+			})
 		})
 
 		t.Run("CAs with auth disabled can no longer authenticate", func(t *testing.T) {


### PR DESCRIPTION
```
fixes openziti/ziti#4222 report isCertExtendable correctly for OIDC cert auth

- removes a stray assignment that overwrote isCertExtendable with a literal true on every OIDC certificate authentication
- reports isCertExtendable as false over OIDC for cert authenticators not issued by the network, matching legacy cert auth
- adds coverage asserting the z_ice claim and current-api-session both report a 3rd party CA certificate as not extendable
```

## Backports
- `release-v2.0.x` — shipped in v2.0.2
- `release-v1.6.x` — shipped in v1.6.19
