### PR TITLE
Mark the api session enforcer delete meter on every delete attempt

### DIFF
--- a/controller/internal/policy/api_session_enforcer.go
+++ b/controller/internal/policy/api_session_enforcer.go
@@ -108,16 +108,20 @@ func (s *ApiSessionEnforcer) Run() error {
 		logrus.Debugf("found %v expired api-sessions to remove", len(ids))
 
 		ctx := change.New().SetSourceType("api-session.enforcer").SetChangeAuthorType(change.AuthorTypeController)
+		deleted := int64(len(ids))
 		if err = s.appEnv.GetManagers().ApiSession.DeleteBatch(ids, ctx); err != nil {
 			logrus.WithError(err).Error("failure while batch deleting expired api sessions")
 
+			deleted = 0
 			for _, id := range ids {
 				if err = s.appEnv.GetManagers().ApiSession.Delete(id, ctx); err != nil {
 					logrus.WithError(err).Errorf("failure while deleting expired api session: %v", id)
+				} else {
+					deleted++
 				}
 			}
-			s.deleteMeter.Mark(int64(len(ids)))
 		}
+		s.deleteMeter.Mark(deleted)
 	}
 
 	return nil

--- a/controller/internal/policy/session_enforcer_test.go
+++ b/controller/internal/policy/session_enforcer_test.go
@@ -82,6 +82,7 @@ func (ctx *enforcerTestContext) testSessionsCleanup() {
 	}
 
 	ctx.NoError(enforcer.Run())
+	ctx.Equal(int64(1), enforcer.deleteMeter.Count())
 
 	done, err := ctx.GetStores().EventualEventer.Trigger()
 	ctx.NoError(err)


### PR DESCRIPTION
Fixes #4378

The `api.session.enforcer.delete` meter was marked only inside the batch-delete failure branch, so a healthy controller reported zero while it expired api sessions, and a failed batch reported the full batch size even when the per-id fallbacks also failed. Placement dates from when the metric was added; #4353's review surfaced it.

The mark now happens after every delete attempt. On batch success it records the batch size; on batch failure it records only the fallback deletes that succeeded. The session enforcer test asserts the count.

Backports: #4379 (2.0), #4380 (1.6, riding along in #4355).
