### PR TITLE
backport openziti/ziti#4118 to release-v2.0.x serve the overlapping-k…

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -532,8 +532,6 @@ github.com/openziti/channel/v4 v4.3.12 h1:kpox7z7aILokmzejUlOobORzQutH6q3t4E5abu
 github.com/openziti/channel/v4 v4.3.12/go.mod h1:WZpOeuPliA7mJ3m7Pal8WdYu74eHMzkM/1Z9AMLmUAg=
 github.com/openziti/cobra-to-md v1.0.1 h1:WRinNoIRmwWUSJm+pSNXMjOrtU48oxXDZgeCYQfVXxE=
 github.com/openziti/cobra-to-md v1.0.1/go.mod h1:FjCpk/yzHF7/r28oSTNr5P57yN5VolpdAtS/g7KNi2c=
-github.com/openziti/edge-api v0.31.0 h1:QdaaPnKQj4B40q404+c8VZxMsoVpfGpfOhzs3LLCd/A=
-github.com/openziti/edge-api v0.31.0/go.mod h1:pDtCR6Mq0h5e8ulJhmuhPshEBa39hpQy+yTtLpUSBOs=
 github.com/openziti/edge-api v0.36.0 h1:adp0gCDbxee3r4tPBCXm7IyLTcIGhDcWmQ9QJMO+AwY=
 github.com/openziti/edge-api v0.36.0/go.mod h1:m1oAQ6+fnkEO0NOAkDy6WpnXDxPhj2sko4eBUvIMxkE=
 github.com/openziti/foundation/v2 v2.0.91 h1:gjXFu+fxKKMCs1hCkfLNI9jfdiSBW2gXAnBCy5xG/UI=

