### PR TITLE
Report the applied raft index from fabric inspect data-model-index

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -180,7 +180,7 @@ func (c *Controller) IsRaftLeader() bool {
 }
 
 func (c *Controller) GetRaftIndex() uint64 {
-	return c.raftController.Raft.LastIndex()
+	return c.raftController.GetAppliedIndex()
 }
 
 func (c *Controller) GetStartRaftIndex() uint64 {

--- a/controller/raft/raft.go
+++ b/controller/raft/raft.go
@@ -235,6 +235,12 @@ func (self *Controller) GetRaft() *raft.Raft {
 	return self.Raft
 }
 
+// GetAppliedIndex returns the last command index applied to the local bolt store. Deliberately not
+// Raft.AppliedIndex(), which advances when a commit is handed to the FSM, not when the FSM has finished it.
+func (self *Controller) GetAppliedIndex() uint64 {
+	return self.indexTracker.Index()
+}
+
 // GetMesh returns the related Mesh instance
 func (self *Controller) GetMesh() mesh.Mesh {
 	return self.Mesh

--- a/controller/sync_strats/sync_instant.go
+++ b/controller/sync_strats/sync_instant.go
@@ -2116,7 +2116,13 @@ func (strategy *InstantStrategy) inspect(val string) (bool, *string, error) {
 		return marshalResult(data)
 	}
 	if val == "data-model-index" {
-		idx := strategy.indexProvider.CurrentIndex()
+		// the index provider only advances on RDM-relevant stores, so raft mode reports the applied raft index instead
+		var idx uint64
+		if strategy.ae.HostController.IsRaftEnabled() {
+			idx = strategy.ae.HostController.GetRaftIndex()
+		} else {
+			idx = strategy.indexProvider.CurrentIndex()
+		}
 		data := map[string]any{
 			"timeline": strategy.ae.TimelineId(),
 			"index":    idx,

--- a/ziti/cmd/fabric/inspect.go
+++ b/ziti/cmd/fabric/inspect.go
@@ -41,7 +41,7 @@ func NewInspectCmd(p common.OptionsProvider) *cobra.Command {
 	cmd.AddCommand(action.newInspectSubCmd(p, "router-data-model", "gets information about the router data model"))
 	cmd.AddCommand(action.newInspectSubCmd(p, "router-data-model-index", "gets current index of the router data model"))
 	cmd.AddCommand(action.newInspectSubCmd(p, inspectCommon.RouterConfigRegistryKey, "gets the router's managed-config registry state (handlers, controller/local versions, applied state)"))
-	cmd.AddCommand(action.newInspectSubCmd(p, "data-model-index", "gets current index of the controller data model"))
+	cmd.AddCommand(action.newInspectSubCmd(p, "data-model-index", "gets the controller's applied raft index (data model index when not clustered)"))
 	cmd.AddCommand(action.newInspectSubCmd(p, "router-controllers", "gets information about the state of a router's connections to its controllers"))
 	cmd.AddCommand(action.newInspectSubCmd(p, "terminator-costs", "gets information about terminator dynamic costs"))
 	cmd.AddCommand(action.newInspectSubCmd(p, inspectCommon.RouterIdentityConnectionStatusesKey, "gets information about controller identity state"))


### PR DESCRIPTION
- `fabric inspect data-model-index` only advanced on router-data-model store writes, so raft writes to other stores like Mfa never moved it and matching indexes across members did not mean the cluster had converged.
- Report the index of the last command applied to the controller's bolt store instead, via the raft controller's indexTracker. Not Raft.AppliedIndex(), which advances before the FSM has applied the entry.
- Closes #4278