### PR TITLE
[Backport-2.0] Evict posture data for disconnected api sessions

### DIFF
--- a/router/posture/checks.go
+++ b/router/posture/checks.go
@@ -16,15 +16,14 @@ import (
 )
 
 type Cache struct {
-	apiSessionInstances       cmap.ConcurrentMap[string, *Instance]
-	apiSessionInstanceHistory cmap.ConcurrentMap[string, []*InstanceData]
-	updateListeners           []func(data *InstanceData)
-	totpParser                TotpTokenParser
+	apiSessionInstances cmap.ConcurrentMap[string, *Instance]
+	updateListeners     []func(data *InstanceData)
+	totpParser          TotpTokenParser
 }
 
-// NewCache creates a new posture data cache for managing device state information
-// across API sessions. The cache maintains both current posture data and historical
-// snapshots to support policy evaluation and audit requirements.
+// NewCache creates a new posture data cache holding the current posture data reported by each
+// API session, for evaluating posture checks. Data is retained until the session's posture
+// instance is evicted; see EvictInactive.
 //
 // Parameters:
 //   - parser: A TOTP token parser implementation, used to verify ToTP tokens on posture response
@@ -33,25 +32,13 @@ type Cache struct {
 //   - *Cache: A new cache instance ready for storing posture responses
 func NewCache(parser TotpTokenParser) *Cache {
 	return &Cache{
-		apiSessionInstances:       cmap.New[*Instance](),
-		apiSessionInstanceHistory: cmap.New[[]*InstanceData](),
-		totpParser:                parser,
+		apiSessionInstances: cmap.New[*Instance](),
+		totpParser:          parser,
 	}
 }
 
 func (cache *Cache) onUpdate(data *InstanceData) {
-	cache.saveHistory(data)
 	cache.emitUpdate(data)
-}
-
-func (cache *Cache) saveHistory(data *InstanceData) {
-	cache.apiSessionInstanceHistory.Upsert(data.ApiSessionId, nil, func(exist bool, valueInMap []*InstanceData, newValue []*InstanceData) []*InstanceData {
-		if len(valueInMap) > 50 {
-			valueInMap = valueInMap[1:]
-		}
-		valueInMap = append(valueInMap, data)
-		return valueInMap
-	})
 }
 
 // AddResponses processes a posture responses from an SDK client and updates the cache.
@@ -73,6 +60,9 @@ func (cache *Cache) AddResponses(identityId, apiSessionId string, responses *edg
 			valueInMap.ApiSessionId = apiSessionId
 			valueInMap.IdentityId = identityId
 			valueInMap.updatedListeners = []func(data *InstanceData){cache.onUpdate}
+		} else {
+			// fresh posture activity for the session: it is not a candidate for eviction
+			valueInMap.clearDisconnected()
 		}
 
 		return valueInMap
@@ -110,13 +100,134 @@ func (cache *Cache) GetInstance(apiSessionId string) *Instance {
 	return result
 }
 
+// MarkConnected records that an api session has a connection again, so its posture data is no
+// longer a candidate for eviction. A session with no posture instance is a no-op: there is
+// nothing to retain.
+//
+// Safe to call concurrently with EvictInactive: the two are mutually exclusive, so a session is
+// either retained or already evicted, never left half-retained.
+func (cache *Cache) MarkConnected(apiSessionId string) {
+	// Updating under the map's lock is what makes this exclusive with EvictInactive's removal.
+	// Looking the instance up and then updating it leaves a window where an eviction confirms the
+	// disconnect time and deletes the entry, and the update lands on a detached instance.
+	cache.apiSessionInstances.RemoveCb(apiSessionId, func(_ string, instance *Instance, exists bool) bool {
+		if exists && instance != nil {
+			instance.clearDisconnected()
+		}
+		return false // borrow the lock without removing
+	})
+}
+
+// MarkDisconnected records that an api session's last connection has gone away, starting its
+// retention window. A session already recorded as disconnected keeps its earlier time, and a
+// session with no posture instance is a no-op.
+//
+// Safe to call concurrently with EvictInactive, as for MarkConnected.
+func (cache *Cache) MarkDisconnected(apiSessionId string) {
+	cache.markDisconnectedAt(apiSessionId, time.Now())
+}
+
+func (cache *Cache) markDisconnectedAt(apiSessionId string, at time.Time) {
+	cache.apiSessionInstances.RemoveCb(apiSessionId, func(_ string, instance *Instance, exists bool) bool {
+		if exists && instance != nil {
+			instance.setDisconnected(at)
+		}
+		return false // borrow the lock without removing
+	})
+}
+
+// ReconcileDisconnected brings cached sessions back in line with isConnected: sessions it reports
+// connected have any recorded disconnect cleared, and sessions it reports disconnected have one
+// recorded if they carry none. It corrects drift if a MarkConnected or MarkDisconnected was
+// missed, and never removes anything, so a missed notification delays eviction rather than
+// preventing it. Eviction decisions are made from the recorded times alone, by EvictInactive.
+func (cache *Cache) ReconcileDisconnected(isConnected func(apiSessionId string) bool) {
+	now := time.Now()
+
+	for entry := range cache.apiSessionInstances.IterBuffered() {
+		if isConnected(entry.Key) {
+			cache.MarkConnected(entry.Key)
+		} else {
+			cache.markDisconnectedAt(entry.Key, now)
+		}
+	}
+}
+
+// EvictInactive removes the posture data of api sessions recorded as disconnected for at least
+// retention, returning the number removed. A session with no recorded disconnect is connected, or
+// still being connected, and is never evicted.
+func (cache *Cache) EvictInactive(retention time.Duration) int {
+	evictBefore := time.Now().Add(-retention)
+	evicted := 0
+
+	for entry := range cache.apiSessionInstances.IterBuffered() {
+		judgedDisconnectedAt, disconnected := entry.Val.getDisconnected()
+		if !disconnected || !judgedDisconnectedAt.Before(evictBefore) {
+			continue
+		}
+
+		// The verdict was formed against one disconnect time, so the removal confirms that exact
+		// time rather than re-reading the state: a reconnect clears it and a later disconnect
+		// replaces it, either of which makes this verdict stale and the removal a no-op.
+		removed := cache.apiSessionInstances.RemoveCb(entry.Key, func(_ string, instance *Instance, exists bool) bool {
+			return exists && instance != nil && instance.disconnectedAtIs(judgedDisconnectedAt)
+		})
+		if removed {
+			evicted++
+		}
+	}
+
+	return evicted
+}
+
 // Instance represents a managed posture data container for a specific API session,
 // providing thread-safe access to posture information and change notification
 // capabilities for real-time posture policy evaluation.
 type Instance struct {
 	lock             sync.Mutex
 	updatedListeners []func(data *InstanceData)
+	// disconnectedAt is when this instance's api session lost its last connection, or the zero
+	// time while it is connected. It starts the eviction retention window. Guarded by lock.
+	disconnectedAt time.Time
 	InstanceData
+}
+
+// setDisconnected records at as when the api session lost its last connection, if no disconnect
+// is recorded yet, and returns the effective time. An existing time is never moved, so the
+// recorded time is always the earliest known disconnect.
+func (instance *Instance) setDisconnected(at time.Time) time.Time {
+	instance.lock.Lock()
+	defer instance.lock.Unlock()
+
+	if instance.disconnectedAt.IsZero() {
+		instance.disconnectedAt = at
+	}
+	return instance.disconnectedAt
+}
+
+// clearDisconnected drops any recorded disconnect, so the instance is not a candidate for
+// eviction.
+func (instance *Instance) clearDisconnected() {
+	instance.lock.Lock()
+	defer instance.lock.Unlock()
+	instance.disconnectedAt = time.Time{}
+}
+
+// getDisconnected returns when the api session lost its last connection, and whether any
+// disconnect is recorded at all.
+func (instance *Instance) getDisconnected() (time.Time, bool) {
+	instance.lock.Lock()
+	defer instance.lock.Unlock()
+	return instance.disconnectedAt, !instance.disconnectedAt.IsZero()
+}
+
+// disconnectedAtIs reports whether the instance still carries exactly the disconnect time a
+// caller judged, identifying the incarnation that verdict was formed against. A cleared time (the
+// session reconnected) or a different one means the caller's verdict has been overtaken.
+func (instance *Instance) disconnectedAtIs(judged time.Time) bool {
+	instance.lock.Lock()
+	defer instance.lock.Unlock()
+	return !instance.disconnectedAt.IsZero() && instance.disconnectedAt.Equal(judged)
 }
 
 // InstanceData is separated from Instance in order to make creating copies without copying locks or other sensitive

--- a/router/posture/checks_evict_test.go
+++ b/router/posture/checks_evict_test.go
@@ -1,0 +1,235 @@
+package posture
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openziti/sdk-golang/pb/edge_client_pb"
+	"github.com/stretchr/testify/require"
+)
+
+func seedInstance(cache *Cache, apiSessionId string) {
+	cache.AddResponses("identity-1", apiSessionId, &edge_client_pb.PostureResponses{
+		Responses: []*edge_client_pb.PostureResponse{
+			{
+				Type: &edge_client_pb.PostureResponse_Domain_{
+					Domain: &edge_client_pb.PostureResponse_Domain{Name: "example.com"},
+				},
+			},
+		},
+	})
+}
+
+func connectedSet(ids ...string) func(string) bool {
+	connected := map[string]struct{}{}
+	for _, id := range ids {
+		connected[id] = struct{}{}
+	}
+	return func(apiSessionId string) bool {
+		_, ok := connected[apiSessionId]
+		return ok
+	}
+}
+
+func Test_EvictInactive_KeepsConnectedSessions(t *testing.T) {
+	req := require.New(t)
+	cache := NewCache(nil)
+	seedInstance(cache, "connected")
+
+	// no disconnect recorded, so there is no retention window to expire
+	req.Equal(0, cache.EvictInactive(0))
+	req.NotNil(cache.GetInstance("connected"))
+}
+
+func Test_EvictInactive_KeepsSessionWithinRetention(t *testing.T) {
+	req := require.New(t)
+	cache := NewCache(nil)
+	seedInstance(cache, "gone")
+
+	cache.MarkDisconnected("gone")
+
+	req.Equal(0, cache.EvictInactive(time.Minute))
+	req.NotNil(cache.GetInstance("gone"), "posture data must survive a brief disconnect")
+}
+
+func Test_EvictInactive_EvictsAfterRetention(t *testing.T) {
+	req := require.New(t)
+	cache := NewCache(nil)
+	seedInstance(cache, "gone")
+
+	cache.MarkDisconnected("gone")
+
+	req.Equal(1, cache.EvictInactive(0))
+	req.Nil(cache.GetInstance("gone"))
+}
+
+func Test_EvictInactive_EvictsOnlyDisconnectedSessions(t *testing.T) {
+	req := require.New(t)
+	cache := NewCache(nil)
+	seedInstance(cache, "keep")
+	seedInstance(cache, "drop-1")
+	seedInstance(cache, "drop-2")
+
+	cache.MarkDisconnected("drop-1")
+	cache.MarkDisconnected("drop-2")
+
+	req.Equal(2, cache.EvictInactive(0))
+	req.NotNil(cache.GetInstance("keep"))
+	req.Nil(cache.GetInstance("drop-1"))
+	req.Nil(cache.GetInstance("drop-2"))
+}
+
+func Test_MarkConnected_CancelsPendingEviction(t *testing.T) {
+	req := require.New(t)
+	cache := NewCache(nil)
+	seedInstance(cache, "reconnected")
+
+	cache.MarkDisconnected("reconnected")
+	cache.MarkConnected("reconnected")
+
+	req.Equal(0, cache.EvictInactive(0))
+	req.NotNil(cache.GetInstance("reconnected"), "a reconnect must cancel a pending eviction")
+}
+
+func Test_MarkDisconnected_KeepsEarliestDisconnect(t *testing.T) {
+	req := require.New(t)
+	cache := NewCache(nil)
+	seedInstance(cache, "gone")
+
+	first := time.Now().Add(-time.Hour)
+	cache.markDisconnectedAt("gone", first)
+	cache.markDisconnectedAt("gone", time.Now())
+
+	recorded, disconnected := cache.GetInstance("gone").getDisconnected()
+	req.True(disconnected)
+	req.True(recorded.Equal(first), "a later disconnect must not extend the retention window")
+}
+
+func Test_MarkDisconnected_UnknownSessionIsNoop(t *testing.T) {
+	req := require.New(t)
+	cache := NewCache(nil)
+
+	cache.MarkDisconnected("never-seen")
+	cache.MarkConnected("never-seen")
+
+	req.Nil(cache.GetInstance("never-seen"), "notifications must not create posture instances")
+}
+
+func Test_PostureActivityCancelsPendingEviction(t *testing.T) {
+	req := require.New(t)
+	cache := NewCache(nil)
+	seedInstance(cache, "busy")
+
+	cache.MarkDisconnected("busy")
+
+	// posture data arriving means the session is in use, whatever the last notification said
+	seedInstance(cache, "busy")
+
+	req.Equal(0, cache.EvictInactive(0))
+	req.NotNil(cache.GetInstance("busy"))
+}
+
+func Test_ReconcileDisconnected_RecordsMissedDisconnect(t *testing.T) {
+	req := require.New(t)
+	cache := NewCache(nil)
+	seedInstance(cache, "drifted")
+
+	// the disconnect notification never arrived, so the session looks connected
+	req.Equal(0, cache.EvictInactive(0))
+
+	// reconciling against the connection tracker records the disconnect, making it evictable
+	cache.ReconcileDisconnected(connectedSet())
+	req.Equal(1, cache.EvictInactive(0))
+	req.Nil(cache.GetInstance("drifted"))
+}
+
+func Test_ReconcileDisconnected_ClearsMissedReconnect(t *testing.T) {
+	req := require.New(t)
+	cache := NewCache(nil)
+	seedInstance(cache, "drifted")
+
+	// the connect notification never arrived, so the session still looks disconnected
+	cache.MarkDisconnected("drifted")
+
+	cache.ReconcileDisconnected(connectedSet("drifted"))
+	req.Equal(0, cache.EvictInactive(0))
+	req.NotNil(cache.GetInstance("drifted"), "reconciling must not evict a connected session")
+}
+
+func Test_ReconcileDisconnected_NeverEvicts(t *testing.T) {
+	req := require.New(t)
+	cache := NewCache(nil)
+	seedInstance(cache, "gone")
+
+	cache.markDisconnectedAt("gone", time.Now().Add(-time.Hour))
+
+	cache.ReconcileDisconnected(connectedSet())
+	req.NotNil(cache.GetInstance("gone"), "reconciling corrects state; only EvictInactive removes")
+}
+
+func Test_DisconnectedAtIs_IdentifiesTheJudgedIncarnation(t *testing.T) {
+	req := require.New(t)
+	instance := newInstance()
+
+	judged := instance.setDisconnected(time.Now())
+	req.True(instance.disconnectedAtIs(judged), "the time just recorded is the judged incarnation")
+
+	// a reconnect clears the recorded disconnect, so the verdict no longer applies
+	instance.clearDisconnected()
+	req.False(instance.disconnectedAtIs(judged))
+
+	// a later disconnect is a different incarnation than the one judged
+	relapsed := instance.setDisconnected(judged.Add(time.Minute))
+	req.False(instance.disconnectedAtIs(judged))
+	req.True(instance.disconnectedAtIs(relapsed))
+}
+
+// Test_MarkConnected_IsAtomicWithRemoval races a reconnect against the removal decision of a
+// sweep that has already judged the same session evictable, and asserts the outcome is always one
+// of the two consistent ones: either the reconnect won and the session is still cached, or the
+// eviction won and the instance it removed still carries the disconnect time it judged. The
+// inconsistent outcome, an entry removed while the reconnect cleared the disconnect on the
+// detached instance, is what a lookup-then-update MarkConnected produces.
+//
+// Note this is a probabilistic guard, not proof: the window it targets is a few instructions
+// wide. Atomicity rests on MarkConnected and the removal predicate sharing one critical section.
+func Test_MarkConnected_IsAtomicWithRemoval(t *testing.T) {
+	req := require.New(t)
+
+	for range 2000 {
+		cache := NewCache(nil)
+		seedInstance(cache, "racing")
+		instance := cache.GetInstance("racing")
+		req.NotNil(instance)
+
+		cache.markDisconnectedAt("racing", time.Now().Add(-time.Hour))
+
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		evicted := 0
+
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			evicted = cache.EvictInactive(0)
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			cache.MarkConnected("racing")
+		}()
+		close(start)
+		wg.Wait()
+
+		if evicted > 0 {
+			req.Nil(cache.GetInstance("racing"))
+			_, stillDisconnected := instance.getDisconnected()
+			req.True(stillDisconnected,
+				"eviction won, so the reconnect must not have cleared the disconnect of the instance it removed")
+		} else {
+			req.NotNil(cache.GetInstance("racing"), "the reconnect won, so the session must still be cached")
+		}
+	}
+}

