### PR TITLE
backport openziti/ziti#4304 to release-v2.0.x build time provided cap…

### DIFF
--- a/common/build/flags.go
+++ b/common/build/flags.go
@@ -1,0 +1,63 @@
+package build
+
+import (
+	"regexp"
+	"strings"
+)
+
+const (
+	// maxBuildFlags is the greatest number of flag names accepted from buildFlags.
+	maxBuildFlags = 32
+
+	// maxBuildFlagNameLength is the greatest length accepted for a single flag name.
+	maxBuildFlagNameLength = 64
+)
+
+// buildFlagNamePattern matches a well formed build flag name.
+var buildFlagNamePattern = regexp.MustCompile(`^[A-Z0-9_]+$`)
+
+// buildFlags is a comma separated list of flag names supplied at build time by the linker, empty
+// in a stock build:
+//
+//	-X github.com/openziti/ziti/v2/common/build.buildFlags=ALPHA,BRAVO
+//
+// The symbol path is a contract with downstream builds. The linker silently ignores -X against a
+// symbol it cannot resolve, so renaming this variable or moving it to another package produces a
+// binary with no build flags rather than a build error. A second -X against this symbol replaces
+// the first rather than adding to it: one build owner composes the whole list.
+var buildFlags string
+
+// GetBuildFlags returns the well formed flag names supplied at build time, in the order they were
+// given. It returns an empty slice for a stock build.
+func GetBuildFlags() []string {
+	return parseBuildFlags(buildFlags)
+}
+
+// parseBuildFlags splits raw on commas and returns the well formed names in first seen order,
+// dropping blanks, duplicates, and anything outside [A-Z0-9_]. The result is never nil, so it
+// serializes as an empty JSON array rather than null. The count of names and the length of each
+// are capped, because the result is served over an unauthenticated API.
+func parseBuildFlags(raw string) []string {
+	result := []string{}
+	seen := map[string]struct{}{}
+
+	for _, token := range strings.Split(raw, ",") {
+		if len(result) == maxBuildFlags {
+			break
+		}
+
+		name := strings.TrimSpace(token)
+		if len(name) > maxBuildFlagNameLength || !buildFlagNamePattern.MatchString(name) {
+			continue
+		}
+
+		if _, ok := seen[name]; ok {
+			continue
+		}
+
+		seen[name] = struct{}{}
+		result = append(result, name)
+	}
+
+	return result
+}

