### PR TITLE
[Backport-1.6] Hold the policy enforcers' meters rather than resolving one per run

### DIFF
--- a/controller/internal/policy/api_session_enforcer.go
+++ b/controller/internal/policy/api_session_enforcer.go
@@ -18,13 +18,15 @@ package policy
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/michaelquigley/pfxlog"
+	"github.com/openziti/metrics"
 	"github.com/openziti/ziti/common/runner"
+	"github.com/openziti/ziti/controller/change"
 	"github.com/openziti/ziti/controller/env"
 	"github.com/openziti/ziti/controller/model"
-	"github.com/openziti/ziti/controller/change"
 	"github.com/sirupsen/logrus"
-	"time"
 )
 
 const (
@@ -38,6 +40,11 @@ const (
 type ApiSessionEnforcer struct {
 	appEnv         model.Env
 	sessionTimeout time.Duration
+	// Resolved once and held. A Meter lookup takes a reference on every call and only Dispose releases
+	// one, so looking one up per run accumulates references and leaves the meter sampling after the
+	// registry is disposed. Timer is not reference counted, and is held here so the two read alike.
+	runTimer    metrics.Timer
+	deleteMeter metrics.Meter
 	*runner.BaseOperation
 }
 
@@ -54,6 +61,8 @@ func NewSessionEnforcer(appEnv *env.AppEnv, frequency time.Duration, sessionTime
 	return &ApiSessionEnforcer{
 		appEnv:         appEnv,
 		sessionTimeout: sessionTimeout,
+		runTimer:       appEnv.GetMetricsRegistry().Timer(ApiSessionEnforcerRun),
+		deleteMeter:    appEnv.GetMetricsRegistry().Meter(ApiSessionEnforcerDelete),
 		BaseOperation:  runner.NewBaseOperation("ApiSessionEnforcer", frequency),
 	}
 }
@@ -62,7 +71,7 @@ func (s *ApiSessionEnforcer) Run() error {
 	startTime := time.Now()
 
 	defer func() {
-		s.appEnv.GetMetricsRegistry().Timer(ApiSessionEnforcerRun).UpdateSince(startTime)
+		s.runTimer.UpdateSince(startTime)
 	}()
 
 	oldest := time.Now().Add(s.sessionTimeout * -1)
@@ -107,7 +116,7 @@ func (s *ApiSessionEnforcer) Run() error {
 					logrus.WithError(err).Errorf("failure while deleting expired api session: %v", id)
 				}
 			}
-			s.appEnv.GetMetricsRegistry().Meter(ApiSessionEnforcerDelete).Mark(int64(len(ids)))
+			s.deleteMeter.Mark(int64(len(ids)))
 		}
 	}
 

--- a/controller/internal/policy/api_session_enforcer.go
+++ b/controller/internal/policy/api_session_enforcer.go
@@ -108,16 +108,20 @@ func (s *ApiSessionEnforcer) Run() error {
 		logrus.Debugf("found %v expired api-sessions to remove", len(ids))
 
 		ctx := change.New().SetSourceType("api-session.enforcer").SetChangeAuthorType(change.AuthorTypeController)
+		deleted := int64(len(ids))
 		if err = s.appEnv.GetManagers().ApiSession.DeleteBatch(ids, ctx); err != nil {
 			logrus.WithError(err).Error("failure while batch deleting expired api sessions")
 
+			deleted = 0
 			for _, id := range ids {
 				if err = s.appEnv.GetManagers().ApiSession.Delete(id, ctx); err != nil {
 					logrus.WithError(err).Errorf("failure while deleting expired api session: %v", id)
+				} else {
+					deleted++
 				}
 			}
-			s.deleteMeter.Mark(int64(len(ids)))
 		}
+		s.deleteMeter.Mark(deleted)
 	}
 
 	return nil

--- a/controller/internal/policy/revocation_enforcer.go
+++ b/controller/internal/policy/revocation_enforcer.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/michaelquigley/pfxlog"
+	"github.com/openziti/metrics"
 	"github.com/openziti/ziti/common/runner"
 	"github.com/openziti/ziti/controller/change"
 	"github.com/openziti/ziti/controller/command"