--- a/tests/auth_external_jwt_signer_test.go
+++ b/tests/auth_external_jwt_signer_test.go
@@ -26,7 +26,6 @@ import (
 	"encoding/json"
 	"net"
 	"net/http"
-	"os"
 	"strconv"
 	"sync"
 	"testing"
@@ -68,16 +67,6 @@ func newJwksServer(certificates []*x509.Certificate) *jwksServer {
 	srv.server = &http.Server{
 		Handler: mux,
 	}
-	return srv
-}
-
-// newTlsJwksServer returns a jwksServer that serves its JWKS over HTTPS using tlsCert as its
-// server certificate. Callers must ensure the controller trusts tlsCert (see the root CA added
-// to http.DefaultTransport in the overlapping-kid test) for the controller's JWKS fetch to succeed.
-func newTlsJwksServer(tlsCert *tls.Certificate, certificates []*x509.Certificate) *jwksServer {
-	srv := newJwksServer(certificates)
-	srv.tlsCert = tlsCert
-	srv.server.TLSConfig = &tls.Config{Certificates: []tls.Certificate{*tlsCert}}
 	return srv
 }
 
@@ -1071,41 +1060,19 @@ func Test_Authenticate_External_Jwt_Overlapping_Kids(t *testing.T) {
 	ctx.StartServer()
 	ctx.RequireAdminManagementApiLogin()
 
-	// The controller fetches JWKS over the default HTTP transport. Trust the test PKI root so the
-	// controller accepts the HTTPS JWKS providers below, which serve using the controller's own
-	// server certificate. Restore the prior transport config when the test completes.
-	rootPem, err := os.ReadFile("testdata/pki/root/certs/root.cert")
-	ctx.Req.NoError(err)
-
-	rootPool, err := x509.SystemCertPool()
-	if err != nil || rootPool == nil {
-		rootPool = x509.NewCertPool()
-	}
-	ctx.Req.True(rootPool.AppendCertsFromPEM(rootPem), "expected the test root CA to be added to the trust pool")
-
-	httpTransport := http.DefaultTransport.(*http.Transport)
-	priorTlsConfig := httpTransport.TLSClientConfig
-	httpTransport.TLSClientConfig = &tls.Config{RootCAs: rootPool}
-	defer func() { httpTransport.TLSClientConfig = priorTlsConfig }()
-
-	serverTlsCert, err := tls.LoadX509KeyPair("testdata/pki/ctrl1/certs/server.chain.pem", "testdata/pki/ctrl1/keys/server.key")
-	ctx.Req.NoError(err)
-
 	adminIdentityId := *ctx.AdminManagementSession.AuthResponse.IdentityID
 
 	t.Run("two enabled signers sharing a kid authenticate deterministically by issuer", func(t *testing.T) {
 		ctx.testContextChanged(t)
 
-		// One signing key and kid, served by two independent HTTPS JWKS providers - the shared
-		// signing-key pool scenario.
 		sharedCert, sharedKey := newSelfSignedCert("shared-jwks-pool-" + uuid.NewString())
 		sharedKid := sharedCert.Subject.CommonName
 
-		jwksServer1 := newTlsJwksServer(&serverTlsCert, []*x509.Certificate{sharedCert})
+		jwksServer1 := newJwksServer([]*x509.Certificate{sharedCert})
 		ctx.Req.NoError(jwksServer1.Start())
 		defer func() { _ = jwksServer1.Stop() }()
 
-		jwksServer2 := newTlsJwksServer(&serverTlsCert, []*x509.Certificate{sharedCert})
+		jwksServer2 := newJwksServer([]*x509.Certificate{sharedCert})
 		ctx.Req.NoError(jwksServer2.Start())
 		defer func() { _ = jwksServer2.Stop() }()
 
@@ -1170,17 +1137,14 @@ func Test_Authenticate_External_Jwt_Overlapping_Kids(t *testing.T) {
 	t.Run("a disabled signer sharing a kid does not poison an enabled signer", func(t *testing.T) {
 		ctx.testContextChanged(t)
 
-		// One signing key and kid served by two HTTPS JWKS providers - one signer enabled, one
-		// disabled. A disabled signer that shares a kid must not capture the binding and suppress
-		// issuer-string resolution for the enabled signer.
 		sharedCert, sharedKey := newSelfSignedCert("shared-disabled-poison-" + uuid.NewString())
 		sharedKid := sharedCert.Subject.CommonName
 
-		enabledJwksServer := newTlsJwksServer(&serverTlsCert, []*x509.Certificate{sharedCert})
+		enabledJwksServer := newJwksServer([]*x509.Certificate{sharedCert})
 		ctx.Req.NoError(enabledJwksServer.Start())
 		defer func() { _ = enabledJwksServer.Stop() }()
 
-		disabledJwksServer := newTlsJwksServer(&serverTlsCert, []*x509.Certificate{sharedCert})
+		disabledJwksServer := newJwksServer([]*x509.Certificate{sharedCert})
 		ctx.Req.NoError(disabledJwksServer.Start())
 		defer func() { _ = disabledJwksServer.Stop() }()
 

--- a/zititest/go.mod
+++ b/zititest/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/michaelquigley/pfxlog v1.0.0
 	github.com/openziti/agent v1.0.33
 	github.com/openziti/channel/v4 v4.3.12
-	github.com/openziti/edge-api v0.31.0
+	github.com/openziti/edge-api v0.36.0
 	github.com/openziti/fablab v0.6.16
 	github.com/openziti/foundation/v2 v2.0.91
 	github.com/openziti/identity v1.0.129

--- a/zititest/go.sum
+++ b/zititest/go.sum
@@ -603,8 +603,8 @@ github.com/openziti/channel/v4 v4.3.12 h1:kpox7z7aILokmzejUlOobORzQutH6q3t4E5abu
 github.com/openziti/channel/v4 v4.3.12/go.mod h1:WZpOeuPliA7mJ3m7Pal8WdYu74eHMzkM/1Z9AMLmUAg=
 github.com/openziti/cobra-to-md v1.0.1 h1:WRinNoIRmwWUSJm+pSNXMjOrtU48oxXDZgeCYQfVXxE=
 github.com/openziti/cobra-to-md v1.0.1/go.mod h1:FjCpk/yzHF7/r28oSTNr5P57yN5VolpdAtS/g7KNi2c=
-github.com/openziti/edge-api v0.31.0 h1:QdaaPnKQj4B40q404+c8VZxMsoVpfGpfOhzs3LLCd/A=
-github.com/openziti/edge-api v0.31.0/go.mod h1:pDtCR6Mq0h5e8ulJhmuhPshEBa39hpQy+yTtLpUSBOs=
+github.com/openziti/edge-api v0.36.0 h1:adp0gCDbxee3r4tPBCXm7IyLTcIGhDcWmQ9QJMO+AwY=
+github.com/openziti/edge-api v0.36.0/go.mod h1:m1oAQ6+fnkEO0NOAkDy6WpnXDxPhj2sko4eBUvIMxkE=
 github.com/openziti/fablab v0.6.16 h1:JVy5zQ/NXoHl2SxMZDKT7jPnUlZyBSKAZXhVD2vOMKQ=
 github.com/openziti/fablab v0.6.16/go.mod h1:TXrgrWWnE9yxXP5e6RYBgjgmJhT1LXBnOtfir6Av+Ko=
 github.com/openziti/foundation/v2 v2.0.91 h1:gjXFu+fxKKMCs1hCkfLNI9jfdiSBW2gXAnBCy5xG/UI=


### PR DESCRIPTION
…id ext-jwt test's jwks endpoints over loopback http

- serves the overlapping-kid JWKS providers over loopback HTTP, the hardened resolver builds its own transport and trusts only the system root pool
- removes the newTlsJwksServer helper and the http.DefaultTransport root-CA setup


Notes: Apparently I missed this backport.