### PR TITLE
fixes openziti/ziti#4320 normalize reported MAC addresses on the router

### DIFF
--- a/common/posture/hex.go
+++ b/common/posture/hex.go
@@ -1,0 +1,31 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package posture
+
+import (
+	"regexp"
+	"strings"
+)
+
+var nonHex = regexp.MustCompile("[^a-f0-9]")
+
+// CleanMacAddress normalizes a MAC address to lowercase unseparated hex, the form MAC posture
+// check values are persisted in. Reported addresses must be normalized with it before they are
+// compared against check values, whichever separator style the client sent them in.
+func CleanMacAddress(macAddress string) string {
+	return nonHex.ReplaceAllString(strings.ToLower(macAddress), "")
+}

--- a/controller/db/posture_check_mac.go
+++ b/controller/db/posture_check_mac.go
@@ -17,9 +17,7 @@
 package db
 
 import (
-	"regexp"
-	"strings"
-
+	"github.com/openziti/ziti/v2/common/posture"
 	"github.com/openziti/ziti/v2/controller/storage/boltz"
 )
 
@@ -43,7 +41,7 @@ func (entity *PostureCheckMacAddresses) GetTypeId() string {
 
 func (entity *PostureCheckMacAddresses) LoadValues(bucket *boltz.TypedBucket) {
 	for _, macAddress := range bucket.GetStringList(FieldPostureCheckMacAddresses) {
-		macAddress = cleanMacAddress(macAddress)
+		macAddress = posture.CleanMacAddress(macAddress)
 		entity.MacAddresses = append(entity.MacAddresses, macAddress)
 	}
 }
@@ -51,15 +49,9 @@ func (entity *PostureCheckMacAddresses) LoadValues(bucket *boltz.TypedBucket) {
 func (entity *PostureCheckMacAddresses) SetValues(ctx *boltz.PersistContext, bucket *boltz.TypedBucket) {
 	var macAddresses []string
 	for _, macAddress := range entity.MacAddresses {
-		macAddress = cleanMacAddress(macAddress)
+		macAddress = posture.CleanMacAddress(macAddress)
 		macAddresses = append(macAddresses, macAddress)
 	}
 	entity.MacAddresses = macAddresses
 	bucket.SetStringList(FieldPostureCheckMacAddresses, macAddresses, ctx.FieldChecker)
-}
-
-func cleanMacAddress(macAddress string) string {
-	macAddress = strings.ToLower(macAddress)
-	nonHex := regexp.MustCompile("[^a-f0-9]")
-	return nonHex.ReplaceAllString(macAddress, "")
 }

--- a/router/posture/checks.go
+++ b/router/posture/checks.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openziti/sdk-golang/v2/pb/edge_client_pb"
 	"github.com/openziti/ziti/v2/common"
 	"github.com/openziti/ziti/v2/common/pb/edge_ctrl_pb"
+	"github.com/openziti/ziti/v2/common/posture"
 	cmap "github.com/orcaman/concurrent-map/v2"
 	"google.golang.org/protobuf/proto"
 )
@@ -211,8 +212,13 @@ func (instance *Instance) Apply(response *edge_client_pb.PostureResponse, parser
 			updated = true
 		}
 	} else if macs := response.GetMacs(); macs != nil {
-		if instance.Macs == nil || !slices.Equal(macs.Addresses, instance.Macs.Addresses) {
-			instance.Macs = macs
+		addresses := make([]string, 0, len(macs.Addresses))
+		for _, address := range macs.Addresses {
+			addresses = append(addresses, posture.CleanMacAddress(address))
+		}
+
+		if instance.Macs == nil || !slices.Equal(addresses, instance.Macs.Addresses) {
+			instance.Macs = &edge_client_pb.PostureResponse_Macs{Addresses: addresses}
 			updated = true
 		}
 	} else if unlocked := response.GetUnlocked(); unlocked != nil {

--- a/router/posture/mac_test.go
+++ b/router/posture/mac_test.go
@@ -1,0 +1,76 @@
+package posture
+
+import (
+	"testing"
+
+	"github.com/openziti/sdk-golang/v2/pb/edge_client_pb"
+	"github.com/openziti/ziti/v2/common/pb/edge_ctrl_pb"
+	"github.com/stretchr/testify/require"
+)
+
+func newMacCheck(addresses ...string) *MacCheck {
+	return &MacCheck{
+		DataState_PostureCheck: &edge_ctrl_pb.DataState_PostureCheck{Id: "mac-check", Name: "mac-check"},
+		DataState_PostureCheck_Mac: &edge_ctrl_pb.DataState_PostureCheck_Mac{
+			MacAddresses: addresses,
+		},
+	}
+}
+
+func macResponse(addresses ...string) *edge_client_pb.PostureResponse {
+	return &edge_client_pb.PostureResponse{
+		Type: &edge_client_pb.PostureResponse_Macs_{
+			Macs: &edge_client_pb.PostureResponse_Macs{Addresses: addresses},
+		},
+	}
+}
+
+// Test_MacCheck_SeparatedAddressesNormalizedOnIngest locks in that reported addresses in the
+// separated, mixed-case form ziti-sdk-c sends match a check whose values are stored normalized.
+func Test_MacCheck_SeparatedAddressesNormalizedOnIngest(t *testing.T) {
+	tests := []struct {
+		name     string
+		reported string
+	}{
+		{name: "colon separated", reported: "00:11:22:AA:BB:CC"},
+		{name: "hyphen separated", reported: "00-11-22-aa-bb-cc"},
+		{name: "dot separated", reported: "0011.22AA.bbcc"},
+		{name: "uppercase unseparated", reported: "001122AABBCC"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			instance := newInstance()
+			check := newMacCheck("001122aabbcc")
+
+			updated := instance.Apply(macResponse(test.reported), nil)
+
+			data := instance.Snapshot()
+
+			require.True(t, updated)
+			require.Nil(t, check.Evaluate(&data))
+		})
+	}
+}
+
+// Test_MacCheck_NormalizationDoesNotMutateResponse locks in that ingest normalization leaves the
+// caller's protobuf message untouched.
+func Test_MacCheck_NormalizationDoesNotMutateResponse(t *testing.T) {
+	instance := newInstance()
+	response := macResponse("00:11:22:AA:BB:CC")
+
+	instance.Apply(response, nil)
+
+	require.Equal(t, []string{"00:11:22:AA:BB:CC"}, response.GetMacs().Addresses)
+}
+
+// Test_MacCheck_RepeatedResponseNotSeenAsChange locks in that re-reporting the same addresses in
+// their separated form does not read as a posture change once the stored copy is normalized.
+func Test_MacCheck_RepeatedResponseNotSeenAsChange(t *testing.T) {
+	instance := newInstance()
+	require.True(t, instance.Apply(macResponse("00:11:22:AA:BB:CC"), nil))
+
+	updated := instance.Apply(macResponse("00:11:22:AA:BB:CC"), nil)
+
+	require.False(t, updated)
+}


### PR DESCRIPTION
- normalizes reported MAC addresses in Instance.Apply to lowercase unseparated hex, the form MAC posture check values are persisted in
- stores a new PostureResponse_Macs rather than mutating the incoming protobuf message
- compares the normalized addresses when deciding whether posture data changed, so a re-reported separated address no longer reads as an update
- moves the normalizer to a new common/posture package, shared by controller/db and router/posture, and hoists its regexp out of the per-call path