@@ -38,6 +39,11 @@ const (
 type RevocationEnforcer struct {
 	appEnv     *env.AppEnv
 	dispatcher command.Dispatcher
+	// Resolved once and held. A Meter lookup takes a reference on every call and only Dispose releases
+	// one, so looking one up per run accumulates references and leaves the meter sampling after the
+	// registry is disposed. Timer is not reference counted, and is held here so the two read alike.
+	runTimer    metrics.Timer
+	deleteMeter metrics.Meter
 	*runner.BaseOperation
 }
 
@@ -46,6 +52,8 @@ func NewRevocationEnforcer(appEnv *env.AppEnv, frequency time.Duration, dispatch
 	return &RevocationEnforcer{
 		appEnv:        appEnv,
 		dispatcher:    dispatcher,
+		runTimer:      appEnv.GetMetricsRegistry().Timer(RevocationEnforcerRun),
+		deleteMeter:   appEnv.GetMetricsRegistry().Meter(RevocationEnforcerDelete),
 		BaseOperation: runner.NewBaseOperation("RevocationEnforcer", frequency),
 	}
 }
@@ -59,7 +67,7 @@ func (e *RevocationEnforcer) Run() error {
 	startTime := time.Now()
 
 	defer func() {
-		e.appEnv.GetMetricsRegistry().Timer(RevocationEnforcerRun).UpdateSince(startTime)
+		e.runTimer.UpdateSince(startTime)
 	}()
 
 	ctx := change.New().SetSourceType(RevocationEnforcerSource).SetChangeAuthorType(change.AuthorTypeController)
@@ -72,7 +80,7 @@ func (e *RevocationEnforcer) Run() error {
 
 	if total > 0 {
 		pfxlog.Logger().Debugf("removed %d expired revocations", total)
-		e.appEnv.GetMetricsRegistry().Meter(RevocationEnforcerDelete).Mark(int64(total))
+		e.deleteMeter.Mark(int64(total))
 	}
 
 	return nil

--- a/controller/internal/policy/service_policy_enforcer.go
+++ b/controller/internal/policy/service_policy_enforcer.go
@@ -18,12 +18,14 @@ package policy
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/ziti/common/runner"
 	"github.com/openziti/ziti/controller/change"
 	"github.com/openziti/ziti/controller/db"
-	"time"
 
+	"github.com/openziti/metrics"
 	"github.com/openziti/ziti/controller/env"
 	"go.etcd.io/bbolt"
 )
@@ -37,15 +39,27 @@ const (
 
 type ServicePolicyEnforcer struct {
 	appEnv *env.AppEnv
+	// Resolved once and held. A Meter lookup takes a reference on every call and only Dispose releases
+	// one, so looking one up per run accumulates references and leaves the meter sampling after the
+	// registry is disposed. The timers are not reference counted, and are held here so the two read alike.
+	eventTimer       metrics.Timer
+	eventDeleteMeter metrics.Meter
+	runTimer         metrics.Timer
+	runDeleteMeter   metrics.Meter
 	*runner.BaseOperation
 	notify chan struct{}
 }
 
 func NewServicePolicyEnforcer(appEnv *env.AppEnv, f time.Duration) *ServicePolicyEnforcer {
+	registry := appEnv.GetMetricsRegistry()
 	result := &ServicePolicyEnforcer{
-		appEnv:        appEnv,
-		BaseOperation: runner.NewBaseOperation("ServicePolicyEnforcer", f),
-		notify:        make(chan struct{}, 1),
+		appEnv:           appEnv,
+		eventTimer:       registry.Timer(SessionPolicyEnforcerEvent),
+		eventDeleteMeter: registry.Meter(SessionPolicyEnforcerEventDeletes),
+		runTimer:         registry.Timer(SessionPolicyEnforcerRun),
+		runDeleteMeter:   registry.Meter(SessionPolicyEnforcerRunDeletes),
+		BaseOperation:    runner.NewBaseOperation("ServicePolicyEnforcer", f),
+		notify:           make(chan struct{}, 1),
 	}
 	result.notify <- struct{}{} // ensure we do a full scan on startup
 	db.ServiceEvents.AddServiceEventHandler(result.handleServiceEvent)
@@ -69,7 +83,7 @@ func (enforcer *ServicePolicyEnforcer) handleServiceEvent(event *db.ServiceEvent
 
 	startTime := time.Now()
 	defer func() {
-		enforcer.appEnv.GetMetricsRegistry().Timer(SessionPolicyEnforcerEvent).UpdateSince(startTime)
+		enforcer.eventTimer.UpdateSince(startTime)
 	}()
 
 	log := pfxlog.Logger().WithField("event", event.String())
@@ -108,7 +122,7 @@ func (enforcer *ServicePolicyEnforcer) handleServiceEvent(event *db.ServiceEvent
 		log.Debugf("session %v deleted", sessionId)
 	}
 
-	enforcer.appEnv.GetMetricsRegistry().Meter(SessionPolicyEnforcerEventDeletes).Mark(int64(len(sessionsToDelete)))
+	enforcer.eventDeleteMeter.Mark(int64(len(sessionsToDelete)))
 }
 
 func (enforcer *ServicePolicyEnforcer) Run() error {
@@ -122,7 +136,7 @@ func (enforcer *ServicePolicyEnforcer) Run() error {
 	startTime := time.Now()
 
 	defer func() {
-		enforcer.appEnv.GetMetricsRegistry().Timer(SessionPolicyEnforcerRun).UpdateSince(startTime)
+		enforcer.runTimer.UpdateSince(startTime)
 	}()
 
 	result, err := enforcer.appEnv.GetManagers().Session.Query("")
@@ -173,7 +187,7 @@ func (enforcer *ServicePolicyEnforcer) Run() error {
 		_ = enforcer.appEnv.GetManagers().Session.Delete(sessionId, ctx)
 	}
 
-	enforcer.appEnv.GetMetricsRegistry().Meter(SessionPolicyEnforcerRunDeletes).Mark(int64(len(sessionsToRemove)))
+	enforcer.runDeleteMeter.Mark(int64(len(sessionsToRemove)))
 
 	return nil
 }

--- a/controller/internal/policy/session_enforcer_test.go
+++ b/controller/internal/policy/session_enforcer_test.go
@@ -17,6 +17,9 @@
 package policy
 
 import (
+	"testing"
+	"time"
+
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/openziti/storage/boltz"
 	"github.com/openziti/storage/boltztest"
@@ -24,8 +27,6 @@ import (
 	"github.com/openziti/ziti/controller/db"
 	"github.com/openziti/ziti/controller/model"
 	"github.com/sirupsen/logrus"
-	"testing"
-	"time"
 )
 
 func Test_SessionEnforcer(t *testing.T) {
@@ -70,9 +71,14 @@ func (ctx *enforcerTestContext) testSessionsCleanup() {
 	boltztest.RequireReload(ctx, session)
 	boltztest.RequireReload(ctx, session2)
 
+	// Built directly rather than through NewSessionEnforcer, which refuses a session timeout under a
+	// minute; the negative timeout here is what makes every session expired. The metrics still have to be
+	// supplied, since the enforcer holds them rather than resolving one per run.
 	enforcer := &ApiSessionEnforcer{
 		appEnv:         ctx,
 		sessionTimeout: -time.Second,
+		runTimer:       ctx.GetMetricsRegistry().Timer(ApiSessionEnforcerRun),
+		deleteMeter:    ctx.GetMetricsRegistry().Meter(ApiSessionEnforcerDelete),
 	}
 
 	ctx.NoError(enforcer.Run())

--- a/controller/internal/policy/session_enforcer_test.go
+++ b/controller/internal/policy/session_enforcer_test.go
@@ -82,6 +82,7 @@ func (ctx *enforcerTestContext) testSessionsCleanup() {
 	}
 
 	ctx.NoError(enforcer.Run())
+	ctx.Equal(int64(1), enforcer.deleteMeter.Count())
 
 	done, err := ctx.GetStores().EventualEventer.Trigger()
 	ctx.NoError(err)


### PR DESCRIPTION
Fixes #4352

Backport of #4353 to `release-v1.6.x`.

The cherry-pick conflicted on imports only: this branch uses unversioned `github.com/openziti/ziti/...` paths where main uses `/v2`. Resolved by keeping the branch's own paths and adding `github.com/openziti/metrics`, which `go.mod` here already requires at v1.4.5. No `/v2` import remains in the changed files.

The first CI run failed `Test_RevocationSkipThreshold/immediate refresh creates revocation (TTL > threshold)` at `tests/revocation_test.go:430`. That is a timing flake unrelated to this change, and a re-run passed. The test configures a 15s refresh token against a 14s skip threshold, so it has about a second of slack between authenticating and refreshing; on a slow runner the remaining TTL drops below the threshold and the controller correctly skips the revocation, which is the nil the assertion trips on. Nothing in this change touches revocation creation — it caches metric handles in the enforcer that deletes expired revocations.

Worth noting that test exists only on this branch: main and 2.0 have `RevocationMinTokenLifetime` but no coverage for it, so there is no fixed version to backport, and the flake wants fixing here.



Also carries the fix for #4380 as a separate commit (backport of #4381), since that fix lands on main and 2.0 independently and this PR is the open 1.6 vehicle: the api session enforcer delete meter now marks on every delete attempt rather than only when the batch delete fails.
