### PR TITLE
[Backport-2.0] Deliver router ctrl events to each listener in order

### DIFF
--- a/router/env/ctrl_event_queue.go
+++ b/router/env/ctrl_event_queue.go
@@ -1,0 +1,62 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package env
+
+import "sync"
+
+// ctrlEventQueue delivers ctrl events to one listener in the order they were queued, one at a time,
+// on a goroutine of its own. A listener that keys on transitions must see a disconnect before the
+// reconnect that follows it, and a slow listener must delay neither the caller nor other listeners.
+type ctrlEventQueue struct {
+	listener CtrlEventListener
+	lock     sync.Mutex
+	pending  []CtrlEvent
+	draining bool
+}
+
+func newCtrlEventQueue(listener CtrlEventListener) *ctrlEventQueue {
+	return &ctrlEventQueue{listener: listener}
+}
+
+// enqueue adds event and starts a drain if none is running. It never blocks on the listener.
+func (self *ctrlEventQueue) enqueue(event CtrlEvent) {
+	self.lock.Lock()
+	self.pending = append(self.pending, event)
+	startDrain := !self.draining
+	self.draining = true
+	self.lock.Unlock()
+
+	if startDrain {
+		go self.drain()
+	}
+}
+
+func (self *ctrlEventQueue) drain() {
+	for {
+		self.lock.Lock()
+		if len(self.pending) == 0 {
+			self.draining = false
+			self.lock.Unlock()
+			return
+		}
+		event := self.pending[0]
+		self.pending = self.pending[1:]
+		self.lock.Unlock()
+
+		self.listener.NotifyOfCtrlEvent(event)
+	}
+}

