### PR TITLE
[Backport-1.6] Close ER/T dial circuits when the router loses dial access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,14 @@
 ## What's New
 
 * Bug fixes
+* Edge router tunnelers now close a service's circuits when the router loses dial access to it, and
+  the controller verifies the dial policy for tunneler circuits
 
 ## Component Updates and Bug Fixes
 
 * github.com/openziti/ziti: [v1.6.20 -> v1.6.21](https://github.com/openziti/ziti/compare/v1.6.20...v1.6.21)
   * [Issue #4299](https://github.com/openziti/ziti/issues/4299) - [Backport-1.6] Bind message with a short cost header panics the router
+  * [Issue #4336](https://github.com/openziti/ziti/issues/4336) - [Backport-1.6] ER/T does not close existing circuits when the router loses dial access to a service
 
 # Release 1.6.20
 

--- a/controller/handler_edge_ctrl/common.go
+++ b/controller/handler_edge_ctrl/common.go
@@ -367,6 +367,30 @@ func (self *baseSessionRequestContext) verifyServiceBindAccess(identityId string
 	}
 }
 
+func (self *baseSessionRequestContext) verifyServiceDialAccess(identityId string, serviceId string) {
+	if self.err == nil {
+		result, err := self.handler.getAppEnv().Managers.EdgeService.IsDialableByIdentity(serviceId, identityId)
+		if err != nil {
+			self.err = internalError(err)
+			logrus.
+				WithField("routerId", self.sourceRouter.Id).
+				WithField("identityId", identityId).
+				WithField("serviceId", serviceId).
+				WithField("operation", self.handler.Label()).
+				WithError(err).Error("unable to verify edge router access to dial service")
+			return
+		} else if !result {
+			self.err = InvalidServiceError{}
+			logrus.
+				WithField("routerId", self.sourceRouter.Id).
+				WithField("identityId", identityId).
+				WithField("serviceId", serviceId).
+				WithField("operation", self.handler.Label()).
+				Error("edge router does not have dial access to service")
+		}
+	}
+}
+
 func (self *baseSessionRequestContext) verifyRouterEdgeRouterAccess() {
 	if self.err == nil {
 		self.verifyEdgeRouterAccess(self.sourceRouter.Id, self.service.Id)

--- a/controller/handler_edge_ctrl/common_tunnel.go
+++ b/controller/handler_edge_ctrl/common_tunnel.go
@@ -3,6 +3,9 @@ package handler_edge_ctrl
 import (
 	"bytes"
 	"encoding/json"
+	"sync"
+	"time"
+
 	"github.com/google/uuid"
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/openziti/foundation/v2/concurrenz"
@@ -12,8 +15,6 @@ import (
 	"github.com/openziti/ziti/controller/db"
 	"github.com/openziti/ziti/controller/model"
 	"github.com/sirupsen/logrus"
-	"sync"
-	"time"
 )
 
 func NewTunnelState() *TunnelState {
@@ -74,12 +75,33 @@ func (self *baseTunnelRequestContext) loadIdentity() {
 			return
 		}
 
+		// A disabled router identity may retain valid policies and sessions, and neither session
+		// creation nor posture evaluation inspects Disabled, so gate every tunnel operation here
+		// rather than in each handler. This covers dial (V1 and V2), hosting, and terminator paths.
+		if self.identity.Disabled {
+			self.err = identityDisabled(self.identity.Id)
+			logrus.
+				WithField("routerId", self.sourceRouter.Id).
+				WithField("identityId", self.identity.Id).
+				WithField("operation", self.handler.Label()).
+				Error("edge router identity is disabled")
+			return
+		}
+
 		self.logContext = logcontext.NewContext()
 		traceSpec := self.handler.getAppEnv().TraceManager.GetIdentityTrace(self.identity.Id)
 		if traceSpec != nil && time.Now().After(traceSpec.Until) {
 			self.logContext.SetChannelsMask(traceSpec.ChannelMask)
 			self.logContext.WithField("traceId", traceSpec.TraceId)
 		}
+	}
+}
+
+// verifyEdgeRouterServiceDialAccess checks that the requesting router's own identity has dial access
+// to the loaded service. The disabled-identity check lives in loadIdentity, which runs first.
+func (self *baseTunnelRequestContext) verifyEdgeRouterServiceDialAccess() {
+	if self.err == nil {
+		self.verifyServiceDialAccess(self.sourceRouter.Id, self.service.Id)
 	}
 }
 

--- a/controller/handler_edge_ctrl/create_tunnel_circuit_V2.go
+++ b/controller/handler_edge_ctrl/create_tunnel_circuit_V2.go
@@ -81,6 +81,7 @@ func (self *createTunnelCircuitV2Handler) CreateCircuit(ctx *CreateTunnelCircuit
 	}
 	ctx.loadIdentity()
 	ctx.loadServiceForName(ctx.req.ServiceName)
+	ctx.verifyEdgeRouterServiceDialAccess()
 	ctx.verifyRouterEdgeRouterAccess()
 	circuitInfo, peerData := ctx.createCircuit(ctx.req.TerminatorInstanceId, ctx.req.PeerData, ctx.newTunnelCircuitCreateParms)
 

--- a/controller/handler_edge_ctrl/errors.go
+++ b/controller/handler_edge_ctrl/errors.go
@@ -16,7 +16,11 @@
 
 package handler_edge_ctrl
 
-import "github.com/openziti/sdk-golang/ziti/edge"
+import (
+	"fmt"
+
+	"github.com/openziti/sdk-golang/ziti/edge"
+)
 
 type controllerError interface {
 	error
@@ -123,6 +127,13 @@ func encryptionDataMissing(msg string) controllerError {
 	return &genericControllerError{
 		msg:       msg,
 		errorCode: uint32(edge.ErrorCodeEncryptionDataMissing),
+	}
+}
+
+func identityDisabled(identityId string) controllerError {
+	return &genericControllerError{
+		msg:       fmt.Sprintf("identity %s is disabled", identityId),
+		errorCode: uint32(edge.ErrorCodeAccessDenied),
 	}
 }
 

--- a/router/xgress_common/dial_circuits.go
+++ b/router/xgress_common/dial_circuits.go
@@ -1,0 +1,102 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package xgress_common
+
+import (
+	"github.com/michaelquigley/pfxlog"
+	"github.com/openziti/sdk-golang/xgress"
+	cmap "github.com/orcaman/concurrent-map/v2"
+)
+
+// DialCircuitRegistry tracks the initiating xgress of every dial circuit a router-local
+// client (an edge router tunneler or an embedded SDK) has established, keyed by circuit id,
+// so they can be closed when the router's identity loses dial access to a service.
+// Safe for concurrent use.
+type DialCircuitRegistry struct {
+	circuits cmap.ConcurrentMap[string, *dialCircuit]
+}
+
+type dialCircuit struct {
+	serviceId string
+	x         *xgress.Xgress
+}
+
+// NewDialCircuitRegistry returns an empty registry. Register a dial circuit with PrepareTrack
+// followed by Publish, and close tracked circuits with CloseForService or CloseAll.
+func NewDialCircuitRegistry() *DialCircuitRegistry {
+	return &DialCircuitRegistry{
+		circuits: cmap.New[*dialCircuit](),
+	}
+}
+
+// PrepareTrack installs x's registry cleanup handler, so that x is removed from the registry when it
+// closes. Call it before x is exposed to any close path (before HandleXgressBind hands x to the
+// forwarder): the handler must be present before anything can call Xgress.Close, because
+// Xgress.AddCloseHandler mutates the same unsynchronized handler slice that Close iterates. Pair
+// every PrepareTrack with a Publish once x is bound.
+func (self *DialCircuitRegistry) PrepareTrack(x *xgress.Xgress) {
+	x.AddCloseHandler(xgress.CloseHandlerF(func(closed *xgress.Xgress) { self.remove(closed) }))
+}
+
+// Publish makes x visible to revocation under serviceId, keyed by circuit id. Call it after x is
+// bound: a revocation may close x as soon as it is published, and closing an unbound xgress
+// dereferences a nil data-plane adapter. Requires PrepareTrack to have installed x's cleanup
+// handler. If x was already closed before publication (its handler ran while nothing was
+// published), Publish reconciles by removing the just-set entry.
+func (self *DialCircuitRegistry) Publish(serviceId string, x *xgress.Xgress) {
+	self.circuits.Set(x.CircuitId(), &dialCircuit{serviceId: serviceId, x: x})
+	if x.IsClosed() {
+		self.remove(x)
+	}
+}
+
+func (self *DialCircuitRegistry) remove(x *xgress.Xgress) {
+	self.circuits.RemoveCb(x.CircuitId(), func(_ string, v *dialCircuit, exists bool) bool {
+		return exists && v.x == x
+	})
+}
+
+// CloseForService closes every tracked dial circuit for serviceId.
+func (self *DialCircuitRegistry) CloseForService(serviceId string, reason string) {
+	self.closeMatching(func(c *dialCircuit) bool {
+		return c.serviceId == serviceId
+	}, reason)
+}
+
+// CloseAll closes every tracked dial circuit.
+func (self *DialCircuitRegistry) CloseAll(reason string) {
+	self.closeMatching(func(*dialCircuit) bool { return true }, reason)
+}
+
+// closeMatching closes every circuit for which matches returns true, using reason.
+func (self *DialCircuitRegistry) closeMatching(matches func(*dialCircuit) bool, reason string) {
+	// collect first: closing removes entries from the map being iterated
+	var toClose []*dialCircuit
+	self.circuits.IterCb(func(_ string, c *dialCircuit) {
+		if matches(c) {
+			toClose = append(toClose, c)
+		}
+	})
+
+	for _, c := range toClose {
+		pfxlog.Logger().WithField("circuitId", c.x.CircuitId()).
+			WithField("serviceId", c.serviceId).
+			WithField("reason", reason).
+			Info("closing dial circuit")
+		c.x.Close()
+	}
+}

--- a/router/xgress_edge_tunnel_v2/fabric.go
+++ b/router/xgress_edge_tunnel_v2/fabric.go
@@ -17,7 +17,6 @@
 package xgress_edge_tunnel_v2
 
 import (
-	"fmt"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -36,7 +35,6 @@ import (
 	"github.com/openziti/ziti/common/pb/edge_ctrl_pb"
 	"github.com/openziti/ziti/controller/idgen"
 	"github.com/openziti/ziti/router/env"
-	"github.com/openziti/ziti/router/posture"
 	"github.com/openziti/ziti/router/xgress_common"
 	"github.com/openziti/ziti/tunnel"
 	"github.com/pkg/errors"
@@ -48,6 +46,7 @@ func NewTunnelFabricProvider(routerEnv env.RouterEnv, hostedServicesRegistry *Ho
 		env:            routerEnv,
 		hostedServices: hostedServicesRegistry,
 		bindHandler:    routerEnv.GetXgressBindHandler(),
+		dialCircuits:   xgress_common.NewDialCircuitRegistry(),
 	}
 }
 
@@ -56,6 +55,7 @@ type fabricProvider struct {
 	hostedServices *HostedServiceRegistry
 	options        *xgress.Options
 	bindHandler    xgress.BindHandler
+	dialCircuits   *xgress_common.DialCircuitRegistry
 
 	currentIdentity atomic.Pointer[rest_model.IdentityDetail]
 }
@@ -72,6 +72,14 @@ func (self *fabricProvider) GetCurrentIdentityWithBackoff() (*rest_model.Identit
 
 func (self *fabricProvider) UpdateIdentity(i *rest_model.IdentityDetail) {
 	self.currentIdentity.Store(i)
+}
+
+func (self *fabricProvider) CloseDialCircuits(serviceId string, reason string) {
+	self.dialCircuits.CloseForService(serviceId, reason)
+}
+
+func (self *fabricProvider) CloseAllDialCircuits(reason string) {
+	self.dialCircuits.CloseAll(reason)
 }
 
 func (self *fabricProvider) SetXgressOptions(options *xgress.Options) {
@@ -106,11 +114,6 @@ func (self *fabricProvider) TunnelService(service tunnel.Service, terminatorInst
 
 	log = log.WithField("ctrlId", ctrlCh.Id())
 
-	rdm := self.env.GetRouterDataModel()
-	if policy, err := posture.HasAccess(rdm, self.env.GetRouterId().Token, service.GetId(), nil, edge_ctrl_pb.PolicyType_DialPolicy); err != nil && policy != nil {
-		return fmt.Errorf("router does not have access to service '%s' (%w)", service.GetName(), err)
-	}
-
 	request := &edge_ctrl_pb.CreateTunnelCircuitV2Request{
 		ServiceName:          service.GetName(),
 		TerminatorInstanceId: terminatorInstanceId,
@@ -141,7 +144,12 @@ func (self *fabricProvider) TunnelService(service tunnel.Service, terminatorInst
 	}
 
 	x := xgress.NewXgress(response.CircuitId, ctrlCh.Id(), xgress.Address(response.Address), xgConn, xgress.Initiator, self.options, response.Tags)
+	// Install the registry close handler before HandleXgressBind exposes x to the forwarder, then
+	// publish once bound, so revocation can neither race the handler registration nor close an
+	// unbound xgress.
+	self.dialCircuits.PrepareTrack(x)
 	self.bindHandler.HandleXgressBind(x)
+	self.dialCircuits.Publish(service.GetId(), x)
 	x.Start()
 
 	return nil

--- a/router/xgress_edge_tunnel_v2/tunneler.go
+++ b/router/xgress_edge_tunnel_v2/tunneler.go
@@ -43,6 +43,10 @@ type TunnelFabricProvider interface {
 	tunnel.FabricProvider
 	SetXgressOptions(*xgress.Options)
 	UpdateIdentity(i *rest_model.IdentityDetail)
+	// CloseDialCircuits closes every dial circuit this provider established for serviceId.
+	CloseDialCircuits(serviceId string, reason string)
+	// CloseAllDialCircuits closes every dial circuit this provider established.
+	CloseAllDialCircuits(reason string)
 }
 
 type tunneler struct {
@@ -153,6 +157,7 @@ func (self *tunneler) NotifyIdentityEvent(state *common.IdentityState, eventType
 		pfxlog.Logger().Infof("identity deleted or disabled %s, eventType: %s", state.Identity.Id, eventType)
 		self.fabricProvider.UpdateIdentity(self.mapRdmIdentityToRest(state.Identity))
 		self.serviceListener.Reset()
+		self.fabricProvider.CloseAllDialCircuits("identity deleted or disabled")
 	} else if eventType == common.EventFullState || eventType == common.EventIdentityUpdated {
 		pfxlog.Logger().Infof("identity updated %s, eventType: %s", state.Identity.Id, eventType)
 		self.fabricProvider.UpdateIdentity(self.mapRdmIdentityToRest(state.Identity))
@@ -171,8 +176,15 @@ func (self *tunneler) NotifyServiceChange(state *common.IdentityState, service *
 		self.serviceListener.HandleServicesChange(ziti.ServiceAdded, tunSvc)
 	case common.EventUpdated:
 		self.serviceListener.HandleServicesChange(ziti.ServiceChanged, tunSvc)
+		// The service's denorm changed; if the router no longer has dial access (e.g. its dial
+		// policy was removed while a bind policy kept the service otherwise accessible), close the
+		// circuits it dialed. DialAllowed is the router data model's own denorm flag.
+		if !service.DialAllowed {
+			self.fabricProvider.CloseDialCircuits(service.GetId(), "dial access lost")
+		}
 	case common.EventAccessRemoved:
 		self.serviceListener.HandleServicesChange(ziti.ServiceRemoved, tunSvc)
+		self.fabricProvider.CloseDialCircuits(service.GetId(), "service access lost")
 	}
 }
 

--- a/router/xgress_sdk/fabric.go
+++ b/router/xgress_sdk/fabric.go
@@ -32,7 +32,6 @@ import (
 	"github.com/openziti/ziti/common/ctrl_msg"
 	"github.com/openziti/ziti/common/pb/edge_ctrl_pb"
 	"github.com/openziti/ziti/router/env"
-	"github.com/openziti/ziti/router/posture"
 	"github.com/openziti/ziti/router/xgress_common"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -40,8 +39,9 @@ import (
 
 func NewFabric(env env.RouterEnv, options *xgress.Options) (Fabric, error) {
 	result := &fabricImpl{
-		env:     env,
-		options: options,
+		env:          env,
+		options:      options,
+		dialCircuits: xgress_common.NewDialCircuitRegistry(),
 	}
 
 	env.MarkRouterDataModelRequired()
@@ -57,6 +57,7 @@ type fabricImpl struct {
 	options         *xgress.Options
 	currentIdentity atomic.Pointer[common.IdentityState]
 	servicesByName  concurrenz.AtomicValue[map[string]*common.IdentityService]
+	dialCircuits    *xgress_common.DialCircuitRegistry
 }
 
 func (self *fabricImpl) updateIdentityState(state *common.IdentityState) {
@@ -73,7 +74,9 @@ func (self *fabricImpl) updateIdentityState(state *common.IdentityState) {
 func (self *fabricImpl) NotifyIdentityEvent(state *common.IdentityState, eventType common.IdentityEventType) {
 	self.updateIdentityState(state)
 	pfxlog.Logger().Infof("identity %s event %s", state.Identity.Name, eventType.String())
-	if eventType == common.EventFullState {
+	if eventType == common.EventIdentityDeleted || state.Identity.Disabled {
+		self.dialCircuits.CloseAll("identity deleted or disabled")
+	} else if eventType == common.EventFullState {
 		for _, service := range state.Services {
 			pfxlog.Logger().Infof("identity %s gained access to %s", state.Identity.Name, service.GetName())
 		}
@@ -87,6 +90,9 @@ func (self *fabricImpl) NotifyServiceChange(state *common.IdentityState, service
 		pfxlog.Logger().Infof("identity %s gained access to %s", state.Identity.Name, service.GetName())
 	} else if eventType == common.EventAccessRemoved {
 		pfxlog.Logger().Infof("identity %s lost access to %s", state.Identity.Name, service.GetName())
+		self.dialCircuits.CloseForService(service.GetId(), "service access lost")
+	} else if eventType == common.EventUpdated && !service.DialAllowed {
+		self.dialCircuits.CloseForService(service.GetId(), "dial access lost")
 	}
 }
 
@@ -124,11 +130,6 @@ func (self *fabricImpl) TunnelWithOptions(serviceName string, options *ziti.Dial
 
 	log = log.WithField("ctrlId", ctrlCh.Id())
 
-	rdm := self.env.GetRouterDataModel()
-	if policy, err := posture.HasAccess(rdm, self.env.GetRouterId().Token, service.GetId(), nil, edge_ctrl_pb.PolicyType_DialPolicy); err != nil && policy != nil {
-		return fmt.Errorf("router does not have access to service '%s' (%w)", serviceName, err)
-	}
-
 	request := &edge_ctrl_pb.CreateTunnelCircuitV2Request{
 		ServiceName:          serviceName,
 		TerminatorInstanceId: options.Identity,
@@ -157,7 +158,9 @@ func (self *fabricImpl) TunnelWithOptions(serviceName string, options *ziti.Dial
 	}
 
 	x := xgress.NewXgress(response.CircuitId, ctrlCh.Id(), xgress.Address(response.Address), xgConn, xgress.Initiator, self.options, response.Tags)
+	self.dialCircuits.PrepareTrack(x)
 	self.env.GetXgressBindHandler().HandleXgressBind(x)
+	self.dialCircuits.Publish(service.GetId(), x)
 	x.Start()
 
 	return nil

--- a/tests/context.go
+++ b/tests/context.go
@@ -565,10 +565,18 @@ func (ctx *TestContext) startTransitRouter() {
 	ctx.Req.NoError(newRouter.Start())
 }
 
-func (ctx *TestContext) CreateEnrollAndStartTunnelerEdgeRouter(roleAttributes ...string) {
+func (ctx *TestContext) CreateEnrollAndStartTunnelerEdgeRouter(roleAttributes ...string) *EdgeRouterHelper {
 	ctx.shutdownRouters()
 	ctx.createAndEnrollEdgeRouter(true, roleAttributes...)
-	ctx.startEdgeRouter(nil)
+	return ctx.startEdgeRouter(nil)
+}
+
+// CreateEnrollAndStartTunnelerEdgeRouterWithCfgTweaks creates a tunneler-enabled edge router
+// and allows the caller to modify the router config before startup.
+func (ctx *TestContext) CreateEnrollAndStartTunnelerEdgeRouterWithCfgTweaks(cfgTweaks func(*routerEnv.Config), roleAttributes ...string) *EdgeRouterHelper {
+	ctx.shutdownRouters()
+	ctx.createAndEnrollEdgeRouter(true, roleAttributes...)
+	return ctx.startEdgeRouter(cfgTweaks)
 }
 
 func (ctx *TestContext) CreateEnrollAndStartEdgeRouter(roleAttributes ...string) *EdgeRouterHelper {

--- a/tests/tunneler_permission_loss_test.go
+++ b/tests/tunneler_permission_loss_test.go
@@ -1,0 +1,466 @@
+//go:build dataflow
+
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package tests
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/openziti/channel/v4"
+	"github.com/openziti/channel/v4/protobufs"
+	"github.com/openziti/edge-api/rest_model"
+	"github.com/openziti/sdk-golang/ziti"
+	"github.com/openziti/sdk-golang/ziti/edge"
+	"github.com/openziti/ziti/common/eid"
+	"github.com/openziti/ziti/common/pb/edge_ctrl_pb"
+	routerEnv "github.com/openziti/ziti/router/env"
+)
+
+const (
+	ertDialLossService1 = "ert-dial-loss-svc-1"
+	ertDialLossService2 = "ert-dial-loss-svc-2"
+	ertDialLossPort1    = 8691
+	ertDialLossPort2    = 8692
+)
+
+// tunnelerDialFixture is a running controller, an ER/T in proxy mode intercepting two services on
+// fixed local ports, an SDK host echoing on both, and one established client connection per service.
+// dialPolicy1 is the only dial policy granting the router access to service1.
+type tunnelerDialFixture struct {
+	ctx         *TestContext
+	service1    *service
+	service2    *service
+	dialPolicy1 *servicePolicy
+	addr1       string
+	addr2       string
+	conn1       net.Conn
+	conn2       net.Conn
+}
+
+func newTunnelerDialFixture(ctx *TestContext, oidcHost bool) *tunnelerDialFixture {
+	svcRole1 := eid.New()
+	svcRole2 := eid.New()
+
+	// the proxy interceptor maps fixed service names to local ports, so the names must match the
+	// router config tweak below
+	service1 := ctx.newService(s(svcRole1), nil)
+	service1.Name = ertDialLossService1
+	service1.Id = ctx.AdminManagementSession.requireCreateEntity(service1)
+
+	service2 := ctx.newService(s(svcRole2), nil)
+	service2.Name = ertDialLossService2
+	service2.Id = ctx.AdminManagementSession.requireCreateEntity(service2)
+
+	ctx.AdminManagementSession.requireNewEdgeRouterPolicy(s("#all"), s("#all"))
+	ctx.AdminManagementSession.requireNewServiceEdgeRouterPolicy(s("#all"), s("#all"))
+	ctx.AdminManagementSession.requireNewServicePolicy("Bind", s("#all"), s("#all"), nil)
+
+	// one dial policy per service, so changing dialPolicy1 affects the router's access to service1 only
+	dialPolicy1 := ctx.AdminManagementSession.requireNewServicePolicy("Dial", s("#"+svcRole1), s("#all"), nil)
+	ctx.AdminManagementSession.requireNewServicePolicy("Dial", s("#"+svcRole2), s("#all"), nil)
+
+	ctx.CreateEnrollAndStartTunnelerEdgeRouterWithCfgTweaks(func(cfg *routerEnv.Config) {
+		for _, l := range cfg.Listeners {
+			if l.Name == "tunnel" {
+				if opts, ok := l.Options["options"].(map[interface{}]interface{}); ok {
+					opts["services"] = []interface{}{
+						fmt.Sprintf("%s:%d", ertDialLossService1, ertDialLossPort1),
+						fmt.Sprintf("%s:%d", ertDialLossService2, ertDialLossPort2),
+					}
+				}
+			}
+		}
+	})
+
+	service1Watcher := ctx.AdminManagementSession.newTerminatorWatcher()
+	defer service1Watcher.Close()
+
+	service2Watcher := ctx.AdminManagementSession.newTerminatorWatcher()
+	defer service2Watcher.Close()
+
+	_, hostZtx := ctx.AdminManagementSession.RequireCreateSdkContext()
+	ctx.testing.Cleanup(hostZtx.Close)
+
+	if oidcHost {
+		hostContext := hostZtx.(*ziti.ContextImpl)
+		hostContext.CtrlClt.SetAllowOidcDynamicallyEnabled(true)
+		ctx.Req.NoError(hostContext.Authenticate())
+	}
+
+	listener1, err := hostZtx.Listen(service1.Name)
+	ctx.Req.NoError(err)
+	ctx.testing.Cleanup(func() { _ = listener1.Close() })
+
+	listener2, err := hostZtx.Listen(service2.Name)
+	ctx.Req.NoError(err)
+	ctx.testing.Cleanup(func() { _ = listener2.Close() })
+
+	service1Watcher.waitForTerminators(service1.Id, 1, 10*time.Second)
+	service2Watcher.waitForTerminators(service2.Id, 1, 10*time.Second)
+
+	newTestServer(listener1, tcpEchoHandler).start()
+	newTestServer(listener2, tcpEchoHandler).start()
+
+	f := &tunnelerDialFixture{
+		ctx:         ctx,
+		service1:    service1,
+		service2:    service2,
+		dialPolicy1: dialPolicy1,
+		addr1:       fmt.Sprintf("127.0.0.1:%d", ertDialLossPort1),
+		addr2:       fmt.Sprintf("127.0.0.1:%d", ertDialLossPort2),
+	}
+
+	f.conn1 = requireDialWithRetry(ctx, f.addr1, 15*time.Second)
+	ctx.testing.Cleanup(func() { _ = f.conn1.Close() })
+
+	f.conn2 = requireDialWithRetry(ctx, f.addr2, 15*time.Second)
+	ctx.testing.Cleanup(func() { _ = f.conn2.Close() })
+
+	requireTcpEcho(ctx, f.conn1)
+	requireTcpEcho(ctx, f.conn2)
+
+	return f
+}
+
+// requireService1Revoked requires conn1 to be closed, service1 to refuse new connections, and
+// service2 to be unaffected on both its existing connection and a new one.
+func (f *tunnelerDialFixture) requireService1Revoked() {
+	ctx := f.ctx
+	requireNetConnClosed(ctx, f.conn1, 15*time.Second)
+
+	// service2 is unaffected, on the existing connection and a new one
+	requireTcpEcho(ctx, f.conn2)
+
+	conn3 := requireDialWithRetry(ctx, f.addr2, 5*time.Second)
+	defer func() { _ = conn3.Close() }()
+	requireTcpEcho(ctx, conn3)
+}
+
+func tcpEchoHandler(conn *testServerConn) error {
+	for {
+		name, eof := conn.ReadString(1024, time.Minute)
+		if eof {
+			return nil
+		}
+		conn.WriteString("hello, "+name, time.Second)
+	}
+}
+
+// Test_TunnelerCircuitCloseOnDialPermissionLoss_LegacyHost verifies that circuits intercepted by an
+// ER/T are closed when the router loses dial access, with the service hosted by a legacy-auth SDK.
+func Test_TunnelerCircuitCloseOnDialPermissionLoss_LegacyHost(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+	ctx.RequireAdminManagementApiLogin()
+
+	f := newTunnelerDialFixture(ctx, false)
+	ctx.AdminManagementSession.requireDeleteEntity(f.dialPolicy1)
+	f.requireService1Revoked()
+}
+
+// Test_TunnelerCircuitCloseOnDialPermissionLoss_OidcHost is the same scenario with the service
+// hosted by an OIDC-auth SDK.
+func Test_TunnelerCircuitCloseOnDialPermissionLoss_OidcHost(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+	ctx.RequireAdminManagementApiLogin()
+
+	f := newTunnelerDialFixture(ctx, true)
+	ctx.AdminManagementSession.requireDeleteEntity(f.dialPolicy1)
+	f.requireService1Revoked()
+}
+
+// Test_TunnelerCircuitCloseOnIdentityDisabled verifies that disabling the router's identity closes
+// every dial circuit and refuses new dials, even though the policies still list the identity.
+func Test_TunnelerCircuitCloseOnIdentityDisabled(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+	ctx.RequireAdminManagementApiLogin()
+
+	f := newTunnelerDialFixture(ctx, false)
+
+	disable := &rest_model.DisableParams{DurationMinutes: ToPtr[int64](0)}
+	resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(disable).Post("identities/" + ctx.edgeRouterEntity.id + "/disable")
+	ctx.Req.NoError(err)
+	ctx.Req.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body()))
+
+	requireNetConnClosed(ctx, f.conn1, 15*time.Second)
+	requireNetConnClosed(ctx, f.conn2, 15*time.Second)
+
+	for _, addr := range []string{f.addr1, f.addr2} {
+		addr := addr
+		ctx.Req.Eventually(func() bool {
+			return newDialRefused(addr)
+		}, 10*time.Second, 250*time.Millisecond, "expected dials to be refused while the router identity is disabled")
+	}
+}
+
+// Test_TunnelerCircuitDeniedWithoutDialPolicy verifies the controller refuses a tunnel circuit for a
+// service the router's identity has no dial policy for, even when the router asks for it directly.
+func Test_TunnelerCircuitDeniedWithoutDialPolicy(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+	ctx.RequireAdminManagementApiLogin()
+
+	svcRole := eid.New()
+	hostRole := eid.New()
+
+	service := ctx.AdminManagementSession.requireNewService(s(svcRole), nil)
+
+	ctx.AdminManagementSession.requireNewEdgeRouterPolicy(s("#all"), s("#all"))
+	ctx.AdminManagementSession.requireNewServiceEdgeRouterPolicy(s("#all"), s("#all"))
+	ctx.AdminManagementSession.requireNewServicePolicy("Bind", s("#"+svcRole), s("#"+hostRole), nil)
+
+	edgeRouter := ctx.CreateEnrollAndStartTunnelerEdgeRouter()
+
+	watcher := ctx.AdminManagementSession.newTerminatorWatcher()
+	defer watcher.Close()
+
+	_, hostContext := ctx.AdminManagementSession.RequireCreateSdkContext(hostRole)
+	defer hostContext.Close()
+
+	listener, err := hostContext.Listen(service.Name)
+	ctx.Req.NoError(err)
+	defer func() { _ = listener.Close() }()
+
+	watcher.waitForTerminators(service.Id, 1, 10*time.Second)
+
+	ctrlCh := edgeRouter.GetNetworkControllers().AnyCtrlChannel()
+	ctx.Req.NotNil(ctrlCh)
+
+	request := &edge_ctrl_pb.CreateTunnelCircuitV2Request{
+		ServiceName: service.Name,
+	}
+	reply, err := protobufs.MarshalTyped(request).WithTimeout(5 * time.Second).SendForReply(ctrlCh)
+	ctx.Req.NoError(err)
+	ctx.Req.Equal(int32(edge_ctrl_pb.ContentType_ErrorType), reply.ContentType, "expected an error reply, got content type %v", reply.ContentType)
+
+	code, found := reply.GetUint32Header(edge.ErrorCodeHeader)
+	ctx.Req.True(found, "error replies carry an edge error code")
+	ctx.Req.Equal(uint32(edge.ErrorCodeInvalidService), code)
+}
+
+// Test_TunnelerCircuitDeniedForDisabledIdentity verifies the controller rejects a tunnel circuit
+// request from a router whose identity is disabled, even though its policies still grant access.
+func Test_TunnelerCircuitDeniedForDisabledIdentity(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+	ctx.RequireAdminManagementApiLogin()
+
+	svcRole := eid.New()
+	hostRole := eid.New()
+
+	service := ctx.AdminManagementSession.requireNewService(s(svcRole), nil)
+
+	ctx.AdminManagementSession.requireNewEdgeRouterPolicy(s("#all"), s("#all"))
+	ctx.AdminManagementSession.requireNewServiceEdgeRouterPolicy(s("#all"), s("#all"))
+	ctx.AdminManagementSession.requireNewServicePolicy("Bind", s("#"+svcRole), s("#"+hostRole), nil)
+	ctx.AdminManagementSession.requireNewServicePolicy("Dial", s("#"+svcRole), s("#all"), nil)
+
+	edgeRouter := ctx.CreateEnrollAndStartTunnelerEdgeRouter()
+
+	watcher := ctx.AdminManagementSession.newTerminatorWatcher()
+	defer watcher.Close()
+
+	_, hostContext := ctx.AdminManagementSession.RequireCreateSdkContext(hostRole)
+	defer hostContext.Close()
+
+	listener, err := hostContext.Listen(service.Name)
+	ctx.Req.NoError(err)
+	defer func() { _ = listener.Close() }()
+
+	watcher.waitForTerminators(service.Id, 1, 10*time.Second)
+
+	ctrlCh := edgeRouter.GetNetworkControllers().AnyCtrlChannel()
+	ctx.Req.NotNil(ctrlCh)
+
+	sendDial := func() (*channel.Message, error) {
+		request := &edge_ctrl_pb.CreateTunnelCircuitV2Request{ServiceName: service.Name}
+		return protobufs.MarshalTyped(request).WithTimeout(5 * time.Second).SendForReply(ctrlCh)
+	}
+
+	// disable the router identity; its policies are unchanged
+	disable := &rest_model.DisableParams{DurationMinutes: ToPtr[int64](0)}
+	resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(disable).Post("identities/" + edgeRouter.GetRouterId().Token + "/disable")
+	ctx.Req.NoError(err)
+	ctx.Req.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body()))
+
+	// the controller must deny the dial with an access-denied error: the disabled-identity check in
+	// shared identity loading runs before the dial-policy check, so this holds regardless of the
+	// dialable denorm state. The router's control channel stays up (it authenticates by certificate),
+	// so poll until the disable has been applied to the identity store the handler reads.
+	ctx.Req.Eventually(func() bool {
+		reply, err := sendDial()
+		if err != nil {
+			return false
+		}
+		if reply.ContentType != int32(edge_ctrl_pb.ContentType_ErrorType) {
+			return false
+		}
+		code, found := reply.GetUint32Header(edge.ErrorCodeHeader)
+		return found && code == edge.ErrorCodeAccessDenied
+	}, 10*time.Second, 200*time.Millisecond, "controller should deny dials for a disabled router identity")
+}
+
+// newDialRefused reports whether a fresh TCP dial to addr is refused, either because the connect
+// fails (the intercept was removed) or the router closes the connection without answering (the dial
+// was denied before a circuit formed). A read timeout means the connection is alive and hanging,
+// which is not a refusal, so it returns false and lets the caller keep polling.
+func newDialRefused(addr string) bool {
+	conn, err := net.DialTimeout("tcp", addr, time.Second)
+	if err != nil {
+		return true
+	}
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
+	if _, err = conn.Write([]byte(eid.New())); err != nil {
+		return true
+	}
+	_, err = conn.Read(make([]byte, 1))
+	if err == nil {
+		return false
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return false
+	}
+	return true
+}
+
+// Test_TunnelerV1CircuitDeniedForDisabledIdentity verifies the controller rejects a legacy
+// (CreateCircuitForService) tunnel circuit request from a router whose identity is disabled. The
+// disabled check lives in shared identity loading, so it must apply to this older content type too.
+func Test_TunnelerV1CircuitDeniedForDisabledIdentity(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctx.StartServer()
+	ctx.RequireAdminManagementApiLogin()
+
+	svcRole := eid.New()
+	hostRole := eid.New()
+
+	service := ctx.AdminManagementSession.requireNewService(s(svcRole), nil)
+
+	ctx.AdminManagementSession.requireNewEdgeRouterPolicy(s("#all"), s("#all"))
+	ctx.AdminManagementSession.requireNewServiceEdgeRouterPolicy(s("#all"), s("#all"))
+	ctx.AdminManagementSession.requireNewServicePolicy("Bind", s("#"+svcRole), s("#"+hostRole), nil)
+	ctx.AdminManagementSession.requireNewServicePolicy("Dial", s("#"+svcRole), s("#all"), nil)
+
+	edgeRouter := ctx.CreateEnrollAndStartTunnelerEdgeRouter()
+
+	watcher := ctx.AdminManagementSession.newTerminatorWatcher()
+	defer watcher.Close()
+
+	_, hostContext := ctx.AdminManagementSession.RequireCreateSdkContext(hostRole)
+	defer hostContext.Close()
+
+	listener, err := hostContext.Listen(service.Name)
+	ctx.Req.NoError(err)
+	defer func() { _ = listener.Close() }()
+
+	watcher.waitForTerminators(service.Id, 1, 10*time.Second)
+
+	ctrlCh := edgeRouter.GetNetworkControllers().AnyCtrlChannel()
+	ctx.Req.NotNil(ctrlCh)
+
+	sendV1Dial := func() (*channel.Message, error) {
+		request := &edge_ctrl_pb.CreateCircuitForServiceRequest{ServiceName: service.Name}
+		return protobufs.MarshalTyped(request).WithTimeout(5 * time.Second).SendForReply(ctrlCh)
+	}
+
+	// the legacy dial succeeds while the identity is enabled
+	reply, err := sendV1Dial()
+	ctx.Req.NoError(err)
+	ctx.Req.Equal(int32(edge_ctrl_pb.ContentType_CreateCircuitForServiceResponseType), reply.ContentType, "legacy dial should succeed while enabled")
+
+	disable := &rest_model.DisableParams{DurationMinutes: ToPtr[int64](0)}
+	resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetBody(disable).Post("identities/" + edgeRouter.GetRouterId().Token + "/disable")
+	ctx.Req.NoError(err)
+	ctx.Req.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body()))
+
+	ctx.Req.Eventually(func() bool {
+		reply, err := sendV1Dial()
+		if err != nil || reply.ContentType != int32(edge_ctrl_pb.ContentType_ErrorType) {
+			return false
+		}
+		code, found := reply.GetUint32Header(edge.ErrorCodeHeader)
+		return found && code == edge.ErrorCodeAccessDenied
+	}, 10*time.Second, 200*time.Millisecond, "controller should deny legacy dials for a disabled router identity")
+}
+
+// requireDialWithRetry dials addr until it connects or timeout elapses, failing the test on timeout.
+func requireDialWithRetry(ctx *TestContext, addr string, timeout time.Duration) net.Conn {
+	deadline := time.Now().Add(timeout)
+	for {
+		conn, err := net.DialTimeout("tcp", addr, time.Second)
+		if err == nil {
+			return conn
+		}
+		if time.Now().After(deadline) {
+			ctx.Req.NoError(err, "timed out waiting to connect to %s", addr)
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// requireTcpEcho sends a unique token over conn and requires the echo server's greeting in reply.
+func requireTcpEcho(ctx *TestContext, conn net.Conn) {
+	name := eid.New()
+	ctx.Req.NoError(conn.SetDeadline(time.Now().Add(5 * time.Second)))
+	_, err := conn.Write([]byte(name))
+	ctx.Req.NoError(err)
+
+	expected := "hello, " + name
+	buf := make([]byte, len(expected))
+	_, err = io.ReadFull(conn, buf)
+	ctx.Req.NoError(err)
+	ctx.Req.Equal(expected, string(buf))
+	ctx.Req.NoError(conn.SetDeadline(time.Time{}))
+}
+
+// requireNetConnClosed requires conn to be closed by its peer within timeout. Unsolicited data is
+// tolerated, since only a non-timeout read error indicates closure.
+func requireNetConnClosed(ctx *TestContext, conn net.Conn, timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	buf := make([]byte, 64)
+	for time.Now().Before(deadline) {
+		_ = conn.SetReadDeadline(time.Now().Add(250 * time.Millisecond))
+		_, err := conn.Read(buf)
+		if err == nil {
+			continue
+		}
+		var netErr net.Error
+		if errors.As(err, &netErr) && netErr.Timeout() {
+			continue
+		}
+		return
+	}
+	ctx.Req.Fail("timed out waiting for connection to be closed")
+}


### PR DESCRIPTION
Fixes #4336

Backport of #4331 (#4330) to release-v1.6.x. Hand-ported rather than cherry-picked: the router-data-model tunneler is a separate package on this branch (`xgress_edge_tunnel_v2`), the subscriber uses different event names with no previous-service argument, and the branch uses sdk-golang v1 / channel v4.

Per the backport decision, this omits the posture-enforcement half of the fix. The router does not gate its own dial path on a policy check here, so a posture-gated dial policy still grants a router as it does today on 1.6; the controller's dial-policy check is authoritative. There is therefore no posture warning in the release notes.

The core fix is included: the tunneler and embedded SDK now close a service's circuits when the router loses dial access (the `DialAllowed` denorm flag drops or access is removed) or when the router identity is deleted or disabled, the disabled identity is rejected in shared tunnel identity loading, and the controller verifies the dial policy for tunneler circuits.

Nine tunneler dataflow tests pass on release-v1.6.x.

Note: the `tests` package does not compile at this branch tip in a stock checkout, because `tests/data_flow_hs_rotating_test.go` expects a newer sdk-golang edge API than the pinned v1.6.0. This is pre-existing and unrelated to this change; the new tests here were validated with that file set aside.
