### PR TITLE
[Backport-2.0] Scope terminator operations to the requesting router

### DIFF
--- a/controller/handler_ctrl/base.go
+++ b/controller/handler_ctrl/base.go
@@ -34,6 +34,13 @@ func (self *baseHandler) newChangeContext(ch channel.Channel, method string) *ch
 	return change.NewControlChannelChange(self.router.Id, self.router.Name, method, ch)
 }
 
+// ownsTerminator reports whether terminator belongs to the router on the other end of this handler's
+// control channel. Terminator operations arriving on the fabric control channel are scoped to the
+// requesting router, mirroring the edge control channel's verifyTerminator.
+func (self *baseHandler) ownsTerminator(terminator *model.Terminator) bool {
+	return terminator.Router == self.router.Id
+}
+
 // lookupTerminatorOwner returns the id of the router that owns terminator id and whether the
 // terminator currently exists. A not-found terminator returns ("", false, nil); other read errors
 // are returned so the caller can default to keeping the id rather than acting on incomplete state.

--- a/controller/handler_ctrl/base_test.go
+++ b/controller/handler_ctrl/base_test.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/openziti/ziti/v2/controller/model"
+	"github.com/openziti/ziti/v2/controller/models"
 	"github.com/stretchr/testify/require"
 )
 
@@ -67,5 +69,24 @@ func Test_filterOwnedTerminators(t *testing.T) {
 		kept, rejected := filterOwnedTerminators([]string{"mine", "other", "gone", "err"}, me, lookup)
 		req.Equal([]string{"mine", "gone", "err"}, kept)
 		req.Equal(1, rejected)
+	})
+}
+
+// Test_ownsTerminator covers the single-terminator check used by the remove and update handlers,
+// which reject outright rather than filtering.
+func Test_ownsTerminator(t *testing.T) {
+	handler := &baseHandler{router: &model.Router{BaseEntity: models.BaseEntity{Id: "router-me"}}}
+
+	t.Run("owned by the requesting router", func(t *testing.T) {
+		require.True(t, handler.ownsTerminator(&model.Terminator{Router: "router-me"}))
+	})
+
+	t.Run("owned by a different router", func(t *testing.T) {
+		require.False(t, handler.ownsTerminator(&model.Terminator{Router: "router-other"}))
+	})
+
+	t.Run("unset owner", func(t *testing.T) {
+		require.False(t, handler.ownsTerminator(&model.Terminator{}),
+			"a terminator with no owner must not be treated as owned by the requester")
 	})
 }

--- a/controller/handler_ctrl/remove_terminator.go
+++ b/controller/handler_ctrl/remove_terminator.go
@@ -64,6 +64,16 @@ func (self *removeTerminatorHandler) handleRemoveTerminator(msg *channel.Message
 		return
 	}
 
