### PR TITLE
Use the length-checked accessor for the bind cost header

### DIFF
--- a/router/xgress_edge/listener.go
+++ b/router/xgress_edge/listener.go
@@ -17,7 +17,6 @@
 package xgress_edge
 
 import (
-	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -1385,8 +1384,8 @@ func (self *edgeClientConn) processBindV2(serviceSessionToken *state.ServiceSess
 	log.Debugf("client requested router provided connection ids: %v", assignIds)
 
 	cost := uint16(0)
-	if costBytes, hasCost := req.Headers[sdkedge.CostHeader]; hasCost {
-		cost = binary.LittleEndian.Uint16(costBytes)
+	if costVal, hasCost := req.GetUint16Header(sdkedge.CostHeader); hasCost {
+		cost = costVal
 	}
 
 	precedence := edge_ctrl_pb.TerminatorPrecedence_Default


### PR DESCRIPTION
Fixes #4296.

`processBindV2` decoded the cost header by indexing the raw header value, so a
value shorter than two bytes panicked. The bind handler runs on a bare goroutine
via `AsyncFunctionReceiveAdapter`, so nothing recovers it.

Reads it through `GetUint16Header` instead, which returns `(0, false)` on a
wrong-width value. That is the accessor already used for the same header in
`processUpdateBind` a couple of hundred lines below, so this brings the two
readers into line.

Exploitation is limited to authenticated sources: the rxer does not start until
the edge listener's bind handler has validated the API session and its bound
client certificate, and reaching this code additionally requires a service
session permitting bind.