### PR TITLE
fixes openziti/ziti#4348 process check with no signer fingerprint alw…

### DIFF
--- a/controller/sync_strats/sync_instant.go
+++ b/controller/sync_strats/sync_instant.go
@@ -1797,12 +1797,17 @@ func newPostureCheck(postureModel *db.PostureCheck) *edge_ctrl_pb.DataState_Post
 
 	switch subType := postureModel.SubType.(type) {
 	case *db.PostureCheckProcess:
+		var fingerprints []string
+		if subType.Fingerprint != "" {
+			fingerprints = []string{subType.Fingerprint}
+		}
+
 		newVal.Subtype = &edge_ctrl_pb.DataState_PostureCheck_Process_{
 			Process: &edge_ctrl_pb.DataState_PostureCheck_Process{
 				OsType:       subType.OperatingSystem,
 				Path:         subType.Path,
 				Hashes:       subType.Hashes,
-				Fingerprints: []string{subType.Fingerprint},
+				Fingerprints: fingerprints,
 			},
 		}
 	case *db.PostureCheckProcessMulti:

--- a/controller/sync_strats/sync_instant_test.go
+++ b/controller/sync_strats/sync_instant_test.go
@@ -20,9 +20,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openziti/ziti/v2/common/pb/edge_ctrl_pb"
+	"github.com/openziti/ziti/v2/controller/db"
 	"github.com/openziti/ziti/v2/controller/env"
 	"github.com/openziti/ziti/v2/controller/model"
 	"github.com/openziti/ziti/v2/controller/models"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
 	"github.com/stretchr/testify/require"
 )
 
@@ -77,4 +80,50 @@ func Test_RouterConnected_ignoresClosedChannel(t *testing.T) {
 
 	req.Nil(strategy.rtxMap.Get("r1"), "no sender should be created for a closed channel")
 	req.Len(strategy.routerConnectedQueue, 0, "nothing should be queued for a closed channel")
+}
+
+// Test_newPostureCheck_ProcessWithoutFingerprint covers a process check the administrator
+// configured no signer for. Routers treat every entry in the fingerprint list as a signer the
+// client must report, and no client reports an empty one, so an unconfigured fingerprint must
+// reach the router as no entries at all.
+func Test_newPostureCheck_ProcessWithoutFingerprint(t *testing.T) {
+	req := require.New(t)
+
+	stored := &db.PostureCheck{
+		BaseExtEntity: boltz.BaseExtEntity{Id: "pc1"},
+		Name:          "proc",
+		TypeId:        db.PostureCheckTypeProcess,
+		SubType: &db.PostureCheckProcess{
+			OperatingSystem: "Windows",
+			Path:            "C:\\Windows\\System32\\notepad.exe",
+			Fingerprint:     "",
+		},
+	}
+
+	result := newPostureCheck(stored)
+
+	process := result.Subtype.(*edge_ctrl_pb.DataState_PostureCheck_Process_).Process
+	req.Len(process.Fingerprints, 0)
+}
+
+// Test_newPostureCheck_ProcessWithFingerprint covers the configured case, where the single stored
+// signer is the one entry the router must match against.
+func Test_newPostureCheck_ProcessWithFingerprint(t *testing.T) {
+	req := require.New(t)
+
+	stored := &db.PostureCheck{
+		BaseExtEntity: boltz.BaseExtEntity{Id: "pc1"},
+		Name:          "proc",
+		TypeId:        db.PostureCheckTypeProcess,
+		SubType: &db.PostureCheckProcess{
+			OperatingSystem: "Windows",
+			Path:            "C:\\Windows\\System32\\notepad.exe",
+			Fingerprint:     "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678",
+		},
+	}
+
+	result := newPostureCheck(stored)
+
+	process := result.Subtype.(*edge_ctrl_pb.DataState_PostureCheck_Process_).Process
+	req.Equal([]string{"a1b2c3d4e5f60718293a4b5c6d7e8f9012345678"}, process.Fingerprints)
 }

--- a/router/posture/process.go
+++ b/router/posture/process.go
@@ -179,13 +179,17 @@ func (p *ProcessCheck) compareProcesses(osType string, given *edge_client_pb.Pos
 		return result
 	}
 
-	if len(valid.Fingerprints) > 0 {
-		validPrints := map[string]struct{}{}
+	validPrints := map[string]struct{}{}
 
-		for _, validPrint := range valid.Fingerprints {
-			validPrints[strings.ToLower(validPrint)] = struct{}{}
+	for _, validPrint := range valid.Fingerprints {
+		if validPrint == "" {
+			continue
 		}
 
+		validPrints[strings.ToLower(validPrint)] = struct{}{}
+	}
+
+	if len(validPrints) > 0 {
 		validPrintFound := false
 		for _, givenPrint := range given.SignerFingerprints {
 			if _, ok := validPrints[strings.ToLower(givenPrint)]; ok {
@@ -195,7 +199,7 @@ func (p *ProcessCheck) compareProcesses(osType string, given *edge_client_pb.Pos
 		}
 
 		if !validPrintFound {
-			result.Reason = fmt.Errorf("valid signer not found, given: %v, expected one of: %v", given.SignerFingerprints, valid.Hashes)
+			result.Reason = fmt.Errorf("valid signer not found, given: %v, expected one of: %v", given.SignerFingerprints, valid.Fingerprints)
 			return result
 		}
 	}

--- a/router/posture/process_test.go
+++ b/router/posture/process_test.go
@@ -227,3 +227,21 @@ func Test_ProcessCheck_RepeatedResponseNotSeenAsChange(t *testing.T) {
 
 	require.False(t, updated)
 }
+
+// Test_ProcessCheck_EmptyConfiguredFingerprintImposesNoConstraint locks in that a process check
+// with no configured signer accepts whatever signer the client reports. The controller holds the
+// single optional fingerprint as a string, so an unconfigured one can reach the router as a
+// one-element list holding an empty string, which no client ever reports.
+func Test_ProcessCheck_EmptyConfiguredFingerprintImposesNoConstraint(t *testing.T) {
+	t.Run("client reports no signer", func(t *testing.T) {
+		check := newProcessCheckWith(nil, []string{""})
+
+		require.Nil(t, check.Evaluate(reportedProcess(lowerHash, nil)))
+	})
+
+	t.Run("client reports a signer", func(t *testing.T) {
+		check := newProcessCheckWith(nil, []string{""})
+
+		require.Nil(t, check.Evaluate(reportedProcess(lowerHash, []string{otherPrint})))
+	})
+}


### PR DESCRIPTION
…ays fail

- sends no signer fingerprints in the router data model when a process check has none configured, the single stored fingerprint was wrapped into a one-element list holding an empty string
- treats an empty configured signer fingerprint as no constraint when evaluating a process check, routers require a reported signer to match any entry in the list
- reports the configured fingerprints in the signer failure message, it reported the hashes