### PR TITLE
[Backport-2.0] Mark the api session enforcer delete meter on every delete attempt

### DIFF
--- a/controller/internal/policy/api_session_enforcer.go
+++ b/controller/internal/policy/api_session_enforcer.go
@@ -108,16 +108,20 @@ func (s *ApiSessionEnforcer) Run() error {
 		logrus.Debugf("found %v expired api-sessions to remove", len(ids))
 
 		ctx := change.New().SetSourceType("api-session.enforcer").SetChangeAuthorType(change.AuthorTypeController)
+		deleted := int64(len(ids))
 		if err = s.appEnv.GetManagers().ApiSession.DeleteBatch(ids, ctx); err != nil {
 			logrus.WithError(err).Error("failure while batch deleting expired api sessions")
 
+			deleted = 0
 			for _, id := range ids {
 				if err = s.appEnv.GetManagers().ApiSession.Delete(id, ctx); err != nil {
 					logrus.WithError(err).Errorf("failure while deleting expired api session: %v", id)
+				} else {
+					deleted++
 				}
 			}
-			s.deleteMeter.Mark(int64(len(ids)))
 		}
+		s.deleteMeter.Mark(deleted)
 	}
 
 	return nil

--- a/controller/internal/policy/session_enforcer_test.go
+++ b/controller/internal/policy/session_enforcer_test.go
@@ -82,6 +82,7 @@ func (ctx *enforcerTestContext) testSessionsCleanup() {
 	}
 
 	ctx.NoError(enforcer.Run())
+	ctx.Equal(int64(1), enforcer.deleteMeter.Count())
 
 	done, err := ctx.GetStores().EventualEventer.Trigger()
 	ctx.NoError(err)


### PR DESCRIPTION
Fixes #4379

Backport of #4381 to `release-v2.0.x`. Cherry-picked cleanly; builds and `controller/internal/policy` tests pass.
