### PR TITLE
Close ER/T dial circuits when the router loses dial access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [Controller Read Throughput Under Load](#controller-read-throughput-under-load) - a bbolt upgrade lifts a ceiling on concurrent read transactions that could stall a busy controller
 * [Logging Now Uses slog with an Async Handler](#logging-now-uses-slog-with-an-async-handler) - Logging moves to Go's `log/slog` behind an asynchronous sink; output is unchanged by default, with new flags to tune buffering
 * [Build Flags](#build-flags) - A build of the controller can name the build time choices it was made with, and clients can read them from `/version`
+* [Edge Router Tunneler Policy Enforcement](#edge-router-tunneler-policy-enforcement) - Removing a tunneler's dial access now closes its live circuits, and the controller verifies the dial policy for tunneler circuits. **Read the posture check warning.**
 * [Security Advisories](#security-advisories) - Eight security advisories, plus the two control-plane certificate validation fixes first released in 2.0.2
 
 ## Security Advisories
@@ -533,6 +534,37 @@ the controller offers over the API, is defined by this repository, and is
 enumerated at `/enumerated-capabilities`. Build flags describe how the binary
 was built, are open-ended, and are enumerated nowhere.
 
+## Edge Router Tunneler Policy Enforcement
+
+When an edge router tunneler (ER/T) intercepts a service and the router's identity later loses dial
+access to that service, through a service policy change, an identity being disabled, or the identity
+being deleted, the router now closes the circuits it established for that service. Previously only new
+intercepts were stopped, and existing connections kept flowing until the application or the router
+ended them. The same applies to circuits created through the router-embedded SDK. See
+[#4330](https://github.com/openziti/ziti/issues/4330).
+
+Two related gaps are closed at the same time:
+
+* The router's pre-dial policy check for tunneler circuits was miswritten and never denied a dial.
+* The controller did not verify the dial service policy when a router requested a tunneler circuit;
+  it verified only edge router and service edge router policy. It now rejects the request when no dial
+  policy grants the router's identity access to the service.
+
+### Warning: posture checks and edge router tunnelers
+
+Edge routers do not submit posture data. Because the tunneler's dial check previously never denied,
+a service policy that carried posture checks and granted access to a router identity, whether
+directly or through `#all`, let the router dial the service as though the checks had passed.
+
+That is no longer the case. The router now evaluates the dial policy the same way it does for any
+other identity, and with no posture data every posture check fails. **After upgrading, a router
+granted dial access only through a policy with posture checks will be denied**, and connections that
+were flowing through such a policy before the upgrade will not re-establish. Before upgrading, find
+any service policies that both carry posture checks and include router identities, and split the
+routers out into their own policy without posture checks. `ziti edge list service-policies` shows the
+Identity Roles and Posture Check Roles of each policy; `#all` in Identity Roles includes every router
+identity.
+
 ## Deprecated Features
 
 Deprecated features still work, but are no longer recommended and will be removed
@@ -624,6 +656,7 @@ Thanks to the community members who contributed to this release.
 
 * github.com/openziti/xweb/v3: [v3.0.4 -> v3.0.5](https://github.com/openziti/xweb/compare/v3.0.4...v3.0.5)
 * github.com/openziti/ziti/v2: [v2.0.0 -> v2.1.0](https://github.com/openziti/ziti/compare/v2.0.0...v2.1.0)
+    * [Issue #4330](https://github.com/openziti/ziti/issues/4330) - ER/T does not close existing circuits when the router loses dial access to a service
     * [Issue #4184](https://github.com/openziti/ziti/issues/4184) - Router leaks LinkSendBuffer goroutines in `drainDeadlines()` — circuits accumulate until the router OOMs
     * [Issue #4278](https://github.com/openziti/ziti/issues/4278) - fabric inspect data-model-index doesn't move for writes outside the router data model
     * [Issue #4196](https://github.com/openziti/ziti/issues/4196) - Router control-channel connect/disconnect race can leave a reconnected router de-registered

--- a/controller/handler_edge_ctrl/common.go
+++ b/controller/handler_edge_ctrl/common.go
@@ -428,6 +428,30 @@ func (self *baseSessionRequestContext) verifyServiceBindAccess(identityId string
 	}
 }
 
+func (self *baseSessionRequestContext) verifyServiceDialAccess(identityId string, serviceId string) {
+	if self.err == nil {
+		result, err := self.handler.getAppEnv().Managers.EdgeService.IsDialableByIdentity(serviceId, identityId)
+		if err != nil {
+			self.err = internalError(err)
+			logrus.
+				WithField("routerId", self.sourceRouter.Id).
+				WithField("identityId", identityId).
+				WithField("serviceId", serviceId).
+				WithField("operation", self.handler.Label()).
+				WithError(err).Error("unable to verify edge router access to dial service")
+			return
+		} else if !result {
+			self.err = InvalidServiceError{}
+			logrus.
+				WithField("routerId", self.sourceRouter.Id).
+				WithField("identityId", identityId).
+				WithField("serviceId", serviceId).
+				WithField("operation", self.handler.Label()).
+				Error("edge router does not have dial access to service")
+		}
+	}
+}
+
 // verifyRouterEdgeRouterAccess checks that the requesting router may act on the service on its
 // own behalf, as an edge router tunneler does. No edge session is involved, so denials are
 // reported with the missing policy link rather than as a session error.

--- a/controller/handler_edge_ctrl/common_tunnel.go
+++ b/controller/handler_edge_ctrl/common_tunnel.go
@@ -9,11 +9,11 @@ import (
 	"github.com/google/uuid"
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/openziti/foundation/v2/concurrenz"
-	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/openziti/ziti/v2/common/logcontext"
 	"github.com/openziti/ziti/v2/common/pb/edge_ctrl_pb"
 	"github.com/openziti/ziti/v2/controller/db"
 	"github.com/openziti/ziti/v2/controller/model"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/sirupsen/logrus"
 )
 
@@ -75,12 +75,33 @@ func (self *baseTunnelRequestContext) loadIdentity() {
 			return
 		}
 
+		// A disabled router identity may retain valid policies and sessions, and neither session
+		// creation nor posture evaluation inspects Disabled, so gate every tunnel operation here
+		// rather than in each handler. This covers dial (V1 and V2), hosting, and terminator paths.
+		if self.identity.Disabled {
+			self.err = identityDisabled(self.identity.Id)
+			logrus.
+				WithField("routerId", self.sourceRouter.Id).
+				WithField("identityId", self.identity.Id).
+				WithField("operation", self.handler.Label()).
+				Error("edge router identity is disabled")
+			return
+		}
+
 		self.logContext = logcontext.NewContext()
 		traceSpec := self.handler.getAppEnv().TraceManager.GetIdentityTrace(self.identity.Id)
 		if traceSpec != nil && time.Now().After(traceSpec.Until) {
 			self.logContext.SetChannelsMask(traceSpec.ChannelMask)
 			self.logContext.WithField("traceId", traceSpec.TraceId)
 		}
+	}
+}
+
+// verifyEdgeRouterServiceDialAccess checks that the requesting router's own identity has dial access
+// to the loaded service. The disabled-identity check lives in loadIdentity, which runs first.
+func (self *baseTunnelRequestContext) verifyEdgeRouterServiceDialAccess() {
+	if self.err == nil {
+		self.verifyServiceDialAccess(self.sourceRouter.Id, self.service.Id)
 	}
 }
 

--- a/controller/handler_edge_ctrl/create_tunnel_circuit_V2.go
+++ b/controller/handler_edge_ctrl/create_tunnel_circuit_V2.go
@@ -81,6 +81,7 @@ func (self *createTunnelCircuitV2Handler) CreateCircuit(ctx *CreateTunnelCircuit
 	}
 	ctx.loadIdentity()
 	ctx.loadServiceForName(ctx.req.ServiceName)
+	ctx.verifyEdgeRouterServiceDialAccess()
 	ctx.verifyRouterEdgeRouterAccess()
 	circuitInfo, peerData := ctx.createCircuit(ctx.req.TerminatorInstanceId, ctx.req.PeerData, ctx.newTunnelCircuitCreateParms)
 

--- a/controller/handler_edge_ctrl/errors.go
+++ b/controller/handler_edge_ctrl/errors.go
@@ -18,6 +18,7 @@ package handler_edge_ctrl
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/openziti/sdk-golang/v2/ziti/edge"
 	"github.com/openziti/ziti/v2/common/pb/edge_ctrl_pb"
@@ -184,6 +185,14 @@ func (self TunnelingNotEnabledError) ErrorCode() uint32 {
 
 func (TunnelingNotEnabledError) GetRetryHint() edge.RetryHint {
 	return edge.RetryNotRetriable
+}
+
+func identityDisabled(identityId string) controllerError {
+	return &genericControllerError{
+		Message:   fmt.Sprintf("identity %s is disabled", identityId),
+		Code:      edge.ErrorCodeAccessDenied,
+		RetryHint: edge.RetryNotRetriable,
+	}
 }
 
 func invalidTerminator(msg string) controllerError {

--- a/router/xgress_common/dial_circuits.go
+++ b/router/xgress_common/dial_circuits.go
@@ -1,0 +1,127 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package xgress_common
+
+import (
+	"github.com/michaelquigley/pfxlog"
+	"github.com/openziti/sdk-golang/v2/xgress"
+	cmap "github.com/orcaman/concurrent-map/v2"
+)
+
+// DialCircuitRegistry tracks the initiating xgress of every dial circuit a router-local
+// client (an edge router tunneler or an embedded SDK) has established, keyed by circuit id,
+// so they can be closed when the router's identity loses dial access to a service.
+// Safe for concurrent use.
+type DialCircuitRegistry struct {
+	circuits cmap.ConcurrentMap[string, *dialCircuit]
+}
+
+type dialCircuit struct {
+	serviceId string
+	x         *xgress.Xgress
+}
+
+// NewDialCircuitRegistry returns an empty registry. Register a dial circuit with PrepareTrack
+// followed by Publish, and close tracked circuits with CloseForService, CloseAll, or RevalidateAll.
+func NewDialCircuitRegistry() *DialCircuitRegistry {
+	return &DialCircuitRegistry{
+		circuits: cmap.New[*dialCircuit](),
+	}
+}
+
+// PrepareTrack installs x's registry cleanup handler, so that x is removed from the registry when it
+// closes. Call it before x is exposed to any close path (before HandleXgressBind hands x to the
+// forwarder): the handler must be present before anything can call Xgress.Close, because
+// Xgress.AddCloseHandler mutates the same unsynchronized handler slice that Close iterates. Pair
+// every PrepareTrack with a Publish once x is bound.
+func (self *DialCircuitRegistry) PrepareTrack(x *xgress.Xgress) {
+	x.AddCloseHandler(xgress.CloseHandlerF(func(closed *xgress.Xgress) { self.remove(closed) }))
+}
+
+// Publish makes x visible to revocation under serviceId, keyed by circuit id. Call it after x is
+// bound: a revocation may close x as soon as it is published, and closing an unbound xgress
+// dereferences a nil data-plane adapter. Requires PrepareTrack to have installed x's cleanup
+// handler. If x was already closed before publication (its handler ran while nothing was
+// published), Publish reconciles by removing the just-set entry.
+func (self *DialCircuitRegistry) Publish(serviceId string, x *xgress.Xgress) {
+	self.circuits.Set(x.CircuitId(), &dialCircuit{serviceId: serviceId, x: x})
+	if x.IsClosed() {
+		self.remove(x)
+	}
+}
+
+func (self *DialCircuitRegistry) remove(x *xgress.Xgress) {
+	self.circuits.RemoveCb(x.CircuitId(), func(_ string, v *dialCircuit, exists bool) bool {
+		return exists && v.x == x
+	})
+}
+
+// CloseForService closes every tracked dial circuit for serviceId.
+func (self *DialCircuitRegistry) CloseForService(serviceId string, reason string) {
+	self.closeMatching(func(c *dialCircuit) (bool, string) {
+		return c.serviceId == serviceId, reason
+	})
+}
+
+// CloseAll closes every tracked dial circuit.
+func (self *DialCircuitRegistry) CloseAll(reason string) {
+	self.closeMatching(func(*dialCircuit) (bool, string) {
+		return true, reason
+	})
+}
+
+// RevalidateAll closes every tracked dial circuit for which check returns an error. check is
+// called at most once per service. check must not call back into the registry.
+func (self *DialCircuitRegistry) RevalidateAll(check func(serviceId string) error) {
+	results := map[string]error{}
+	self.closeMatching(func(c *dialCircuit) (bool, string) {
+		err, checked := results[c.serviceId]
+		if !checked {
+			err = check(c.serviceId)
+			results[c.serviceId] = err
+		}
+		if err != nil {
+			return true, err.Error()
+		}
+		return false, ""
+	})
+}
+
+// closeMatching closes every circuit for which decide returns true, using the returned reason.
+// decide runs under the registry's iteration and must not call back into the registry.
+func (self *DialCircuitRegistry) closeMatching(decide func(*dialCircuit) (bool, string)) {
+	type closing struct {
+		circuit *dialCircuit
+		reason  string
+	}
+
+	// collect first: closing removes entries from the map being iterated
+	var toClose []closing
+	self.circuits.IterCb(func(_ string, c *dialCircuit) {
+		if match, reason := decide(c); match {
+			toClose = append(toClose, closing{circuit: c, reason: reason})
+		}
+	})
+
+	for _, entry := range toClose {
+		pfxlog.Logger().WithField("circuitId", entry.circuit.x.CircuitId()).
+			WithField("serviceId", entry.circuit.serviceId).
+			WithField("reason", entry.reason).
+			Info("closing dial circuit")
+		entry.circuit.x.Close()
+	}
+}

--- a/router/xgress_common/router_access.go
+++ b/router/xgress_common/router_access.go
@@ -1,0 +1,44 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package xgress_common
+
+import (
+	"fmt"
+
+	"github.com/openziti/ziti/v2/common"
+	"github.com/openziti/ziti/v2/common/pb/edge_ctrl_pb"
+	"github.com/openziti/ziti/v2/router/posture"
+)
+
+// CheckRouterDialAccess returns nil when the router identity routerId is enabled and a dial policy
+// grants it access to serviceId. Routers submit no posture data, so a policy carrying posture
+// checks denies. A non-nil error names the reason.
+func CheckRouterDialAccess(rdm *common.RouterDataModel, routerId string, serviceId string) error {
+	identity, found := rdm.Identities.Get(routerId)
+	if !found {
+		return fmt.Errorf("router identity '%s' not present in data model", routerId)
+	}
+	if identity.Disabled {
+		return fmt.Errorf("router identity '%s' is disabled", routerId)
+	}
+
+	policy, err := posture.HasAccess(rdm, routerId, serviceId, nil, edge_ctrl_pb.PolicyType_DialPolicy)
+	if err != nil || policy == nil {
+		return fmt.Errorf("router does not have dial access to service '%s' (%w)", serviceId, err)
+	}
+	return nil
+}

--- a/router/xgress_edge_tunnel/fabric.go
+++ b/router/xgress_edge_tunnel/fabric.go
@@ -17,7 +17,6 @@
 package xgress_edge_tunnel
 
 import (
-	"fmt"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -36,7 +35,6 @@ import (
 	"github.com/openziti/ziti/v2/common/pb/edge_ctrl_pb"
 	"github.com/openziti/ziti/v2/controller/idgen"
 	"github.com/openziti/ziti/v2/router/env"
-	"github.com/openziti/ziti/v2/router/posture"
 	"github.com/openziti/ziti/v2/router/xgress_common"
 	"github.com/openziti/ziti/v2/tunnel"
 	"github.com/pkg/errors"
@@ -48,6 +46,7 @@ func NewTunnelFabricProvider(routerEnv env.RouterEnv, hostedServicesRegistry *Ho
 		env:            routerEnv,
 		hostedServices: hostedServicesRegistry,
 		bindHandler:    routerEnv.GetXgressBindHandler(),
+		dialCircuits:   xgress_common.NewDialCircuitRegistry(),
 	}
 }
 
@@ -56,6 +55,7 @@ type fabricProvider struct {
 	hostedServices *HostedServiceRegistry
 	options        *xgress.Options
 	bindHandler    xgress.BindHandler
+	dialCircuits   *xgress_common.DialCircuitRegistry
 
 	currentIdentity atomic.Pointer[rest_model.IdentityDetail]
 }
@@ -76,6 +76,24 @@ func (self *fabricProvider) UpdateIdentity(i *rest_model.IdentityDetail) {
 
 func (self *fabricProvider) SetXgressOptions(options *xgress.Options) {
 	self.options = options
+}
+
+func (self *fabricProvider) CloseDialCircuits(serviceId string, reason string) {
+	self.dialCircuits.CloseForService(serviceId, reason)
+}
+
+func (self *fabricProvider) CloseAllDialCircuits(reason string) {
+	self.dialCircuits.CloseAll(reason)
+}
+
+func (self *fabricProvider) RevalidateAllDialCircuits() {
+	self.dialCircuits.RevalidateAll(self.checkDialAccess)
+}
+
+// checkDialAccess reports whether this router currently has dial access to serviceId. Routers
+// submit no posture data, so a policy carrying posture checks denies.
+func (self *fabricProvider) checkDialAccess(serviceId string) error {
+	return xgress_common.CheckRouterDialAccess(self.env.GetRouterDataModel(), self.env.GetRouterId().Token, serviceId)
 }
 
 func (self *fabricProvider) TunnelService(service tunnel.Service, terminatorInstanceId string, conn net.Conn, halfClose bool, appData []byte) error {
@@ -106,9 +124,8 @@ func (self *fabricProvider) TunnelService(service tunnel.Service, terminatorInst
 
 	log = log.WithField("ctrlId", ctrlCh.PeerId())
 
-	rdm := self.env.GetRouterDataModel()
-	if policy, err := posture.HasAccess(rdm, self.env.GetRouterId().Token, service.GetId(), nil, edge_ctrl_pb.PolicyType_DialPolicy); err != nil && policy != nil {
-		return fmt.Errorf("router does not have access to service '%s' (%w)", service.GetName(), err)
+	if err = self.checkDialAccess(service.GetId()); err != nil {
+		return err
 	}
 
 	request := &edge_ctrl_pb.CreateTunnelCircuitV2Request{
@@ -141,8 +158,17 @@ func (self *fabricProvider) TunnelService(service tunnel.Service, terminatorInst
 	}
 
 	x := xgress.NewXgress(response.CircuitId, ctrlCh.PeerId(), xgress.Address(response.Address), xgConn, xgress.Initiator, self.options, response.Tags)
+	self.dialCircuits.PrepareTrack(x)
 	self.bindHandler.HandleXgressBind(x)
+	self.dialCircuits.Publish(service.GetId(), x)
 	x.Start()
+
+	// Access lost between the pre-dial check and Publish is only closed by the revocation
+	// notification if it saw the circuit in the registry, so re-check now that it is published.
+	if err = self.checkDialAccess(service.GetId()); err != nil {
+		x.Close()
+		return err
+	}
 
 	return nil
 }

--- a/router/xgress_edge_tunnel/tunneler.go
+++ b/router/xgress_edge_tunnel/tunneler.go
@@ -43,6 +43,13 @@ type TunnelFabricProvider interface {
 	tunnel.FabricProvider
 	SetXgressOptions(*xgress.Options)
 	UpdateIdentity(i *rest_model.IdentityDetail)
+	// CloseDialCircuits closes every dial circuit this provider established for serviceId.
+	CloseDialCircuits(serviceId string, reason string)
+	// CloseAllDialCircuits closes every dial circuit this provider established.
+	CloseAllDialCircuits(reason string)
+	// RevalidateAllDialCircuits re-checks dial access for every circuit this provider established
+	// and closes those no longer granted.
+	RevalidateAllDialCircuits()
 }
 
 type tunneler struct {
@@ -154,6 +161,7 @@ func (self *tunneler) NotifyIdentityEvent(state *common.IdentityState, eventType
 		pfxlog.Logger().Infof("identity deleted or disabled %s, eventType: %s", state.Identity.Id, eventType)
 		self.fabricProvider.UpdateIdentity(self.mapRdmIdentityToRest(state.Identity))
 		self.serviceListener.Reset()
+		self.fabricProvider.CloseAllDialCircuits("identity deleted or disabled")
 	} else if eventType == common.IdentityFullState || eventType == common.IdentityUpdatedEvent {
 		pfxlog.Logger().Infof("identity updated %s, eventType: %s", state.Identity.Id, eventType)
 		self.fabricProvider.UpdateIdentity(self.mapRdmIdentityToRest(state.Identity))
@@ -161,12 +169,19 @@ func (self *tunneler) NotifyIdentityEvent(state *common.IdentityState, eventType
 		for _, svc := range state.Services {
 			self.NotifyServiceChange(state, nil, svc, common.ServiceAccessGainedEvent)
 		}
+	} else if eventType == common.IdentityPostureChecksUpdatedEvent {
+		// A posture check added to a dial policy that grants this router (or a check definition
+		// edited) does not change service membership, so it arrives here rather than as a service
+		// change. Routers cannot pass posture checks, so re-evaluate and close any dial circuit the
+		// policy no longer grants. This event is dispatched outside the data model's identity lock,
+		// unlike ServiceDialPoliciesChanged, so the access check here cannot re-enter that lock.
+		self.fabricProvider.RevalidateAllDialCircuits()
 	}
 }
 
 func (self *tunneler) NotifyBatchComplete(_ *common.RouterDataModel, _ uint64) {}
 
-func (self *tunneler) NotifyServiceChange(state *common.IdentityState, _, service *common.IdentityService, eventType common.ServiceEventType) {
+func (self *tunneler) NotifyServiceChange(state *common.IdentityState, previousService, service *common.IdentityService, eventType common.ServiceEventType) {
 	pfxlog.Logger().Infof("service changed for %s. service %s was %s", state.Identity.Name, service.Service.Name, eventType)
 	tunSvc := self.mapRdmServiceToRest(service)
 	switch eventType {
@@ -174,8 +189,12 @@ func (self *tunneler) NotifyServiceChange(state *common.IdentityState, _, servic
 		self.serviceListener.HandleServicesChange(ziti.ServiceAdded, tunSvc)
 	case common.ServiceUpdatedEvent:
 		self.serviceListener.HandleServicesChange(ziti.ServiceChanged, tunSvc)
+		if previousService != nil && previousService.IsDialAllowed() && !service.IsDialAllowed() {
+			self.fabricProvider.CloseDialCircuits(service.GetId(), "dial access lost")
+		}
 	case common.ServiceAccessLostEvent:
 		self.serviceListener.HandleServicesChange(ziti.ServiceRemoved, tunSvc)
+		self.fabricProvider.CloseDialCircuits(service.GetId(), "service access lost")
 	}
 }
 

--- a/router/xgress_sdk/fabric.go
+++ b/router/xgress_sdk/fabric.go
@@ -32,7 +32,6 @@ import (
 	"github.com/openziti/ziti/v2/common/ctrl_msg"
 	"github.com/openziti/ziti/v2/common/pb/edge_ctrl_pb"
 	"github.com/openziti/ziti/v2/router/env"
-	"github.com/openziti/ziti/v2/router/posture"
 	"github.com/openziti/ziti/v2/router/xgress_common"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -40,8 +39,9 @@ import (
 
 func NewFabric(env env.RouterEnv, options *xgress.Options) (Fabric, error) {
 	result := &fabricImpl{
-		env:     env,
-		options: options,
+		env:          env,
+		options:      options,
+		dialCircuits: xgress_common.NewDialCircuitRegistry(),
 	}
 
 	env.MarkRouterDataModelRequired()
@@ -55,6 +55,7 @@ type fabricImpl struct {
 	options         *xgress.Options
 	currentIdentity atomic.Pointer[common.IdentityState]
 	servicesByName  concurrenz.AtomicValue[map[string]*common.IdentityService]
+	dialCircuits    *xgress_common.DialCircuitRegistry
 }
 
 func (self *fabricImpl) updateIdentityState(state *common.IdentityState) {
@@ -71,7 +72,14 @@ func (self *fabricImpl) updateIdentityState(state *common.IdentityState) {
 func (self *fabricImpl) NotifyIdentityEvent(state *common.IdentityState, eventType common.IdentityEventType) {
 	self.updateIdentityState(state)
 	pfxlog.Logger().Infof("identity %s event %s", state.Identity.Name, eventType.String())
-	if eventType == common.IdentityFullState {
+	if eventType == common.IdentityDeletedEvent || state.Identity.Disabled {
+		self.dialCircuits.CloseAll("identity deleted or disabled")
+	} else if eventType == common.IdentityPostureChecksUpdatedEvent {
+		// Posture checks added to a granting dial policy arrive here rather than as a service change;
+		// routers cannot pass them, so re-evaluate and close circuits no longer granted. Dispatched
+		// outside the data model's identity lock, so the access check cannot re-enter it.
+		self.dialCircuits.RevalidateAll(self.checkDialAccess)
+	} else if eventType == common.IdentityFullState {
 		for _, service := range state.Services {
 			pfxlog.Logger().Infof("identity %s gained access to %s", state.Identity.Name, service.GetName())
 		}
@@ -87,6 +95,9 @@ func (self *fabricImpl) NotifyServiceChange(state *common.IdentityState, oldServ
 		pfxlog.Logger().Infof("identity %s gained access to %s", state.Identity.Name, newService.GetName())
 	} else if eventType == common.ServiceAccessLostEvent {
 		pfxlog.Logger().Infof("identity %s lost access to %s", state.Identity.Name, oldService.GetName())
+		self.dialCircuits.CloseForService(oldService.GetId(), "service access lost")
+	} else if eventType == common.ServiceUpdatedEvent && oldService != nil && oldService.IsDialAllowed() && !newService.IsDialAllowed() {
+		self.dialCircuits.CloseForService(newService.GetId(), "dial access lost")
 	}
 }
 
@@ -124,9 +135,8 @@ func (self *fabricImpl) TunnelWithOptions(serviceName string, options *ziti.Dial
 
 	log = log.WithField("ctrlId", ctrlCh.Id())
 
-	rdm := self.env.GetRouterDataModel()
-	if policy, err := posture.HasAccess(rdm, self.env.GetRouterId().Token, service.GetId(), nil, edge_ctrl_pb.PolicyType_DialPolicy); err != nil && policy != nil {
-		return fmt.Errorf("router does not have access to service '%s' (%w)", serviceName, err)
+	if err = self.checkDialAccess(service.GetId()); err != nil {
+		return err
 	}
 
 	request := &edge_ctrl_pb.CreateTunnelCircuitV2Request{
@@ -157,8 +167,23 @@ func (self *fabricImpl) TunnelWithOptions(serviceName string, options *ziti.Dial
 	}
 
 	x := xgress.NewXgress(response.CircuitId, ctrlCh.Id(), xgress.Address(response.Address), xgConn, xgress.Initiator, self.options, response.Tags)
+	self.dialCircuits.PrepareTrack(x)
 	self.env.GetXgressBindHandler().HandleXgressBind(x)
+	self.dialCircuits.Publish(service.GetId(), x)
 	x.Start()
 
+	// Access lost between the pre-dial check and Publish is only closed by the revocation
+	// notification if it saw the circuit in the registry, so re-check now that it is published.
+	if err = self.checkDialAccess(service.GetId()); err != nil {
+		x.Close()
+		return err
+	}
+
 	return nil
+}
+
+// checkDialAccess reports whether this router currently has dial access to serviceId. Routers
+// submit no posture data, so a policy carrying posture checks denies.
+func (self *fabricImpl) checkDialAccess(serviceId string) error {
+	return xgress_common.CheckRouterDialAccess(self.env.GetRouterDataModel(), self.env.GetRouterId().Token, serviceId)
 }

--- a/tests/context.go
+++ b/tests/context.go
@@ -613,18 +613,18 @@ func (ctx *TestContext) startTransitRouter() {
 	ctx.Req.NoError(newRouter.Start())
 }
 
-func (ctx *TestContext) CreateEnrollAndStartTunnelerEdgeRouter(roleAttributes ...string) {
+func (ctx *TestContext) CreateEnrollAndStartTunnelerEdgeRouter(roleAttributes ...string) *EdgeRouterHelper {
 	ctx.shutdownRouters()
 	ctx.createAndEnrollEdgeRouter(true, roleAttributes...)
-	ctx.startEdgeRouter(nil)
+	return ctx.startEdgeRouter(nil)
 }
 
 // CreateEnrollAndStartTunnelerEdgeRouterWithCfgTweaks creates a tunneler-enabled edge router
 // and allows the caller to modify the router config before startup.
-func (ctx *TestContext) CreateEnrollAndStartTunnelerEdgeRouterWithCfgTweaks(cfgTweaks func(*routerEnv.Config), roleAttributes ...string) {
+func (ctx *TestContext) CreateEnrollAndStartTunnelerEdgeRouterWithCfgTweaks(cfgTweaks func(*routerEnv.Config), roleAttributes ...string) *EdgeRouterHelper {
 	ctx.shutdownRouters()
 	ctx.createAndEnrollEdgeRouter(true, roleAttributes...)
-	ctx.startEdgeRouter(cfgTweaks)
+	return ctx.startEdgeRouter(cfgTweaks)
 }
 
 func (ctx *TestContext) CreateEnrollAndStartEdgeRouter(roleAttributes ...string) *EdgeRouterHelper {

--- a/tests/tunneler_permission_loss_test.go
+++ b/tests/tunneler_permission_loss_test.go
@@ -1,0 +1,566 @@
+//go:build dataflow
+
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package tests
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/openziti/channel/v5"
+	"github.com/openziti/channel/v5/protobufs"
+	"github.com/openziti/edge-api/rest_model"
+	"github.com/openziti/sdk-golang/v2/ziti"
+	"github.com/openziti/sdk-golang/v2/ziti/edge"
+	"github.com/openziti/ziti/v2/common/eid"
+	"github.com/openziti/ziti/v2/common/pb/edge_ctrl_pb"
+	routerEnv "github.com/openziti/ziti/v2/router/env"
+)
+
+const (
+	ertDialLossService1 = "ert-dial-loss-svc-1"
+	ertDialLossService2 = "ert-dial-loss-svc-2"
+	ertDialLossPort1    = 8691
+	ertDialLossPort2    = 8692
+	ertPostureService   = "ert-posture-svc"
+	ertPosturePort      = 8693
+)
+
+// tunnelerDialFixture is a running controller, an ER/T in proxy mode intercepting two services on
+// fixed local ports, an SDK host echoing on both, and one established client connection per service.
+// dialPolicy1 is the only dial policy granting the router access to service1.
+type tunnelerDialFixture struct {
+	ctx         *TestContext
+	service1    *service
+	service2    *service
+	dialPolicy1 *servicePolicy
+	addr1       string
+	addr2       string
+	conn1       net.Conn
+	conn2       net.Conn
+}
+
+func newTunnelerDialFixture(ctx *TestContext, oidcHost bool) *tunnelerDialFixture {
+	svcRole1 := eid.New()
+	svcRole2 := eid.New()
+
+	// the proxy interceptor maps fixed service names to local ports, so the names must match the
+	// router config tweak below
+	service1 := ctx.newService(s(svcRole1), nil)
+	service1.Name = ertDialLossService1
+	service1.Id = ctx.AdminManagementSession.requireCreateEntity(service1)
+
+	service2 := ctx.newService(s(svcRole2), nil)
+	service2.Name = ertDialLossService2
+	service2.Id = ctx.AdminManagementSession.requireCreateEntity(service2)
+
+	ctx.AdminManagementSession.requireNewEdgeRouterPolicy(s("#all"), s("#all"))
+	ctx.AdminManagementSession.requireNewServiceEdgeRouterPolicy(s("#all"), s("#all"))
+	ctx.AdminManagementSession.requireNewServicePolicy("Bind", s("#all"), s("#all"), nil)
+
+	// one dial policy per service, so changing dialPolicy1 affects the router's access to service1 only
+	dialPolicy1 := ctx.AdminManagementSession.requireNewServicePolicy("Dial", s("#"+svcRole1), s("#all"), nil)
+	ctx.AdminManagementSession.requireNewServicePolicy("Dial", s("#"+svcRole2), s("#all"), nil)
+
+	ctx.CreateEnrollAndStartTunnelerEdgeRouterWithCfgTweaks(func(cfg *routerEnv.Config) {
+		for _, l := range cfg.Listeners {
+			if l.Name == "tunnel" {
+				if opts, ok := l.Options["options"].(map[interface{}]interface{}); ok {
+					opts["services"] = []interface{}{
+						fmt.Sprintf("%s:%d", ertDialLossService1, ertDialLossPort1),
+						fmt.Sprintf("%s:%d", ertDialLossService2, ertDialLossPort2),
+					}
+				}
+			}
+		}
+	})
+
+	service1Watcher := ctx.AdminManagementSession.newTerminatorWatcher(service1.Id, 1)
+	defer service1Watcher.Close()
+
+	service2Watcher := ctx.AdminManagementSession.newTerminatorWatcher(service2.Id, 1)
+	defer service2Watcher.Close()
+
+	_, hostZtx := ctx.AdminManagementSession.RequireCreateSdkContext()
+	ctx.testing.Cleanup(hostZtx.Close)
+
+	if oidcHost {
+		hostContext := hostZtx.(*ziti.ContextImpl)
+		hostContext.CtrlClt.SetAllowOidcDynamicallyEnabled(true)
+		ctx.Req.NoError(hostContext.Authenticate())
+	}
+
+	listener1, err := hostZtx.Listen(service1.Name)
+	ctx.Req.NoError(err)
+	ctx.testing.Cleanup(func() { _ = listener1.Close() })
+
+	listener2, err := hostZtx.Listen(service2.Name)
+	ctx.Req.NoError(err)
+	ctx.testing.Cleanup(func() { _ = listener2.Close() })
+
+	service1Watcher.waitForTerminators(10 * time.Second)
+	service2Watcher.waitForTerminators(10 * time.Second)
+
+	newTestServer(listener1, tcpEchoHandler).start()
+	newTestServer(listener2, tcpEchoHandler).start()
+
+	f := &tunnelerDialFixture{
+		ctx:         ctx,
+		service1:    service1,
+		service2:    service2,
+		dialPolicy1: dialPolicy1,
+		addr1:       fmt.Sprintf("127.0.0.1:%d", ertDialLossPort1),
+		addr2:       fmt.Sprintf("127.0.0.1:%d", ertDialLossPort2),
+	}
+
+	f.conn1 = requireDialWithRetry(ctx, f.addr1, 15*time.Second)
+	ctx.testing.Cleanup(func() { _ = f.conn1.Close() })
+
+	f.conn2 = requireDialWithRetry(ctx, f.addr2, 15*time.Second)
+	ctx.testing.Cleanup(func() { _ = f.conn2.Close() })
+
+	requireTcpEcho(ctx, f.conn1)
+	requireTcpEcho(ctx, f.conn2)
+
+	return f
+}
+
+// requireService1Revoked requires conn1 to be closed, service1 to refuse new connections, and
+// service2 to be unaffected on both its existing connection and a new one.
+func (f *tunnelerDialFixture) requireService1Revoked() {
+	ctx := f.ctx
+	requireNetConnClosed(ctx, f.conn1, 15*time.Second)
+
+	requireTcpEcho(ctx, f.conn2)
+
+	// either the intercept listener is gone or the router refuses the dial before a circuit is created
+	ctx.Req.Eventually(func() bool {
+		return newDialRefused(f.addr1)
+	}, 10*time.Second, 250*time.Millisecond, "expected service1 dials to be refused")
+
+	conn3 := requireDialWithRetry(ctx, f.addr2, 5*time.Second)
+	defer func() { _ = conn3.Close() }()
+	requireTcpEcho(ctx, conn3)
+}
+
+func tcpEchoHandler(conn *testServerConn) error {
+	for {
+		name, eof := conn.ReadString(1024, time.Minute)
+		if eof {
+			return nil
+		}
+		conn.WriteString("hello, "+name, time.Second)
+	}
+}
+
+// Test_TunnelerCircuitCloseOnDialPermissionLoss_LegacyHost verifies that circuits intercepted by an
+// ER/T are closed when the router loses dial access, with the service hosted by a legacy-auth SDK.
+func Test_TunnelerCircuitCloseOnDialPermissionLoss_LegacyHost(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+	ctx.RequireAdminManagementApiLogin()
+
+	f := newTunnelerDialFixture(ctx, false)
+	ctx.AdminManagementSession.requireDeleteEntity(f.dialPolicy1)
+	f.requireService1Revoked()
+}
+
+// Test_TunnelerCircuitCloseOnDialPermissionLoss_OidcHost is the same scenario with the service
+// hosted by an OIDC-auth SDK.
+func Test_TunnelerCircuitCloseOnDialPermissionLoss_OidcHost(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+	ctx.RequireAdminManagementApiLogin()
+
+	f := newTunnelerDialFixture(ctx, true)
+	ctx.AdminManagementSession.requireDeleteEntity(f.dialPolicy1)
+	f.requireService1Revoked()
+}
+
+// Test_TunnelerCircuitCloseOnPostureCheckAdded verifies that adding a posture check to the dial
+// policy granting the router closes its existing circuits, since routers cannot satisfy posture checks.
+// Membership does not change, so this exercises the dial-policies-changed path rather than access lost.
+func Test_TunnelerCircuitCloseOnPostureCheckAdded(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+	ctx.RequireAdminManagementApiLogin()
+
+	postureRole := eid.New()
+	ctx.AdminManagementSession.requireNewPostureCheckDomain(s("example.com"), s(postureRole))
+
+	f := newTunnelerDialFixture(ctx, false)
+
+	f.dialPolicy1.postureCheckRoles = s("#" + postureRole)
+	ctx.AdminManagementSession.requirePatchEntity(f.dialPolicy1, "postureCheckRoles")
+
+	f.requireService1Revoked()
+}
+
+// Test_TunnelerCircuitCloseOnIdentityDisabled verifies that disabling the router's identity closes
+// every dial circuit and refuses new dials, even though the policies still list the identity.
+func Test_TunnelerCircuitCloseOnIdentityDisabled(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+	ctx.RequireAdminManagementApiLogin()
+
+	f := newTunnelerDialFixture(ctx, false)
+
+	disable := &rest_model.DisableParams{DurationMinutes: ToPtr[int64](0)}
+	resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(disable).Post("identities/" + ctx.edgeRouterEntity.id + "/disable")
+	ctx.Req.NoError(err)
+	ctx.Req.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body()))
+
+	requireNetConnClosed(ctx, f.conn1, 15*time.Second)
+	requireNetConnClosed(ctx, f.conn2, 15*time.Second)
+
+	for _, addr := range []string{f.addr1, f.addr2} {
+		addr := addr
+		ctx.Req.Eventually(func() bool {
+			return newDialRefused(addr)
+		}, 10*time.Second, 250*time.Millisecond, "expected dials to be refused while the router identity is disabled")
+	}
+}
+
+// Test_TunnelerCircuitDeniedWithoutDialPolicy verifies the controller refuses a tunnel circuit for a
+// service the router's identity has no dial policy for, even when the router asks for it directly.
+func Test_TunnelerCircuitDeniedWithoutDialPolicy(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+	ctx.RequireAdminManagementApiLogin()
+
+	svcRole := eid.New()
+	hostRole := eid.New()
+
+	service := ctx.AdminManagementSession.requireNewService(s(svcRole), nil)
+
+	ctx.AdminManagementSession.requireNewEdgeRouterPolicy(s("#all"), s("#all"))
+	ctx.AdminManagementSession.requireNewServiceEdgeRouterPolicy(s("#all"), s("#all"))
+	ctx.AdminManagementSession.requireNewServicePolicy("Bind", s("#"+svcRole), s("#"+hostRole), nil)
+
+	edgeRouter := ctx.CreateEnrollAndStartTunnelerEdgeRouter()
+
+	watcher := ctx.AdminManagementSession.newTerminatorWatcher(service.Id, 1)
+	defer watcher.Close()
+
+	_, hostContext := ctx.AdminManagementSession.RequireCreateSdkContext(hostRole)
+	defer hostContext.Close()
+
+	listener, err := hostContext.Listen(service.Name)
+	ctx.Req.NoError(err)
+	defer func() { _ = listener.Close() }()
+
+	watcher.waitForTerminators(10 * time.Second)
+
+	ctrlCh := edgeRouter.GetNetworkControllers().AnyCtrlChannel()
+	ctx.Req.NotNil(ctrlCh)
+
+	request := &edge_ctrl_pb.CreateTunnelCircuitV2Request{
+		ServiceName: service.Name,
+	}
+	reply, err := protobufs.MarshalTyped(request).WithTimeout(5 * time.Second).SendForReply(ctrlCh.GetDefaultSender())
+	ctx.Req.NoError(err)
+	ctx.Req.Equal(int32(edge_ctrl_pb.ContentType_ErrorType), reply.ContentType, "expected an error reply, got content type %v", reply.ContentType)
+
+	code, found := reply.GetUint32Header(edge.ErrorCodeHeader)
+	ctx.Req.True(found, "error replies carry an edge error code")
+	ctx.Req.Equal(uint32(edge.ErrorCodeInvalidService), code)
+}
+
+// Test_TunnelerDialDeniedByPostureCheck verifies that a dial policy carrying a posture check does not
+// grant a tunneler access, since routers submit no posture data: the intercepted connection is closed
+// without a circuit being established.
+func Test_TunnelerDialDeniedByPostureCheck(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+	ctx.RequireAdminManagementApiLogin()
+
+	svcRole := eid.New()
+	hostRole := eid.New()
+	postureRole := eid.New()
+
+	service := ctx.newService(s(svcRole), nil)
+	service.Name = ertPostureService
+	service.Id = ctx.AdminManagementSession.requireCreateEntity(service)
+
+	ctx.AdminManagementSession.requireNewPostureCheckDomain(s("example.com"), s(postureRole))
+
+	ctx.AdminManagementSession.requireNewEdgeRouterPolicy(s("#all"), s("#all"))
+	ctx.AdminManagementSession.requireNewServiceEdgeRouterPolicy(s("#all"), s("#all"))
+	ctx.AdminManagementSession.requireNewServicePolicy("Bind", s("#"+svcRole), s("#"+hostRole), nil)
+	ctx.AdminManagementSession.requireNewServicePolicy("Dial", s("#"+svcRole), s("#all"), s("#"+postureRole))
+
+	ctx.CreateEnrollAndStartTunnelerEdgeRouterWithCfgTweaks(func(cfg *routerEnv.Config) {
+		for _, l := range cfg.Listeners {
+			if l.Name == "tunnel" {
+				if opts, ok := l.Options["options"].(map[interface{}]interface{}); ok {
+					opts["services"] = []interface{}{
+						fmt.Sprintf("%s:%d", ertPostureService, ertPosturePort),
+					}
+				}
+			}
+		}
+	})
+
+	watcher := ctx.AdminManagementSession.newTerminatorWatcher(service.Id, 1)
+	defer watcher.Close()
+
+	_, hostContext := ctx.AdminManagementSession.RequireCreateSdkContext(hostRole)
+	defer hostContext.Close()
+
+	listener, err := hostContext.Listen(service.Name)
+	ctx.Req.NoError(err)
+	defer func() { _ = listener.Close() }()
+
+	watcher.waitForTerminators(10 * time.Second)
+
+	newTestServer(listener, func(conn *testServerConn) error {
+		for {
+			name, eof := conn.ReadString(1024, time.Minute)
+			if eof {
+				return nil
+			}
+			conn.WriteString("hello, "+name, time.Second)
+		}
+	}).start()
+
+	// the intercept is still installed, since intercept setup is driven by policy membership, but the
+	// dial itself must be refused
+	conn := requireDialWithRetry(ctx, fmt.Sprintf("127.0.0.1:%d", ertPosturePort), 15*time.Second)
+	defer func() { _ = conn.Close() }()
+
+	ctx.Req.NoError(conn.SetDeadline(time.Now().Add(5 * time.Second)))
+	_, _ = conn.Write([]byte(eid.New()))
+	n, err := conn.Read(make([]byte, 64))
+	ctx.Req.Error(err, "expected the tunneler to close the connection without a reply, got %d bytes", n)
+	var netErr net.Error
+	ctx.Req.False(errors.As(err, &netErr) && netErr.Timeout(), "connection was neither answered nor closed")
+}
+
+// Test_TunnelerCircuitDeniedForDisabledIdentity verifies the controller rejects a tunnel circuit
+// request from a router whose identity is disabled, even though its policies still grant access.
+func Test_TunnelerCircuitDeniedForDisabledIdentity(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+	ctx.RequireAdminManagementApiLogin()
+
+	svcRole := eid.New()
+	hostRole := eid.New()
+
+	service := ctx.AdminManagementSession.requireNewService(s(svcRole), nil)
+
+	ctx.AdminManagementSession.requireNewEdgeRouterPolicy(s("#all"), s("#all"))
+	ctx.AdminManagementSession.requireNewServiceEdgeRouterPolicy(s("#all"), s("#all"))
+	ctx.AdminManagementSession.requireNewServicePolicy("Bind", s("#"+svcRole), s("#"+hostRole), nil)
+	ctx.AdminManagementSession.requireNewServicePolicy("Dial", s("#"+svcRole), s("#all"), nil)
+
+	edgeRouter := ctx.CreateEnrollAndStartTunnelerEdgeRouter()
+
+	watcher := ctx.AdminManagementSession.newTerminatorWatcher(service.Id, 1)
+	defer watcher.Close()
+
+	_, hostContext := ctx.AdminManagementSession.RequireCreateSdkContext(hostRole)
+	defer hostContext.Close()
+
+	listener, err := hostContext.Listen(service.Name)
+	ctx.Req.NoError(err)
+	defer func() { _ = listener.Close() }()
+
+	watcher.waitForTerminators(10 * time.Second)
+
+	ctrlCh := edgeRouter.GetNetworkControllers().AnyCtrlChannel()
+	ctx.Req.NotNil(ctrlCh)
+
+	// sanity: the dial is granted while the identity is enabled
+	sendDial := func() (*channel.Message, error) {
+		request := &edge_ctrl_pb.CreateTunnelCircuitV2Request{ServiceName: service.Name}
+		return protobufs.MarshalTyped(request).WithTimeout(5 * time.Second).SendForReply(ctrlCh.GetDefaultSender())
+	}
+	reply, err := sendDial()
+	ctx.Req.NoError(err)
+	ctx.Req.Equal(int32(edge_ctrl_pb.ContentType_CreateTunnelCircuitV2ResponseType), reply.ContentType, "dial should succeed while enabled")
+
+	// disable the router identity; its policies are unchanged
+	disable := &rest_model.DisableParams{DurationMinutes: ToPtr[int64](0)}
+	resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(disable).Post("identities/" + edgeRouter.GetRouterId().Token + "/disable")
+	ctx.Req.NoError(err)
+	ctx.Req.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body()))
+
+	// the controller must now deny the dial with an access-denied error. The router's control channel
+	// stays up (it authenticates by certificate, not by the disabled identity's session), so poll
+	// until the disable has been applied to the identity store the handler reads.
+	ctx.Req.Eventually(func() bool {
+		reply, err := sendDial()
+		if err != nil {
+			return false
+		}
+		if reply.ContentType != int32(edge_ctrl_pb.ContentType_ErrorType) {
+			return false
+		}
+		code, found := reply.GetUint32Header(edge.ErrorCodeHeader)
+		return found && code == edge.ErrorCodeAccessDenied
+	}, 10*time.Second, 200*time.Millisecond, "controller should deny dials for a disabled router identity")
+}
+
+// newDialRefused reports whether a fresh TCP dial to addr is refused, either because the connect
+// fails (the intercept was removed) or the router closes the connection without answering (the dial
+// was denied before a circuit formed). A read timeout means the connection is alive and hanging,
+// which is not a refusal, so it returns false and lets the caller keep polling.
+func newDialRefused(addr string) bool {
+	conn, err := net.DialTimeout("tcp", addr, time.Second)
+	if err != nil {
+		return true
+	}
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
+	if _, err = conn.Write([]byte(eid.New())); err != nil {
+		return true
+	}
+	_, err = conn.Read(make([]byte, 1))
+	if err == nil {
+		return false
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return false
+	}
+	return true
+}
+
+// Test_TunnelerV1CircuitDeniedForDisabledIdentity verifies the controller rejects a legacy
+// (CreateCircuitForService) tunnel circuit request from a router whose identity is disabled. The
+// disabled check lives in shared identity loading, so it must apply to this older content type too.
+func Test_TunnelerV1CircuitDeniedForDisabledIdentity(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+	ctx.RequireAdminManagementApiLogin()
+
+	svcRole := eid.New()
+	hostRole := eid.New()
+
+	service := ctx.AdminManagementSession.requireNewService(s(svcRole), nil)
+
+	ctx.AdminManagementSession.requireNewEdgeRouterPolicy(s("#all"), s("#all"))
+	ctx.AdminManagementSession.requireNewServiceEdgeRouterPolicy(s("#all"), s("#all"))
+	ctx.AdminManagementSession.requireNewServicePolicy("Bind", s("#"+svcRole), s("#"+hostRole), nil)
+	ctx.AdminManagementSession.requireNewServicePolicy("Dial", s("#"+svcRole), s("#all"), nil)
+
+	edgeRouter := ctx.CreateEnrollAndStartTunnelerEdgeRouter()
+
+	watcher := ctx.AdminManagementSession.newTerminatorWatcher(service.Id, 1)
+	defer watcher.Close()
+
+	_, hostContext := ctx.AdminManagementSession.RequireCreateSdkContext(hostRole)
+	defer hostContext.Close()
+
+	listener, err := hostContext.Listen(service.Name)
+	ctx.Req.NoError(err)
+	defer func() { _ = listener.Close() }()
+
+	watcher.waitForTerminators(10 * time.Second)
+
+	ctrlCh := edgeRouter.GetNetworkControllers().AnyCtrlChannel()
+	ctx.Req.NotNil(ctrlCh)
+
+	sendV1Dial := func() (*channel.Message, error) {
+		request := &edge_ctrl_pb.CreateCircuitForServiceRequest{ServiceName: service.Name}
+		return protobufs.MarshalTyped(request).WithTimeout(5 * time.Second).SendForReply(ctrlCh.GetDefaultSender())
+	}
+
+	// the legacy dial succeeds while the identity is enabled
+	reply, err := sendV1Dial()
+	ctx.Req.NoError(err)
+	ctx.Req.Equal(int32(edge_ctrl_pb.ContentType_CreateCircuitForServiceResponseType), reply.ContentType, "legacy dial should succeed while enabled")
+
+	disable := &rest_model.DisableParams{DurationMinutes: ToPtr[int64](0)}
+	resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(disable).Post("identities/" + edgeRouter.GetRouterId().Token + "/disable")
+	ctx.Req.NoError(err)
+	ctx.Req.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body()))
+
+	ctx.Req.Eventually(func() bool {
+		reply, err := sendV1Dial()
+		if err != nil || reply.ContentType != int32(edge_ctrl_pb.ContentType_ErrorType) {
+			return false
+		}
+		code, found := reply.GetUint32Header(edge.ErrorCodeHeader)
+		return found && code == edge.ErrorCodeAccessDenied
+	}, 10*time.Second, 200*time.Millisecond, "controller should deny legacy dials for a disabled router identity")
+}
+
+// requireDialWithRetry dials addr until it connects or timeout elapses, failing the test on timeout.
+func requireDialWithRetry(ctx *TestContext, addr string, timeout time.Duration) net.Conn {
+	deadline := time.Now().Add(timeout)
+	for {
+		conn, err := net.DialTimeout("tcp", addr, time.Second)
+		if err == nil {
+			return conn
+		}
+		if time.Now().After(deadline) {
+			ctx.Req.NoError(err, "timed out waiting to connect to %s", addr)
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// requireTcpEcho sends a unique token over conn and requires the echo server's greeting in reply.
+func requireTcpEcho(ctx *TestContext, conn net.Conn) {
+	name := eid.New()
+	ctx.Req.NoError(conn.SetDeadline(time.Now().Add(5 * time.Second)))
+	_, err := conn.Write([]byte(name))
+	ctx.Req.NoError(err)
+
+	expected := "hello, " + name
+	buf := make([]byte, len(expected))
+	_, err = io.ReadFull(conn, buf)
+	ctx.Req.NoError(err)
+	ctx.Req.Equal(expected, string(buf))
+	ctx.Req.NoError(conn.SetDeadline(time.Time{}))
+}
+
+// requireNetConnClosed requires conn to be closed by its peer within timeout. Unsolicited data is
+// tolerated, since only a non-timeout read error indicates closure.
+func requireNetConnClosed(ctx *TestContext, conn net.Conn, timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	buf := make([]byte, 64)
+	for time.Now().Before(deadline) {
+		_ = conn.SetReadDeadline(time.Now().Add(250 * time.Millisecond))
+		_, err := conn.Read(buf)
+		if err == nil {
+			continue
+		}
+		var netErr net.Error
+		if errors.As(err, &netErr) && netErr.Timeout() {
+			continue
+		}
+		return
+	}
+	ctx.Req.Fail("timed out waiting for connection to be closed")
+}


### PR DESCRIPTION
Fixes #4330

When an edge router tunneler loses dial access to a service it is intercepting, the router only stopped
intercepting; circuits already established kept flowing until the application or the router ended them.
This tracks each tunneler (and embedded-SDK) dial circuit by service and closes them when access is lost,
whether through a service policy change or the identity being disabled or deleted.

Two related gaps are closed in the same path. The router's pre-dial policy check used a condition that
could never deny, so it is corrected. The controller now verifies the dial service policy for tunneler
circuit requests, which it previously did not check at all.

Correcting the router check means posture checks on policies granting router identities are now
evaluated, and since routers submit no posture data, such a policy denies the router. The release notes
carry a warning to split routers out of posture-gated policies before upgrading.

Tests cover circuit close with legacy and OIDC hosts, controller denial without a dial policy, and
denial by posture check. All three original tests fail on the previous code.