--- a/router/env/ctrl_event_queue_test.go
+++ b/router/env/ctrl_event_queue_test.go
@@ -1,0 +1,100 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package env
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCtrlEventQueue_DeliversInOrderToSlowListener: a listener that is slow on one event must still see
+// the events after it in the order they were queued, and queuing must not wait for it.
+func TestCtrlEventQueue_DeliversInOrderToSlowListener(t *testing.T) {
+	var lock sync.Mutex
+	var seen []CtrlEventType
+	release := make(chan struct{})
+	first := true
+
+	queue := newCtrlEventQueue(CtrlEventListenerFunc(func(event CtrlEvent) {
+		if first {
+			first = false
+			<-release
+		}
+		lock.Lock()
+		seen = append(seen, event.Type)
+		lock.Unlock()
+	}))
+
+	expected := []CtrlEventType{ControllerAdded, ControllerDisconnected, ControllerReconnected, ControllerLeaderChange}
+	done := make(chan struct{})
+	go func() {
+		for _, eventType := range expected {
+			queue.enqueue(CtrlEvent{Type: eventType})
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("enqueue must not block on a slow listener")
+	}
+
+	lock.Lock()
+	require.Empty(t, seen, "nothing is delivered while the listener is still handling the first event")
+	lock.Unlock()
+
+	close(release)
+	require.Eventually(t, func() bool {
+		lock.Lock()
+		defer lock.Unlock()
+		return len(seen) == len(expected)
+	}, time.Second, time.Millisecond)
+
+	lock.Lock()
+	defer lock.Unlock()
+	require.Equal(t, expected, seen)
+}
+
+// TestCtrlEventQueue_ResumesAfterDraining: once a drain finishes, a later event must start a new one
+// rather than sit in the queue.
+func TestCtrlEventQueue_ResumesAfterDraining(t *testing.T) {
+	received := make(chan CtrlEventType, 4)
+	queue := newCtrlEventQueue(CtrlEventListenerFunc(func(event CtrlEvent) {
+		received <- event.Type
+	}))
+
+	queue.enqueue(CtrlEvent{Type: ControllerAdded})
+	require.Equal(t, ControllerAdded, <-received)
+
+	require.Eventually(t, func() bool {
+		queue.lock.Lock()
+		defer queue.lock.Unlock()
+		return !queue.draining
+	}, time.Second, time.Millisecond)
+
+	queue.enqueue(CtrlEvent{Type: ControllerDisconnected})
+	select {
+	case eventType := <-received:
+		require.Equal(t, ControllerDisconnected, eventType)
+	case <-time.After(time.Second):
+		t.Fatal("event queued after a drain finished was never delivered")
+	}
+}

--- a/router/env/ctrls.go
+++ b/router/env/ctrls.go
@@ -120,7 +120,7 @@ type networkControllers struct {
 	idsBeingDialed        cmap.ConcurrentMap[string, struct{}]
 	ctrls                 concurrenz.CopyOnWriteMap[string, NetworkController]
 	leaderId              concurrenz.AtomicValue[string]
-	ctrlChangeListeners   concurrenz.CopyOnWriteSlice[CtrlEventListener]
+	ctrlChangeListeners   concurrenz.CopyOnWriteSlice[*ctrlEventQueue]
 	controllerDetails     concurrenz.AtomicValue[map[string]*ctrl_pb.CtrlDetail]
 	closed                atomic.Bool
 	// everConnected records that a control channel was established at some point. It is never cleared, so it
@@ -160,7 +160,7 @@ func (self *networkControllers) ControllersHaveMinVersion(version string) bool {
 }
 
 func (self *networkControllers) AddChangeListener(listener CtrlEventListener) {
-	self.ctrlChangeListeners.Append(listener)
+	self.ctrlChangeListeners.Append(newCtrlEventQueue(listener))
 }
 
 func (self *networkControllers) GetControllerDetails() map[string]*ctrl_pb.CtrlDetail {
@@ -395,13 +395,13 @@ func (self *networkControllers) connectToController(endpoint string, addr transp
 	}
 
 	// Track connectivity transitions for reconnect/disconnect notifications
-	var wasDisconnected atomic.Bool
+	connectivity := &connectivityState{}
 	changeCallback := func(ch *ctrlchan.DialCtrlChannel, _, newCount uint32) {
 		multiCh := ch.GetChannel()
 		if multiCh == nil || multiCh.IsClosed() {
 			return
 		}
-		self.notifyOfConnectivityChange(ch.PeerId(), &wasDisconnected, newCount, func() {
+		self.notifyOfConnectivityChange(ch.PeerId(), connectivity, newCount, func() {
 			self.dialEnv.NotifyOfReconnect(ch)
 		})
 	}
@@ -625,17 +625,33 @@ func (self *networkControllers) AcceptCtrlChannel(address string, ctrlCh ctrlcha
 // ControllerReconnected ctrl event is what listeners keyed on connectivity wait for.
 // Sending only the first leaves those listeners believing the controller is still gone.
 //
-// wasDisconnected belongs to the one channel and is swapped rather than stored, so each
-// edge is reported exactly once however many underlays come or go at the same moment.
-func (self *networkControllers) notifyOfConnectivityChange(ctrlId string, wasDisconnected *atomic.Bool, newCount uint32, notifyReconnect func()) {
+// state belongs to the one channel. Its lock is held from deciding that an edge occurred until the
+// event is queued, so each edge is reported exactly once however many underlays come or go at the
+// same moment, and a disconnect is always queued before the reconnect that follows it.
+func (self *networkControllers) notifyOfConnectivityChange(ctrlId string, state *connectivityState, newCount uint32, notifyReconnect func()) {
+	state.lock.Lock()
+	reconnected := false
 	if newCount > 0 {
-		if wasDisconnected.CompareAndSwap(true, false) {
-			notifyReconnect()
+		if state.disconnected {
+			state.disconnected = false
+			reconnected = true
 			self.NotifyOfReconnect(ctrlId)
 		}
-	} else if wasDisconnected.CompareAndSwap(false, true) {
+	} else if !state.disconnected {
+		state.disconnected = true
 		self.NotifyOfDisconnect(ctrlId)
 	}
+	state.lock.Unlock()
+
+	if reconnected {
+		notifyReconnect()
+	}
+}
+
+// connectivityState tracks whether a control channel is currently without underlays.
+type connectivityState struct {
+	lock         sync.Mutex
+	disconnected bool
 }
 
 func (self *networkControllers) NotifyOfDisconnect(ctrlId string) {
@@ -650,12 +666,15 @@ func (self *networkControllers) NotifyOfReconnect(ctrlId string) {
 	}
 }
 
+// notifyOfChange queues the event for every listener. Listeners are notified off the caller's
+// goroutine, and each sees events in the order they were queued.
 func (self *networkControllers) notifyOfChange(controller NetworkController, eventType CtrlEventType) {
-	for _, l := range self.ctrlChangeListeners.Value() {
-		go l.NotifyOfCtrlEvent(CtrlEvent{
-			Type:       eventType,
-			Controller: controller,
-		})
+	event := CtrlEvent{
+		Type:       eventType,
+		Controller: controller,
+	}
+	for _, queue := range self.ctrlChangeListeners.Value() {
+		queue.enqueue(event)
 	}
 }
 

--- a/router/env/ctrls_test.go
+++ b/router/env/ctrls_test.go
@@ -127,24 +127,24 @@ func newTestNetworkCtrl(nc *networkControllers, ctrlId string, label string) (*n
 	return newNetworkCtrl(&ctrlsTestCtrlChannel{ch: ch}, "tls:"+ctrlId+":6262", nc.heartbeatOptions), ch
 }
 
-// collectCtrlEvents registers a listener and returns a function draining the events seen so far. Listeners
-// are notified on their own goroutine, so the buffer carries them back to the test.
+// collectCtrlEvents registers a listener and returns a function reporting every event seen so far, oldest
+// first. Listeners are notified on their own goroutine, so the collector carries them back to the test. It
+// accumulates rather than consumes: Eventually and Never run each condition check on its own goroutine and
+// do not wait for a slow one, so a consuming drain could hand an event to a straggler check whose result is
+// discarded, and the event would be lost to the assertion that needed it.
 func collectCtrlEvents(nc *networkControllers) func() []CtrlEvent {
-	received := make(chan CtrlEvent, 16)
+	var lock sync.Mutex
+	var received []CtrlEvent
 	nc.AddChangeListener(CtrlEventListenerFunc(func(event CtrlEvent) {
-		received <- event
+		lock.Lock()
+		defer lock.Unlock()
+		received = append(received, event)
 	}))
 
 	return func() []CtrlEvent {
-		var result []CtrlEvent
-		for {
-			select {
-			case e := <-received:
-				result = append(result, e)
-			default:
-				return result
-			}
-		}
+		lock.Lock()
+		defer lock.Unlock()
+		return append([]CtrlEvent(nil), received...)
 	}
 }
 
@@ -187,12 +187,11 @@ func TestHandleChannelClose_CurrentUnregisters(t *testing.T) {
 
 	require.Nil(t, nc.ctrls.Get("ctrl1"), "the registered channel closing must unregister the controller")
 
-	var events []CtrlEvent
 	require.Eventually(t, func() bool {
-		events = append(events, drain()...)
-		return len(events) > 0
+		return len(drain()) > 0
 	}, time.Second, 10*time.Millisecond, "expected a controller change event")
 
+	events := drain()
 	require.Len(t, events, 1)
 	require.Equal(t, ControllerDisconnected, events[0].Type)
 	require.Same(t, current, events[0].Controller)
@@ -462,25 +461,6 @@ func TestEverConnected_StaysTrueAcrossLosingEveryController(t *testing.T) {
 		"having reached a controller once must not be forgotten when the connection is lost")
 }
 
-// awaitCtrlEvents collects n controller events, failing if they do not arrive in time.
-// Collection happens on the calling goroutine: testify runs Eventually and Never conditions
-// on their own goroutine, so accumulating into a slice the test body also reads would race.
-func awaitCtrlEvents(t *testing.T, drain func() []CtrlEvent, n int) []CtrlEvent {
-	t.Helper()
-
-	var events []CtrlEvent
-	deadline := time.Now().Add(2 * time.Second)
-	for len(events) < n && time.Now().Before(deadline) {
-		events = append(events, drain()...)
-		if len(events) < n {
-			time.Sleep(5 * time.Millisecond)
-		}
-	}
-
-	require.GreaterOrEqual(t, len(events), n, "expected %d controller events, got %v", n, events)
-	return events
-}
-
 // TestNotifyOfConnectivityChange_ReconnectReportsBothHalves guards the reconnect half of a
 // grouped control channel losing every underlay and getting one back. The registration
 // survives that, so nothing else reports it: a reconnect that re-offers state without
@@ -493,21 +473,25 @@ func TestNotifyOfConnectivityChange_ReconnectReportsBothHalves(t *testing.T) {
 	ctrl, _ := newTestNetworkCtrl(nc, "ctrl1", "current")
 	nc.ctrls.Put("ctrl1", ctrl)
 
-	var wasDisconnected atomic.Bool
+	connectivity := &connectivityState{}
 	var reconnectNotifications int
 	notifyReconnect := func() { reconnectNotifications++ }
 
 	// Last underlay lost, then one back.
-	nc.notifyOfConnectivityChange("ctrl1", &wasDisconnected, 0, notifyReconnect)
-	nc.notifyOfConnectivityChange("ctrl1", &wasDisconnected, 1, notifyReconnect)
+	nc.notifyOfConnectivityChange("ctrl1", connectivity, 0, notifyReconnect)
+	nc.notifyOfConnectivityChange("ctrl1", connectivity, 1, notifyReconnect)
 
-	events := awaitCtrlEvents(t, drain, 2)
+	require.Eventually(t, func() bool {
+		return len(drain()) >= 2
+	}, time.Second, 10*time.Millisecond, "expected a disconnect and a reconnect event")
 
-	// Listeners are notified on their own goroutine per event, so the two can arrive in
-	// either order; what matters is that both were reported, once each.
+	// A listener keyed on connectivity clears its state on the disconnect and acts on the reconnect, so
+	// it must see them in that order however the notifications are delivered.
+	events := drain()
 	require.Len(t, events, 2)
-	types := []CtrlEventType{events[0].Type, events[1].Type}
-	require.ElementsMatch(t, []CtrlEventType{ControllerDisconnected, ControllerReconnected}, types,
+	require.Equal(t, ControllerDisconnected, events[0].Type)
+	require.Same(t, ctrl, events[0].Controller)
+	require.Equal(t, ControllerReconnected, events[1].Type,
 		"regaining an underlay must report the controller as reconnected")
 	for _, e := range events {
 		require.Same(t, ctrl, e.Controller)
@@ -525,36 +509,41 @@ func TestNotifyOfConnectivityChange_ReportsEachEdgeOnce(t *testing.T) {
 	ctrl, _ := newTestNetworkCtrl(nc, "ctrl1", "current")
 	nc.ctrls.Put("ctrl1", ctrl)
 
-	var wasDisconnected atomic.Bool
+	connectivity := &connectivityState{}
 	var reconnectNotifications int
 	notifyReconnect := func() { reconnectNotifications++ }
 
 	// A second underlay arriving and leaving while one remains is not a transition.
-	nc.notifyOfConnectivityChange("ctrl1", &wasDisconnected, 2, notifyReconnect)
-	nc.notifyOfConnectivityChange("ctrl1", &wasDisconnected, 1, notifyReconnect)
+	nc.notifyOfConnectivityChange("ctrl1", connectivity, 2, notifyReconnect)
+	nc.notifyOfConnectivityChange("ctrl1", connectivity, 1, notifyReconnect)
 
 	require.Never(t, func() bool { return len(drain()) > 0 }, 100*time.Millisecond, 10*time.Millisecond,
 		"underlay churn that never cost connectivity must not be reported")
 	require.Zero(t, reconnectNotifications)
 
 	// Two reports of the count reaching zero are one disconnect.
-	nc.notifyOfConnectivityChange("ctrl1", &wasDisconnected, 0, notifyReconnect)
-	nc.notifyOfConnectivityChange("ctrl1", &wasDisconnected, 0, notifyReconnect)
+	nc.notifyOfConnectivityChange("ctrl1", connectivity, 0, notifyReconnect)
+	nc.notifyOfConnectivityChange("ctrl1", connectivity, 0, notifyReconnect)
 
-	events := awaitCtrlEvents(t, drain, 1)
+	require.Eventually(t, func() bool {
+		return len(drain()) >= 1
+	}, time.Second, 10*time.Millisecond, "expected a disconnect event")
 
 	// Same for the count coming back.
-	nc.notifyOfConnectivityChange("ctrl1", &wasDisconnected, 1, notifyReconnect)
-	nc.notifyOfConnectivityChange("ctrl1", &wasDisconnected, 2, notifyReconnect)
+	nc.notifyOfConnectivityChange("ctrl1", connectivity, 1, notifyReconnect)
+	nc.notifyOfConnectivityChange("ctrl1", connectivity, 2, notifyReconnect)
 
-	events = append(events, awaitCtrlEvents(t, drain, 1)...)
+	require.Eventually(t, func() bool {
+		return len(drain()) >= 2
+	}, time.Second, 10*time.Millisecond, "expected a reconnect event")
 
-	// Waiting for each edge before triggering the next fixes their order here, unlike the
-	// back-to-back case, where the per-event goroutines can deliver in either order.
+	require.Never(t, func() bool {
+		return len(drain()) > 2
+	}, 100*time.Millisecond, 10*time.Millisecond, "each edge must be reported once")
+
+	events := drain()
+	require.Len(t, events, 2)
 	require.Equal(t, ControllerDisconnected, events[0].Type)
 	require.Equal(t, ControllerReconnected, events[1].Type)
-
-	require.Never(t, func() bool { return len(drain()) > 0 }, 100*time.Millisecond, 10*time.Millisecond,
-		"each edge must be reported once")
 	require.Equal(t, 1, reconnectNotifications)
 }


### PR DESCRIPTION
For #4371. Backport of #4370 (fixes #4369) to release-v2.0.x.

Ctrl events were fanned out to listeners with a goroutine per listener per event, so a disconnect and the reconnect that followed it could reach a listener in either order. The ER/T hosted service registry keys its leader-connected state on exactly that pair, so a reordered pair leaves hosted terminators un-re-established after a real down-and-up. Each listener now gets its own queue drained in order, and the producer holds the connectivity state lock from deciding an edge through queuing its event.

This branch had already taken the test-only relaxation from #4266 via #4265, which asserted the pair as an unordered set. The cherry-pick conflicted there; the resolution restores the ordered assertions from main, since the order is now guaranteed, and drops the `awaitCtrlEvents` helper that only that relaxation used. `go test -race -count=200` on the affected tests is clean.