### PR TITLE
Wait for the hosting side before tearing down the listener-close test

### DIFF
--- a/tests/data_flow_close_test.go
+++ b/tests/data_flow_close_test.go
@@ -219,6 +219,18 @@ func Test_ServerCloseListenerPropagation(t *testing.T) {
 	name = eid.New()
 	conn.WriteString(name, time.Second)
 	conn.ReadExpected("hello, "+name, time.Second)
+
+	// Wait for the hosting side to finish before the deferred teardown runs. Reading the last
+	// reply only proves the data reached the wire, not that the hosting write has returned:
+	// the SDK writes with SendAndWaitForWire, so the write is still waiting to be told its
+	// buffer went out. Closing the context under it resolves that wait as "channel closed"
+	// and fails a write whose data the client already has.
+	select {
+	case err := <-errC:
+		ctx.Req.NoError(err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out after 2 seconds")
+	}
 }
 
 func Test_ClientConnClosePropagation(t *testing.T) {


### PR DESCRIPTION
`Test_ServerCloseListenerPropagation` fails intermittently in CI with `channel closed` from the hosting
side's final write:

```
--- FAIL: Test_ServerCloseListenerPropagation
    context.go:1102: data_flow_close_test.go:204
    Error: Received unexpected error: channel closed
```

### Cause

The test never received from `errC`, making it the only one of the seven tests in the file that did not
wait for its hosting goroutine.

Reading the last reply only proves the data reached the wire. The SDK writes with
`SendAndWaitForWire`, which deliberately does not return until it is told the buffer went out, so the
hosting write is still in progress when the client's read returns. The test body returning then ran the
deferred `conn.Close()`, `listener.Close()`, `context.Close()` and `ctx.Teardown()` under it, and closing
the channel resolved that wait as `channel closed` — failing a write whose data the client had already
received.

The single-failure signature is what pins the ordering: the failing job contains exactly one error, from
the hosting goroutine, with no client-side failure. That is only possible if the payload was delivered
and the write returned an error afterwards.

### Fix

Wait on `errC` before returning, which is what the other six tests in the file already do. The deferred
closes then cannot run until the hosting write has returned.

Test-only change; no product code is touched.

### On reproducing it

The window is between the data hitting the wire and the sender being notified, which is not reachable
from the test and does not open on an idle machine. It needs a loaded runner. So the argument for this
fix is the mechanism above plus the consistency with the sibling tests, not a local red-to-green
demonstration. Worth a reviewer's eye on that reasoning.

Verified: `go vet -tags dataflow` clean, the target test passes 10x consecutively, and the full
`dataflow` suite passes.

`release-v2.0.x` and `release-v1.6.x` have the same omission and will want backports once this lands.
