### PR TITLE
fix openziti/ziti#4350: cache policy enforcer meters

### DIFF
--- a/controller/internal/policy/api_session_enforcer.go
+++ b/controller/internal/policy/api_session_enforcer.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/michaelquigley/pfxlog"
+	"github.com/openziti/metrics"
 	"github.com/openziti/ziti/v2/common/runner"
 	"github.com/openziti/ziti/v2/controller/change"
 	"github.com/openziti/ziti/v2/controller/env"
@@ -39,6 +40,7 @@ const (
 type ApiSessionEnforcer struct {
 	appEnv         model.Env
 	sessionTimeout time.Duration
+	deleteMeter    metrics.Meter
 	*runner.BaseOperation
 }
 
@@ -55,6 +57,7 @@ func NewSessionEnforcer(appEnv *env.AppEnv, frequency time.Duration, sessionTime
 	return &ApiSessionEnforcer{
 		appEnv:         appEnv,
 		sessionTimeout: sessionTimeout,
+		deleteMeter:    appEnv.GetMetricsRegistry().Meter(ApiSessionEnforcerDelete),
 		BaseOperation:  runner.NewBaseOperation("ApiSessionEnforcer", frequency),
 	}
 }
@@ -108,7 +111,7 @@ func (s *ApiSessionEnforcer) Run() error {
 					logrus.WithError(err).Errorf("failure while deleting expired api session: %v", id)
 				}
 			}
-			s.appEnv.GetMetricsRegistry().Meter(ApiSessionEnforcerDelete).Mark(int64(len(ids)))
+			s.deleteMeter.Mark(int64(len(ids)))
 		}
 	}
 

--- a/controller/internal/policy/revocation_enforcer.go
+++ b/controller/internal/policy/revocation_enforcer.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/michaelquigley/pfxlog"
+	"github.com/openziti/metrics"
 	"github.com/openziti/ziti/v2/common/runner"
 	"github.com/openziti/ziti/v2/controller/change"
 	"github.com/openziti/ziti/v2/controller/command"
@@ -36,8 +37,9 @@ const (
 // controller database and router data models. It only runs on the raft leader
 // (or in a leaderless configuration) to avoid redundant batch-delete dispatches.
 type RevocationEnforcer struct {
-	appEnv     *env.AppEnv
-	dispatcher command.Dispatcher
+	appEnv      *env.AppEnv
+	dispatcher  command.Dispatcher
+	deleteMeter metrics.Meter
 	*runner.BaseOperation
 }
 
@@ -46,6 +48,7 @@ func NewRevocationEnforcer(appEnv *env.AppEnv, frequency time.Duration, dispatch
 	return &RevocationEnforcer{
 		appEnv:        appEnv,
 		dispatcher:    dispatcher,
+		deleteMeter:   appEnv.GetMetricsRegistry().Meter(RevocationEnforcerDelete),
 		BaseOperation: runner.NewBaseOperation("RevocationEnforcer", frequency),
 	}
 }
@@ -72,7 +75,7 @@ func (e *RevocationEnforcer) Run() error {
 
 	if total > 0 {
 		pfxlog.Logger().Debugf("removed %d expired revocations", total)
-		e.appEnv.GetMetricsRegistry().Meter(RevocationEnforcerDelete).Mark(int64(total))
+		e.deleteMeter.Mark(int64(total))
 	}
 
 	return nil

--- a/controller/internal/policy/service_policy_enforcer.go
+++ b/controller/internal/policy/service_policy_enforcer.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/michaelquigley/pfxlog"
+	"github.com/openziti/metrics"
 	"github.com/openziti/ziti/v2/common/runner"
 	"github.com/openziti/ziti/v2/controller/change"
 	"github.com/openziti/ziti/v2/controller/db"
@@ -39,14 +40,18 @@ const (
 type ServicePolicyEnforcer struct {
 	appEnv *env.AppEnv
 	*runner.BaseOperation
-	notify chan struct{}
+	notify            chan struct{}
+	eventDeletesMeter metrics.Meter
+	runDeletesMeter   metrics.Meter
 }
 
 func NewServicePolicyEnforcer(appEnv *env.AppEnv, f time.Duration) *ServicePolicyEnforcer {
 	result := &ServicePolicyEnforcer{
-		appEnv:        appEnv,
-		BaseOperation: runner.NewBaseOperation("ServicePolicyEnforcer", f),
-		notify:        make(chan struct{}, 1),
+		appEnv:            appEnv,
+		BaseOperation:     runner.NewBaseOperation("ServicePolicyEnforcer", f),
+		notify:            make(chan struct{}, 1),
+		eventDeletesMeter: appEnv.GetMetricsRegistry().Meter(SessionPolicyEnforcerEventDeletes),
+		runDeletesMeter:   appEnv.GetMetricsRegistry().Meter(SessionPolicyEnforcerRunDeletes),
 	}
 	result.notify <- struct{}{} // ensure we do a full scan on startup
 	db.ServiceEvents.AddServiceEventHandler(result.handleServiceEvent)
@@ -109,7 +114,7 @@ func (enforcer *ServicePolicyEnforcer) handleServiceEvent(event *db.ServiceEvent
 		log.Debugf("session %v deleted", sessionId)
 	}
 
-	enforcer.appEnv.GetMetricsRegistry().Meter(SessionPolicyEnforcerEventDeletes).Mark(int64(len(sessionsToDelete)))
+	enforcer.eventDeletesMeter.Mark(int64(len(sessionsToDelete)))
 }
 
 func (enforcer *ServicePolicyEnforcer) Run() error {
@@ -174,7 +179,7 @@ func (enforcer *ServicePolicyEnforcer) Run() error {
 		_ = enforcer.appEnv.GetManagers().Session.Delete(sessionId, ctx)
 	}
 
-	enforcer.appEnv.GetMetricsRegistry().Meter(SessionPolicyEnforcerRunDeletes).Mark(int64(len(sessionsToRemove)))
+	enforcer.runDeletesMeter.Mark(int64(len(sessionsToRemove)))
 
 	return nil
 }

--- a/controller/internal/policy/session_enforcer_test.go
+++ b/controller/internal/policy/session_enforcer_test.go
@@ -21,11 +21,11 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/openziti/ziti/v2/controller/storage/boltz"
-	"github.com/openziti/ziti/v2/controller/storage/boltztest"
 	"github.com/openziti/ziti/v2/common/eid"
 	"github.com/openziti/ziti/v2/controller/db"
 	"github.com/openziti/ziti/v2/controller/model"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
+	"github.com/openziti/ziti/v2/controller/storage/boltztest"
 	"github.com/sirupsen/logrus"
 )
 
@@ -74,6 +74,7 @@ func (ctx *enforcerTestContext) testSessionsCleanup() {
 	enforcer := &ApiSessionEnforcer{
 		appEnv:         ctx,
 		sessionTimeout: -time.Second,
+		deleteMeter:    ctx.GetMetricsRegistry().Meter(ApiSessionEnforcerDelete),
 	}
 
 	ctx.NoError(enforcer.Run())


### PR DESCRIPTION
fix openziti/ziti#4350

## Summary

Cache the reference-counted metrics meters used by the policy enforcers instead of resolving them during every enforcement cycle or service-policy event. This prevents the registry reference count from growing indefinitely and allows `DisposeAll` to release the meters correctly.

The existing timers remain unchanged because they are not reference-counted.

## Testing

- `go test ./controller/internal/policy`
- `git diff --check`