### PR TITLE
backport openziti/ziti#4348 to release-v2.0.x process check with no s…

### DIFF
--- a/controller/sync_strats/sync_instant.go
+++ b/controller/sync_strats/sync_instant.go
@@ -1666,12 +1666,17 @@ func newPostureCheck(postureModel *db.PostureCheck) *edge_ctrl_pb.DataState_Post
 
 	switch subType := postureModel.SubType.(type) {
 	case *db.PostureCheckProcess:
+		var fingerprints []string
+		if subType.Fingerprint != "" {
+			fingerprints = []string{subType.Fingerprint}
+		}
+
 		newVal.Subtype = &edge_ctrl_pb.DataState_PostureCheck_Process_{
 			Process: &edge_ctrl_pb.DataState_PostureCheck_Process{
 				OsType:       subType.OperatingSystem,
 				Path:         subType.Path,
 				Hashes:       subType.Hashes,
-				Fingerprints: []string{subType.Fingerprint},
+				Fingerprints: fingerprints,
 			},
 		}
 	case *db.PostureCheckProcessMulti:

--- a/controller/sync_strats/sync_instant_test.go
+++ b/controller/sync_strats/sync_instant_test.go
@@ -1,0 +1,72 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package sync_strats
+
+import (
+	"testing"
+
+	"github.com/openziti/ziti/v2/common/pb/edge_ctrl_pb"
+	"github.com/openziti/ziti/v2/controller/db"
+	"github.com/openziti/ziti/v2/controller/storage/boltz"
+	"github.com/stretchr/testify/require"
+)
+
+// Test_newPostureCheck_ProcessWithoutFingerprint covers a process check the administrator
+// configured no signer for. Routers treat every entry in the fingerprint list as a signer the
+// client must report, and no client reports an empty one, so an unconfigured fingerprint must
+// reach the router as no entries at all.
+func Test_newPostureCheck_ProcessWithoutFingerprint(t *testing.T) {
+	req := require.New(t)
+
+	stored := &db.PostureCheck{
+		BaseExtEntity: boltz.BaseExtEntity{Id: "pc1"},
+		Name:          "proc",
+		TypeId:        db.PostureCheckTypeProcess,
+		SubType: &db.PostureCheckProcess{
+			OperatingSystem: "Windows",
+			Path:            "C:\\Windows\\System32\\notepad.exe",
+			Fingerprint:     "",
+		},
+	}
+
+	result := newPostureCheck(stored)
+
+	process := result.Subtype.(*edge_ctrl_pb.DataState_PostureCheck_Process_).Process
+	req.Len(process.Fingerprints, 0)
+}
+
+// Test_newPostureCheck_ProcessWithFingerprint covers the configured case, where the single stored
+// signer is the one entry the router must match against.
+func Test_newPostureCheck_ProcessWithFingerprint(t *testing.T) {
+	req := require.New(t)
+
+	stored := &db.PostureCheck{
+		BaseExtEntity: boltz.BaseExtEntity{Id: "pc1"},
+		Name:          "proc",
+		TypeId:        db.PostureCheckTypeProcess,
+		SubType: &db.PostureCheckProcess{
+			OperatingSystem: "Windows",
+			Path:            "C:\\Windows\\System32\\notepad.exe",
+			Fingerprint:     "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678",
+		},
+	}
+
+	result := newPostureCheck(stored)
+
+	process := result.Subtype.(*edge_ctrl_pb.DataState_PostureCheck_Process_).Process
+	req.Equal([]string{"a1b2c3d4e5f60718293a4b5c6d7e8f9012345678"}, process.Fingerprints)
+}

--- a/router/posture/process.go
+++ b/router/posture/process.go
@@ -179,13 +179,17 @@ func (p *ProcessCheck) compareProcesses(osType string, given *edge_client_pb.Pos
 		return result
 	}
 
-	if len(valid.Fingerprints) > 0 {
-		validPrints := map[string]struct{}{}
+	validPrints := map[string]struct{}{}
 
-		for _, validPrint := range valid.Fingerprints {
-			validPrints[strings.ToLower(validPrint)] = struct{}{}
+	for _, validPrint := range valid.Fingerprints {
+		if validPrint == "" {
+			continue
 		}
 
+		validPrints[strings.ToLower(validPrint)] = struct{}{}
+	}
+
+	if len(validPrints) > 0 {
 		validPrintFound := false
 		for _, givenPrint := range given.SignerFingerprints {
 			if _, ok := validPrints[strings.ToLower(givenPrint)]; ok {
@@ -195,7 +199,7 @@ func (p *ProcessCheck) compareProcesses(osType string, given *edge_client_pb.Pos
 		}
 
 		if !validPrintFound {
-			result.Reason = fmt.Errorf("valid signer not found, given: %v, expected one of: %v", given.SignerFingerprints, valid.Hashes)
+			result.Reason = fmt.Errorf("valid signer not found, given: %v, expected one of: %v", given.SignerFingerprints, valid.Fingerprints)
 			return result
 		}
 	}

--- a/router/posture/process_test.go
+++ b/router/posture/process_test.go
@@ -227,3 +227,21 @@ func Test_ProcessCheck_RepeatedResponseNotSeenAsChange(t *testing.T) {
 
 	require.False(t, updated)
 }
+
+// Test_ProcessCheck_EmptyConfiguredFingerprintImposesNoConstraint locks in that a process check
+// with no configured signer accepts whatever signer the client reports. The controller holds the
+// single optional fingerprint as a string, so an unconfigured one can reach the router as a
+// one-element list holding an empty string, which no client ever reports.
+func Test_ProcessCheck_EmptyConfiguredFingerprintImposesNoConstraint(t *testing.T) {
+	t.Run("client reports no signer", func(t *testing.T) {
+		check := newProcessCheckWith(nil, []string{""})
+
+		require.Nil(t, check.Evaluate(reportedProcess(lowerHash, nil)))
+	})
+
+	t.Run("client reports a signer", func(t *testing.T) {
+		check := newProcessCheckWith(nil, []string{""})
+
+		require.Nil(t, check.Evaluate(reportedProcess(lowerHash, []string{otherPrint})))
+	})
+}


### PR DESCRIPTION
…igner fingerprint always fails

- sends no fingerprint entries to routers when a process check has no configured signer, the single optional fingerprint was wrapped into a one-element list holding an empty string
- ignores empty fingerprint entries when the router builds the valid signer set, an unpatched controller still sends them
- reports valid.Fingerprints in the signer failure message where it reported valid.Hashes
- adds router and controller unit coverage for the unconfigured and configured signer cases