### PR TITLE
Allow the adopter name Actieve in the codespell word list

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -14,5 +14,5 @@ jobs:
       - name: Run code spelling check
         uses: codespell-project/actions-codespell@v2
         with:
-          ignore_words_list: allos,ans,dne,noe,referr,ssudo,te,tranfer,ue
+          ignore_words_list: actieve,allos,ans,dne,noe,referr,ssudo,te,tranfer,ue
           skip: go.*,zititest/go.*,./controller/storage/zitiql/zitiql_parser.go


### PR DESCRIPTION
codespell reports `Actieve` in `ADOPTERS.md` as a misspelling of `active`:

```
./ADOPTERS.md:49: Actieve ==> Active
./ADOPTERS.md:49: actieve ==> active
```

It is the name of an adopter (actieve.com). The workflow pins `codespell-project/actions-codespell@v2`, so a dictionary update lands automatically, and this word appears to be a recent addition. Since the check runs only `on: pull_request`, it never fails on the release branch itself and instead turns every open pull request red.

Adds `actieve` to the existing `ignore_words_list`, matching the fix already on release-v1.6.x (4116f623b).