### PR TITLE
Stop codespell flagging the Actieve adopter entry

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -14,5 +14,5 @@ jobs:
       - name: Run code spelling check
         uses: codespell-project/actions-codespell@v2
         with:
-          ignore_words_list: allos,ans,dne,noe,referr,ssudo,te,tranfer,ue
+          ignore_words_list: actieve,allos,ans,dne,noe,referr,ssudo,te,tranfer,ue
           skip: go.*,zititest/go.*,./controller/storage/zitiql/zitiql_parser.go,*.pem,*.cert,*.key


### PR DESCRIPTION
codespell started reporting `Actieve` in `ADOPTERS.md` as a misspelling of `active`:

```
./ADOPTERS.md:49: Actieve ==> Active
./ADOPTERS.md:49: actieve ==> active
```

It is the name of an adopter (actieve.com) and has been in the file since #1731, so nothing changed on our side. The workflow pins `codespell-project/actions-codespell@v2`, so a dictionary update lands automatically, and this word appears to be a recent addition.

Because the check runs only `on: pull_request`, it never fails on main; it surfaced as every open pull request going red at once.

Adds `actieve` to the existing `ignore_words_list`. Reproduced locally with the workflow's exact flags, and confirmed the entry clears with the word ignored.