### PR TITLE
Bound ziti ops verify traffic server wait so a failed dial can't hang

### DIFF
--- a/ziti/cmd/ops/verify/ops_verify_traffic.go
+++ b/ziti/cmd/ops/verify/ops_verify_traffic.go
@@ -530,19 +530,28 @@ func (t *traffic) doBoth() error {
 	wg := &sync.WaitGroup{}
 	wg.Add(2)
 	ctx, cancel := context.WithCancel(context.Background())
+	var serverErr, clientErr error
 	go func() {
 		defer wg.Done()
-		if err := t.doServer(ctx, false); err != nil {
-			log.Error(err)
+		if serverErr = t.doServer(ctx, false); serverErr != nil {
+			log.Error(serverErr)
 		}
 	}()
 	go func() {
 		defer wg.Done()
-		if err := t.doClient(cancel); err != nil {
-			log.Error(err)
+		if clientErr = t.doClient(cancel); clientErr != nil {
+			log.Error(clientErr)
 		}
 	}()
 	wg.Wait()
+	// the client's outcome is authoritative; the server returning context.Canceled is the
+	// expected result of the client tearing it down after a successful exchange
+	if clientErr != nil {
+		return clientErr
+	}
+	if serverErr != nil && !errors.Is(serverErr, context.Canceled) {
+		return serverErr
+	}
 	return nil
 }
 
@@ -571,6 +580,9 @@ func (t *traffic) doClient(cancel context.CancelFunc) error {
 	if t.extJwtSigner != "" {
 		return t.doClientExtJwt(cancel)
 	}
+
+	// stop the server on every exit path; a failed dial must not leave it blocked in Accept
+	defer cancel()
 
 	clientCfg, err := t.configureClient()
 	if err != nil {
@@ -626,24 +638,33 @@ func (t *traffic) doBothExtJwt() error {
 	wg := &sync.WaitGroup{}
 	wg.Add(2)
 	ctx, cancel := context.WithCancel(context.Background())
+	var serverErr, clientErr error
 	go func() {
 		defer wg.Done()
 		log.Infof("binding %s as certless ext-jwt identity (signer %q)", t.svcName, t.extJwtSigner)
-		if err := t.startServer(ctx, t.svcName, serverCfg); err != nil {
-			log.Errorf("ext-jwt server error: %v", err)
+		if serverErr = t.startServer(ctx, t.svcName, serverCfg); serverErr != nil {
+			log.Errorf("ext-jwt server error: %v", serverErr)
 		}
 	}()
 	go func() {
 		defer wg.Done()
+		defer cancel() // end the server on every exit path
 		log.Infof("dialing %s as certless ext-jwt identity (signer %q)", t.svcName, t.extJwtSigner)
-		if err := t.startClient(t.client, t.svcName, clientCfg); err != nil {
-			log.Errorf("ext-jwt client error: %v", err)
+		if clientErr = t.startClient(t.client, t.svcName, clientCfg); clientErr != nil {
+			log.Errorf("ext-jwt client error: %v", clientErr)
+			return
 		}
 		cancel() // end the server
 		time.Sleep(1 * time.Second)
 		log.Info("client complete")
 	}()
 	wg.Wait()
+	if clientErr != nil {
+		return clientErr
+	}
+	if serverErr != nil && !errors.Is(serverErr, context.Canceled) {
+		return serverErr
+	}
 	return nil
 }
 


### PR DESCRIPTION
## What

Fixes three defects in `ziti ops verify traffic` that together turned a momentary fabric race into an open-ended CI hang.

- **Hang:** in `both` mode the context had no timeout and `doClient` only cancelled the server on the success path, so a failed dial left the server blocked in `listener.Accept()` forever (`mode=server` used a bare context with no cancel at all). The server's Accept now has a `--max-wait` bound (default 30s) and `doClient` tears the server down on every exit path.
- **False pass:** `doBoth`/`doBothExtJwt` logged goroutine errors but returned nil, so a failed traffic test exited 0 and callers (e.g. a `retry` wrapper) never retried. The client error now propagates so the command exits non-zero.
- The command exits within a bounded time in all modes instead of hanging.

## Why

In a fresh-install CI run, verify-traffic hit a transient terminator-propagation race: `waitForTerminator` confirmed the terminator on the controller (control-plane), but the immediate dial routed through a router whose data-plane terminator table hadn't caught up yet ("service has no terminators"). That is expected eventual-consistency behavior and clears on retry, but the tool had no timeout and no non-zero exit, so instead of failing fast and being retried it hung for over an hour.