+	if !self.ownsTerminator(terminator) {
+		log.
+			WithField("routerId", self.router.Id).
+			WithField("terminator", request.TerminatorId).
+			WithField("terminatorRouterId", terminator.Router).
+			Warn("router attempted to remove a terminator it does not own; rejected")
+		handler_common.SendFailure(msg, ch, "terminator not owned by requesting router")
+		return
+	}
+
 	if err := self.network.Terminator.Delete(request.TerminatorId, self.newChangeContext(ch, "fabric.remove.terminator")); err == nil {
 		log.
 			WithField("routerId", ch.Id()).

--- a/controller/handler_ctrl/update_terminator.go
+++ b/controller/handler_ctrl/update_terminator.go
@@ -66,6 +66,16 @@ func (self *updateTerminatorHandler) handleUpdateTerminator(msg *channel.Message
 		return
 	}
 
+	if !self.ownsTerminator(terminator) {
+		log.
+			WithField("routerId", self.router.Id).
+			WithField("terminator", request.TerminatorId).
+			WithField("terminatorRouterId", terminator.Router).
+			Warn("router attempted to update a terminator it does not own; rejected")
+		handler_common.SendFailure(msg, ch, "terminator not owned by requesting router")
+		return
+	}
+
 	if !request.UpdateCost && !request.UpdatePrecedence {
 		// nothing to do
 		handler_common.SendSuccess(msg, ch, "")

--- a/tests/terminator_ownership_test.go
+++ b/tests/terminator_ownership_test.go
@@ -1,0 +1,131 @@
+//go:build apitests
+
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openziti/channel/v4"
+	"github.com/openziti/ziti/v2/common/pb/ctrl_pb"
+	"github.com/openziti/ziti/v2/controller/xt_smartrouting"
+	"google.golang.org/protobuf/proto"
+)
+
+// Test_TerminatorOwnership drives the fabric control channel directly to confirm that terminator
+// operations are scoped to the requesting router: a router may only remove or update terminators it
+// owns. Without that scoping any enrolled router can delete another router's terminators (taking
+// down services hosted elsewhere) or re-weight them to steer traffic.
+func Test_TerminatorOwnership(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+	ctx.RequireAdminManagementApiLogin()
+
+	svc := ctx.AdminManagementSession.RequireNewServiceAccessibleToAll(xt_smartrouting.Name)
+
+	// The requesting router: real, enrolled, and connected, so we can send on its control channel.
+	requestingRouter := ctx.CreateEnrollAndStartEdgeRouter()
+
+	// The victim router only needs to exist in the model to own a terminator; it is never started.
+	victimRouter := ctx.AdminManagementSession.requireNewEdgeRouter()
+
+	ctrlCh := requestingRouter.GetNetworkControllers().AnyCtrlChannel()
+	ctx.Req.NotNil(ctrlCh)
+
+	// sendForResult sends a fabric ctrl_pb request and returns the controller's Result.
+	sendForResult := func(contentType int32, body proto.Message) *channel.Result {
+		bodyBytes, err := proto.Marshal(body)
+		ctx.Req.NoError(err)
+
+		msg := channel.NewMessage(contentType, bodyBytes)
+		reply, err := msg.WithTimeout(5 * time.Second).SendForReply(ctrlCh.GetDefaultSender())
+		ctx.Req.NoError(err)
+
+		return channel.UnmarshalResult(reply)
+	}
+
+	terminatorExists := func(id string) bool {
+		return ctx.AdminManagementSession.requireQuery("terminators/"+id) != nil
+	}
+
+	terminatorPrecedence := func(id string) string {
+		entity := ctx.AdminManagementSession.requireQuery("terminators/" + id)
+		return entity.Path("data.precedence").Data().(string)
+	}
+
+	newVictimTerminator := func() string {
+		term := ctx.AdminManagementSession.requireNewTerminator(svc.Id, victimRouter.id, "transport", "tcp:localhost:1234")
+		return term.id
+	}
+
+	t.Run("cannot remove a terminator owned by another router", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		terminatorId := newVictimTerminator()
+
+		result := sendForResult(int32(ctrl_pb.ContentType_RemoveTerminatorRequestType),
+			&ctrl_pb.RemoveTerminatorRequest{TerminatorId: terminatorId})
+
+		ctx.Req.False(result.Success, "removing another router's terminator must be rejected")
+		ctx.Req.True(terminatorExists(terminatorId), "the victim's terminator must survive the rejected removal")
+	})
+
+	t.Run("cannot remove another router's terminator in a batch", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		terminatorId := newVictimTerminator()
+
+		// The batch handler drops ids it does not own rather than failing the whole request, so the
+		// assertion that matters is that the terminator survives.
+		sendForResult(int32(ctrl_pb.ContentType_RemoveTerminatorsRequestType),
+			&ctrl_pb.RemoveTerminatorsRequest{TerminatorIds: []string{terminatorId}})
+
+		ctx.Req.True(terminatorExists(terminatorId), "the victim's terminator must survive the batch removal")
+	})
+
+	t.Run("cannot re-weight a terminator owned by another router", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		terminatorId := newVictimTerminator()
+		ctx.Req.Equal("default", terminatorPrecedence(terminatorId))
+
+		result := sendForResult(int32(ctrl_pb.ContentType_UpdateTerminatorRequestType),
+			&ctrl_pb.UpdateTerminatorRequest{
+				TerminatorId:     terminatorId,
+				UpdatePrecedence: true,
+				Precedence:       ctrl_pb.TerminatorPrecedence_Failed,
+			})
+
+		ctx.Req.False(result.Success, "updating another router's terminator must be rejected")
+		ctx.Req.Equal("default", terminatorPrecedence(terminatorId),
+			"the victim's terminator precedence must be unchanged")
+	})
+
+	t.Run("can remove a terminator it owns", func(t *testing.T) {
+		ctx.NextTest(t)
+
+		term := ctx.AdminManagementSession.requireNewTerminator(svc.Id, requestingRouter.GetRouterId().Token, "transport", "tcp:localhost:1234")
+
+		result := sendForResult(int32(ctrl_pb.ContentType_RemoveTerminatorRequestType),
+			&ctrl_pb.RemoveTerminatorRequest{TerminatorId: term.id})
+
+		ctx.Req.True(result.Success, "a router must still be able to remove its own terminator: %v", result.Message)
+	})
+}


### PR DESCRIPTION
Backport of #4234 / #4235 to `release-v2.0.x`. Fixes #4236.

The batch remove handler was already scoped on this line by #4166, so this covers only the two handlers that
fix missed: the singular `remove_terminator.go` and `update_terminator.go`. Both were reachable, since all
three handlers are registered in `bind.go`.

Reuses the existing `ownsTerminator`-style check against the terminator each handler has already read, so
neither adds a second lookup. The helper is byte-identical to the one on `main`, so the two lines stay
convergent.

Also brings over the end-to-end test from #4235, which drives the fabric control channel from a real enrolled
router against a second router's terminator. Its batch case passes here on the strength of the existing
#4166 fix, so the test now covers all three paths on this line.