### PR TITLE
Fix two flaky OIDC integration tests

### DIFF
--- a/tests/api_client_management.go
+++ b/tests/api_client_management.go
@@ -198,6 +198,21 @@ func (helper *ManagementHelperClient) ListIdentitiesByFilter(filter string) ([]*
 	return resp.Payload.Data, nil
 }
 
+// RequireIdentitySdkInfoUpdated polls until the identity reports appId as its SDK app id, returning the
+// identity as read and failing the test if it does not appear within 10 seconds. The controller applies
+// sdk/env info updates on a background queue, so they are not guaranteed to be visible by the time
+// authentication returns.
+func (helper *ManagementHelperClient) RequireIdentitySdkInfoUpdated(identityId string, appId string) *rest_model.IdentityDetail {
+	var identityDetail *rest_model.IdentityDetail
+	helper.testCtx.Req.Eventually(func() bool {
+		var err error
+		identityDetail, err = helper.GetIdentity(identityId)
+		return err == nil && identityDetail.SdkInfo != nil && identityDetail.SdkInfo.AppID == appId
+	}, 10*time.Second, 50*time.Millisecond, "identity %s sdk info was not updated", identityId)
+
+	return identityDetail
+}
+
 func (helper *ManagementHelperClient) CreateEnrollmentOtt(identityId *string, expiresAt *time.Time) (*rest_model.CreateLocation, error) {
 	var expAt *strfmt.DateTime
 

--- a/tests/auth_oidc_test.go
+++ b/tests/auth_oidc_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
-	"time"
 
 	"github.com/go-resty/resty/v2"
 	"github.com/golang-jwt/jwt/v5"
@@ -202,7 +201,7 @@ func Test_Authenticate_OIDC_Auth(t *testing.T) {
 			t.Run("has the correct sdk and env info", func(t *testing.T) {
 				ctx.testContextChanged(t)
 
-				identityDetail := requireIdentitySdkInfoUpdated(ctx, managementHelper, accessClaims.Subject, payload.SdkInfo.AppID)
+				identityDetail := managementHelper.RequireIdentitySdkInfoUpdated(accessClaims.Subject, payload.SdkInfo.AppID)
 
 				ctx.Req.Equal(payload.SdkInfo.AppID, identityDetail.SdkInfo.AppID)
 				ctx.Req.Equal(payload.SdkInfo.AppVersion, identityDetail.SdkInfo.AppVersion)
@@ -317,7 +316,7 @@ func Test_Authenticate_OIDC_Auth(t *testing.T) {
 			t.Run("has the correct sdk and env info", func(t *testing.T) {
 				ctx.testContextChanged(t)
 
-				identityDetail := requireIdentitySdkInfoUpdated(ctx, managementHelper, accessClaims.Subject, payload.SdkInfo.AppID)
+				identityDetail := managementHelper.RequireIdentitySdkInfoUpdated(accessClaims.Subject, payload.SdkInfo.AppID)
 
 				ctx.Req.Equal(payload.SdkInfo.AppID, identityDetail.SdkInfo.AppID)
 				ctx.Req.Equal(payload.SdkInfo.AppVersion, identityDetail.SdkInfo.AppVersion)
@@ -693,18 +692,4 @@ func Test_Authenticate_OIDC_Auth(t *testing.T) {
 		})
 
 	})
-}
-
-// requireIdentitySdkInfoUpdated polls the management API until the identity reports the given SDK app id and
-// returns the identity as read, failing the test if it doesn't appear within 10 seconds. The controller may apply
-// sdk/env info updates on a background queue, so they are not guaranteed to be visible when authentication returns.
-func requireIdentitySdkInfoUpdated(ctx *TestContext, managementHelper *ManagementHelperClient, identityId string, appId string) *rest_model.IdentityDetail {
-	var identityDetail *rest_model.IdentityDetail
-	ctx.Req.Eventually(func() bool {
-		var err error
-		identityDetail, err = managementHelper.GetIdentity(identityId)
-		return err == nil && identityDetail.SdkInfo != nil && identityDetail.SdkInfo.AppID == appId
-	}, 10*time.Second, 50*time.Millisecond, "identity %s sdk info was not updated", identityId)
-
-	return identityDetail
 }

--- a/tests/auth_oidc_test.go
+++ b/tests/auth_oidc_test.go
@@ -202,10 +202,7 @@ func Test_Authenticate_OIDC_Auth(t *testing.T) {
 			t.Run("has the correct sdk and env info", func(t *testing.T) {
 				ctx.testContextChanged(t)
 
-				time.Sleep(time.Second)
-				identityDetail, err := managementHelper.GetIdentity(accessClaims.Subject)
-
-				ctx.Req.NoError(err)
+				identityDetail := requireIdentitySdkInfoUpdated(ctx, managementHelper, accessClaims.Subject, payload.SdkInfo.AppID)
 
 				ctx.Req.Equal(payload.SdkInfo.AppID, identityDetail.SdkInfo.AppID)
 				ctx.Req.Equal(payload.SdkInfo.AppVersion, identityDetail.SdkInfo.AppVersion)
@@ -320,9 +317,7 @@ func Test_Authenticate_OIDC_Auth(t *testing.T) {
 			t.Run("has the correct sdk and env info", func(t *testing.T) {
 				ctx.testContextChanged(t)
 
-				identityDetail, err := managementHelper.GetIdentity(accessClaims.Subject)
-
-				ctx.Req.NoError(err)
+				identityDetail := requireIdentitySdkInfoUpdated(ctx, managementHelper, accessClaims.Subject, payload.SdkInfo.AppID)
 
 				ctx.Req.Equal(payload.SdkInfo.AppID, identityDetail.SdkInfo.AppID)
 				ctx.Req.Equal(payload.SdkInfo.AppVersion, identityDetail.SdkInfo.AppVersion)
@@ -698,4 +693,18 @@ func Test_Authenticate_OIDC_Auth(t *testing.T) {
 		})
 
 	})
+}
+
+// requireIdentitySdkInfoUpdated polls the management API until the identity reports the given SDK app id and
+// returns the identity as read, failing the test if it doesn't appear within 10 seconds. The controller may apply
+// sdk/env info updates on a background queue, so they are not guaranteed to be visible when authentication returns.
+func requireIdentitySdkInfoUpdated(ctx *TestContext, managementHelper *ManagementHelperClient, identityId string, appId string) *rest_model.IdentityDetail {
+	var identityDetail *rest_model.IdentityDetail
+	ctx.Req.Eventually(func() bool {
+		var err error
+		identityDetail, err = managementHelper.GetIdentity(identityId)
+		return err == nil && identityDetail.SdkInfo != nil && identityDetail.SdkInfo.AppID == appId
+	}, 10*time.Second, 50*time.Millisecond, "identity %s sdk info was not updated", identityId)
+
+	return identityDetail
 }

--- a/tests/revocation_enforcement_oidc_test.go
+++ b/tests/revocation_enforcement_oidc_test.go
@@ -140,6 +140,18 @@ func echoServerHandler(conn *testServerConn) error {
 	}
 }
 
+// waitForSecondAfter blocks until the wall clock reaches a whole second later than the one containing
+// ts, returning immediately when it already has. Call it before authenticating a session that has to
+// be observably newer than a revocation created at ts: a token's iat claim carries whole seconds, so
+// enforcement cannot tell a session issued just before a revocation from one issued just after it
+// within the same second, and revokes both.
+func waitForSecondAfter(ts time.Time) {
+	next := ts.Truncate(time.Second).Add(time.Second)
+	if remaining := time.Until(next); remaining > 0 {
+		time.Sleep(remaining + 10*time.Millisecond)
+	}
+}
+
 // freshAuthedContext creates and authenticates a new OIDC SDK context for an
 // existing identity, yielding a brand-new api-session (a fresh z_asid and issue
 // time). Authenticate on an already-authenticated context is a no-op, so a new
@@ -258,6 +270,7 @@ func Test_Revocation_IdentityCutoff_PostCutoffSessionSurvives_OIDC(t *testing.T)
 	// can still authenticate a new session below.)
 	_, err := adminApi.CreateRevocation(dialIdentity.Id, rest_model.RevocationTypeEnumIDENTITY)
 	ctx.Req.NoError(err)
+	revocationCreated := time.Now()
 	requireConnClosedByReaper(ctx, clientConn)
 
 	t.Run("a session authenticated after the cutoff survives", func(t *testing.T) {
@@ -265,6 +278,7 @@ func Test_Revocation_IdentityCutoff_PostCutoffSessionSurvives_OIDC(t *testing.T)
 
 		// A fresh session is issued after the cutoff, so it must not be revoked
 		// even though the identity revocation still lingers.
+		waitForSecondAfter(revocationCreated)
 		freshContext := freshAuthedContext(t, ctx, dialIdentity)
 		newConn := ctx.WrapConn(freshContext.Dial(svc.Name))
 		requireConnSurvivesReaper(ctx, newConn)


### PR DESCRIPTION
Two OIDC integration tests fail intermittently on CI for unrelated reasons. Both are fixed here.

## `Test_Authenticate_OIDC_Auth`

The test asserts that the sdk/env info posted during OIDC login is persisted on the identity, reading the identity back immediately after the token exchange. The controller applies that update through the background command queue, which runs the work inline only while recent background writes have been fast and hands it to a worker pool otherwise. On a loaded CI runner the read wins the race and the assertion sees empty sdk info, which is what turns unrelated pull requests red.

Both assertion sites now poll until the update lands, replacing an immediate read on the cert path and a fixed one second sleep on the updb path. The test is sound under a forced-async queue and finishes faster than before.

## `Test_Revocation_IdentityCutoff_PostCutoffSessionSurvives_OIDC`

The test creates an identity revocation and then authenticates a fresh session, asserting that a session issued after the cutoff survives. A token's `iat` claim carries whole seconds, while the revocation cutoff keeps full precision, so enforcement cannot distinguish a session issued just before the cutoff from one issued just after it within the same second and rejects both. The test passed only when the reaper's latency happened to push the re-authentication into the next second.

It now waits until a whole second after the revocation before authenticating, so the fresh token's issued-at is unambiguously later. The wait returns immediately when the clock has already moved on, which is the usual case, so it costs nothing outside the race.

Confirmed by authenticating immediately after the revocation, which reproduces the CI failure exactly, and again after the wait, which succeeds.
