### PR TITLE
[Backport-2.0] Wait for the hosting side before tearing down the listener-close test

### DIFF
--- a/tests/data_flow_close_test.go
+++ b/tests/data_flow_close_test.go
@@ -219,6 +219,18 @@ func Test_ServerCloseListenerPropagation(t *testing.T) {
 	name = eid.New()
 	conn.WriteString(name, time.Second)
 	conn.ReadExpected("hello, "+name, time.Second)
+
+	// Wait for the hosting side to finish before the deferred teardown runs. Reading the last
+	// reply only proves the data reached the wire, not that the hosting write has returned:
+	// the SDK writes with SendAndWaitForWire, so the write is still waiting to be told its
+	// buffer went out. Closing the context under it resolves that wait as "channel closed"
+	// and fails a write whose data the client already has.
+	select {
+	case err := <-errC:
+		ctx.Req.NoError(err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out after 2 seconds")
+	}
 }
 
 func Test_ClientConnClosePropagation(t *testing.T) {


### PR DESCRIPTION
Backport of #4309 to `release-v2.0.x`. No tracking issue; this is a flaky-test fix.

`Test_ServerCloseListenerPropagation` fails intermittently in CI on this branch with `channel closed`
from the hosting side's final write, most recently on #4300:

```
--- FAIL: Test_ServerCloseListenerPropagation
    context.go:1102: data_flow_close_test.go:204
    Error: Received unexpected error: channel closed
```

### Cause

The test never received from `errC`, making it the only one of the seven tests in the file that did not
wait for its hosting goroutine.

Reading the last reply only proves the data reached the wire. The SDK writes with
`SendAndWaitForWire`, which deliberately does not return until it is told the buffer went out, so the
hosting write is still in progress when the client's read returns. The test body returning then ran the
deferred `conn.Close()`, `listener.Close()`, `context.Close()` and `ctx.Teardown()` under it, and closing
the channel resolved that wait as `channel closed` — failing a write whose data the client had already
received.

The single-failure signature is what pins the ordering: the failing job contains exactly one error, from
the hosting goroutine, with no client-side failure. That is only possible if the payload was delivered and
the write returned an error afterwards. `SendAndWaitForWire` is present in sdk-golang v1.7.0, which this
branch pins.

### Fix

Wait on `errC` before returning, which is what the other six tests in the file already do. Cherry-picked
cleanly; test-only, no product code touched.

### Verification

`go vet -tags dataflow` clean and the target test passes repeatedly on this branch. Note the window is
between the data hitting the wire and the sender being notified, so it does not open on an idle machine;
the argument is the mechanism plus consistency with the sibling tests rather than a local red-to-green
demonstration.
