### PR TITLE
Stop forwarding the crypto method header to hosting SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,7 +180,6 @@ controller and add new peers normally with `ziti ops cluster add`.
 
 ### End-to-End Encryption (e2ee) Improvements
 
-* Add support for negotiating e2ee scheme during Dial/Accept handshake
 * Allow hosting-side crypto material to be generated on per connection basis (instead of per terminator)
 
 

--- a/router/xgress_edge/dialer.go
+++ b/router/xgress_edge/dialer.go
@@ -132,10 +132,6 @@ func (dialer *dialer) Dial(params xgress_router.DialParams) (xt.PeerData, error)
 		dialRequest.Headers[edgeSdk.PublicKeyHeader] = pk
 	}
 
-	if meth, ok := circuitId.Data[uint32(edgeSdk.CryptoMethodHeader)]; ok {
-		dialRequest.Headers[edgeSdk.CryptoMethodHeader] = meth
-	}
-
 	if marker, ok := circuitId.Data[uint32(edgeSdk.ConnectionMarkerHeader)]; ok {
 		dialRequest.Headers[edgeSdk.ConnectionMarkerHeader] = marker
 	}
@@ -234,10 +230,6 @@ func (dialer *dialer) dialSdkXgress(terminator *edgeTerminator, params xgress_ro
 		dialRequest.Headers[edgeSdk.PublicKeyHeader] = pk
 	}
 
-	if meth, ok := circuitId.Data[uint32(edgeSdk.CryptoMethodHeader)]; ok {
-		dialRequest.Headers[edgeSdk.CryptoMethodHeader] = meth
-	}
-
 	if marker, ok := circuitId.Data[uint32(edgeSdk.ConnectionMarkerHeader)]; ok {
 		dialRequest.Headers[edgeSdk.ConnectionMarkerHeader] = marker
 	}
@@ -333,9 +325,6 @@ func (dialer *dialer) dialLegacy(terminator *edgeTerminator, params xgress_route
 
 	if pk, ok := circuitId.Data[uint32(edgeSdk.PublicKeyHeader)]; ok {
 		dialRequest.Headers[edgeSdk.PublicKeyHeader] = pk
-	}
-	if meth, ok := circuitId.Data[uint32(edgeSdk.CryptoMethodHeader)]; ok {
-		dialRequest.Headers[edgeSdk.CryptoMethodHeader] = meth
 	}
 
 	if marker, ok := circuitId.Data[uint32(edgeSdk.ConnectionMarkerHeader)]; ok {

--- a/router/xgress_edge/listener.go
+++ b/router/xgress_edge/listener.go
@@ -58,9 +58,12 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+// CryptoMethodHeader is deliberately absent. The Go and C SDKs encode it differently under the same
+// header id, a numeric enum byte versus a string method id, so handing a client's value to a host
+// running the other SDK fails that host's method check. Unmapped, each end keeps its own default.
+// Restore it once the SDKs agree on one encoding.
 var peerHeaderRequestMappings = map[uint32]uint32{
 	uint32(sdkedge.PublicKeyHeader):        uint32(sdkedge.PublicKeyHeader),
-	uint32(sdkedge.CryptoMethodHeader):     uint32(sdkedge.CryptoMethodHeader),
 	uint32(sdkedge.CallerIdHeader):         uint32(sdkedge.CallerIdHeader),
 	uint32(sdkedge.AppDataHeader):          uint32(sdkedge.AppDataHeader),
 	uint32(sdkedge.ConnectionMarkerHeader): uint32(sdkedge.ConnectionMarkerHeader),


### PR DESCRIPTION
Unreleased 2.1 work started forwarding `CryptoMethodHeader` from the dialing client through the router to the hosting SDK. The Go and C SDKs encode that header differently under the same header id, a numeric enum byte versus a string method id, so once it is actually delivered end to end an encrypted dial between the two SDKs fails. The C SDK rejects with `crypto method mismatch`; the Go SDK rejects as unsupported crypto. Both directions are affected, which covers Go applications dialing tunneler-hosted services and tunnelers dialing Go-hosted services.

Neither side is wrong on its own terms, and both actually agree on the crypto in use. They just disagree on how to spell it, and nothing carried one SDK's value to the other until the forwarding landed.

Since the forwarding is unreleased, this removes it and restores 2.0.x behavior, where each side falls back to its own default. This is a hold, not a resolution: reverting this commit restores the feature once the SDKs agree on one encoding.

Found by the in-place upgrade smoke test, which runs a Go SDK client against a ziti-edge-tunnel-hosted service on current versions of both.