### PR TITLE
[Backport-2.0] wss edge listener rejects all clients on 2.0: certValidatingIdentity forces client-cert verification on a listener that intentionally sets NoClientCert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Release 2.0.5
+
+## What's New
+
+* Bug fixes
+
+## Component Updates and Bug Fixes
+
+* github.com/openziti/ziti/v2: [v2.0.4 -> v2.0.5](https://github.com/openziti/ziti/compare/v2.0.4...v2.0.5)
+  * [Issue #4289](https://github.com/openziti/ziti/issues/4289) - [Backport-2.0] wss edge listener rejects all clients on 2.0: certValidatingIdentity forces client-cert verification on a listener that intentionally sets NoClientCert
+
 # Release 2.0.4
 
 ## What's New

--- a/router/state/cert_validating_identity.go
+++ b/router/state/cert_validating_identity.go
@@ -32,7 +32,8 @@ import (
 // certValidatingIdentity wraps an identity.Identity to add client certificate chain verification
 // at the TLS level via a VerifyConnection callback. It dynamically builds a CA pool from the
 // router data model's client cert validation PublicKeys, ensuring the latest trust anchors
-// are always used.
+// are always used. Verification is skipped for TLS layers that don't require a client
+// certificate.
 type certValidatingIdentity struct {
 	identity.Identity
 	stateManager Manager
@@ -52,9 +53,23 @@ func WrapIdentityWithCertValidation(id *identity.TokenId, stateManager Manager) 
 	}
 }
 
+// ServerTLSConfig returns a tls.Config which validates client certificate chains against the
+// router data model CA pool, unless the config is later set to not require a client certificate.
 func (self *certValidatingIdentity) ServerTLSConfig() *tls.Config {
 	cfg := self.Identity.ServerTLSConfig()
-	cfg.VerifyConnection = self.verifyConnection
+	if cfg == nil {
+		return nil
+	}
+
+	// ClientAuth is read at verification time rather than here because transport listeners may
+	// change it after this call. The wss listener sets NoClientCert on the outer TLS layer and
+	// requires the client certificate on the inner TLS layer established over the websocket.
+	cfg.VerifyConnection = func(state tls.ConnectionState) error {
+		if len(state.PeerCertificates) == 0 && !requiresClientCert(cfg.ClientAuth) {
+			return nil
+		}
+		return self.verifyConnection(state)
+	}
 	return cfg
 }
 
@@ -106,12 +121,18 @@ func buildClientCertRoots(rdm *common.RouterDataModel, parseCert func(kid string
 	return roots, intermediates, rootCount
 }
 
+// requiresClientCert reports whether the given client auth type makes a handshake fail when the
+// client presents no certificate.
+func requiresClientCert(clientAuth tls.ClientAuthType) bool {
+	return clientAuth == tls.RequireAnyClientCert || clientAuth == tls.RequireAndVerifyClientCert
+}
+
 // verifyConnection is a TLS VerifyConnection callback that verifies client certificates against
 // the CA pool built from RDM PublicKeys.
 func (self *certValidatingIdentity) verifyConnection(state tls.ConnectionState) error {
 	if len(state.PeerCertificates) == 0 {
-		// No client cert presented. The edge listener requires a cert (RequireAnyClientCert),
-		// so this should not happen. Reject to be safe.
+		// The listener requires a client cert, so the handshake should not have gotten this far
+		// without one. Reject to be safe.
 		return errors.New("no client certificate presented")
 	}
 

--- a/router/state/cert_validating_identity_test.go
+++ b/router/state/cert_validating_identity_test.go
@@ -1,0 +1,92 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package state
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"testing"
+
+	"github.com/openziti/identity"
+	"github.com/stretchr/testify/require"
+)
+
+// stubServerIdentity provides just enough of identity.Identity to exercise ServerTLSConfig. The
+// embedded nil interface panics if anything else is called, which keeps the stub honest.
+type stubServerIdentity struct {
+	identity.Identity
+	cfg *tls.Config
+}
+
+func (self *stubServerIdentity) ServerTLSConfig() *tls.Config {
+	return self.cfg
+}
+
+func (self *stubServerIdentity) CA() *x509.CertPool {
+	return nil
+}
+
+func newTestValidatingIdentity(clientAuth tls.ClientAuthType) *tls.Config {
+	wrapped := &certValidatingIdentity{
+		Identity: &stubServerIdentity{
+			cfg: &tls.Config{ClientAuth: clientAuth},
+		},
+	}
+	return wrapped.ServerTLSConfig()
+}
+
+func TestCertValidatingIdentityAllowsNoCertWhenNotRequired(t *testing.T) {
+	// A listener that doesn't ask for a client cert must not be failed for not receiving one.
+	// The wss transport does this on its outer TLS layer and requires the client cert on the
+	// inner TLS layer established over the websocket.
+	for _, clientAuth := range []tls.ClientAuthType{tls.NoClientCert, tls.RequestClientCert, tls.VerifyClientCertIfGiven} {
+		t.Run(clientAuth.String(), func(t *testing.T) {
+			cfg := newTestValidatingIdentity(clientAuth)
+			require.NotNil(t, cfg.VerifyConnection)
+			require.NoError(t, cfg.VerifyConnection(tls.ConnectionState{}))
+		})
+	}
+}
+
+func TestCertValidatingIdentityRejectsNoCertWhenRequired(t *testing.T) {
+	for _, clientAuth := range []tls.ClientAuthType{tls.RequireAnyClientCert, tls.RequireAndVerifyClientCert} {
+		t.Run(clientAuth.String(), func(t *testing.T) {
+			cfg := newTestValidatingIdentity(clientAuth)
+			require.NotNil(t, cfg.VerifyConnection)
+			require.ErrorContains(t, cfg.VerifyConnection(tls.ConnectionState{}), "no client certificate presented")
+		})
+	}
+}
+
+// TestCertValidatingIdentityHonorsLateClientAuthChange covers the ordering that transport listeners
+// rely on: they take the config from ServerTLSConfig and only then decide whether the layer needs a
+// client certificate.
+func TestCertValidatingIdentityHonorsLateClientAuthChange(t *testing.T) {
+	cfg := newTestValidatingIdentity(tls.RequireAnyClientCert)
+	require.ErrorContains(t, cfg.VerifyConnection(tls.ConnectionState{}), "no client certificate presented")
+
+	cfg.ClientAuth = tls.NoClientCert
+	require.NoError(t, cfg.VerifyConnection(tls.ConnectionState{}))
+
+	cfg.ClientAuth = tls.RequireAndVerifyClientCert
+	require.ErrorContains(t, cfg.VerifyConnection(tls.ConnectionState{}), "no client certificate presented")
+}
+
+func TestCertValidatingIdentityNilServerConfig(t *testing.T) {
+	wrapped := &certValidatingIdentity{Identity: &stubServerIdentity{}}
+	require.Nil(t, wrapped.ServerTLSConfig())
+}


### PR DESCRIPTION
Backport of #4218 to the v2.0 LTS line (targets `release-v2.0.x`, not `main`). Fixes #4289.

Original fix on main: #4218, merged in 804f55abb.

## What it fixes

A `wss:` edge listener on 2.0.x rejects every connection right after the outer TLS handshake, breaking all browser-based access (BrowZer, browser/WASM SDK clients). The router's cert-validating identity wrapper attaches a `VerifyConnection` callback to every edge listener's TLS config, and that callback fails any connection with no peer certificates. That assumption holds for the `tls:` binding, but the wss transport deliberately sets `NoClientCert` on its outer TLS layer and requires the client certificate on the inner TLS layer established over the websocket. Setting `NoClientCert` stops the server asking for a cert; it does nothing about a callback that demands one.

The fix skips validation when the TLS layer's `ClientAuth` doesn't require a certificate, leaving enforcement to the layer that does. `ClientAuth` is read at verification time rather than when the config is built, because transport listeners set it after obtaining the config.

## Cherry-pick provenance

Cherry-pick (`-x`) of b3894309 onto `release-v2.0.x`. It conflicted textually with the #4094 backport (#4153), which had since rewritten `cert_validating_identity.go` to build the client-cert trust pool from first/third-party RDM keys:

- the type's doc comment, where 2.0.x's first-party wording met the fix's added sentence
- the placement of `requiresClientCert`, which the fix adds next to `verifyConnection`, now separated by `buildClientCertRoots`

Both were resolved to match `main`: the file on this branch is byte-identical to `origin/main`'s, which is the right target, since main's copy differs from `release-v2.0.x`'s only by this fix. The new test file needed no adaptation and is likewise identical to main's.

## Changelog

`v2.0.4` is released, so this lands in the next patch release. A second commit opens the `Release 2.0.5` section listing the tracking issue.

## Verification

- `go build ./router/...`, `go vet ./router/state/` and `go test ./router/state/...` pass.
- Verified end-to-end against this branch's `transport/v2` v2.0.215 wss listener, the version that shipped in 2.0.0: a certless browser-style client negotiating `http/1.1` now gets `101 Switching Protocols`, while reverting just `cert_validating_identity.go` to the branch tip reproduces the reported `broken pipe`. The inner TLS layer still runs and still requires the client certificate.
