### PR TITLE
Route stdlib slog.Default() into the sink on Install

### DIFF
--- a/common/logging/bridge.go
+++ b/common/logging/bridge.go
@@ -83,7 +83,8 @@ func (slogBridge) Fire(e *logrus.Entry) error {
 // (which drives both slog and logrus in lockstep), redirects logrus output to
 // io.Discard, replaces its formatter with a noop, enables ReportCaller so the
 // bridge can forward a real PC to slog, and registers the slogBridge hook so
-// every legacy log call routes through slog.
+// every legacy log call routes through slog. It also points stdlib
+// slog.Default() at the same sink so un-named slog output lands there too.
 //
 // Registering the hook replaces logrus's entire hook set, so any logrus hooks
 // added before Install are discarded. ziti adds none; a caller that does must
@@ -94,7 +95,22 @@ func (slogBridge) Fire(e *logrus.Entry) error {
 // output, formatter, or ReportCaller, or the bridge invariant breaks.
 func Install(handler slog.Handler, initialLevel slog.Level) {
 	InstallTo(logrus.StandardLogger(), handler, initialLevel)
+	// Point stdlib slog.Default() at the same sink, gated at the live global
+	// level, so un-named slog output - including libraries that log through
+	// slog.Default(), such as openziti/channel's internal loggers - lands in
+	// ziti's configured handler instead of slog's built-in stderr text handler.
+	// HandlerFor's namedHandler gates against the global level and forwards to
+	// the root Configure just installed, and binds no name attr of its own, so
+	// records that already carry a "channel" attr are not double-tagged.
+	slog.SetDefault(slog.New(HandlerFor(DefaultLoggerName)))
 }
+
+// DefaultLoggerName is the registry name whose level gates the stdlib
+// slog.Default() output that Install routes into the sink. Operators can adjust
+// it with "set-channel-log-level default <level>", which affects un-named slog
+// and any library that logs through slog.Default() (e.g. openziti/channel
+// internals).
+const DefaultLoggerName = "default"
 
 // InstallTo is the testable form of Install: it wires the given *logrus.Logger
 // instead of the global standard logger. Production code calls Install; tests

--- a/common/logging/bridge_test.go
+++ b/common/logging/bridge_test.go
@@ -187,6 +187,40 @@ func TestInstallToFiltersBelowLevel(t *testing.T) {
 	require.Equal(t, "passed", rec.snapshot()[0].Message)
 }
 
+// TestInstallSetsSlogDefault proves Install points stdlib slog.Default() at the
+// configured sink and gates it at the global level, so un-named slog output
+// (and libraries that log through slog.Default()) reaches ziti's handler and
+// respects the operator's level. Global logrus/slog state is saved and restored
+// so this test does not leak into others.
+func TestInstallSetsSlogDefault(t *testing.T) {
+	resetDefaultForTest()
+	rec := &recordingHandler{}
+	async, err := NewAsyncHandler(rec, DefaultOptions())
+	require.NoError(t, err)
+
+	prevDefault := slog.Default()
+	std := logrus.StandardLogger()
+	prevOut, prevFmt, prevLevel, prevHooks := std.Out, std.Formatter, std.Level, std.Hooks
+	t.Cleanup(func() {
+		slog.SetDefault(prevDefault)
+		std.SetOutput(prevOut)
+		std.SetFormatter(prevFmt)
+		std.SetLevel(prevLevel)
+		std.ReplaceHooks(prevHooks)
+	})
+
+	Install(async, slog.LevelInfo)
+
+	slog.Default().Debug("dropped-below-global")
+	slog.Default().Info("kept")
+
+	require.NoError(t, async.Close())
+	<-async.drainDone
+
+	require.Equal(t, 1, rec.count(), "Debug must be gated at the global level, Info must reach the sink")
+	require.Equal(t, "kept", rec.snapshot()[0].Message)
+}
+
 // TestSyncEmitFallsBackForNonAsyncRoot proves SyncEmit handles a Registry
 // whose root is not an *AsyncHandler by falling back to Handle. Handle on a
 // non-async handler is already synchronous, so durability is preserved.


### PR DESCRIPTION
`logging.Install` bridged `logrus.StandardLogger()` into the async slog sink but never set `slog.Default()`, so stdlib `slog.Default()` output — and any library that logs through it — went to slog's built-in stderr text handler instead of ziti's configured (JSON/pretty, async, level-gated) sink.

This adds a `slog.SetDefault` in `Install` that gates at the live global level and forwards to the root handler `Configure` just installed, reusing the registry's `HandlerFor` (which adds no name attr, so records that already carry a `channel` attr aren't double-tagged). The gating name `"default"` is operator-targetable via `set-channel-log-level default <level>`.

**Why now:** libraries dropping pfxlog log through slog directly. `openziti/channel`'s internal loggers back onto `slog.Default()` after its pfxlog removal (openziti/channel#284). Without this, once ziti bumps to the converted channel, channel's internal logs would regress from ziti's sink to plain stderr text. This is the companion that keeps "libraries emit slog, ziti collects it" working end-to-end.

Verified: `go build`, `go vet`, and `go test ./common/logging/` pass; new `TestInstallSetsSlogDefault` asserts `slog.Default()` reaches the sink and gates Debug below the global level.

Fixes #4232