### PR TITLE
Keep applied raft index durable across restarts

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -180,7 +180,7 @@ func (c *Controller) IsRaftLeader() bool {
 }
 
 func (c *Controller) GetRaftIndex() uint64 {
-	return c.raftController.Raft.LastIndex()
+	return c.raftController.GetAppliedIndex()
 }
 
 func (c *Controller) GetStartRaftIndex() uint64 {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -179,6 +179,7 @@ func (c *Controller) IsRaftLeader() bool {
 	return c.raftController.IsLeader()
 }
 
+// GetRaftIndex implements env.HostController.
 func (c *Controller) GetRaftIndex() uint64 {
 	return c.raftController.GetAppliedIndex()
 }

--- a/controller/env/appenv.go
+++ b/controller/env/appenv.go
@@ -558,6 +558,7 @@ type HostController interface {
 	GetCommandDispatcher() command.Dispatcher
 	GetPeerSigners() []*x509.Certificate
 	GetEventDispatcher() event.Dispatcher
+	// GetRaftIndex returns the last raft command or configuration index durably recorded by the local Bolt FSM.
 	GetRaftIndex() uint64
 	GetPeerAddresses() []string
 	GetRaftInfo() (string, string, string)

--- a/controller/raft/fsm.go
+++ b/controller/raft/fsm.go
@@ -203,7 +203,7 @@ func (self *BoltDbFsm) loadServers() error {
 	return err
 }
 
-func (self *BoltDbFsm) storeConfigurationInRaft(index uint64, servers []raft.Server) {
+func (self *BoltDbFsm) storeConfigurationInRaft(index uint64, servers []raft.Server) bool {
 	err := self.db.Update(nil, func(ctx boltz.MutateContext) error {
 		if err := self.updateIndexInTx(ctx.Tx(), index); err != nil {
 			return err
@@ -213,7 +213,9 @@ func (self *BoltDbFsm) storeConfigurationInRaft(index uint64, servers []raft.Ser
 	if err != nil {
 		pfxlog.Logger().WithField("index", index).WithField("servers", servers).
 			WithError(err).Error("failed to store current raft configuration")
+		return false
 	}
+	return true
 }
 func (self *BoltDbFsm) storeServers(tx *bbolt.Tx, servers []raft.Server) error {
 	raftBucket := boltz.GetOrCreatePath(tx, db.RootBucket, db.MetadataBucket)
@@ -241,13 +243,15 @@ func (self *BoltDbFsm) updateIndexInTx(tx *bbolt.Tx, index uint64) error {
 	return raftBucket.GetError()
 }
 
-func (self *BoltDbFsm) updateIndex(index uint64) {
+func (self *BoltDbFsm) updateIndex(index uint64) bool {
 	err := self.db.Update(nil, func(ctx boltz.MutateContext) error {
 		return self.updateIndexInTx(ctx.Tx(), index)
 	})
 	if err != nil {
 		pfxlog.Logger().WithError(err).Error("unable to update raft index in database")
+		return false
 	}
+	return true
 }
 
 func (self *BoltDbFsm) GetCurrentState(r *raft.Raft) *ServersWithIndex {
@@ -295,7 +299,7 @@ func (self *BoltDbFsm) initializeCurrentState(raft *raft.Raft) {
 func (self *BoltDbFsm) StoreConfiguration(index uint64, configuration raft.Configuration) {
 	current := self.currentState.Load()
 	if current == nil || current.Index < index {
-		self.storeConfigurationInRaft(index, configuration.Servers)
+		indexPersisted := self.storeConfigurationInRaft(index, configuration.Servers)
 		serversWithIndex := &ServersWithIndex{
 			Servers: configuration.Servers,
 			Index:   index,
@@ -311,14 +315,15 @@ func (self *BoltDbFsm) StoreConfiguration(index uint64, configuration raft.Confi
 			})
 		}
 		self.eventDispatcher.AcceptClusterEvent(evt)
+		if indexPersisted {
+			self.indexTracker.NotifyOfIndex(index)
+		}
 	}
 }
 
 func (self *BoltDbFsm) Apply(log *raft.Log) interface{} {
 	logger := pfxlog.Logger().WithField("index", log.Index)
 	if log.Type == raft.LogCommand {
-		defer self.indexTracker.NotifyOfIndex(log.Index)
-
 		if log.Index <= self.index {
 			logger.Debug("skipping replay of command")
 			return nil
@@ -354,9 +359,12 @@ func (self *BoltDbFsm) Apply(log *raft.Log) interface{} {
 				}
 				logger.WithError(err).Error("applying log resulted in error")
 				// apply rolled back the in-tx index update; persist it here since raft advances regardless
-				self.updateIndex(log.Index)
+				if !self.updateIndex(log.Index) {
+					return err
+				}
 			}
 
+			self.indexTracker.NotifyOfIndex(log.Index)
 			return err
 		} else {
 			return fmt.Errorf("log data contained invalid message type. data: %+v", log.Data)

--- a/controller/raft/fsm_test.go
+++ b/controller/raft/fsm_test.go
@@ -19,6 +19,7 @@ package raft
 import (
 	"testing"
 
+	hraft "github.com/hashicorp/raft"
 	"github.com/openziti/ziti/v2/controller/command"
 	"github.com/openziti/ziti/v2/controller/event"
 	"github.com/openziti/ziti/v2/controller/storage/boltz"
@@ -48,4 +49,51 @@ func TestBoltDbFsm_GetStartIndex_AfterRestart(t *testing.T) {
 	req.NoError(fsm2.Init())
 	req.Equal(persistedIndex, fsm2.GetStartIndex(), "GetStartIndex should reflect the persisted raft index after restart")
 	req.NoError(fsm2.Close())
+}
+
+// TestBoltDbFsm_AppliedIndex_AfterConfigurationAndRestart verifies that live and reloaded progress
+// use the same persisted index.
+func TestBoltDbFsm_AppliedIndex_AfterConfigurationAndRestart(t *testing.T) {
+	req := require.New(t)
+	dataDir := t.TempDir()
+
+	tracker := NewIndexTracker()
+	fsm := NewFsm(dataDir, false, command.GetDefaultDecoders(), tracker, event.DispatcherMock{})
+	req.NoError(fsm.Init())
+
+	const configurationIndex uint64 = 42
+	fsm.StoreConfiguration(configurationIndex, hraft.Configuration{})
+	req.Equal(configurationIndex, tracker.Index())
+	req.NoError(fsm.Close())
+
+	reloadedTracker := NewIndexTracker()
+	reloadedFsm := NewFsm(dataDir, false, command.GetDefaultDecoders(), reloadedTracker, event.DispatcherMock{})
+	req.NoError(reloadedFsm.Init())
+	req.Equal(configurationIndex, reloadedTracker.Index())
+	req.NoError(reloadedFsm.Close())
+}
+
+// TestBoltDbFsm_AppliedIndex_DoesNotAdvanceForRejectedCommand verifies that unpersisted progress is
+// not exposed as applied.
+func TestBoltDbFsm_AppliedIndex_DoesNotAdvanceForRejectedCommand(t *testing.T) {
+	req := require.New(t)
+	dataDir := t.TempDir()
+	tracker := NewIndexTracker()
+	fsm := NewFsm(dataDir, false, command.GetDefaultDecoders(), tracker, event.DispatcherMock{})
+	req.NoError(fsm.Init())
+
+	result := fsm.Apply(&hraft.Log{
+		Index: 42,
+		Type:  hraft.LogCommand,
+		Data:  []byte{1},
+	})
+	req.Error(result.(error))
+	req.Zero(tracker.Index())
+	req.NoError(fsm.Close())
+
+	reloadedTracker := NewIndexTracker()
+	reloadedFsm := NewFsm(dataDir, false, command.GetDefaultDecoders(), reloadedTracker, event.DispatcherMock{})
+	req.NoError(reloadedFsm.Init())
+	req.Zero(reloadedTracker.Index())
+	req.NoError(reloadedFsm.Close())
 }

--- a/controller/raft/raft.go
+++ b/controller/raft/raft.go
@@ -235,8 +235,8 @@ func (self *Controller) GetRaft() *raft.Raft {
 	return self.Raft
 }
 
-// GetAppliedIndex returns the last command index applied to the local bolt store. Deliberately not
-// Raft.AppliedIndex(), which advances when a commit is handed to the FSM, not when the FSM has finished it.
+// GetAppliedIndex returns the last raft command or configuration index durably recorded by the local Bolt FSM.
+// It deliberately differs from Raft.AppliedIndex(), which advances before the FSM finishes applying the entry.
 func (self *Controller) GetAppliedIndex() uint64 {
 	return self.indexTracker.Index()
 }

--- a/controller/raft/raft.go
+++ b/controller/raft/raft.go
@@ -235,6 +235,12 @@ func (self *Controller) GetRaft() *raft.Raft {
 	return self.Raft
 }
 
+// GetAppliedIndex returns the last command index applied to the local bolt store. Deliberately not
+// Raft.AppliedIndex(), which advances when a commit is handed to the FSM, not when the FSM has finished it.
+func (self *Controller) GetAppliedIndex() uint64 {
+	return self.indexTracker.Index()
+}
+
 // GetMesh returns the related Mesh instance
 func (self *Controller) GetMesh() mesh.Mesh {
 	return self.Mesh

--- a/controller/sync_strats/sync_instant.go
+++ b/controller/sync_strats/sync_instant.go
@@ -2116,7 +2116,13 @@ func (strategy *InstantStrategy) inspect(val string) (bool, *string, error) {
 		return marshalResult(data)
 	}
 	if val == "data-model-index" {
-		idx := strategy.indexProvider.CurrentIndex()
+		// the index provider only advances on RDM-relevant stores, so raft mode reports the applied raft index instead
+		var idx uint64
+		if strategy.ae.HostController.IsRaftEnabled() {
+			idx = strategy.ae.HostController.GetRaftIndex()
+		} else {
+			idx = strategy.indexProvider.CurrentIndex()
+		}
 		data := map[string]any{
 			"timeline": strategy.ae.TimelineId(),
 			"index":    idx,

--- a/ziti/cmd/fabric/inspect.go
+++ b/ziti/cmd/fabric/inspect.go
@@ -41,7 +41,7 @@ func NewInspectCmd(p common.OptionsProvider) *cobra.Command {
 	cmd.AddCommand(action.newInspectSubCmd(p, "router-data-model", "gets information about the router data model"))
 	cmd.AddCommand(action.newInspectSubCmd(p, "router-data-model-index", "gets current index of the router data model"))
 	cmd.AddCommand(action.newInspectSubCmd(p, inspectCommon.RouterConfigRegistryKey, "gets the router's managed-config registry state (handlers, controller/local versions, applied state)"))
-	cmd.AddCommand(action.newInspectSubCmd(p, "data-model-index", "gets current index of the controller data model"))
+	cmd.AddCommand(action.newInspectSubCmd(p, "data-model-index", "gets the controller's applied raft index (data model index when not clustered)"))
 	cmd.AddCommand(action.newInspectSubCmd(p, "router-controllers", "gets information about the state of a router's connections to its controllers"))
 	cmd.AddCommand(action.newInspectSubCmd(p, "terminator-costs", "gets information about terminator dynamic costs"))
 	cmd.AddCommand(action.newInspectSubCmd(p, inspectCommon.RouterIdentityConnectionStatusesKey, "gets information about controller identity state"))


### PR DESCRIPTION
Depends on #4281 and is based on its head commit. Merge after #4281.

## Summary

- advance reported progress after a raft configuration entry is persisted
- do not report rejected commands whose index was not persisted
- document that the getter covers durably recorded command and configuration indexes
- cover configuration and rejected-command behavior before and after FSM restart

## Validation

- go test ./controller/...
- go test -race ./controller/raft
- go vet ./controller/raft ./controller ./controller/env ./controller/sync_strats ./ziti/cmd/fabric
- git diff --check