### PR TITLE
Scope terminator operations to the requesting router

### DIFF
--- a/controller/handler_ctrl/base.go
+++ b/controller/handler_ctrl/base.go
@@ -17,10 +17,12 @@
 package handler_ctrl
 
 import (
+	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/channel/v5"
 	"github.com/openziti/ziti/v2/controller/change"
 	"github.com/openziti/ziti/v2/controller/model"
 	"github.com/openziti/ziti/v2/controller/network"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
 )
 
 type baseHandler struct {
@@ -30,4 +32,56 @@ type baseHandler struct {
 
 func (self *baseHandler) newChangeContext(ch channel.Channel, method string) *change.Context {
 	return change.NewControlChannelChange(self.router.Id, self.router.Name, method, ch)
+}
+
+// ownsTerminator reports whether terminator belongs to the router on the other end of this handler's
+// control channel. Terminator operations arriving on the fabric control channel are scoped to the
+// requesting router, mirroring the edge control channel's verifyTerminator.
+func (self *baseHandler) ownsTerminator(terminator *model.Terminator) bool {
+	return terminator.Router == self.router.Id
+}
+
+// lookupTerminatorOwner returns the id of the router that owns terminator id and whether the
+// terminator currently exists. A not-found terminator returns ("", false, nil); other read errors
+// are returned so the caller can default to keeping the id rather than acting on incomplete state.
+func (self *baseHandler) lookupTerminatorOwner(id string) (routerId string, present bool, err error) {
+	terminator, err := self.network.Terminator.Read(id)
+	if err != nil {
+		if boltz.IsErrNotFoundErr(err) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	return terminator.Router, true, nil
+}
+
+// selectOwnedTerminators returns the terminator ids from a remove request that this router may
+// remove, dropping (and logging) any whose terminator is owned by a different router, so a router
+// can only remove terminators it owns. Absent ids are kept so a delete racing a not-yet-applied
+// create is still ordered after it.
+func (self *baseHandler) selectOwnedTerminators(ids []string) []string {
+	kept, rejected := filterOwnedTerminators(ids, self.router.Id, self.lookupTerminatorOwner)
+	if rejected > 0 {
+		pfxlog.Logger().
+			WithField("routerId", self.router.Id).
+			WithField("rejected", rejected).
+			Warn("router attempted to remove terminators it does not own; rejected")
+	}
+	return kept
+}
+
+// filterOwnedTerminators returns the ids owned by requestingRouterId (or not currently present),
+// dropping ids whose terminator resolves to a different router; rejected counts those drops. A
+// lookup error keeps the id, so an unresolved owner is not treated as an ownership violation.
+func filterOwnedTerminators(ids []string, requestingRouterId string, lookup func(string) (routerId string, present bool, err error)) (kept []string, rejected int) {
+	kept = make([]string, 0, len(ids))
+	for _, id := range ids {
+		routerId, present, err := lookup(id)
+		if err == nil && present && routerId != requestingRouterId {
+			rejected++
+			continue
+		}
+		kept = append(kept, id)
+	}
+	return kept, rejected
 }

--- a/controller/handler_ctrl/base_test.go
+++ b/controller/handler_ctrl/base_test.go
@@ -1,0 +1,99 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package handler_ctrl
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/openziti/ziti/v2/controller/model"
+	"github.com/openziti/ziti/v2/controller/models"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_filterOwnedTerminators(t *testing.T) {
+	const me = "router-me"
+
+	// mine: present, owned by the requesting router; other: present, owned by a different router;
+	// gone: not present; err: lookup fails.
+	lookup := func(id string) (string, bool, error) {
+		switch id {
+		case "mine":
+			return me, true, nil
+		case "other":
+			return "router-other", true, nil
+		case "err":
+			return "", false, errors.New("boom")
+		default: // "gone" and anything else
+			return "", false, nil
+		}
+	}
+
+	t.Run("keeps owned and absent ids", func(t *testing.T) {
+		req := require.New(t)
+		kept, rejected := filterOwnedTerminators([]string{"mine", "gone"}, me, lookup)
+		req.Equal([]string{"mine", "gone"}, kept)
+		req.Zero(rejected)
+	})
+
+	t.Run("rejects ids owned by another router", func(t *testing.T) {
+		req := require.New(t)
+		kept, rejected := filterOwnedTerminators([]string{"other", "mine"}, me, lookup)
+		req.Equal([]string{"mine"}, kept, "a router may only remove terminators it owns")
+		req.Equal(1, rejected)
+	})
+
+	t.Run("a lookup error keeps the id", func(t *testing.T) {
+		req := require.New(t)
+		kept, rejected := filterOwnedTerminators([]string{"err"}, me, lookup)
+		req.Equal([]string{"err"}, kept, "an unresolved owner must not be treated as an ownership violation")
+		req.Zero(rejected)
+	})
+
+	t.Run("mixes kept and rejected", func(t *testing.T) {
+		req := require.New(t)
+		kept, rejected := filterOwnedTerminators([]string{"mine", "other", "gone", "err"}, me, lookup)
+		req.Equal([]string{"mine", "gone", "err"}, kept)
+		req.Equal(1, rejected)
+	})
+
+	t.Run("rejects every id when none are owned", func(t *testing.T) {
+		req := require.New(t)
+		kept, rejected := filterOwnedTerminators([]string{"other", "other"}, me, lookup)
+		req.Empty(kept, "an all-foreign batch must delete nothing")
+		req.Equal(2, rejected)
+	})
+}
+
+// Test_ownsTerminator covers the single-terminator check used by the remove and update handlers,
+// which reject outright rather than filtering.
+func Test_ownsTerminator(t *testing.T) {
+	handler := &baseHandler{router: &model.Router{BaseEntity: models.BaseEntity{Id: "router-me"}}}
+
+	t.Run("owned by the requesting router", func(t *testing.T) {
+		require.True(t, handler.ownsTerminator(&model.Terminator{Router: "router-me"}))
+	})
+
+	t.Run("owned by a different router", func(t *testing.T) {
+		require.False(t, handler.ownsTerminator(&model.Terminator{Router: "router-other"}))
+	})
+
+	t.Run("unset owner", func(t *testing.T) {
+		require.False(t, handler.ownsTerminator(&model.Terminator{}),
+			"a terminator with no owner must not be treated as owned by the requester")
+	})
+}

--- a/controller/handler_ctrl/remove_terminator.go
+++ b/controller/handler_ctrl/remove_terminator.go
@@ -64,6 +64,16 @@ func (self *removeTerminatorHandler) handleRemoveTerminator(msg *channel.Message
 		return
 	}
 
+	if !self.ownsTerminator(terminator) {
+		log.
+			WithField("routerId", self.router.Id).
+			WithField("terminator", request.TerminatorId).
+			WithField("terminatorRouterId", terminator.Router).
+			Warn("router attempted to remove a terminator it does not own; rejected")
+		handler_common.SendFailure(msg, ch, "terminator not owned by requesting router")
+		return
+	}
+
 	if err := self.network.Terminator.Delete(request.TerminatorId, self.newChangeContext(ch, "fabric.remove.terminator")); err == nil {
 		log.
 			WithField("routerId", ch.Id()).

--- a/controller/handler_ctrl/remove_terminators.go
+++ b/controller/handler_ctrl/remove_terminators.go
@@ -59,20 +59,25 @@ func (self *removeTerminatorsHandler) HandleReceive(msg *channel.Message, ch cha
 func (self *removeTerminatorsHandler) handleRemoveTerminators(msg *channel.Message, ch channel.Channel, request *ctrl_pb.RemoveTerminatorsRequest) {
 	log := pfxlog.ContextLogger(ch.Label())
 
-	// Don't pre-filter by IsEntityPresent here. The create for a terminator may be
-	// in-flight in raft but not yet applied to the DB. If we skip it here, the create
-	// will apply after we return success, leaving an orphan. By sending all IDs through
-	// raft, the delete will be ordered after the create and ApplyDeleteBatch will handle
-	// non-existent IDs gracefully.
 	if len(request.TerminatorIds) == 0 {
 		handler_common.SendSuccess(msg, ch, "")
 		return
 	}
 
-	if err := self.network.Terminator.DeleteBatch(request.TerminatorIds, self.newChangeContext(ch, "fabric.remove.terminators.batch")); err == nil {
+	// Drop ids this router doesn't own, so it can't remove another router's terminators. Absent ids
+	// are kept (not pre-filtered by presence): the create for a terminator may be in-flight in raft
+	// but not yet applied to the DB, so sending it through raft orders the delete after the create,
+	// and ApplyDeleteBatch handles non-existent ids gracefully.
+	toDelete := self.selectOwnedTerminators(request.TerminatorIds)
+	if len(toDelete) == 0 {
+		handler_common.SendSuccess(msg, ch, "")
+		return
+	}
+
+	if err := self.network.Terminator.DeleteBatch(toDelete, self.newChangeContext(ch, "fabric.remove.terminators.batch")); err == nil {
 		log.
 			WithField("routerId", ch.Id()).
-			WithField("terminatorIds", request.TerminatorIds).
+			WithField("terminatorIds", toDelete).
 			Info("removed terminators")
 		handler_common.SendSuccess(msg, ch, "")
 	} else if command.WasRateLimited(err) {

--- a/controller/handler_ctrl/update_terminator.go
+++ b/controller/handler_ctrl/update_terminator.go
@@ -66,6 +66,16 @@ func (self *updateTerminatorHandler) handleUpdateTerminator(msg *channel.Message
 		return
 	}
 
+	if !self.ownsTerminator(terminator) {
+		log.
+			WithField("routerId", self.router.Id).
+			WithField("terminator", request.TerminatorId).
+			WithField("terminatorRouterId", terminator.Router).
+			Warn("router attempted to update a terminator it does not own; rejected")
+		handler_common.SendFailure(msg, ch, "terminator not owned by requesting router")
+		return
+	}
+
 	if !request.UpdateCost && !request.UpdatePrecedence {
 		// nothing to do
 		handler_common.SendSuccess(msg, ch, "")

--- a/tests/terminator_ownership_test.go
+++ b/tests/terminator_ownership_test.go
@@ -1,0 +1,131 @@
+//go:build apitests
+
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openziti/channel/v5"
+	"github.com/openziti/ziti/v2/common/pb/ctrl_pb"
+	"github.com/openziti/ziti/v2/controller/xt_smartrouting"
+	"google.golang.org/protobuf/proto"
+)
+
+// Test_TerminatorOwnership drives the fabric control channel directly to confirm that terminator
+// operations are scoped to the requesting router: a router may only remove or update terminators it
+// owns. Without that scoping any enrolled router can delete another router's terminators (taking
+// down services hosted elsewhere) or re-weight them to steer traffic.
+func Test_TerminatorOwnership(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+	ctx.RequireAdminManagementApiLogin()
+
+	svc := ctx.AdminManagementSession.RequireNewServiceAccessibleToAll(xt_smartrouting.Name)
+
+	// The requesting router: real, enrolled, and connected, so we can send on its control channel.
+	requestingRouter := ctx.CreateEnrollAndStartEdgeRouter()
+
+	// The victim router only needs to exist in the model to own a terminator; it is never started.
+	victimRouter := ctx.AdminManagementSession.requireNewEdgeRouter()
+
+	ctrlCh := requestingRouter.GetNetworkControllers().AnyCtrlChannel()
+	ctx.Req.NotNil(ctrlCh)
+
+	// sendForResult sends a fabric ctrl_pb request and returns the controller's Result.
+	sendForResult := func(contentType int32, body proto.Message) *channel.Result {
+		bodyBytes, err := proto.Marshal(body)
+		ctx.Req.NoError(err)
+
+		msg := channel.NewMessage(contentType, bodyBytes)
+		reply, err := msg.WithTimeout(5 * time.Second).SendForReply(ctrlCh.GetDefaultSender())
+		ctx.Req.NoError(err)
+
+		return channel.UnmarshalResult(reply)
+	}
+
+	terminatorExists := func(id string) bool {
+		return ctx.AdminManagementSession.requireQuery("terminators/"+id) != nil
+	}
+
+	terminatorPrecedence := func(id string) string {
+		entity := ctx.AdminManagementSession.requireQuery("terminators/" + id)
+		return entity.Path("data.precedence").Data().(string)
+	}
+
+	newVictimTerminator := func() string {
+		term := ctx.AdminManagementSession.requireNewTerminator(svc.Id, victimRouter.id, "transport", "tcp:localhost:1234")
+		return term.id
+	}
+
+	t.Run("cannot remove a terminator owned by another router", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		terminatorId := newVictimTerminator()
+
+		result := sendForResult(int32(ctrl_pb.ContentType_RemoveTerminatorRequestType),
+			&ctrl_pb.RemoveTerminatorRequest{TerminatorId: terminatorId})
+
+		ctx.Req.False(result.Success, "removing another router's terminator must be rejected")
+		ctx.Req.True(terminatorExists(terminatorId), "the victim's terminator must survive the rejected removal")
+	})
+
+	t.Run("cannot remove another router's terminator in a batch", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		terminatorId := newVictimTerminator()
+
+		// The batch handler drops ids it does not own rather than failing the whole request, so the
+		// assertion that matters is that the terminator survives.
+		sendForResult(int32(ctrl_pb.ContentType_RemoveTerminatorsRequestType),
+			&ctrl_pb.RemoveTerminatorsRequest{TerminatorIds: []string{terminatorId}})
+
+		ctx.Req.True(terminatorExists(terminatorId), "the victim's terminator must survive the batch removal")
+	})
+
+	t.Run("cannot re-weight a terminator owned by another router", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		terminatorId := newVictimTerminator()
+		ctx.Req.Equal("default", terminatorPrecedence(terminatorId))
+
+		result := sendForResult(int32(ctrl_pb.ContentType_UpdateTerminatorRequestType),
+			&ctrl_pb.UpdateTerminatorRequest{
+				TerminatorId:     terminatorId,
+				UpdatePrecedence: true,
+				Precedence:       ctrl_pb.TerminatorPrecedence_Failed,
+			})
+
+		ctx.Req.False(result.Success, "updating another router's terminator must be rejected")
+		ctx.Req.Equal("default", terminatorPrecedence(terminatorId),
+			"the victim's terminator precedence must be unchanged")
+	})
+
+	t.Run("can remove a terminator it owns", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		term := ctx.AdminManagementSession.requireNewTerminator(svc.Id, requestingRouter.GetRouterId().Token, "transport", "tcp:localhost:1234")
+
+		result := sendForResult(int32(ctrl_pb.ContentType_RemoveTerminatorRequestType),
+			&ctrl_pb.RemoveTerminatorRequest{TerminatorId: term.id})
+
+		ctx.Req.True(result.Success, "a router must still be able to remove its own terminator: %v", result.Message)
+	})
+}


### PR DESCRIPTION
Fixes #4234.

The fabric control-channel terminator handlers acted on a message-supplied terminator id without checking
that the requesting router owns it, so a router could delete or re-weight terminators belonging to other
routers. Deleting takes down services hosted elsewhere; re-weighting (setting another router's terminator to
`Failed`, or to `Required`/`Cost=0`) changes where the network sends traffic for that service. The edge
control channel already enforced this via `verifyTerminator`; this closes the same gap on the fabric side.

The single remove and update handlers already read the terminator, so they check it directly and fail the
request. The batch handler filters instead, keeping ids that are absent so a delete racing a not-yet-applied
create still orders correctly through raft.

Covered by unit tests for the filter and the single-terminator check, and by an end-to-end test that drives
the control channel from a real enrolled router against a second router's terminator. Reverting just the
handler changes fails all three negative cases, so the test exercises the control rather than the happy path.

