### PR TITLE
Use the length-checked accessor for the bind cost header (1.6 backport)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Release 1.6.21
+
+## What's New
+
+* Bug fixes
+
+## Component Updates and Bug Fixes
+
+* github.com/openziti/ziti: [v1.6.20 -> v1.6.21](https://github.com/openziti/ziti/compare/v1.6.20...v1.6.21)
+  * [Issue #4299](https://github.com/openziti/ziti/issues/4299) - [Backport-1.6] Bind message with a short cost header panics the router
+
 # Release 1.6.20
 
 ## What's New

--- a/router/xgress_edge/listener.go
+++ b/router/xgress_edge/listener.go
@@ -17,7 +17,6 @@
 package xgress_edge
 
 import (
-	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -508,8 +507,8 @@ func (self *edgeClientConn) processBindV1(manager state.Manager, req *channel.Me
 	}
 
 	cost := uint16(0)
-	if costBytes, hasCost := req.Headers[sdkedge.CostHeader]; hasCost {
-		cost = binary.LittleEndian.Uint16(costBytes)
+	if costVal, hasCost := req.GetUint16Header(sdkedge.CostHeader); hasCost {
+		cost = costVal
 	}
 
 	precedence := edge_ctrl_pb.TerminatorPrecedence_Default
@@ -647,8 +646,8 @@ func (self *edgeClientConn) processBindV2(req *channel.Message, ch channel.Chann
 	log.Debugf("client requested router provided connection ids: %v", assignIds)
 
 	cost := uint16(0)
-	if costBytes, hasCost := req.Headers[sdkedge.CostHeader]; hasCost {
-		cost = binary.LittleEndian.Uint16(costBytes)
+	if costVal, hasCost := req.GetUint16Header(sdkedge.CostHeader); hasCost {
+		cost = costVal
 	}
 
 	precedence := edge_ctrl_pb.TerminatorPrecedence_Default


### PR DESCRIPTION
Fixes #4299. Backport of #4297 to release-v1.6.x.

The bind paths decoded the cost header by indexing the raw header value, so a
value shorter than two bytes panicked. The bind handler runs on a bare goroutine
via `AsyncFunctionReceiveAdapter`, so nothing recovers it.

Reads it through `GetUint16Header` instead, which returns `(0, false)` on a
wrong-width value. This line has two unguarded reads where main has one, in the
V1 and V2 bind paths; both are changed.

Exploitation is limited to authenticated sources: the rxer does not start until
the edge listener's bind handler has validated the API session, and reaching this
code additionally requires a service session permitting bind.