### PR TITLE
Fix router posture process-list response handling

### DIFF
--- a/router/posture/checks.go
+++ b/router/posture/checks.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/michaelquigley/pfxlog"
-	"github.com/openziti/foundation/v2/stringz"
 	"github.com/openziti/sdk-golang/v2/pb/edge_client_pb"
 	"github.com/openziti/ziti/v2/common"
 	"github.com/openziti/ziti/v2/common/pb/edge_ctrl_pb"
@@ -199,10 +198,8 @@ func (instance *Instance) Apply(response *edge_client_pb.PostureResponse, parser
 
 	if os := response.GetOs(); os != nil {
 		if isOsDifferent(instance.Os, os) {
-			if instance.Os == nil {
-				instance.Os = &edge_client_pb.PostureResponse_Os{}
-			}
-			instance.Os.Os = os
+			// replace rather than mutate: snapshots share the previous pointer with concurrent readers
+			instance.Os = &edge_client_pb.PostureResponse_Os{Os: os}
 			updated = true
 		}
 	} else if domain := response.GetDomain(); domain != nil {
@@ -225,9 +222,10 @@ func (instance *Instance) Apply(response *edge_client_pb.PostureResponse, parser
 			instance.Woken = woken
 			updated = true
 		}
-	} else if processList := response.GetProcessList(); isProcessListDifferent(instance.ProcessList, processList) {
-		instance.ProcessList = processList
-		updated = true
+	} else if processList := response.GetProcessList(); processList != nil {
+		if instance.mergeProcessList(processList) {
+			updated = true
+		}
 	} else if totpToken := response.GetTotpToken(); totpToken != nil {
 		if totpToken.Token == "" {
 			pfxlog.Logger().Error("received empty totp token for posture response")
@@ -256,6 +254,45 @@ func (instance *Instance) Apply(response *edge_client_pb.PostureResponse, parser
 	}
 
 	return updated
+}
+
+// mergeProcessList folds an incoming process-list delta into the stored process state, keyed by
+// process path, reporting whether anything changed. SDKs report processes as per-path deltas (a
+// message may carry any subset of the watched paths), so entries for paths absent from the
+// incoming list are preserved. The stored list is replaced rather than mutated: snapshots share
+// the previous pointer with concurrent readers. Caller must hold the instance lock.
+func (instance *Instance) mergeProcessList(incoming *edge_client_pb.PostureResponse_ProcessList) bool {
+	if len(incoming.Processes) == 0 {
+		return false
+	}
+
+	existing := instance.ProcessList.GetProcesses()
+
+	merged := make([]*edge_client_pb.PostureResponse_Process, 0, len(existing)+len(incoming.Processes))
+	indexByPath := make(map[string]int, len(existing)+len(incoming.Processes))
+	for _, proc := range existing {
+		indexByPath[proc.Path] = len(merged)
+		merged = append(merged, proc)
+	}
+
+	changed := false
+	for _, proc := range incoming.Processes {
+		if idx, ok := indexByPath[proc.Path]; ok {
+			if compareProc(merged[idx], proc) != 0 {
+				merged[idx] = proc
+				changed = true
+			}
+		} else {
+			indexByPath[proc.Path] = len(merged)
+			merged = append(merged, proc)
+			changed = true
+		}
+	}
+
+	if changed {
+		instance.ProcessList = &edge_client_pb.PostureResponse_ProcessList{Processes: merged}
+	}
+	return changed
 }
 
 func isOsDifferent(old *edge_client_pb.PostureResponse_Os, new *edge_client_pb.PostureResponse_OperatingSystem) bool {
@@ -360,64 +397,6 @@ func CtrlCheckToLogic(postureCheck *edge_ctrl_pb.DataState_PostureCheck) Checker
 	}
 
 	return nil
-}
-
-func isProcessListDifferent(listA *edge_client_pb.PostureResponse_ProcessList, listB *edge_client_pb.PostureResponse_ProcessList) bool {
-
-	listAEmpty := listA == nil || len(listA.Processes) == 0
-	listBEmpty := listB == nil || len(listB.Processes) == 0
-
-	if listAEmpty && listBEmpty {
-		return false
-	}
-
-	if listAEmpty != listBEmpty {
-		return true
-	}
-
-	procAs := map[string]*edge_client_pb.PostureResponse_Process{}
-	for _, proc := range listA.Processes {
-		procAs[proc.Path] = proc
-	}
-
-	procBs := map[string]*edge_client_pb.PostureResponse_Process{}
-	for _, proc := range listB.Processes {
-		procBs[proc.Path] = proc
-	}
-
-	if len(procAs) != len(procBs) {
-		return true
-	}
-
-	var checkedPaths []string
-	for pathA, procA := range procAs {
-		procB, ok := procBs[pathA]
-
-		if !ok {
-			return true
-		}
-		if compareProc(procA, procB) != 0 {
-			return true
-		}
-
-		checkedPaths = append(checkedPaths, pathA)
-	}
-
-	for pathB, procB := range procBs {
-		if !stringz.Contains(checkedPaths, pathB) {
-			procA, ok := procAs[pathB]
-
-			if !ok {
-				return true
-			}
-
-			if compareProc(procA, procB) != 0 {
-				return true
-			}
-		}
-	}
-
-	return false
 }
 
 func compareProc(procA, procB *edge_client_pb.PostureResponse_Process) int {

--- a/router/posture/checks_apply_test.go
+++ b/router/posture/checks_apply_test.go
@@ -1,0 +1,133 @@
+package posture
+
+import (
+	"testing"
+	"time"
+
+	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/openziti/sdk-golang/v2/pb/edge_client_pb"
+	"github.com/openziti/ziti/v2/common"
+	"github.com/stretchr/testify/require"
+)
+
+type stubTotpParser struct {
+	claims *common.TotpClaims
+}
+
+func (s *stubTotpParser) ParseTotpToken(string) (*common.TotpClaims, error) {
+	return s.claims, nil
+}
+
+func processListResponse(procs ...*edge_client_pb.PostureResponse_Process) *edge_client_pb.PostureResponse {
+	return &edge_client_pb.PostureResponse{
+		Type: &edge_client_pb.PostureResponse_ProcessList_{
+			ProcessList: &edge_client_pb.PostureResponse_ProcessList{Processes: procs},
+		},
+	}
+}
+
+func totpResponse(token string) *edge_client_pb.PostureResponse {
+	return &edge_client_pb.PostureResponse{
+		Type: &edge_client_pb.PostureResponse_TotpToken_{
+			TotpToken: &edge_client_pb.PostureResponse_TotpToken{Token: token},
+		},
+	}
+}
+
+func Test_Apply_TotpResponsePreservesProcessListAndAdvancesMfa(t *testing.T) {
+	req := require.New(t)
+
+	claims := &common.TotpClaims{}
+	claims.ApiSessionId = "api-session-1"
+	claims.IssuedAt = jwt.NewNumericDate(time.Now())
+
+	cache := NewCache(&stubTotpParser{claims: claims})
+
+	cache.AddResponses("identity-1", "api-session-1", &edge_client_pb.PostureResponses{
+		Responses: []*edge_client_pb.PostureResponse{
+			processListResponse(&edge_client_pb.PostureResponse_Process{
+				Path: "/usr/bin/foo", IsRunning: true, Hash: "abc",
+			}),
+		},
+	})
+
+	cache.AddResponses("identity-1", "api-session-1", &edge_client_pb.PostureResponses{
+		Responses: []*edge_client_pb.PostureResponse{totpResponse("some-token")},
+	})
+
+	data := cache.GetInstance("api-session-1").Snapshot()
+	req.NotNil(data.PassedMfaAt, "TOTP token should advance PassedMfaAt")
+	req.Len(data.ProcessList.GetProcesses(), 1, "process list should survive a TOTP response")
+}
+
+func Test_Apply_PerPathProcessResponsesAccumulate(t *testing.T) {
+	req := require.New(t)
+	instance := newInstance()
+
+	// the Go SDK reports each watched process as its own single-entry process list
+	req.True(instance.Apply(processListResponse(
+		&edge_client_pb.PostureResponse_Process{Path: "/usr/bin/foo", IsRunning: true}), nil))
+	req.True(instance.Apply(processListResponse(
+		&edge_client_pb.PostureResponse_Process{Path: "/usr/bin/bar", IsRunning: true}), nil))
+
+	procs := instance.Snapshot().ProcessList.GetProcesses()
+	req.Len(procs, 2, "both watched processes should be cached")
+}
+
+func Test_Apply_ProcessUpdateReplacesEntryByPath(t *testing.T) {
+	req := require.New(t)
+	instance := newInstance()
+
+	req.True(instance.Apply(processListResponse(
+		&edge_client_pb.PostureResponse_Process{Path: "/usr/bin/foo", IsRunning: true, Hash: "v1"},
+		&edge_client_pb.PostureResponse_Process{Path: "/usr/bin/bar", IsRunning: true, Hash: "v1"}), nil))
+
+	// identical re-send is not a change
+	req.False(instance.Apply(processListResponse(
+		&edge_client_pb.PostureResponse_Process{Path: "/usr/bin/foo", IsRunning: true, Hash: "v1"}), nil))
+
+	// changed entry updates in place without disturbing the other path
+	req.True(instance.Apply(processListResponse(
+		&edge_client_pb.PostureResponse_Process{Path: "/usr/bin/foo", IsRunning: false, Hash: "v1"}), nil))
+
+	procs := instance.Snapshot().ProcessList.GetProcesses()
+	req.Len(procs, 2)
+	byPath := map[string]*edge_client_pb.PostureResponse_Process{}
+	for _, p := range procs {
+		byPath[p.Path] = p
+	}
+	req.False(byPath["/usr/bin/foo"].IsRunning)
+	req.True(byPath["/usr/bin/bar"].IsRunning)
+}
+
+func Test_Apply_EmptyResponseChangesNothing(t *testing.T) {
+	req := require.New(t)
+	instance := newInstance()
+
+	req.True(instance.Apply(processListResponse(
+		&edge_client_pb.PostureResponse_Process{Path: "/usr/bin/foo", IsRunning: true}), nil))
+
+	req.False(instance.Apply(&edge_client_pb.PostureResponse{}, nil))
+	req.Len(instance.Snapshot().ProcessList.GetProcesses(), 1)
+}
+
+func Test_Apply_OsUpdateDoesNotMutateSnapshots(t *testing.T) {
+	req := require.New(t)
+	instance := newInstance()
+
+	osResponse := func(version string) *edge_client_pb.PostureResponse {
+		return &edge_client_pb.PostureResponse{
+			Type: &edge_client_pb.PostureResponse_Os{
+				Os: &edge_client_pb.PostureResponse_OperatingSystem{Type: "linux", Version: version},
+			},
+		}
+	}
+
+	req.True(instance.Apply(osResponse("1.0.0"), nil))
+	before := instance.Snapshot()
+
+	req.True(instance.Apply(osResponse("2.0.0"), nil))
+
+	req.Equal("1.0.0", before.Os.Os.GetVersion(), "prior snapshot must not observe later updates")
+	req.Equal("2.0.0", instance.Snapshot().Os.Os.GetVersion())
+}

--- a/router/xgress_edge/listener.go
+++ b/router/xgress_edge/listener.go
@@ -1829,6 +1829,7 @@ func (self *edgeClientConn) processPostureResponse(msg *channel.Message, ch chan
 
 		if err := proto.Unmarshal(msg.Body, postureResponses); err != nil {
 			pfxlog.Logger().WithError(err).Error("failed to unmarshal posture responses")
+			return
 		}
 
 		go self.listener.factory.stateManager.ProcessPostureResponses(ch, postureResponses)


### PR DESCRIPTION
Fixes #4314

The router posture cache's response dispatch mishandled process-list data in two ways: a TOTP-only response fell into the process-list branch (wiping cached process data and dropping the token, so `PassedMfaAt` never advanced), and each process-list response replaced the cached list wholesale even though SDKs report processes as per-path deltas, so multi-process checks could never stay passing.

- guards the process-list branch so only actual process-list responses reach it
- merges process entries by path (copy-on-write), preserving entries for paths not in the incoming delta
- replaces OS posture state on update instead of mutating a pointer shared with snapshots
- returns early when posture response unmarshalling fails
- adds regression tests covering response application