### PR TITLE
[Backport-2.0] Restore legacy API session activity marking for REST requests

### DIFF
--- a/common/security_tokens.go
+++ b/common/security_tokens.go
@@ -17,6 +17,9 @@ import (
 // MaxBearerTokensProcessed represents the maximum number of bearer tokens that will be processed.
 const MaxBearerTokensProcessed = 3
 
+// ZtSessionHeader is the request and response header carrying a legacy API session token.
+const ZtSessionHeader = "zt-session"
+
 // TokenIssuer represents a JWT token issuer capable of verifying tokens.
 // Implementations provide token verification, configuration queries, and claim extraction.
 type TokenIssuer interface {
@@ -397,6 +400,12 @@ func (s *SecurityTokenCtx) AddToRequest(r *http.Request) {
 	*r = *r.WithContext(context.WithValue(r.Context(), SecurityTokenCtxKey, s))
 }
 
+// HasZtSessionHeader reports whether the request carries a non-empty zt-Session header. It
+// inspects the header only; no tokens are parsed or verified.
+func (s *SecurityTokenCtx) HasZtSessionHeader() bool {
+	return s.httpRequest != nil && strings.TrimSpace(s.httpRequest.Header.Get(ZtSessionHeader)) != ""
+}
+
 // IsZtSession returns true if the request carried a legacy zt-Session header. It triggers
 // header processing if not already done.
 func (s *SecurityTokenCtx) IsZtSession() bool {
@@ -479,7 +488,7 @@ func (s *SecurityTokenCtx) processHeaders() error {
 	s.fillOnce.Do(func() {
 		defer func() { s.hasProcessedHeaders = true }()
 
-		s.ztSession = strings.TrimSpace(s.httpRequest.Header.Get("zt-Session"))
+		s.ztSession = strings.TrimSpace(s.httpRequest.Header.Get(ZtSessionHeader))
 
 		s.rawAuthorizationHeaders = s.httpRequest.Header.Values("Authorization")
 

--- a/controller/api/cors.go
+++ b/controller/api/cors.go
@@ -20,11 +20,7 @@ import (
 	"net/http"
 
 	"github.com/gorilla/handlers"
-)
-
-const (
-	// ZitiSession is the header value used to pass Ziti sessions around
-	ZitiSession = "zt-session"
+	"github.com/openziti/ziti/v2/common"
 )
 
 func WrapCorsHandler(innerHandler http.Handler) http.Handler {
@@ -35,7 +31,7 @@ func WrapCorsHandler(innerHandler http.Handler) http.Handler {
 			"content-type",
 			"accept",
 			"authorization",
-			ZitiSession,
+			common.ZtSessionHeader,
 		}),
 		handlers.AllowedMethods([]string{
 			http.MethodGet,

--- a/controller/env/appenv.go
+++ b/controller/env/appenv.go
@@ -81,7 +81,6 @@ import (
 var _ model.Env = &AppEnv{}
 
 const (
-	ZitiSession      = "zt-session"
 	ClientApiBinding = "edge-client"
 
 	JwtAudEnrollment = "openziti-enroller"
@@ -915,6 +914,13 @@ func (ae *AppEnv) CreateRequestContext(rw http.ResponseWriter, r *http.Request) 
 
 	securityCtx := NewSecurityCtx(securityTokenCtx, ae)
 	securityCtx.AddToRequest(r)
+
+	// Legacy zt-session tokens are resolved up front so that every request carrying one counts as
+	// activity on its API session and gets session lifetime headers, regardless of endpoint.
+	// Bearer tokens stay lazy.
+	if securityTokenCtx.HasZtSessionHeader() {
+		securityCtx.resolve()
+	}
 
 	requestContext := &response.RequestContext{
 		Id:             rid,

--- a/controller/env/security_ctx.go
+++ b/controller/env/security_ctx.go
@@ -27,12 +27,12 @@ import (
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/edge-api/rest_model"
 	"github.com/openziti/foundation/v2/errorz"
-	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/openziti/ziti/v2/common"
 	"github.com/openziti/ziti/v2/common/spiffehlp"
 	"github.com/openziti/ziti/v2/controller/model"
 	"github.com/openziti/ziti/v2/controller/models"
 	"github.com/openziti/ziti/v2/controller/permissions"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
 )
 
 // SecurityCtx resolves and caches the full authentication context for a single HTTP request.
@@ -341,6 +341,8 @@ func (ctx *SecurityCtx) resolveZtSession(securityToken *common.SecurityToken) {
 		ctx.setApiSessionError(errorz.NewUnauthorizedZtSessionInvalid())
 		return
 	}
+
+	ctx.env.GetManagers().ApiSession.MarkLastActivityById(apiSession.Id)
 
 	identity, err := ctx.env.GetManagers().Identity.Read(apiSession.IdentityId)
 

--- a/controller/internal/routes/authenticate_router.go
+++ b/controller/internal/routes/authenticate_router.go
@@ -210,7 +210,7 @@ func (ro *AuthRouter) authHandler(ae *env.AppEnv, rc *response.RequestContext, h
 
 	ae.GetManagers().PostureResponse.SetSdkInfo(identity.Id, sessionId, identity.SdkInfo)
 
-	rc.Request.Header.Set("zt-session", filledApiSession.Token)
+	rc.Request.Header.Set(common.ZtSessionHeader, filledApiSession.Token)
 	securityToken, err := common.NewSecurityTokenCtx(rc.Request, ae.TokenIssuerCache)
 
 	if err != nil {
@@ -228,7 +228,7 @@ func (ro *AuthRouter) authHandler(ae *env.AppEnv, rc *response.RequestContext, h
 
 	envelope := &rest_model.CurrentAPISessionDetailEnvelope{Data: apiSession, Meta: &rest_model.Meta{}}
 
-	rc.ResponseWriter.Header().Set(env.ZitiSession, filledApiSession.Token)
+	rc.ResponseWriter.Header().Set(common.ZtSessionHeader, filledApiSession.Token)
 
 	ro.createTimer.UpdateSince(start)
 

--- a/controller/response/headers.go
+++ b/controller/response/headers.go
@@ -38,26 +38,34 @@ func AddHeaders(rc *RequestContext) {
 		rc.ResponseWriter.Header().Set(ServerHeader, "ziti-controller/"+buildInfo.Version())
 	}
 
-	AddApiSessionHeaders(rc)
+	addApiSessionLifetimeHeaders(rc)
 }
 
 // AddApiSessionHeaders writes API-session lifetime headers when a resolved session is
 // available, and appends WWW-Authenticate or other structured error headers from any
-// MFA or session-level errors so that clients can determine the next required action.
+// MFA error so that clients can determine the next required action. Session-level errors
+// are not reported here; the unauthorized response for a protected endpoint carries them.
 func AddApiSessionHeaders(rc *RequestContext) {
-	if apiSession, apiSessionErr := rc.SecurityCtx.GetApiSessionWithoutResolve(); apiSession != nil {
-		rc.ResponseWriter.Header().Set(ApiSessionExpirationSecondsHeader, strconv.FormatInt(int64(apiSession.ExpirationDuration.Seconds()), 10))
-		rc.ResponseWriter.Header().Set(ApiSessionExpiresAtHeader, apiSession.ExpiresAt.String())
-
-		// add any headers for MFA errors
-		mfaErr := rc.SecurityCtx.GetMfaErrorWithoutResolve()
-
-		if mfaErr != nil {
-			addApiErrorHeaders(rc, mfaErr)
-		}
-	} else if apiSessionErr != nil {
-		addApiErrorHeaders(rc, apiSessionErr)
+	if !addApiSessionLifetimeHeaders(rc) {
+		return
 	}
+
+	if mfaErr := rc.SecurityCtx.GetMfaErrorWithoutResolve(); mfaErr != nil {
+		addApiErrorHeaders(rc, mfaErr)
+	}
+}
+
+// addApiSessionLifetimeHeaders writes the expiration headers for an already-resolved API
+// session and reports whether a session was present.
+func addApiSessionLifetimeHeaders(rc *RequestContext) bool {
+	apiSession, _ := rc.SecurityCtx.GetApiSessionWithoutResolve()
+	if apiSession == nil {
+		return false
+	}
+
+	rc.ResponseWriter.Header().Set(ApiSessionExpirationSecondsHeader, strconv.FormatInt(int64(apiSession.ExpirationDuration.Seconds()), 10))
+	rc.ResponseWriter.Header().Set(ApiSessionExpiresAtHeader, apiSession.ExpiresAt.String())
+	return true
 }
 
 // addApiErrorHeaders extracts header key-value pairs from an errorz.ApiError and writes

--- a/tests/api_session_activity_test.go
+++ b/tests/api_session_activity_test.go
@@ -1,0 +1,99 @@
+//go:build apitests
+
+package tests
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/openziti/edge-api/rest_model"
+	"github.com/openziti/ziti/v2/controller/response"
+)
+
+// Test_ApiSession_LegacyRestActivity verifies that REST requests carrying a legacy zt-session token
+// count as activity on that API session, so the session's idle timeout is reset by API use and not
+// only by edge router connections.
+func Test_ApiSession_LegacyRestActivity(t *testing.T) {
+	ctx := NewTestContext(t)
+	defer ctx.Teardown()
+	ctrl := ctx.StartServer()
+	ctx.RequireAdminManagementApiLogin()
+
+	collector := ctrl.AppEnv.GetManagers().ApiSession.HeartbeatCollector
+	apiSessionId := *ctx.AdminManagementSession.AuthResponse.ID
+
+	lastActivity := func() time.Time {
+		at, ok := collector.LastAccessedAt(apiSessionId)
+		ctx.Req.True(ok, "expected api session %s to have a last activity time", apiSessionId)
+		return *at
+	}
+
+	// The collector records wall-clock time, so leave a gap between the reference read and the
+	// request under test rather than relying on sub-millisecond resolution.
+	settle := func() { time.Sleep(20 * time.Millisecond) }
+
+	t.Run("an anonymous request does not mark activity", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		before := lastActivity()
+		settle()
+
+		resp, err := ctx.newAnonymousManagementApiRequest().Get("/version")
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusOK, resp.StatusCode(), resp.String())
+
+		ctx.Req.Equal(before, lastActivity())
+	})
+
+	t.Run("a request to an authenticated endpoint marks activity", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		before := lastActivity()
+		settle()
+
+		resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().Get("/current-identity")
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusOK, resp.StatusCode(), resp.String())
+
+		after := lastActivity()
+		ctx.Req.True(after.After(before), "expected activity to advance past %s, got %s", before, after)
+	})
+
+	t.Run("a request to an anonymous endpoint with a session token marks activity", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		before := lastActivity()
+		settle()
+
+		resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().Get("/")
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusOK, resp.StatusCode(), resp.String())
+
+		after := lastActivity()
+		ctx.Req.True(after.After(before), "expected activity to advance past %s, got %s", before, after)
+
+		t.Run("and the response carries session lifetime headers", func(t *testing.T) {
+			ctx.testContextChanged(t)
+
+			ctx.Req.NotEmpty(resp.Header().Get(response.ApiSessionExpirationSecondsHeader))
+			ctx.Req.NotEmpty(resp.Header().Get(response.ApiSessionExpiresAtHeader))
+		})
+	})
+
+	t.Run("current api session reports the latest activity", func(t *testing.T) {
+		ctx.testContextChanged(t)
+
+		before := lastActivity()
+		settle()
+
+		envelope := &rest_model.CurrentAPISessionDetailEnvelope{}
+		resp, err := ctx.AdminManagementSession.newAuthenticatedRequest().SetResult(envelope).Get("/current-api-session")
+		ctx.Req.NoError(err)
+		ctx.Req.Equal(http.StatusOK, resp.StatusCode(), resp.String())
+		ctx.Req.NotNil(envelope.Data)
+
+		reported := time.Time(envelope.Data.CachedLastActivityAt)
+		ctx.Req.True(reported.After(before), "expected reported activity %s to be after %s", reported, before)
+	})
+}

--- a/tests/auth_cert_test.go
+++ b/tests/auth_cert_test.go
@@ -36,11 +36,11 @@ import (
 	"github.com/openziti/edge-api/rest_model"
 	nfPem "github.com/openziti/foundation/v2/pem"
 	edge_apis "github.com/openziti/sdk-golang/edge-apis"
+	"github.com/openziti/ziti/v2/common"
 	"github.com/openziti/ziti/v2/common/cert"
 	"github.com/openziti/ziti/v2/common/eid"
 	"github.com/openziti/ziti/v2/controller/change"
 	"github.com/openziti/ziti/v2/controller/config"
-	"github.com/openziti/ziti/v2/controller/env"
 	"github.com/openziti/ziti/v2/controller/model"
 	"github.com/stretchr/testify/require"
 )
@@ -166,7 +166,7 @@ func (test *authCertTests) testAuthenticateValidCertValidClientInfoBody(t *testi
 	standardJsonResponseTests(resp, http.StatusOK, t)
 
 	t.Run("returns a session token HTTP headers", func(t *testing.T) {
-		require.New(t).NotEmpty(resp.Header().Get(env.ZitiSession), fmt.Sprintf("HTTP header %s is empty", env.ZitiSession))
+		require.New(t).NotEmpty(resp.Header().Get(common.ZtSessionHeader), fmt.Sprintf("HTTP header %s is empty", common.ZtSessionHeader))
 	})
 
 	t.Run("returns a session token in body", func(t *testing.T) {
@@ -186,7 +186,7 @@ func (test *authCertTests) testAuthenticateValidCertValidClientInfoBody(t *testi
 		r.NoError(err)
 
 		bodyToken := data.Path("data.token").Data().(string)
-		headerToken := resp.Header().Get(env.ZitiSession)
+		headerToken := resp.Header().Get(common.ZtSessionHeader)
 		r.Equal(bodyToken, headerToken)
 	})
 
@@ -299,7 +299,7 @@ func (test *authCertTests) testAuthenticateValidCertInvalidJson(t *testing.T) {
 	standardErrorJsonResponseTests(resp, "COULD_NOT_PARSE_BODY", http.StatusBadRequest, t)
 
 	t.Run("returns without a ziti session header", func(t *testing.T) {
-		require.New(t).Equal("", resp.Header().Get(env.ZitiSession))
+		require.New(t).Equal("", resp.Header().Get(common.ZtSessionHeader))
 	})
 }
 
@@ -382,7 +382,7 @@ rv1CXRECfHglY+vO0CFumQOV5bec2R8=
 	standardErrorJsonResponseTests(resp, "INVALID_AUTH", http.StatusUnauthorized, t)
 
 	t.Run("returns without a ziti session header", func(t *testing.T) {
-		require.New(t).Equal("", resp.Header().Get(env.ZitiSession))
+		require.New(t).Equal("", resp.Header().Get(common.ZtSessionHeader))
 	})
 }
 
@@ -483,7 +483,7 @@ func (test *authCertTests) testAuthenticateValidCertEmptyBody(t *testing.T) {
 	standardJsonResponseTests(resp, http.StatusOK, t)
 
 	t.Run("returns a session token HTTP headers", func(t *testing.T) {
-		require.New(t).NotEmpty(resp.Header().Get(env.ZitiSession), fmt.Sprintf("HTTP header %s is empty", env.ZitiSession))
+		require.New(t).NotEmpty(resp.Header().Get(common.ZtSessionHeader), fmt.Sprintf("HTTP header %s is empty", common.ZtSessionHeader))
 	})
 
 	t.Run("returns a session token in body", func(t *testing.T) {
@@ -511,7 +511,7 @@ func (test *authCertTests) testAuthenticateValidCertEmptyBody(t *testing.T) {
 		r.NoError(err)
 
 		bodyToken := data.Path("data.token").Data().(string)
-		headerToken := resp.Header().Get(env.ZitiSession)
+		headerToken := resp.Header().Get(common.ZtSessionHeader)
 		r.Equal(bodyToken, headerToken)
 	})
 

--- a/tests/authenticate.go
+++ b/tests/authenticate.go
@@ -38,9 +38,9 @@ import (
 	"github.com/openziti/edge-api/rest_model"
 	"github.com/openziti/foundation/v2/stringz"
 	"github.com/openziti/sdk-golang/ziti"
+	"github.com/openziti/ziti/v2/common"
 	"github.com/openziti/ziti/v2/common/cert"
 	"github.com/openziti/ziti/v2/common/eid"
-	"github.com/openziti/ziti/v2/controller/env"
 	"github.com/pkg/errors"
 	"gopkg.in/resty.v1"
 )
@@ -318,7 +318,7 @@ func (sess *session) CloneToManagementApi(ctx *TestContext) (*session, error) {
 
 func (sess *session) NewRequest() *resty.Request {
 	if sess.AuthResponse != nil && sess.AuthResponse.Token != nil {
-		return sess.client.R().SetHeader(env.ZitiSession, *sess.AuthResponse.Token)
+		return sess.client.R().SetHeader(common.ZtSessionHeader, *sess.AuthResponse.Token)
 	}
 
 	return sess.client.R()

--- a/tests/context.go
+++ b/tests/context.go
@@ -61,10 +61,10 @@ import (
 	"github.com/openziti/transport/v2"
 	"github.com/openziti/transport/v2/tcp"
 	"github.com/openziti/transport/v2/tls"
+	"github.com/openziti/ziti/v2/common"
 	"github.com/openziti/ziti/v2/common/eid"
 	"github.com/openziti/ziti/v2/controller"
 	"github.com/openziti/ziti/v2/controller/config"
-	"github.com/openziti/ziti/v2/controller/env"
 	restClientRouter "github.com/openziti/ziti/v2/controller/rest_client/router"
 	fabricRestModel "github.com/openziti/ziti/v2/controller/rest_model"
 	"github.com/openziti/ziti/v2/controller/server"
@@ -395,7 +395,7 @@ func (ctx *TestContext) NewWsMgmtChannel(bindHandler channel.BindHandler) (chann
 	}
 
 	authHeader := http.Header{}
-	authHeader.Set(env.ZitiSession, *ctx.AdminManagementSession.AuthResponse.Token)
+	authHeader.Set(common.ZtSessionHeader, *ctx.AdminManagementSession.AuthResponse.Token)
 
 	conn, resp, err := dialer.Dial(wsUrl, authHeader)
 	if err != nil {

--- a/tests/enrollment_identity_extend_test.go
+++ b/tests/enrollment_identity_extend_test.go
@@ -40,7 +40,6 @@ import (
 	edge_apis "github.com/openziti/sdk-golang/edge-apis"
 	"github.com/openziti/ziti/v2/common"
 	"github.com/openziti/ziti/v2/common/eid"
-	"github.com/openziti/ziti/v2/controller/env"
 	"github.com/openziti/ziti/v2/ziti/util"
 	"gopkg.in/resty.v1"
 )
@@ -404,7 +403,7 @@ func Test_EnrollmentIdentityExtend(t *testing.T) {
 		client := resty.New().SetTLSClientConfig(&tls.Config{
 			InsecureSkipVerify: true,
 		})
-		extendResp, err := client.R().SetHeader(env.ZitiSession, *identityApiSession.AuthResponse.Token).SetBody(csrRequest).Post(resolvedUrl)
+		extendResp, err := client.R().SetHeader(common.ZtSessionHeader, *identityApiSession.AuthResponse.Token).SetBody(csrRequest).Post(resolvedUrl)
 		ctx.Req.NoError(err)
 		ctx.Req.Equal(401, extendResp.StatusCode())
 	})
@@ -449,7 +448,7 @@ func Test_EnrollmentIdentityExtend(t *testing.T) {
 
 		extendUrl := fmt.Sprintf("/current-identity/authenticators/%s/extend", *currentAuthenticator.ID)
 		//use second identity http client w/ first identity's API Session
-		extendResp, err := secondIdentityApiSession.NewRequest().SetHeader(env.ZitiSession, *identityApiSession.AuthResponse.Token).SetBody(csrRequest).Post(extendUrl)
+		extendResp, err := secondIdentityApiSession.NewRequest().SetHeader(common.ZtSessionHeader, *identityApiSession.AuthResponse.Token).SetBody(csrRequest).Post(extendUrl)
 		ctx.Req.NoError(err)
 		ctx.Req.Equal(401, extendResp.StatusCode())
 	})

--- a/ziti/util/identities.go
+++ b/ziti/util/identities.go
@@ -20,7 +20,7 @@ import (
 	"github.com/openziti/edge-api/rest_management_api_client"
 	edge_apis "github.com/openziti/sdk-golang/edge-apis"
 	"github.com/openziti/sdk-golang/ziti"
-	"github.com/openziti/ziti/v2/controller/env"
+	zitiCommon "github.com/openziti/ziti/v2/common"
 	fabric_rest_client "github.com/openziti/ziti/v2/controller/rest_client"
 	"github.com/openziti/ziti/v2/ziti/cmd/common"
 	"github.com/openziti/ziti/v2/ziti/constants"
@@ -180,12 +180,12 @@ func (self *RestClientEdgeIdentity) NewRequest(client *resty.Client) *resty.Requ
 			authHeader := "Bearer " + strings.TrimSpace(string(self.ApiSession.ApiSession.GetToken()))
 			r.SetHeader("Authorization", authHeader)
 		case edge_apis.ApiSessionTypeLegacy:
-			r.SetHeader(env.ZitiSession, string(self.ApiSession.ApiSession.GetToken()))
+			r.SetHeader(zitiCommon.ZtSessionHeader, string(self.ApiSession.ApiSession.GetToken()))
 		default:
 			panic("unsupported api session type " + self.ApiSession.ApiSession.GetType())
 		}
 	} else {
-		r.SetHeader(env.ZitiSession, self.Token)
+		r.SetHeader(zitiCommon.ZtSessionHeader, self.Token)
 	}
 	return r
 }
@@ -331,10 +331,10 @@ func (self *RestClientEdgeIdentity) NewWsHeader() http.Header {
 		if self.ApiSession.ApiSession.GetType() == edge_apis.ApiSessionTypeOidc {
 			result.Set("Authorization", "Bearer "+strings.TrimSpace(string(self.ApiSession.ApiSession.GetToken())))
 		} else {
-			result.Set(env.ZitiSession, string(self.ApiSession.ApiSession.GetToken()))
+			result.Set(zitiCommon.ZtSessionHeader, string(self.ApiSession.ApiSession.GetToken()))
 		}
 	} else if self.Token != "" {
-		result.Set(env.ZitiSession, self.Token)
+		result.Set(zitiCommon.ZtSessionHeader, self.Token)
 	} else {
 		panic("no  authentication mechanism set")
 	}

--- a/ziti/util/rest.go
+++ b/ziti/util/rest.go
@@ -34,7 +34,7 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/openziti/edge-api/rest_management_api_client"
 	"github.com/openziti/edge-api/rest_model"
-	"github.com/openziti/ziti/v2/controller/api"
+	"github.com/openziti/ziti/v2/common"
 	fabric_rest_client "github.com/openziti/ziti/v2/controller/rest_client"
 	"gopkg.in/resty.v1"
 )
@@ -310,7 +310,7 @@ type EdgeManagementAuth struct {
 
 func (e EdgeManagementAuth) AuthenticateRequest(request openApiRuntime.ClientRequest, registry strfmt.Registry) error {
 	if e.LegacyToken != "" {
-		return request.SetHeaderParam(api.ZitiSession, e.LegacyToken)
+		return request.SetHeaderParam(common.ZtSessionHeader, e.LegacyToken)
 	} else {
 		return request.SetHeaderParam("Authorization", "Bearer "+e.BearerToken)
 	}

--- a/zitirest/clients.go
+++ b/zitirest/clients.go
@@ -42,8 +42,7 @@ import (
 	"github.com/openziti/edge-api/rest_model"
 	"github.com/openziti/foundation/v2/concurrenz"
 	"github.com/openziti/identity"
-	"github.com/openziti/ziti/v2/controller/api"
-	"github.com/openziti/ziti/v2/controller/env"
+	"github.com/openziti/ziti/v2/common"
 	fabricRestClient "github.com/openziti/ziti/v2/controller/rest_client"
 	"github.com/openziti/ziti/v2/ziti/util"
 	"github.com/pkg/errors"
@@ -113,7 +112,7 @@ func (self *Clients) Authenticate(user, password string) error {
 }
 
 func (self *Clients) AuthenticateRequest(request openApiRuntime.ClientRequest, registry strfmt.Registry) error {
-	return request.SetHeaderParam(api.ZitiSession, self.token.Load())
+	return request.SetHeaderParam(common.ZtSessionHeader, self.token.Load())
 }
 
 func (self *Clients) SetSessionToken(token string) {
@@ -132,7 +131,7 @@ func (self *Clients) NewWsMgmtChannel(bindHandler channel.BindHandler) (channel.
 	}
 
 	result := http.Header{}
-	result.Set(env.ZitiSession, self.token.Load())
+	result.Set(common.ZtSessionHeader, self.token.Load())
 
 	conn, resp, err := dialer.Dial(wsUrl, result)
 	if err != nil {


### PR DESCRIPTION
For #4367. Backport of #4366 (fixes #4365) to release-v2.0.x.

Since 2.0.0, REST requests carrying a legacy `zt-session` token no longer mark activity on the API session, so sessions for management-API-only clients expire `sessionTimeout` after login regardless of use, and the session lifetime response headers stopped being emitted outside the authenticate response. This restores the 1.6.x behavior for legacy sessions only: a `zt-session` is resolved eagerly when the request context is created and resolution marks the session's last activity. Bearer tokens remain lazy.

Cherry-picked cleanly; build and the API session, authentication, and auth header tests pass on this branch.