--- a/common/build/flags_test.go
+++ b/common/build/flags_test.go
@@ -1,0 +1,87 @@
+package build
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseBuildFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      string
+		expected []string
+	}{
+		{
+			name:     "empty string yields an empty, non nil slice",
+			raw:      "",
+			expected: []string{},
+		},
+		{
+			name:     "single name",
+			raw:      "ALPHA",
+			expected: []string{"ALPHA"},
+		},
+		{
+			name:     "multiple names keep their order",
+			raw:      "ALPHA,BRAVO,CHARLIE",
+			expected: []string{"ALPHA", "BRAVO", "CHARLIE"},
+		},
+		{
+			name:     "surrounding whitespace is trimmed",
+			raw:      "  ALPHA , BRAVO\t,\nCHARLIE  ",
+			expected: []string{"ALPHA", "BRAVO", "CHARLIE"},
+		},
+		{
+			name:     "blank tokens are dropped",
+			raw:      ",ALPHA,,  ,BRAVO,",
+			expected: []string{"ALPHA", "BRAVO"},
+		},
+		{
+			name:     "duplicates are dropped, first occurrence wins",
+			raw:      "ALPHA,BRAVO,ALPHA",
+			expected: []string{"ALPHA", "BRAVO"},
+		},
+		{
+			name:     "digits and underscores are accepted",
+			raw:      "ALPHA_2,BRAVO_MODE,3",
+			expected: []string{"ALPHA_2", "BRAVO_MODE", "3"},
+		},
+		{
+			name:     "malformed tokens are dropped, well formed ones survive",
+			raw:      "alpha,BRAVO,Char-lie,DELTA ECHO,FOXTROT!,GOLF",
+			expected: []string{"BRAVO", "GOLF"},
+		},
+		{
+			name:     "names longer than the cap are dropped",
+			raw:      "ALPHA," + strings.Repeat("B", maxBuildFlagNameLength+1) + ",CHARLIE",
+			expected: []string{"ALPHA", "CHARLIE"},
+		},
+		{
+			name:     "names exactly at the length cap are kept",
+			raw:      strings.Repeat("B", maxBuildFlagNameLength),
+			expected: []string{strings.Repeat("B", maxBuildFlagNameLength)},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := parseBuildFlags(test.raw)
+
+			require.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestParseBuildFlagsStopsAtTheCountCap(t *testing.T) {
+	names := make([]string, 0, maxBuildFlags+5)
+	for i := 0; i < maxBuildFlags+5; i++ {
+		names = append(names, "NAME_"+strings.Repeat("X", i))
+	}
+
+	result := parseBuildFlags(strings.Join(names, ","))
+
+	require.Len(t, result, maxBuildFlags, "accepted names must be capped")
+	require.Equal(t, names[:maxBuildFlags], result, "the first names up to the cap are the ones kept")
+}

--- a/controller/internal/routes/version_router.go
+++ b/controller/internal/routes/version_router.go
@@ -97,6 +97,7 @@ func (ir *VersionRouter) buildVersions(ae *env.AppEnv) *rest_model.Version {
 		Version:        buildInfo.Version(),
 		APIVersions:    map[string]map[string]rest_model.APIVersion{},
 		Capabilities:   []string{},
+		BuildFlags:     build.GetBuildFlags(),
 	}
 
 	for apiBinding, apiVersionToPathMap := range webapis.AllApiBindingVersions {

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/openziti/agent v1.0.33
 	github.com/openziti/channel/v4 v4.3.12
 	github.com/openziti/cobra-to-md v1.0.1
-	github.com/openziti/edge-api v0.31.0
+	github.com/openziti/edge-api v0.36.0
 	github.com/openziti/foundation/v2 v2.0.91
 	github.com/openziti/identity v1.0.129
 	github.com/openziti/jwks v1.0.6

--- a/go.sum
+++ b/go.sum
@@ -534,6 +534,8 @@ github.com/openziti/cobra-to-md v1.0.1 h1:WRinNoIRmwWUSJm+pSNXMjOrtU48oxXDZgeCYQ
 github.com/openziti/cobra-to-md v1.0.1/go.mod h1:FjCpk/yzHF7/r28oSTNr5P57yN5VolpdAtS/g7KNi2c=
 github.com/openziti/edge-api v0.31.0 h1:QdaaPnKQj4B40q404+c8VZxMsoVpfGpfOhzs3LLCd/A=
 github.com/openziti/edge-api v0.31.0/go.mod h1:pDtCR6Mq0h5e8ulJhmuhPshEBa39hpQy+yTtLpUSBOs=
+github.com/openziti/edge-api v0.36.0 h1:adp0gCDbxee3r4tPBCXm7IyLTcIGhDcWmQ9QJMO+AwY=
+github.com/openziti/edge-api v0.36.0/go.mod h1:m1oAQ6+fnkEO0NOAkDy6WpnXDxPhj2sko4eBUvIMxkE=
 github.com/openziti/foundation/v2 v2.0.91 h1:gjXFu+fxKKMCs1hCkfLNI9jfdiSBW2gXAnBCy5xG/UI=
 github.com/openziti/foundation/v2 v2.0.91/go.mod h1:vbAudlD59QTMR+IifKXLL9c8W/OyL8DVsbYqGXWV2dY=
 github.com/openziti/go-term-markdown v1.0.1 h1:9uzMpK4tav6OtvRxRt99WwPTzAzCh+Pj9zWU2FBp3Qg=

--- a/ziti/cmd/common/version.go
+++ b/ziti/cmd/common/version.go
@@ -18,7 +18,9 @@ package common
 
 import (
 	"fmt"
+	"strings"
 
+	"github.com/openziti/ziti/v2/common/build"
 	"github.com/openziti/ziti/v2/common/version"
 	"github.com/spf13/cobra"
 )
@@ -36,6 +38,10 @@ func NewVersionCmd() *cobra.Command {
 				fmt.Printf("Build Date:   %s\n", version.GetBuildDate())
 				fmt.Printf("Go Version:   %s\n", version.GetGoVersion())
 				fmt.Printf("OS/Arch:      %s/%s\n", version.GetOS(), version.GetArchitecture())
+
+				if buildFlags := build.GetBuildFlags(); len(buildFlags) > 0 {
+					fmt.Printf("Build Flags:  %s\n", strings.Join(buildFlags, ", "))
+				}
 			} else {
 				fmt.Println(version.GetVersion())
 			}


### PR DESCRIPTION
…abilities

- adds common/build.buildCapabilities, a linker -X target holding a comma-separated list of capability names, empty in a stock build
- parses it into well-formed [A-Z0-9_] names, dropping blanks, duplicates, and anything past the 32-name and 64-character caps, without validating against a known set
- merges the injected names into /version and /enumerated-capabilities on both the client and management APIs, deduped against the names the controller reports for itself
- prints a Capabilities line under ziti version -v when the list is non-empty