### PR TITLE
fixes openziti/ziti#4318 guard mac and domain posture checks against …

### DIFF
--- a/router/posture/domain.go
+++ b/router/posture/domain.go
@@ -10,7 +10,7 @@ type DomainCheck struct {
 }
 
 func (m *DomainCheck) Evaluate(state *InstanceData) *CheckError {
-	if state == nil {
+	if state == nil || state.Domain == nil {
 		return &CheckError{
 			Id:    m.Id,
 			Name:  m.Name,

--- a/router/posture/domain_test.go
+++ b/router/posture/domain_test.go
@@ -1,0 +1,62 @@
+package posture
+
+import (
+	"testing"
+
+	"github.com/openziti/sdk-golang/v2/pb/edge_client_pb"
+	"github.com/openziti/ziti/v2/common/pb/edge_ctrl_pb"
+	"github.com/stretchr/testify/require"
+)
+
+func newDomainCheck(domains ...string) *DomainCheck {
+	return &DomainCheck{
+		DataState_PostureCheck: &edge_ctrl_pb.DataState_PostureCheck{Id: "domain-check", Name: "domain-check"},
+		DataState_PostureCheck_Domains: &edge_ctrl_pb.DataState_PostureCheck_Domains{
+			Domains: domains,
+		},
+	}
+}
+
+// Test_DomainCheck_NoDomainReported locks in that a session which has not sent a domain posture
+// response fails the check rather than dereferencing the nil Domain state.
+func Test_DomainCheck_NoDomainReported(t *testing.T) {
+	check := newDomainCheck("corp.example.com")
+
+	err := check.Evaluate(&InstanceData{})
+
+	require.NotNil(t, err, "no domain data reported: the check must fail")
+	require.ErrorIs(t, err.Cause, NilStateError)
+}
+
+// Test_DomainCheck_NilState locks in the same for a wholly absent posture instance.
+func Test_DomainCheck_NilState(t *testing.T) {
+	check := newDomainCheck("corp.example.com")
+
+	err := check.Evaluate(nil)
+
+	require.NotNil(t, err, "no posture state at all: the check must fail")
+	require.ErrorIs(t, err.Cause, NilStateError)
+}
+
+// Test_DomainCheck_MatchPasses keeps the guards from swallowing a legitimate pass.
+func Test_DomainCheck_MatchPasses(t *testing.T) {
+	check := newDomainCheck("other.example.com", "corp.example.com")
+	state := &InstanceData{
+		Domain: &edge_client_pb.PostureResponse_Domain{Name: "corp.example.com"},
+	}
+
+	require.Nil(t, check.Evaluate(state), "the reported domain is in the valid list")
+}
+
+// Test_DomainCheck_NoMatchFails covers the reported-but-not-matching case.
+func Test_DomainCheck_NoMatchFails(t *testing.T) {
+	check := newDomainCheck("corp.example.com")
+	state := &InstanceData{
+		Domain: &edge_client_pb.PostureResponse_Domain{Name: "other.example.com"},
+	}
+
+	err := check.Evaluate(state)
+
+	require.NotNil(t, err, "the reported domain is not in the valid list")
+	require.NotErrorIs(t, err.Cause, NilStateError)
+}

--- a/router/posture/errors.go
+++ b/router/posture/errors.go
@@ -89,6 +89,15 @@ func EvaluatePostureCheck(postureCheck *edge_ctrl_pb.DataState_PostureCheck, dat
 	}()
 
 	check := CtrlCheckToLogic(postureCheck)
+
+	if check == nil {
+		return &CheckError{
+			Id:    postureCheck.Id,
+			Name:  postureCheck.Name,
+			Cause: UnsupportedCheckTypeError,
+		}
+	}
+
 	return check.Evaluate(data)
 }
 
@@ -184,3 +193,5 @@ func (s Str) String() string {
 var NilStateError = errors.New("posture state was nil, no posture data has been sent")
 
 var NotEqualError = errors.New("the values were not equal")
+
+var UnsupportedCheckTypeError = errors.New("the posture check subtype is not supported by this router")

--- a/router/posture/errors_test.go
+++ b/router/posture/errors_test.go
@@ -1,0 +1,53 @@
+package posture
+
+import (
+	"testing"
+
+	"github.com/openziti/ziti/v2/common/pb/edge_ctrl_pb"
+	"github.com/stretchr/testify/require"
+)
+
+// Test_EvaluatePostureCheck_UnsupportedSubtype locks in that a check whose subtype the router does
+// not recognize fails the check rather than calling the nil Checker CtrlCheckToLogic returns for it.
+func Test_EvaluatePostureCheck_UnsupportedSubtype(t *testing.T) {
+	postureCheck := &edge_ctrl_pb.DataState_PostureCheck{Id: "unknown-check", Name: "unknown-check"}
+
+	err := EvaluatePostureCheck(postureCheck, &InstanceData{})
+
+	require.NotNil(t, err, "an unrecognized subtype must fail the check")
+	require.ErrorIs(t, err.Cause, UnsupportedCheckTypeError)
+}
+
+// Test_EvaluatePostureCheck_NoMacsReported drives the MAC nil-data case through the evaluation
+// funnel both dial evaluation and posture push use, so a missing response never reaches the
+// panic recovery.
+func Test_EvaluatePostureCheck_NoMacsReported(t *testing.T) {
+	postureCheck := &edge_ctrl_pb.DataState_PostureCheck{
+		Id:   "mac-check",
+		Name: "mac-check",
+		Subtype: &edge_ctrl_pb.DataState_PostureCheck_Mac_{
+			Mac: &edge_ctrl_pb.DataState_PostureCheck_Mac{MacAddresses: []string{"00:11:22:33:44:55"}},
+		},
+	}
+
+	err := EvaluatePostureCheck(postureCheck, &InstanceData{})
+
+	require.NotNil(t, err, "no MAC data reported: the check must fail")
+	require.ErrorIs(t, err.Cause, NilStateError)
+}
+
+// Test_EvaluatePostureCheck_NoDomainReported does the same for the domain check.
+func Test_EvaluatePostureCheck_NoDomainReported(t *testing.T) {
+	postureCheck := &edge_ctrl_pb.DataState_PostureCheck{
+		Id:   "domain-check",
+		Name: "domain-check",
+		Subtype: &edge_ctrl_pb.DataState_PostureCheck_Domains_{
+			Domains: &edge_ctrl_pb.DataState_PostureCheck_Domains{Domains: []string{"corp.example.com"}},
+		},
+	}
+
+	err := EvaluatePostureCheck(postureCheck, &InstanceData{})
+
+	require.NotNil(t, err, "no domain data reported: the check must fail")
+	require.ErrorIs(t, err.Cause, NilStateError)
+}

--- a/router/posture/mac.go
+++ b/router/posture/mac.go
@@ -9,8 +9,8 @@ type MacCheck struct {
 	*edge_ctrl_pb.DataState_PostureCheck_Mac
 }
 
-func (m MacCheck) Evaluate(state *InstanceData) *CheckError {
-	if state == nil {
+func (m *MacCheck) Evaluate(state *InstanceData) *CheckError {
+	if state == nil || state.Macs == nil {
 		return &CheckError{
 			Id:    m.Id,
 			Name:  m.Name,

--- a/router/posture/mac_test.go
+++ b/router/posture/mac_test.go
@@ -74,3 +74,47 @@ func Test_MacCheck_RepeatedResponseNotSeenAsChange(t *testing.T) {
 
 	require.False(t, updated)
 }
+
+// Test_MacCheck_NoMacsReported locks in that a session which has not sent a MAC posture response
+// fails the check rather than dereferencing the nil Macs state.
+func Test_MacCheck_NoMacsReported(t *testing.T) {
+	check := newMacCheck("001122aabbcc")
+
+	err := check.Evaluate(&InstanceData{})
+
+	require.NotNil(t, err, "no MAC data reported: the check must fail")
+	require.ErrorIs(t, err.Cause, NilStateError)
+}
+
+// Test_MacCheck_NilState locks in the same for a wholly absent posture instance.
+func Test_MacCheck_NilState(t *testing.T) {
+	check := newMacCheck("001122aabbcc")
+
+	err := check.Evaluate(nil)
+
+	require.NotNil(t, err, "no posture state at all: the check must fail")
+	require.ErrorIs(t, err.Cause, NilStateError)
+}
+
+// Test_MacCheck_MatchPasses keeps the guards from swallowing a legitimate pass.
+func Test_MacCheck_MatchPasses(t *testing.T) {
+	check := newMacCheck("001122aabbcc", "aabbccddeeff")
+	state := &InstanceData{
+		Macs: &edge_client_pb.PostureResponse_Macs{Addresses: []string{"aabbccddeeff"}},
+	}
+
+	require.Nil(t, check.Evaluate(state), "a reported address is in the valid list")
+}
+
+// Test_MacCheck_NoMatchFails covers the reported-but-not-matching case.
+func Test_MacCheck_NoMatchFails(t *testing.T) {
+	check := newMacCheck("001122aabbcc")
+	state := &InstanceData{
+		Macs: &edge_client_pb.PostureResponse_Macs{Addresses: []string{"aabbccddeeff"}},
+	}
+
+	err := check.Evaluate(state)
+
+	require.NotNil(t, err, "the reported address is not in the valid list")
+	require.NotErrorIs(t, err.Cause, NilStateError)
+}


### PR DESCRIPTION
…unreported data

- treats a missing MAC posture response as a failed check instead of dereferencing nil state
- treats a missing domain posture response the same way
- fails a posture check whose subtype the router does not recognize, rather than calling the nil checker CtrlCheckToLogic returns for it
- adds UnsupportedCheckTypeError alongside the existing posture sentinels
- moves MacCheck.Evaluate to a pointer receiver, matching every other checker
- adds unit tests for the nil-data and unsupported-subtype paths