### PR TITLE
backport openziti/ziti#4222 to release-v1.6.x report isCertExtendable correctly for OIDC cert auth

### DIFF
--- a/controller/oidc_auth/storage.go
+++ b/controller/oidc_auth/storage.go
@@ -379,7 +379,6 @@ func (s *HybridStorage) Authenticate(authCtx model.AuthContext, id string, confi
 
 		if certAuth != nil {
 			authRequest.IsCertExtendable = certAuth.IsIssuedByNetwork
-			authRequest.IsCertExtendable = true
 			authRequest.IsCertKeyRollRequested = certAuth.IsKeyRollRequested
 			authRequest.ImproperClientCertChain = result.ImproperClientCertChain()
 		}

--- a/tests/ca_test.go
+++ b/tests/ca_test.go
@@ -5,7 +5,10 @@ package tests
 import (
 	"fmt"
 	"github.com/Jeffail/gabs"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/openziti/edge-api/rest_model"
+	edge_apis "github.com/openziti/sdk-golang/edge-apis"
+	"github.com/openziti/ziti/common"
 	"github.com/openziti/ziti/common/eid"
 	"github.com/openziti/ziti/controller/model"
 	"net/http"
@@ -264,6 +267,40 @@ func Test_CA(t *testing.T) {
 			ctx.Req.NotNil(enrolledSession.AuthResponse)
 			ctx.Req.NotNil(enrolledSession.AuthResponse.IsCertExtendable)
 			ctx.Req.False(*enrolledSession.AuthResponse.IsCertExtendable, "expected isCertExtendable on 3rd party CA certificate authentication to be false")
+		})
+
+		t.Run("oidc auth from CA should not be extendable", func(t *testing.T) {
+			ctx.testContextChanged(t)
+
+			clientHelper := ctx.NewEdgeClientApi(nil)
+			clientHelper.SetUseOidc(true)
+
+			certCreds := edge_apis.NewCertCredentials(clientAuthenticator.certs, clientAuthenticator.key)
+
+			apiSession, err := clientHelper.Authenticate(certCreds, nil)
+			ctx.Req.NoError(err)
+			ctx.Req.NotNil(apiSession)
+
+			oidcSession, ok := apiSession.(*edge_apis.ApiSessionOidc)
+			ctx.Req.True(ok, "expected an OIDC api session, got %T", apiSession)
+
+			t.Run("access token reports the certificate as not extendable", func(t *testing.T) {
+				ctx.testContextChanged(t)
+
+				accessClaims := &common.AccessClaims{}
+				_, _, err := jwt.NewParser().ParseUnverified(oidcSession.OidcTokens.AccessToken, accessClaims)
+				ctx.Req.NoError(err)
+				ctx.Req.False(accessClaims.IsCertExtendable, "expected the z_ice claim on 3rd party CA certificate OIDC authentication to be false")
+			})
+
+			t.Run("current api session reports the certificate as not extendable", func(t *testing.T) {
+				ctx.testContextChanged(t)
+
+				currentSession, err := clientHelper.GetCurrentApiSessionDetail()
+				ctx.Req.NoError(err)
+				ctx.Req.NotNil(currentSession.IsCertExtendable)
+				ctx.Req.False(*currentSession.IsCertExtendable, "expected isCertExtendable on 3rd party CA certificate OIDC authentication to be false")
+			})
 		})
 
 		t.Run("CAs with auth disabled can no longer authenticate", func(t *testing.T) {


### PR DESCRIPTION
Backport of #4224 to the v1.6 LTS line (targets `release-v1.6.x`, not `main`).

Original fix on main: f2173f8a470b989e0a60bd299f7c315e06d0cde1.

```
backport openziti/ziti#4222 to release-v1.6.x report isCertExtendable correctly for OIDC cert auth

- removes a stray assignment that overwrote isCertExtendable with a literal true on every OIDC certificate authentication
- reports isCertExtendable as false over OIDC for cert authenticators not issued by the network, matching legacy cert auth
- adds coverage asserting the z_ice claim and current-api-session both report a 3rd party CA certificate as not extendable
```

## Backport notes
- `controller/oidc_auth/storage.go` ports verbatim, one line removed; the assignment pair sits at 381-382 on this branch.
- `tests/ca_test.go` deviates from main. `ClientHelperClient.OidcAccessToken` does not exist on `release-v1.6.x`, so the new sub-test authenticates once through `SetUseOidc` and `Authenticate`, casts to `*edge_apis.ApiSessionOidc`, and parses the access token with `jwt.ParseUnverified` — the idiom this branch's other OIDC tests already use. Import paths are pre-`/v2`.
