### PR TITLE
Index links by router id instead of scanning at connect time

### DIFF
--- a/common/concurrency/locked_set.go
+++ b/common/concurrency/locked_set.go
@@ -1,0 +1,82 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package concurrency
+
+import "sync"
+
+// LockedSet is a set guarded by a single RWMutex. Safe for concurrent use.
+//
+// It is intended for sets small enough, or written rarely enough, that one lock is not a bottleneck.
+// A sharded map is the alternative when writes are hot, at the cost of a map and a mutex per shard for
+// every set that exists; a copy-on-write set is the alternative when reads dominate and the set is
+// rarely written, at the cost of copying every entry per write.
+type LockedSet[T comparable] struct {
+	lock   sync.RWMutex
+	values map[T]struct{}
+}
+
+// NewLockedSet returns an empty LockedSet.
+func NewLockedSet[T comparable]() *LockedSet[T] {
+	return &LockedSet[T]{values: map[T]struct{}{}}
+}
+
+// Add adds value to the set. Adding a value already present is a no-op.
+func (self *LockedSet[T]) Add(value T) {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+	self.values[value] = struct{}{}
+}
+
+// Remove removes value from the set. Removing a value not present is a no-op.
+func (self *LockedSet[T]) Remove(value T) {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+	delete(self.values, value)
+}
+
+// RemoveIf removes value only if it is present and shouldRemove reports that it should be.
+//
+// shouldRemove runs with the set's write lock held, so it must not call back into this set. Use it when
+// the decision depends on state outside the set that could otherwise change between the check and the
+// removal.
+func (self *LockedSet[T]) RemoveIf(value T, shouldRemove func() bool) {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+	if _, found := self.values[value]; found && shouldRemove() {
+		delete(self.values, value)
+	}
+}
+
+// Contains reports whether value is in the set.
+func (self *LockedSet[T]) Contains(value T) bool {
+	self.lock.RLock()
+	defer self.lock.RUnlock()
+	_, found := self.values[value]
+	return found
+}
+
+// Values returns a snapshot of the set's contents in unspecified order. The caller owns the slice, and it
+// does not track later changes to the set.
+func (self *LockedSet[T]) Values() []T {
+	self.lock.RLock()
+	defer self.lock.RUnlock()
+	result := make([]T, 0, len(self.values))
+	for value := range self.values {
+		result = append(result, value)
+	}
+	return result
+}