--- a/router/state/manager.go
+++ b/router/state/manager.go
@@ -280,6 +280,19 @@ type Manager interface {
 	// the router's posture cache.
 	ProcessPostureResponses(ch channel.Channel, response *edge_client_pb.PostureResponses)
 
+	// SweepInactivePostureData reconciles cached posture data against connectedApiSessionIds and
+	// then evicts sessions that have been disconnected for at least retention, returning the
+	// number evicted.
+	SweepInactivePostureData(connectedApiSessionIds map[string]struct{}, retention time.Duration) int
+
+	// NotifyApiSessionConnected reports that an api session has a connection to this router, so
+	// its posture data is retained and its retention window reset.
+	NotifyApiSessionConnected(apiSessionId string)
+
+	// NotifyApiSessionDisconnected reports that an api session's last connection to this router
+	// has gone away, starting the retention window for its posture data.
+	NotifyApiSessionDisconnected(apiSessionId string)
+
 	// GetEnv returns the router environment instance.
 	GetEnv() env.RouterEnv
 
@@ -477,6 +490,33 @@ func (self *ManagerImpl) HasAccess(identityId, apiSessionId, serviceId string, p
 
 func routerDataModelWorker(_ uint32, f func()) {
 	f()
+}
+
+// NotifyApiSessionConnected retains the posture data of a newly connected api session, cancelling
+// any eviction an in-flight sweep has already judged against it.
+func (self *ManagerImpl) NotifyApiSessionConnected(apiSessionId string) {
+	self.postureCache.MarkConnected(apiSessionId)
+}
+
+// NotifyApiSessionDisconnected starts the retention window for a disconnected api session's
+// posture data, so it is evicted a fixed time after the disconnect rather than after a sweep
+// happens to notice.
+func (self *ManagerImpl) NotifyApiSessionDisconnected(apiSessionId string) {
+	self.postureCache.MarkDisconnected(apiSessionId)
+}
+
+// SweepInactivePostureData bounds the posture cache, which would otherwise grow for the life of
+// the process as clients re-authenticate into new api sessions. Connect and disconnect
+// notifications are what normally record a session's state; the reconcile pass against
+// connectedApiSessionIds only corrects sessions those notifications missed, so a missed
+// notification delays an eviction rather than losing or preventing one.
+func (self *ManagerImpl) SweepInactivePostureData(connectedApiSessionIds map[string]struct{}, retention time.Duration) int {
+	self.postureCache.ReconcileDisconnected(func(apiSessionId string) bool {
+		_, connected := connectedApiSessionIds[apiSessionId]
+		return connected
+	})
+
+	return self.postureCache.EvictInactive(retention)
 }
 
 // HasBindAccess evaluates service binding authorization, determining if an

--- a/router/xgress_edge/connections.go
+++ b/router/xgress_edge/connections.go
@@ -41,6 +41,18 @@ import (
 	cmap "github.com/orcaman/concurrent-map/v2"
 )
 
+const (
+	// postureEvictionInterval is how often disconnected api sessions' posture data is swept.
+	postureEvictionInterval = time.Minute
+
+	// postureDataRetention is how long posture data is kept after an api session's last
+	// connection to this router goes away. It is generous relative to a reconnect so that a
+	// client that drops and comes back keeps its posture state, most importantly the MFA-passed
+	// time, which a reconnect alone does not always re-establish: the SDK only reports posture
+	// for services it is actively dialing or binding.
+	postureDataRetention = 5 * time.Minute
+)
+
 type identityConnect struct {
 	srcAddr     string
 	dstAddr     string
@@ -78,7 +90,10 @@ func (self *identityState) markConnect(ch channel.Channel, queueEvent bool) {
 	}
 }
 
-func (self *identityState) markDisconnect(ch channel.Channel) {
+// markDisconnect removes ch from the identity's connections, reporting whether any remaining
+// connection still belongs to apiSessionId. An empty apiSessionId reports true: with no session
+// to attribute the closing channel to, nothing is treated as having disconnected.
+func (self *identityState) markDisconnect(ch channel.Channel, apiSessionId string) bool {
 	self.Lock()
 	defer self.Unlock()
 	startLen := len(self.connections)
@@ -88,6 +103,21 @@ func (self *identityState) markDisconnect(ch channel.Channel) {
 	if startLen > 0 && len(self.connections) == 0 {
 		self.unreported.stateChanged = true
 	}
+
+	if apiSessionId == "" {
+		return true
+	}
+
+	// An identity can hold several api sessions at once (one per device), and a session can
+	// briefly hold more than one channel across a reconnect, so the session is only disconnected
+	// once none of the remaining channels carry it.
+	for _, remaining := range self.connections {
+		if apiSessionToken := state.GetApiSessionTokenFromCh(remaining); apiSessionToken != nil && apiSessionToken.Id == apiSessionId {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (self *identityState) getConnectedStateEvent(id string) *edge_ctrl_pb.ConnectEvents_IdentityConnectEvents {
@@ -196,6 +226,9 @@ func (self *connectionTracker) runLoop(closeNotify <-chan struct{}) {
 	circuitPostDialAccessCheckTicker := time.NewTicker(time.Minute)
 	defer circuitPostDialAccessCheckTicker.Stop()
 
+	postureEvictionTicker := time.NewTicker(postureEvictionInterval)
+	defer postureEvictionTicker.Stop()
+
 	for {
 		select {
 		case <-reportTicker.C:
@@ -207,6 +240,8 @@ func (self *connectionTracker) runLoop(closeNotify <-chan struct{}) {
 			self.scanForInactiveStateListeners()
 		case <-circuitPostDialAccessCheckTicker.C:
 			self.scanForCircuitsNeedingPolicyCheck()
+		case <-postureEvictionTicker.C:
+			self.evictInactivePostureData()
 		case <-closeNotify:
 			return
 		}
@@ -223,6 +258,33 @@ func (self *connectionTracker) scanForInactiveStateListeners() {
 
 	for _, clientConn := range toCheck {
 		clientConn.removeStateListenerIfEligible()
+	}
+}
+
+// connectedApiSessionIds returns the set of api sessions with at least one connection to this
+// router.
+func (self *connectionTracker) connectedApiSessionIds() map[string]struct{} {
+	result := map[string]struct{}{}
+	for entry := range self.states.IterBuffered() {
+		idState := entry.Val
+		idState.Lock()
+		for _, ch := range idState.connections {
+			if apiSessionToken := state.GetApiSessionTokenFromCh(ch); apiSessionToken != nil {
+				result[apiSessionToken.Id] = struct{}{}
+			}
+		}
+		idState.Unlock()
+	}
+	return result
+}
+
+// evictInactivePostureData drops cached posture data for api sessions that have been disconnected
+// from this router for longer than postureDataRetention. Without it the posture cache grows for
+// the life of the process, since every re-authentication produces a new api session id.
+func (self *connectionTracker) evictInactivePostureData() {
+	evicted := self.stateManager.SweepInactivePostureData(self.connectedApiSessionIds(), postureDataRetention)
+	if evicted > 0 {
+		pfxlog.Logger().WithField("evicted", evicted).Debug("evicted posture data for disconnected api sessions")
 	}
 }
 
@@ -350,6 +412,13 @@ func (self *connectionTracker) notifyNeedsFullSync() {
 
 func (self *connectionTracker) markConnected(identityId string, ch channel.Channel) {
 	pfxlog.Logger().WithField("identityId", identityId).Trace("marking connected")
+
+	// Retain the session's posture data before it is discoverable through the connection snapshot
+	// an eviction sweep takes, so a reconnect cannot be overtaken by a sweep already in flight.
+	if apiSessionToken := state.GetApiSessionTokenFromCh(ch); apiSessionToken != nil {
+		self.stateManager.NotifyApiSessionConnected(apiSessionToken.Id)
+	}
+
 	queueEvent := self.enabled && self.queuedEventCounter.Load() < self.maxQueuedEvents
 	self.states.Upsert(identityId, nil, func(exist bool, valueInMap *identityState, newValue *identityState) *identityState {
 		if valueInMap == nil {
@@ -366,13 +435,27 @@ func (self *connectionTracker) markConnected(identityId string, ch channel.Chann
 
 func (self *connectionTracker) markDisconnected(identityId string, ch channel.Channel) {
 	pfxlog.Logger().WithField("identityId", identityId).Trace("marking disconnected")
+
+	apiSessionId := ""
+	if apiSessionToken := state.GetApiSessionTokenFromCh(ch); apiSessionToken != nil {
+		apiSessionId = apiSessionToken.Id
+	}
+
+	apiSessionStillConnected := true
 	self.states.Upsert(identityId, nil, func(exist bool, valueInMap *identityState, newValue *identityState) *identityState {
 		if valueInMap == nil {
 			valueInMap = &identityState{}
 		}
-		valueInMap.markDisconnect(ch)
+		apiSessionStillConnected = valueInMap.markDisconnect(ch, apiSessionId)
 		return valueInMap
 	})
+
+	// Notified outside the upsert callback: the posture cache takes its own locks, and the
+	// connect path notifies it before touching this map, so notifying while holding the map
+	// would invert that order.
+	if apiSessionId != "" && !apiSessionStillConnected {
+		self.stateManager.NotifyApiSessionDisconnected(apiSessionId)
+	}
 }
 
 func (self *connectionTracker) report() {


### PR DESCRIPTION
Fixes #4357. Backport of #4356 (#4323) to release-v2.0.x.

Cherry-pick of 33eea80f3 with three adaptations for this branch:

- sdk-golang import path in the test (no `/v2` here)
- the `Manager` interface and implementation additions were placed without the `SeedMfaFromApiSession` and `GetPostureData` context they sit beside on main, neither of which exists on this branch
- dropped the mid-connect test case: on this branch `AddResponses` is the only path that creates a posture instance (there is no token-seeded instance), so that case reduces to "never reported disconnected", which `Test_EvictInactive_KeepsConnectedSessions` already covers

Worth a look during review: the hunk that clears the recorded disconnect on posture activity applies to the inline `Upsert` in `AddResponses` here, where main has since factored that out into `getOrCreateInstance`. Same behavior, different shape.