--- a/common/concurrency/locked_set_test.go
+++ b/common/concurrency/locked_set_test.go
@@ -1,0 +1,107 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package concurrency
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLockedSet_AddRemoveContains(t *testing.T) {
+	req := require.New(t)
+	set := NewLockedSet[string]()
+
+	req.False(set.Contains("a"))
+	req.Empty(set.Values())
+
+	set.Add("a")
+	set.Add("a")
+	req.True(set.Contains("a"))
+	req.Equal([]string{"a"}, set.Values(), "adding a value already present must not duplicate it")
+
+	set.Remove("a")
+	set.Remove("a")
+	req.False(set.Contains("a"), "removing a value not present must be a no-op")
+	req.Empty(set.Values())
+}
+
+func TestLockedSet_RemoveIf(t *testing.T) {
+	req := require.New(t)
+	set := NewLockedSet[string]()
+	set.Add("a")
+
+	set.RemoveIf("a", func() bool { return false })
+	req.True(set.Contains("a"), "a refused removal must leave the value")
+
+	set.RemoveIf("a", func() bool { return true })
+	req.False(set.Contains("a"))
+
+	// The predicate decides only whether to remove; it is not consulted for a value that is absent, since
+	// there is nothing to remove either way.
+	consulted := false
+	set.RemoveIf("missing", func() bool {
+		consulted = true
+		return true
+	})
+	req.False(consulted, "the predicate must not run for a value that is not in the set")
+}
+
+func TestLockedSet_ValuesIsASnapshot(t *testing.T) {
+	req := require.New(t)
+	set := NewLockedSet[string]()
+	set.Add("a")
+
+	values := set.Values()
+	set.Add("b")
+	set.Remove("a")
+
+	req.Equal([]string{"a"}, values, "a returned slice must not track later changes")
+	req.Equal([]string{"b"}, set.Values())
+}
+
+func TestLockedSet_ConcurrentUse(t *testing.T) {
+	set := NewLockedSet[int]()
+
+	const writers = 8
+	const perWriter = 500
+
+	var wg sync.WaitGroup
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(base int) {
+			defer wg.Done()
+			for i := 0; i < perWriter; i++ {
+				value := base*perWriter + i
+				set.Add(value)
+				set.Contains(value)
+				set.RemoveIf(value, func() bool { return value%2 == 0 })
+				set.Values()
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	for w := 0; w < writers; w++ {
+		for i := 0; i < perWriter; i++ {
+			value := w*perWriter + i
+			require.Equal(t, value%2 != 0, set.Contains(value), fmt.Sprintf("value %d", value))
+		}
+	}
+}

--- a/controller/handler_ctrl/router_link.go
+++ b/controller/handler_ctrl/router_link.go
@@ -39,11 +39,20 @@ func (h *routerLinkHandler) ContentType() int32 {
 }
 
 func (h *routerLinkHandler) HandleReceive(msg *channel.Message, ch channel.Channel) {
-	if !h.r.Connected.Load() || ch.IsClosed() {
+	log := pfxlog.ContextLogger(ch.Label()).WithField("routerId", h.r.Id)
+
+	// Read once and report what was read: a reconnect can flip these between the decision and the log,
+	// leaving the warning naming a state that would not have discarded anything.
+	routerConnected, channelClosed := h.r.Connected.Load(), ch.IsClosed()
+
+	// A router announces its links once per reconnect and is never asked again, so a discard here leaves
+	// the controller with no links for that router until it reconnects. Do not drop it silently.
+	if !routerConnected || channelClosed {
+		log.WithField("routerConnected", routerConnected).
+			WithField("channelClosed", channelClosed).
+			Warn("discarding link report, this connection is not the router's current one")
 		return
 	}
-
-	log := pfxlog.ContextLogger(ch.Label())
 
 	link := &ctrl_pb.RouterLinks{}
 	if err := proto.Unmarshal(msg.Body, link); err != nil {
@@ -51,28 +60,16 @@ func (h *routerLinkHandler) HandleReceive(msg *channel.Message, ch channel.Chann
 		return
 	}
 
+	log.WithField("linkCount", len(link.Links)).
+		WithField("fullRefresh", link.FullRefresh).
+		Info("received link report from router")
+
 	h.HandleLinks(link)
 }
 
 func (h *routerLinkHandler) HandleLinks(links *ctrl_pb.RouterLinks) {
 	if links.FullRefresh {
-		linkIdMap := map[string]struct{}{}
-
-		for _, link := range links.Links {
-			linkIdMap[link.Id] = struct{}{}
-		}
-
-		var toRemove []*model.Link
-
-		for entry := range h.network.Link.IterateLinks() {
-			if entry.Val.Src.Id == h.r.Id {
-				if _, ok := linkIdMap[entry.Key]; !ok {
-					toRemove = append(toRemove, entry.Val)
-				}
-			}
-		}
-
-		for _, link := range toRemove {
+		for _, link := range linksToPrune(h.r.Id, h.network.Link.LinksForRouter(h.r.Id), links.Links) {
 			h.network.LinkFaulted(link, false)
 			pfxlog.Logger().WithField("linkId", link.Id).Info("removed link not present in full reported set")
 		}
@@ -81,4 +78,25 @@ func (h *routerLinkHandler) HandleLinks(links *ctrl_pb.RouterLinks) {
 	for _, link := range links.Links {
 		h.network.NotifyExistingLink(h.r, link)
 	}
+}
+
+// linksToPrune returns the links a full refresh implies are gone: those routerId is the source of that the
+// report does not list. current may also hold links routerId only accepts; those are the dialing router's to
+// report, so an omission here says nothing about them.
+func linksToPrune(routerId string, current []*model.Link, reported []*ctrl_pb.RouterLinks_RouterLink) []*model.Link {
+	reportedIds := make(map[string]struct{}, len(reported))
+	for _, link := range reported {
+		reportedIds[link.Id] = struct{}{}
+	}
+
+	var toRemove []*model.Link
+	for _, link := range current {
+		if link.Src.Id != routerId {
+			continue
+		}
+		if _, ok := reportedIds[link.Id]; !ok {
+			toRemove = append(toRemove, link)
+		}
+	}
+	return toRemove
 }

--- a/controller/handler_ctrl/router_link_test.go
+++ b/controller/handler_ctrl/router_link_test.go
@@ -1,0 +1,84 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package handler_ctrl
+
+import (
+	"testing"
+
+	"github.com/openziti/ziti/v2/common/pb/ctrl_pb"
+	"github.com/openziti/ziti/v2/controller/model"
+	"github.com/stretchr/testify/require"
+)
+
+// Test_linksToPrune covers the selection a full refresh drives. Its input is now the reporting router's own
+// links rather than the whole link table, so the filter has to be the thing that keeps a report from pruning
+// links the router did not dial.
+func Test_linksToPrune(t *testing.T) {
+	const me = "router-me"
+
+	self := model.NewRouter(me, "", "", 0, true)
+	other := model.NewRouter("router-other", "", "", 0, true)
+
+	dialed := func(id string) *model.Link {
+		return &model.Link{Id: id, Src: self, DstId: other.Id}
+	}
+	accepted := func(id string) *model.Link {
+		return &model.Link{Id: id, Src: other, DstId: me}
+	}
+	reported := func(ids ...string) []*ctrl_pb.RouterLinks_RouterLink {
+		var result []*ctrl_pb.RouterLinks_RouterLink
+		for _, id := range ids {
+			result = append(result, &ctrl_pb.RouterLinks_RouterLink{Id: id})
+		}
+		return result
+	}
+
+	ids := func(links []*model.Link) []string {
+		var result []string
+		for _, link := range links {
+			result = append(result, link.Id)
+		}
+		return result
+	}
+
+	t.Run("prunes dialed links the report omits", func(t *testing.T) {
+		current := []*model.Link{dialed("kept"), dialed("gone")}
+		require.Equal(t, []string{"gone"}, ids(linksToPrune(me, current, reported("kept"))))
+	})
+
+	t.Run("keeps every dialed link a full report lists", func(t *testing.T) {
+		current := []*model.Link{dialed("a"), dialed("b")}
+		require.Empty(t, linksToPrune(me, current, reported("a", "b")))
+	})
+
+	t.Run("an empty report prunes every dialed link", func(t *testing.T) {
+		current := []*model.Link{dialed("a"), dialed("b")}
+		require.Equal(t, []string{"a", "b"}, ids(linksToPrune(me, current, nil)))
+	})
+
+	t.Run("never prunes an accepted link", func(t *testing.T) {
+		// forRouter answers on either endpoint, so the router's accepted links arrive here too. They are
+		// the other router's to report, and an omission says nothing about them.
+		current := []*model.Link{accepted("inbound"), dialed("gone")}
+		require.Equal(t, []string{"gone"}, ids(linksToPrune(me, current, nil)),
+			"a report from one end must not remove links the other end dialed")
+	})
+
+	t.Run("a report naming links the router has no record of prunes nothing", func(t *testing.T) {
+		require.Empty(t, linksToPrune(me, nil, reported("unknown")))
+	})
+}

--- a/controller/model/link_manager.go
+++ b/controller/model/link_manager.go
@@ -28,7 +28,8 @@ import (
 	"github.com/openziti/ziti/v2/controller/models"
 	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/openziti/ziti/v2/controller/storage/objectz"
-	"github.com/orcaman/concurrent-map/v2"
+	cmap "github.com/orcaman/concurrent-map/v2"
+	"go.etcd.io/bbolt"
 )
 
 // linkLog is the logger for the controller's link manager. Its channel name is
@@ -40,6 +41,9 @@ type LinkManager struct {
 	linkLocks      *concurrency.StripedIdLocker
 	initialLatency time.Duration
 	models.BaseObjectStoreManager[*Link]
+	// env is held rather than the router manager, which does not exist yet when this one is built. Nil in
+	// tests that do not need router lookups.
+	env Env
 }
 
 func NewLinkManager(env Env) *LinkManager {
@@ -52,6 +56,7 @@ func NewLinkManager(env Env) *LinkManager {
 		linkTable:      newLinkTable(),
 		linkLocks:      concurrency.NewStripedIdLocker(256),
 		initialLatency: initialLatency,
+		env:            env,
 	}
 
 	result.InitStore(objectz.NewObjectStore[*Link](func() objectz.ObjectIterator[*Link] {
@@ -109,16 +114,41 @@ func (self *LinkManager) BaseLoad(id string) (*Link, error) {
 	return entity, nil
 }
 
+// BuildRouterLinks points every link destined for router at it, and adds each to router's link set. Safe
+// to call repeatedly; links already pointing at router are left alone.
 func (self *LinkManager) BuildRouterLinks(router *Router) {
-	self.linkTable.links.IterCb(func(_ string, link *Link) {
-		if link.DstId == router.Id {
-			router.routerLinks.Add(link, link.Src.Id)
-			link.Dst.Store(router)
-		}
-	})
+	for _, linkId := range self.linkTable.linkIdsForRouter(router.Id) {
+		self.buildRouterLink(router, linkId)
+	}
 }
 
+// buildRouterLink pairs one link with router, taking the link's stripe so the pairing cannot interleave
+// with a removal. Without it a removal that reads no destination completes while this is still deciding,
+// and the link lands in router's link set after the table has dropped it, where it is still routed over.
+func (self *LinkManager) buildRouterLink(router *Router, linkId string) {
+	defer self.linkLocks.LockFor(linkId)()
+
+	// Resolved under the stripe: a replacement may have taken this id since the index was read, and it is
+	// the link the table holds now that has to be paired.
+	link, found := self.Get(linkId)
+	if !found {
+		return
+	}
+	if link.DstId == router.Id && link.PointDestAt(router) {
+		router.routerLinks.Add(link, link.Src.Id)
+	}
+}
+
+// Add publishes link to the link table, to its endpoint routers' link sets, and to the per-router index.
+// Serialized against any other change to the same link id: the table and the index are written in separate
+// steps, and an interleaved removal would leave the link indexed but no longer in the table.
 func (self *LinkManager) Add(link *Link) {
+	defer self.linkLocks.LockFor(link.Id)()
+	self.addLocked(link)
+}
+
+// addLocked publishes a link. The caller must hold the link's stripe.
+func (self *LinkManager) addLocked(link *Link) {
 	self.linkTable.add(link)
 	link.Src.routerLinks.Add(link, link.DstId)
 	if dest := link.GetDest(); dest != nil {
@@ -143,6 +173,27 @@ func (self *LinkManager) ScanForDeadLinks() {
 	}
 }
 
+// repairDest points link at whichever router is currently connected for its destination id, and adds it to
+// that router's link set. It covers a link recorded while that router was not connected, and one still
+// pointing at a connection that has since been replaced. No-op if the router is absent or the link already
+// points at it, so it is safe to call on every report. The link must already be in the link table.
+func (self *LinkManager) repairDest(link *Link) {
+	if self.env == nil || link.Src == nil {
+		return
+	}
+	dst := self.env.GetManagers().Router.GetConnected(link.DstId)
+	if dst == nil {
+		return
+	}
+	if link.PointDestAt(dst) {
+		dst.routerLinks.Add(link, link.Src.Id)
+		linkLog.Info("repaired link destination",
+			"linkId", link.Id,
+			"linkSrcRouterId", link.Src.Id,
+			"linkDestRouterId", link.DstId)
+	}
+}
+
 func (self *LinkManager) RouterReportedLink(reportedLink *ctrl_pb.RouterLinks_RouterLink, src, dst *Router) (*Link, bool) {
 	// Striped by link id so concurrent reports for different links proceed in
 	// parallel; reports for the same link still serialize. Replaces a single
@@ -151,6 +202,9 @@ func (self *LinkManager) RouterReportedLink(reportedLink *ctrl_pb.RouterLinks_Ro
 
 	link, _ := self.Get(reportedLink.Id)
 	if link != nil && link.Iteration >= reportedLink.Iteration {
+		// A link can be left pointing at nothing, or at a connection that has since been replaced. Both are
+		// invisible in the table, so a later report is the only thing that will notice.
+		self.repairDest(link)
 		return link, false
 	}
 
@@ -163,7 +217,7 @@ func (self *LinkManager) RouterReportedLink(reportedLink *ctrl_pb.RouterLinks_Ro
 			"iteration", reportedLink.Iteration)
 
 		oldIteration := link.Iteration
-		self.Remove(link)
+		self.removeLocked(link)
 		log.Info("replaced link with newer iteration",
 			"oldIteration", oldIteration,
 			"newIteration", reportedLink.Iteration)
@@ -176,7 +230,12 @@ func (self *LinkManager) RouterReportedLink(reportedLink *ctrl_pb.RouterLinks_Ro
 	link.DstId = reportedLink.DestRouterId
 	link.SetState(Connected)
 	link.SetConnsState(reportedLink.ConnState)
-	self.Add(link)
+	self.addLocked(link)
+
+	// dst was resolved before the link was in the table, and under the source's connect stripe rather than
+	// the destination's, so the destination may have connected or been replaced since.
+	self.repairDest(link)
+
 	return link, true
 }
 
@@ -188,8 +247,48 @@ func (self *LinkManager) All() []*Link {
 	return self.linkTable.all()
 }
 
-func (self *LinkManager) IterateLinks() <-chan cmap.Tuple[string, *Link] {
-	return self.linkTable.links.IterBuffered()
+// RouterDeleted drops the deleted router's link index, unless the id has since come back.
+//
+// A router id can be reused: fabric router ids are the enrollment certificate's common name, so re-adding
+// a router from the same cert reuses its id. Nothing orders this call against that, since store commit
+// handlers run after bolt has released the writer lock, so it can execute long after the id was recreated,
+// connected, and reported links. Dropping a live router's index is invisible in the link table and surfaces
+// only when a per-router query fails to find links it should have.
+//
+// Re-reading the store closes that rather than narrowing it, because the read happens while the index map's
+// shard is held. Indexing a link takes the same shard, so an entry for a live router cannot appear without
+// its create having committed first, which this read would then see. Anything indexed while the store says
+// the id is absent belongs to the deleted router.
+func (self *LinkManager) RouterDeleted(routerId string) {
+	self.linkTable.dropRouterIndexIf(routerId, func() bool {
+		return !self.routerExists(routerId)
+	})
+}
+
+// routerExists reports whether a router with this id is in the store. A nil env, which only happens in
+// tests that do not build one, reports absent so cleanup still runs.
+func (self *LinkManager) routerExists(routerId string) bool {
+	if self.env == nil {
+		return false
+	}
+	found := false
+	if err := self.env.GetDb().View(func(tx *bbolt.Tx) error {
+		found = self.env.GetStores().Router.IsEntityPresent(tx, routerId)
+		return nil
+	}); err != nil {
+		// Unreadable is not evidence the router is gone, and keeping an index costs only its entry.
+		linkLog.Warn("could not check whether router still exists, keeping its link index",
+			"routerId", routerId,
+			"error", err)
+		return true
+	}
+	return found
+}
+
+// LinksForRouter returns the links with routerId at either end. Per-router work must use this rather than
+// filtering the whole table, which is quadratic in the router count.
+func (self *LinkManager) LinksForRouter(routerId string) []*Link {
+	return self.linkTable.forRouter(routerId)
 }
 
 func (self *LinkManager) GetLinkMap() map[string]*Link {
@@ -200,7 +299,15 @@ func (self *LinkManager) GetLinkMap() map[string]*Link {
 	return linkMap
 }
 
+// Remove retracts link from the link table, its endpoint routers' link sets, and the per-router index.
+// Serialized against any other change to the same link id, for the reason given on Add.
 func (self *LinkManager) Remove(link *Link) {
+	defer self.linkLocks.LockFor(link.Id)()
+	self.removeLocked(link)
+}
+
+// removeLocked retracts a link. The caller must hold the link's stripe.
+func (self *LinkManager) removeLocked(link *Link) {
 	if self.linkTable.remove(link) {
 		link.Src.routerLinks.Remove(link, link.DstId)
 		if dest := link.GetDest(); dest != nil {
@@ -272,14 +379,81 @@ func (self *LinkManager) LinksInMode(mode LinkMode) []*Link {
 
 type linkTable struct {
 	links cmap.ConcurrentMap[string, *Link]
+	// byRouter indexes router id -> link ids, so per-router work does not have to scan the whole table.
+	// It answers which links touch a router; links is what a link id currently resolves to.
+	byRouter cmap.ConcurrentMap[string, *concurrency.LockedSet[string]]
 }
 
 func newLinkTable() *linkTable {
-	return &linkTable{links: cmap.New[*Link]()}
+	return &linkTable{
+		links:    cmap.New[*Link](),
+		byRouter: cmap.New[*concurrency.LockedSet[string]](),
+	}
+}
+
+// endpointIds returns the router ids a link should be indexed under, without duplicates.
+func (lt *linkTable) endpointIds(link *Link) []string {
+	ids := make([]string, 0, 2)
+	if link.Src != nil {
+		ids = append(ids, link.Src.Id)
+	}
+	if link.DstId != "" && (len(ids) == 0 || link.DstId != ids[0]) {
+		ids = append(ids, link.DstId)
+	}
+	return ids
+}
+
+// indexFor returns the link index for a router id, creating it if absent. Indexes are dropped only when
+// their router is deleted; dropping one otherwise, an empty one included, could discard a link another
+// goroutine had already fetched the index to record.
+func (lt *linkTable) indexFor(routerId string) *concurrency.LockedSet[string] {
+	if index, found := lt.byRouter.Get(routerId); found {
+		return index
+	}
+	return lt.byRouter.Upsert(routerId, concurrency.NewLockedSet[string](),
+		func(exists bool, existing, created *concurrency.LockedSet[string]) *concurrency.LockedSet[string] {
+			if exists {
+				return existing
+			}
+			return created
+		})
+}
+
+// dropRouterIndexIf forgets a router's link index when shouldDrop agrees. shouldDrop runs with the index
+// map's shard held, so it must not index a link, and callers relying on that exclusion should say so.
+func (lt *linkTable) dropRouterIndexIf(routerId string, shouldDrop func() bool) {
+	lt.byRouter.RemoveCb(routerId, func(_ string, _ *concurrency.LockedSet[string], _ bool) bool {
+		return shouldDrop()
+	})
+}
+
+// linkIdsForRouter returns the ids indexed under the given router. Ids the table no longer holds are
+// included; callers resolving them get nothing back for those.
+func (lt *linkTable) linkIdsForRouter(routerId string) []string {
+	index, found := lt.byRouter.Get(routerId)
+	if !found {
+		return nil
+	}
+	return index.Values()
+}
+
+// forRouter returns the links with the given router at either end.
+func (lt *linkTable) forRouter(routerId string) []*Link {
+	ids := lt.linkIdsForRouter(routerId)
+	result := make([]*Link, 0, len(ids))
+	for _, linkId := range ids {
+		if link, ok := lt.links.Get(linkId); ok {
+			result = append(result, link)
+		}
+	}
+	return result
 }
 
 func (lt *linkTable) add(link *Link) {
 	lt.links.Set(link.Id, link)
+	for _, routerId := range lt.endpointIds(link) {
+		lt.indexFor(routerId).Add(link.Id)
+	}
 }
 
 func (lt *linkTable) get(linkId string) (*Link, bool) {
@@ -312,7 +486,27 @@ func (lt *linkTable) allInMode(mode LinkMode) []*Link {
 }
 
 func (lt *linkTable) remove(link *Link) bool {
-	return lt.links.RemoveCb(link.Id, func(key string, v *Link, exists bool) bool {
+	removed := lt.links.RemoveCb(link.Id, func(key string, v *Link, exists bool) bool {
 		return v != nil && v.Iteration == link.Iteration
 	})
+	if removed {
+		lt.unindex(link)
+	}
+	return removed
+}
+
+// unindex drops link's id from its endpoint indexes, unless the table holds a link under that id again.
+//
+// A replacement can take the table slot and index itself between a removal's table write and this call, and
+// dropping the id then would leave a live link that per-router queries never find. A stale id is the safe
+// direction to err in, since forRouter resolves ids against the table and skips the ones it no longer holds.
+func (lt *linkTable) unindex(link *Link) {
+	for _, routerId := range lt.endpointIds(link) {
+		if index, found := lt.byRouter.Get(routerId); found {
+			index.RemoveIf(link.Id, func() bool {
+				_, live := lt.links.Get(link.Id)
+				return !live
+			})
+		}
+	}
 }

--- a/controller/model/link_manager_test.go
+++ b/controller/model/link_manager_test.go
@@ -17,9 +17,11 @@
 package model
 
 import (
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/openziti/ziti/v2/common/pb/ctrl_pb"
 	"github.com/stretchr/testify/assert"
@@ -149,4 +151,319 @@ func Test_RouterReportedLink_serializesAndStableOnStaleReport(t *testing.T) {
 	req.True(ok)
 	req.Equal(uint32(maxIteration), got.Iteration, "highest reported iteration wins regardless of arrival order")
 	req.Len(lm.All(), 1, "exactly one link remains in the table")
+}
+
+// Test_linkTable_forRouter asserts a link is indexed under both of its endpoints, and unindexed from both
+// when removed.
+func Test_linkTable_forRouter(t *testing.T) {
+	req := require.New(t)
+	lm := NewLinkManager(nil)
+
+	r0 := NewRouterForTest("r0", "", nil, nil, 0, true)
+	r1 := NewRouterForTest("r1", "", nil, nil, 0, true)
+	r2 := NewRouterForTest("r2", "", nil, nil, 0, true)
+
+	l01 := NewTestLink("l01", r0, r1)
+	l02 := NewTestLink("l02", r0, r2)
+	lm.Add(l01)
+	lm.Add(l02)
+
+	req.ElementsMatch([]*Link{l01, l02}, lm.linkTable.forRouter("r0"), "indexed under the source router")
+	req.Equal([]*Link{l01}, lm.linkTable.forRouter("r1"), "indexed under the destination router")
+	req.Equal([]*Link{l02}, lm.linkTable.forRouter("r2"))
+	req.Empty(lm.linkTable.forRouter("no-such-router"))
+
+	lm.Remove(l01)
+	req.Equal([]*Link{l02}, lm.linkTable.forRouter("r0"), "removal unindexes from the source")
+	req.Empty(lm.linkTable.forRouter("r1"), "removal unindexes from the destination")
+}
+
+// Test_linkTable_indexStaysConsistentUnderChurn is the leak guard for the router-id index: after a mesh is
+// built, partly torn down, and has links replaced by higher iterations, the index must hold exactly what the
+// table holds for every router. A change that altered a link's endpoint ids after it was added, or that
+// bypassed the add/remove path, would strand entries here and keep dead links reachable.
+func Test_linkTable_indexStaysConsistentUnderChurn(t *testing.T) {
+	req := require.New(t)
+	lm := NewLinkManager(nil)
+
+	const routerCount = 12
+	routers := make([]*Router, routerCount)
+	for i := range routers {
+		routers[i] = NewRouterForTest(fmt.Sprintf("r%02d", i), "", nil, nil, 0, true)
+	}
+
+	linkId := func(i, j int) string { return fmt.Sprintf("l-%02d-%02d", i, j) }
+
+	// A full mesh, so every router carries links at both ends.
+	for i := 0; i < routerCount; i++ {
+		for j := i + 1; j < routerCount; j++ {
+			lm.Add(NewTestLink(linkId(i, j), routers[i], routers[j]))
+		}
+	}
+
+	// Remove a scattering of links.
+	for i := 0; i < routerCount; i += 3 {
+		for j := i + 1; j < routerCount; j += 2 {
+			if link, found := lm.Get(linkId(i, j)); found {
+				lm.Remove(link)
+			}
+		}
+	}
+
+	// Replace some links with a higher iteration, which removes and re-adds the same link id.
+	for i := 1; i < routerCount; i += 4 {
+		j := i + 1
+		lm.RouterReportedLink(&ctrl_pb.RouterLinks_RouterLink{
+			Id:           linkId(i, j),
+			DestRouterId: routers[j].Id,
+			LinkProtocol: "tls",
+			DialAddress:  "tcp:localhost:1234",
+			Iteration:    7,
+		}, routers[i], routers[j])
+	}
+
+	// Connect-time repointing replaces the Router objects a link references. The index is keyed on ids, so
+	// this must not disturb it.
+	for i := range routers {
+		fresh := NewRouterForTest(routers[i].Id, "", nil, nil, 0, true)
+		lm.BuildRouterLinks(fresh)
+	}
+
+	// The index must agree with the table, per router, in both directions.
+	for _, router := range routers {
+		expected := map[string]*Link{}
+		for _, link := range lm.All() {
+			if link.Src.Id == router.Id || link.DstId == router.Id {
+				expected[link.Id] = link
+			}
+		}
+
+		indexed := map[string]*Link{}
+		for _, link := range lm.linkTable.forRouter(router.Id) {
+			indexed[link.Id] = link
+		}
+
+		req.Equal(expected, indexed, "index and table disagree for router %v", router.Id)
+	}
+}
+
+// Test_linkTable_removeKeepsAReplacementIndexed covers the guard on index cleanup: a removal must not
+// unindex an id the table holds a link under again. Add and Remove serialize on the link id, so this is
+// belt-and-braces, kept because dropping the id is invisible in the table and surfaces only when a
+// per-router query later fails to find the link.
+func Test_linkTable_removeKeepsAReplacementIndexed(t *testing.T) {
+	req := require.New(t)
+
+	src := NewRouter("r0", "", "", 0, true)
+	dst := NewRouter("r1", "", "", 0, true)
+
+	lt := newLinkTable()
+	link := NewTestLink("l0", src, dst)
+	lt.add(link)
+
+	// The interleave the guard exists for: a replacement takes the table slot and indexes itself between a
+	// removal's table write and its unindex. Driven through unindex directly, since remove's iteration
+	// check refuses the primary removal once the replacement is in the table.
+	replacement := NewTestLink("l0", src, dst)
+	replacement.Iteration = link.Iteration + 1
+	lt.links.Set(replacement.Id, replacement)
+
+	lt.unindex(link)
+
+	for _, routerId := range []string{src.Id, dst.Id} {
+		req.Equal([]*Link{replacement}, lt.forRouter(routerId),
+			"the replacement must stay reachable under %v", routerId)
+	}
+
+	// With nothing live under the id, the same call must drop it rather than strand it. forRouter cannot
+	// tell the two apart, so this asserts against the index.
+	lt.links.Remove(replacement.Id)
+	lt.unindex(link)
+
+	for _, routerId := range []string{src.Id, dst.Id} {
+		index, found := lt.byRouter.Get(routerId)
+		req.True(found)
+		req.False(index.Contains(link.Id), "a removed link's id must not be left indexed under %v", routerId)
+	}
+}
+
+// Test_linkTable_forRouterTreatsTheTableAsAuthoritative asserts a per-router query does not hand back a link
+// the table no longer holds. The index is written in a separate step, so it can briefly disagree.
+func Test_linkTable_forRouterTreatsTheTableAsAuthoritative(t *testing.T) {
+	req := require.New(t)
+
+	src := NewRouter("r0", "", "", 0, true)
+	dst := NewRouter("r1", "", "", 0, true)
+
+	lt := newLinkTable()
+	link := NewTestLink("l0", src, dst)
+	lt.add(link)
+	req.Len(lt.forRouter(src.Id), 1)
+
+	// A stale index entry: gone from the table, still indexed.
+	lt.links.Remove(link.Id)
+
+	req.Empty(lt.forRouter(src.Id), "a link the table no longer holds must not be returned")
+	req.Empty(lt.forRouter(dst.Id), "nor under its other endpoint")
+
+	// The same id resolving to a new link is not staleness, and must be returned.
+	replacement := NewTestLink("l0", src, dst)
+	replacement.Iteration = link.Iteration + 1
+	lt.links.Set(replacement.Id, replacement)
+
+	req.Equal([]*Link{replacement}, lt.forRouter(src.Id), "a replaced link resolves to whatever the table holds")
+	req.Equal([]*Link{replacement}, lt.forRouter(dst.Id))
+}
+
+// Test_LinkManager_BuildRouterLinksSerializesOnLinkId asserts the connect-time pairing takes the same
+// stripe every other change to a link takes. Without it a removal that reads no destination can complete
+// between this reading the table and adding to the router's link set, leaving the link in that set after
+// the table has dropped it, where path computation still routes over it.
+func Test_LinkManager_BuildRouterLinksSerializesOnLinkId(t *testing.T) {
+	req := require.New(t)
+	lm := NewLinkManager(nil)
+
+	src := NewRouter("r0", "", "", 0, true)
+	dst := NewRouter("r1", "", "", 0, true)
+	link := NewTestLink("l0", src, dst)
+	link.Dst.Store(nil)
+	lm.Add(link)
+
+	// Stands in for a removal of this link already in progress.
+	unlock := lm.linkLocks.LockFor(link.Id)
+
+	built := make(chan struct{})
+	go func() {
+		lm.BuildRouterLinks(dst)
+		close(built)
+	}()
+
+	select {
+	case <-built:
+		req.Fail("the link build paired a link while another change to it was in flight")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	unlock()
+
+	select {
+	case <-built:
+	case <-time.After(5 * time.Second):
+		req.Fail("the link build did not proceed once the link's stripe was released")
+	}
+	req.Same(dst, link.GetDest(), "the link must be paired once the stripe is free")
+	req.Len(dst.GetLinks(), 1)
+}
+
+// Test_LinkManager_BuildRouterLinksSkipsUnresolvedIds: the index can name an id the table no longer holds,
+// which is the state a removal leaves behind when it keeps an id a replacement may have taken. The pairing
+// resolves ids under the stripe and must skip the ones that resolve to nothing, rather than adding a link
+// the table has dropped to the router's link set, where nothing would clean it up.
+func Test_LinkManager_BuildRouterLinksSkipsUnresolvedIds(t *testing.T) {
+	req := require.New(t)
+	lm := NewLinkManager(nil)
+
+	src := NewRouter("r0", "", "", 0, true)
+	dst := NewRouter("r1", "", "", 0, true)
+	link := NewTestLink("l0", src, dst)
+	link.Dst.Store(nil)
+	lm.Add(link)
+
+	// Gone from the table, still indexed.
+	lm.linkTable.links.Remove(link.Id)
+	req.Equal([]string{link.Id}, lm.linkTable.linkIdsForRouter(dst.Id), "the id must still be indexed")
+
+	lm.BuildRouterLinks(dst)
+
+	req.Nil(link.GetDest(), "a link the table no longer holds must not be paired")
+	req.Empty(dst.GetLinks(), "nor added to the router's link set")
+}
+
+// Test_LinkManager_RouterDeletedDropsTheIndex: a router id is only ever added to the index, so without a
+// drop on delete every router that has ever had a link is held for the controller's lifetime. The links
+// themselves are left alone, since a deleted router's peers still hold theirs.
+func Test_LinkManager_RouterDeletedDropsTheIndex(t *testing.T) {
+	req := require.New(t)
+	lm := NewLinkManager(nil)
+
+	gone := NewRouter("r0", "", "", 0, true)
+	peer := NewRouter("r1", "", "", 0, true)
+	link := NewTestLink("l0", gone, peer)
+	lm.Add(link)
+
+	req.Len(lm.LinksForRouter(gone.Id), 1)
+	req.Len(lm.LinksForRouter(peer.Id), 1)
+
+	lm.RouterDeleted(gone.Id)
+
+	_, found := lm.linkTable.byRouter.Get(gone.Id)
+	req.False(found, "the deleted router's index must be dropped, not just emptied")
+	req.Empty(lm.LinksForRouter(gone.Id))
+
+	req.Len(lm.LinksForRouter(peer.Id), 1, "the other endpoint's index must be untouched")
+	req.True(lm.has(link), "dropping an index must not remove the link itself")
+
+	// A report still in flight recreates the entry. Nothing reads it, since a deleted router cannot connect.
+	lm.Add(link)
+	req.Len(lm.LinksForRouter(peer.Id), 1, "the peer's index must not be double-counted by the recreate")
+}
+
+// Test_LinkManager_AddAndRemoveSerializeOnLinkId asserts a change to a link cannot begin while another
+// change to the same link is in flight. That is what keeps a removal from running between an add's table and
+// index writes, which would leave the link indexed but untabled. The window is two map writes wide, so the
+// property is asserted directly rather than by stressing it.
+func Test_LinkManager_AddAndRemoveSerializeOnLinkId(t *testing.T) {
+	req := require.New(t)
+	lm := NewLinkManager(nil)
+
+	src := NewRouter("r0", "", "", 0, true)
+	dst := NewRouter("r1", "", "", 0, true)
+	link := NewTestLink("l0", src, dst)
+
+	// Stands in for a change to this link already in progress.
+	unlock := lm.linkLocks.LockFor(link.Id)
+
+	added := make(chan struct{})
+	go func() {
+		lm.Add(link)
+		close(added)
+	}()
+
+	select {
+	case <-added:
+		req.Fail("Add published while another change to the same link was in flight")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	unlock()
+
+	select {
+	case <-added:
+	case <-time.After(5 * time.Second):
+		req.Fail("Add did not proceed once the link's stripe was released")
+	}
+	req.True(lm.has(link))
+
+	// Remove takes the same stripe, so it is serialized against an add for the same link either way round.
+	unlock = lm.linkLocks.LockFor(link.Id)
+	removed := make(chan struct{})
+	go func() {
+		lm.Remove(link)
+		close(removed)
+	}()
+
+	select {
+	case <-removed:
+		req.Fail("Remove retracted while another change to the same link was in flight")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	unlock()
+
+	select {
+	case <-removed:
+	case <-time.After(5 * time.Second):
+		req.Fail("Remove did not proceed once the link's stripe was released")
+	}
+	req.False(lm.has(link))
 }

--- a/controller/model/link_model.go
+++ b/controller/model/link_model.go
@@ -72,6 +72,20 @@ func (link *Link) GetDest() *Router {
 	return link.Dst.Load()
 }
 
+// PointDestAt points the link at dst, reporting whether that changed which router it pointed at. Several
+// paths may point a link at the same router; callers use the false return to avoid adding the link to that
+// router's link set twice, as the set does not deduplicate.
+func (link *Link) PointDestAt(dst *Router) bool {
+	link.lock.Lock()
+	defer link.lock.Unlock()
+
+	if link.Dst.Load() == dst {
+		return false
+	}
+	link.Dst.Store(dst)
+	return true
+}
+
 func (link *Link) CurrentState() LinkState {
 	link.lock.Lock()
 	defer link.lock.Unlock()

--- a/controller/model/testing.go
+++ b/controller/model/testing.go
@@ -21,6 +21,7 @@ import (
 	"crypto/x509"
 	"time"
 
+	"github.com/openziti/foundation/v2/versions"
 	"github.com/openziti/transport/v2"
 	"github.com/openziti/ziti/v2/common/ctrlchan"
 	"github.com/openziti/ziti/v2/controller/models"
@@ -370,6 +371,9 @@ func NewRouterForTest(id string, fingerprint string, advLstnr transport.Address,
 		Control:     ctrl,
 		Cost:        cost,
 		NoTraversal: noTraversal,
+		// The accept path refuses a router whose hello carries no version, so readers are entitled to
+		// assume it is set.
+		VersionInfo: &versions.VersionInfo{Version: "v0.0.0"},
 	}
 	if advLstnr != nil {
 		r.addLinkListener(advLstnr.String(), advLstnr.Type(), []string{"default"})

--- a/controller/network/network.go
+++ b/controller/network/network.go
@@ -184,6 +184,7 @@ func NewNetwork(config Config, env model.Env) (*Network, error) {
 
 func (self *Network) HandleRouterDelete(id string) {
 	self.routerDeleted(id)
+	self.Link.RouterDeleted(id)
 	self.RouterMessaging.RouterDeleted(id)
 }
 
@@ -397,8 +398,10 @@ func (network *Network) ConnectRouter(r *model.Router) error {
 		return ErrConnectChannelClosed
 	}
 
-	network.Link.BuildRouterLinks(r)
+	// Mark connected before building links: repairDest re-reads the connected map for links that land in
+	// the table after this build, and must find the router there.
 	network.Router.MarkConnected(r)
+	network.Link.BuildRouterLinks(r)
 
 	for _, h := range network.routerPresenceHandlers.Value() {
 		if syncCapableHandler, ok := h.(model.SyncRouterPresenceHandler); ok && syncCapableHandler.InvokeRouterConnectedSynchronously() {

--- a/controller/network/router_connect_test.go
+++ b/controller/network/router_connect_test.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/openziti/channel/v5"
 	"github.com/openziti/transport/v2"
@@ -375,4 +376,206 @@ func TestNotifyExistingLink_RaceDisconnect(t *testing.T) {
 				"iteration %d: a link published by a router that has been disconnected must not survive", i)
 		}
 	}
+}
+
+// TestRouterReportedLink_RepairsDestConnectedMidReport drives the interleave where both paths that pair a
+// link with its destination miss: the report resolves the destination before the link is in the table, and
+// the destination's own link build runs before the link lands there. The destination connects through
+// ConnectRouter rather than by calling its steps here, since the order of those steps is load-bearing.
+func TestRouterReportedLink_RepairsDestConnectedMidReport(t *testing.T) {
+	_, network, addr := newConnectTestNetwork(t)
+
+	src := model.NewRouterForTest("r0", "", addr, &fakeCtrlChannel{}, 0, false)
+	dst := model.NewRouterForTest("r1", "", addr, &fakeCtrlChannel{}, 0, false)
+	require.NoError(t, network.ConnectRouter(src))
+
+	report := &ctrl_pb.RouterLinks_RouterLink{
+		Id:           "l0",
+		DestRouterId: dst.Id,
+		LinkProtocol: "tls",
+		DialAddress:  "tcp:localhost:1234",
+		Iteration:    1,
+	}
+
+	// The reporting path resolves the destination first, and finds it absent.
+	resolved := network.Router.GetConnected(dst.Id)
+	require.Nil(t, resolved)
+
+	// The destination connects in the gap. Its link build finds nothing, the link is not in the table yet.
+	require.NoError(t, network.ConnectRouter(dst))
+	require.Empty(t, dst.GetLinks(), "the destination's link build must have found nothing")
+
+	// Only now does the report land, still carrying the resolution that was accurate when it was taken.
+	link, created := network.Link.RouterReportedLink(report, src, resolved)
+	require.True(t, created)
+	require.NotNil(t, link)
+
+	require.Same(t, dst, link.GetDest(),
+		"the link must be pointed at the destination router that connected while the report was in flight")
+
+	// The consequence that matters: path computation can see the adjacency.
+	neighbors := network.Link.ConnectedNeighborsOfRouter(src)
+	require.Len(t, neighbors, 1, "the link must carry adjacency")
+	require.Equal(t, dst.Id, neighbors[0].Id)
+
+	// Exactly once: the router's link set does not deduplicate, and its link build may run again.
+	require.Len(t, dst.GetLinks(), 1)
+	network.Link.BuildRouterLinks(dst)
+	require.Len(t, dst.GetLinks(), 1, "a second link build must not index the link again")
+}
+
+// TestRouterDelete_DropsTheLinkIndex covers the wiring rather than the drop itself: a delete has to
+// actually reach the cleanup. Awaited, since the store dispatches the delete listener on its own goroutine.
+func TestRouterDelete_DropsTheLinkIndex(t *testing.T) {
+	_, network, addr := newConnectTestNetwork(t)
+
+	gone := newPersistedRouter(t, network, addr, "r0")
+	peer := newPersistedRouter(t, network, addr, "r1")
+	network.Link.Add(model.NewTestLink("l0", gone, peer))
+
+	require.Len(t, network.Link.LinksForRouter(gone.Id), 1)
+	require.Len(t, network.Link.LinksForRouter(peer.Id), 1)
+
+	require.NoError(t, network.Router.Delete(gone.Id, change.New()))
+
+	require.Eventually(t, func() bool { return len(network.Link.LinksForRouter(gone.Id)) == 0 },
+		2*time.Second, 10*time.Millisecond, "deleting a router must drop its link index")
+	require.Len(t, network.Link.LinksForRouter(peer.Id), 1, "the other endpoint's index must be untouched")
+}
+
+// TestRouterDelete_KeepsTheIndexOfAReusedId covers the delete cleanup running late against an id that has
+// come back. Fabric router ids are the enrollment certificate's common name, so re-adding a router from the
+// same cert reuses its id, and nothing orders the cleanup against that: store commit handlers run after
+// bolt has released the writer lock. Dropping the live router's index here is invisible in the link table
+// and shows up only when a per-router query misses links it should have.
+//
+// The late callback is invoked directly rather than by pausing the real one, since the guard is a store read
+// taken while the index map's shard is held, so the observable property is the same either way.
+func TestRouterDelete_KeepsTheIndexOfAReusedId(t *testing.T) {
+	_, network, addr := newConnectTestNetwork(t)
+
+	peer := newPersistedRouter(t, network, addr, "r1")
+
+	original := newPersistedRouter(t, network, addr, "r0")
+	require.NoError(t, network.Router.Delete(original.Id, change.New()))
+
+	// The same id comes back and its links are reported, all before the earlier delete's cleanup runs.
+	reused := newPersistedRouter(t, network, addr, "r0")
+	network.Link.Add(model.NewTestLink("l0", reused, peer))
+	require.Len(t, network.Link.LinksForRouter(reused.Id), 1)
+
+	network.Link.RouterDeleted(original.Id)
+
+	require.Len(t, network.Link.LinksForRouter(reused.Id), 1,
+		"a delete that lands after the id was recreated must not drop the live router's index")
+	require.Len(t, network.Link.LinksForRouter(peer.Id), 1)
+}
+
+// TestRouterReportedLink_RepairsDestDisplacedMidReport is the same interleave with a stale destination
+// rather than an absent one. The report resolves the destination under the source's connect stripe, not the
+// destination's, so that router can be replaced before the report lands. A link left pointing at the
+// displaced instance reads as healthy everywhere while carrying no adjacency, since the instance it names
+// is no longer connected.
+func TestRouterReportedLink_RepairsDestDisplacedMidReport(t *testing.T) {
+	_, network, addr := newConnectTestNetwork(t)
+
+	src := model.NewRouterForTest("r0", "", addr, &fakeCtrlChannel{}, 0, false)
+	firstDst := model.NewRouterForTest("r1", "", addr, &fakeCtrlChannel{}, 0, false)
+	require.NoError(t, network.ConnectRouter(src))
+	require.NoError(t, network.ConnectRouter(firstDst))
+
+	// The reporting path resolves the destination, and gets the connection that is current right then.
+	resolved := network.Router.GetConnected(firstDst.Id)
+	require.Same(t, firstDst, resolved)
+
+	// That connection is replaced before the report lands.
+	network.DisconnectRouter(firstDst)
+	secondDst := model.NewRouterForTest("r1", "", addr, &fakeCtrlChannel{}, 0, false)
+	require.NoError(t, network.ConnectRouter(secondDst))
+	require.Empty(t, secondDst.GetLinks(), "the replacement's link build must have found nothing")
+
+	report := &ctrl_pb.RouterLinks_RouterLink{
+		Id:           "l0",
+		DestRouterId: firstDst.Id,
+		LinkProtocol: "tls",
+		DialAddress:  "tcp:localhost:1234",
+		Iteration:    1,
+	}
+	link, created := network.Link.RouterReportedLink(report, src, resolved)
+	require.True(t, created)
+
+	require.Same(t, secondDst, link.GetDest(),
+		"the link must be pointed at the connection that replaced the one the report resolved")
+
+	neighbors := network.Link.ConnectedNeighborsOfRouter(src)
+	require.Len(t, neighbors, 1, "the link must carry adjacency")
+	require.Same(t, secondDst, neighbors[0])
+
+	require.Len(t, secondDst.GetLinks(), 1, "the link must be indexed on the current connection exactly once")
+}
+
+// TestRouterReportedLink_RepairsDestOnALaterReport: a link already pointing at a displaced connection is
+// repaired by the next report for it, which is the only thing left that will look. The report carries no
+// new iteration, so the link is not rebuilt; the repair has to happen on the already-known path.
+func TestRouterReportedLink_RepairsDestOnALaterReport(t *testing.T) {
+	_, network, addr := newConnectTestNetwork(t)
+
+	src := model.NewRouterForTest("r0", "", addr, &fakeCtrlChannel{}, 0, false)
+	firstDst := model.NewRouterForTest("r1", "", addr, &fakeCtrlChannel{}, 0, false)
+	require.NoError(t, network.ConnectRouter(src))
+	require.NoError(t, network.ConnectRouter(firstDst))
+
+	report := &ctrl_pb.RouterLinks_RouterLink{
+		Id:           "l0",
+		DestRouterId: firstDst.Id,
+		LinkProtocol: "tls",
+		DialAddress:  "tcp:localhost:1234",
+		Iteration:    1,
+	}
+	link, created := network.Link.RouterReportedLink(report, src, firstDst)
+	require.True(t, created)
+	require.Same(t, firstDst, link.GetDest())
+
+	// The destination is replaced. Its link build repairs links already in the table, so drive the case it
+	// cannot reach by putting the link back on the stale instance behind its back.
+	network.DisconnectRouter(firstDst)
+	secondDst := model.NewRouterForTest("r1", "", addr, &fakeCtrlChannel{}, 0, false)
+	require.NoError(t, network.ConnectRouter(secondDst))
+	require.True(t, link.PointDestAt(firstDst), "putting the link back on the displaced instance")
+
+	again, created := network.Link.RouterReportedLink(report, src, firstDst)
+	require.False(t, created, "a report at the same iteration must not rebuild the link")
+	require.Same(t, link, again)
+	require.Same(t, secondDst, link.GetDest(), "a later report must repair a displaced destination")
+}
+
+// TestConnectRouter_RepairsLinkAlreadyMissingItsDest covers the other half of the pairing: a link already in
+// the table with no destination is repaired when that destination connects.
+func TestConnectRouter_RepairsLinkAlreadyMissingItsDest(t *testing.T) {
+	_, network, addr := newConnectTestNetwork(t)
+
+	src := model.NewRouterForTest("r0", "", addr, &fakeCtrlChannel{}, 0, false)
+	dst := model.NewRouterForTest("r1", "", addr, &fakeCtrlChannel{}, 0, false)
+	require.NoError(t, network.ConnectRouter(src))
+
+	// A link recorded while its destination was not connected, so it points at nothing.
+	report := &ctrl_pb.RouterLinks_RouterLink{
+		Id:           "l0",
+		DestRouterId: dst.Id,
+		LinkProtocol: "tls",
+		DialAddress:  "tcp:localhost:1234",
+		Iteration:    1,
+	}
+	link, created := network.Link.RouterReportedLink(report, src, nil)
+	require.True(t, created)
+	require.Nil(t, link.GetDest(), "the destination was not connected when the link was recorded")
+
+	require.NoError(t, network.ConnectRouter(dst))
+
+	require.Same(t, dst, link.GetDest(), "connecting the destination must repair the link")
+	require.Len(t, dst.GetLinks(), 1, "and index it on the destination")
+
+	neighbors := network.Link.ConnectedNeighborsOfRouter(src)
+	require.Len(t, neighbors, 1, "the link must carry adjacency once repaired")
+	require.Equal(t, dst.Id, neighbors[0].Id)
 }

--- a/router/link/link_registry.go
+++ b/router/link/link_registry.go
@@ -464,15 +464,18 @@ func (self *linkRegistryImpl) sendFullRefresh(ch channel.Channel) bool {
 		}
 	}
 
+	log := logrus.WithField("ctrlId", ch.Id()).WithField("linkCount", len(routerLinks.Links))
+
 	// SendAndWaitForWire, not Send: Send returns once the message is queued, and the deadline stays live, so
 	// the tx loop discards it if the queue drains too slowly. Nothing is told, since a plain send's listener
 	// ignores the error, and this would report success and mark the links synchronized for an announcement
 	// that never left. Matches how the periodic path sends.
 	if err := protobufs.MarshalTyped(routerLinks).WithTimeout(self.fullRefreshSendTimeout).SendAndWaitForWire(ch); err != nil {
-		logrus.WithError(err).WithField("ctrlId", ch.Id()).Error("failed to send router links on reconnect")
+		log.WithError(err).Error("failed to send router links on reconnect")
 		return false
 	}
 
+	log.Info("sent router links on reconnect")
 	for _, f := range onComplete {
 		f()
 	}


### PR DESCRIPTION
Fixes #4246

`BuildRouterLinks` runs on every router connect and scanned the whole link table to find the connecting
router's links. The table is O(routers²) in a full mesh, so a reconnect wave costs O(routers³) in link
visits. It never shows in steady state; it lands during a mass reconnect, when the connect path is already
the bottleneck.

This indexes every link under both endpoint router ids, so a connect walks only its own router's links. The
full-refresh prune was the same whole-table walk one message later, and now uses the index too.

Three commits: the index and its consequences, a small `LockedSet` it needs, and an unrelated test race
fixed along the way.

### What's worth a close look

**The index holds link ids, not link pointers.** A reconnect replaces a link's `Router` object and a higher
iteration replaces the `Link` object, but neither replaces the id. Per-router queries resolve ids against
the table, which stays authoritative.

**The table and the index are two structures written in sequence,** so `Add`, `Remove` and the connect-time
pairing now serialize on the link id. Previously only `RouterReportedLink` took that lock, and the
connect-time pairing was outside it entirely: a removal reading no destination could complete mid-pairing
and leave the link in the destination's link set after the table had dropped it.

**Pairing a link with its destination was broken two ways,** both leaving a link that reads as healthy
everywhere while carrying no adjacency. A router connecting between a report resolving its destination and
that link reaching the table was seen by neither path; and because the resolve happens under the source
router's connect stripe rather than the destination's, the destination could be replaced before the report
landed. The destination is now re-resolved unconditionally once the link is in the table, which works
because the connect path registers a router before building its links.

**Dropping a router's index on delete is guarded.** Fabric router ids are the enrollment certificate's
common name, so re-adding from the same cert reuses the id, and store event handlers run after bolt
releases the writer lock, so a delete's cleanup can land after the id was recreated and reported links. The
drop happens only while the store still has no router under that id, checked inside the index map's removal
callback — indexing a link takes that same shard, so a live router's entry can't appear without its create
having committed first.

### Also here

- Logs the link count on both sides of the reconnect exchange, and why a report was discarded. A router
  announces its links once per reconnect and is never asked again, so a discarded report left it with no
  links and nothing recorded to compare.
- Test routers get version info, which a connected router always has and the router sync path dereferences
  without a nil check.

### Tests

The index checked against the table for every router after a mesh is built, partly torn down, and has links
replaced by higher iterations; the prune's selection, including that a report from one end never removes
links the other end dialed; both destination-repair interleaves; the pairing serializing on the link id;
index removal in both directions and the concurrent removal/replacement case; and the delete cleanup
running after the same id has been recreated.
