### PR TITLE
Apply posture responses in order, and deliver circuit faults through the faulter

### DIFF
--- a/router/env/config_forwarder.go
+++ b/router/env/config_forwarder.go
@@ -23,9 +23,16 @@ import (
 )
 
 const (
-	DefaultXgressCloseCheckInterval    = 5 * time.Second
-	DefaultXgressDialDwellTime         = 0
-	DefaultFaultTxInterval             = 15 * time.Second
+	DefaultXgressCloseCheckInterval = 5 * time.Second
+	DefaultXgressDialDwellTime      = 0
+	DefaultFaultTxInterval          = 15 * time.Second
+
+	// DefaultEndpointFaultRetention is how long the router keeps retrying an unsent circuit
+	// endpoint fault before giving up on it. Configured as a duration, such as '5m'. Retention bounds the memory held while a controller
+	// is unreachable, since a fault outlives the circuit it refers to: the set grows with the
+	// teardown rate for as long as the outage lasts. Giving up leaves the controller holding a
+	// circuit the router no longer has, until the controller reconciles circuits on reconnect.
+	DefaultEndpointFaultRetention      = 5 * time.Minute
 	DefaultIdleTxInterval              = 60 * time.Second
 	DefaultIdleCircuitTimeout          = 60 * time.Second
 	DefaultXgressDialWorkerQueueLength = 1000
@@ -54,6 +61,7 @@ const (
 )
 
 type ForwarderOptions struct {
+	EndpointFaultRetention   time.Duration
 	FaultTxInterval          time.Duration
 	IdleCircuitTimeout       time.Duration
 	IdleTxInterval           time.Duration
@@ -72,9 +80,10 @@ type WorkerPoolOptions struct {
 
 func DefaultForwarderOptions() *ForwarderOptions {
 	return &ForwarderOptions{
-		FaultTxInterval:    DefaultFaultTxInterval,
-		IdleCircuitTimeout: DefaultIdleCircuitTimeout,
-		IdleTxInterval:     DefaultIdleTxInterval,
+		EndpointFaultRetention: DefaultEndpointFaultRetention,
+		FaultTxInterval:        DefaultFaultTxInterval,
+		IdleCircuitTimeout:     DefaultIdleCircuitTimeout,
+		IdleTxInterval:         DefaultIdleTxInterval,
 		LinkDial: WorkerPoolOptions{
 			QueueLength: DefaultLinkDialQueueLength,
 			WorkerCount: DefaultLinkDialWorkerCount,
@@ -95,6 +104,18 @@ func DefaultForwarderOptions() *ForwarderOptions {
 
 func LoadForwarderOptions(src map[interface{}]interface{}) (*ForwarderOptions, error) {
 	options := DefaultForwarderOptions()
+
+	if value, found := src["endpointFaultRetention"]; found {
+		val, ok := value.(string)
+		if !ok {
+			return nil, errors.New("invalid value for 'endpointFaultRetention', expected a duration, such as '5m'")
+		}
+
+		var err error
+		if options.EndpointFaultRetention, err = time.ParseDuration(val); err != nil {
+			return nil, errors.Wrap(err, "invalid value for 'endpointFaultRetention'")
+		}
+	}
 
 	if value, found := src["faultTxInterval"]; found {
 		if val, ok := value.(int); ok {

--- a/router/env/config_forwarder_test.go
+++ b/router/env/config_forwarder_test.go
@@ -1,0 +1,41 @@
+package env
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_LoadForwarderOptions_EndpointFaultRetentionDefaults(t *testing.T) {
+	options, err := LoadForwarderOptions(map[interface{}]interface{}{})
+	require.NoError(t, err)
+	require.Equal(t, DefaultEndpointFaultRetention, options.EndpointFaultRetention)
+}
+
+func Test_LoadForwarderOptions_EndpointFaultRetentionParsesDuration(t *testing.T) {
+	options, err := LoadForwarderOptions(map[interface{}]interface{}{
+		"endpointFaultRetention": "90s",
+	})
+	require.NoError(t, err)
+	require.Equal(t, 90*time.Second, options.EndpointFaultRetention)
+}
+
+func Test_LoadForwarderOptions_EndpointFaultRetentionRejectsNonDuration(t *testing.T) {
+	_, err := LoadForwarderOptions(map[interface{}]interface{}{
+		"endpointFaultRetention": "not-a-duration",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "endpointFaultRetention")
+}
+
+// Test_LoadForwarderOptions_EndpointFaultRetentionRejectsNumber guards the convention: durations
+// are configured as strings, and a bare number must be rejected rather than silently read as some
+// unit.
+func Test_LoadForwarderOptions_EndpointFaultRetentionRejectsNumber(t *testing.T) {
+	_, err := LoadForwarderOptions(map[interface{}]interface{}{
+		"endpointFaultRetention": 300000,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duration")
+}

--- a/router/env/env.go
+++ b/router/env/env.go
@@ -88,6 +88,11 @@ type Forwarder interface {
 	ForwardAcknowledgement(srcAddr xgress.Address, acknowledgement *xgress.Acknowledgement) error
 	ForwardControl(srcAddr xgress.Address, control *xgress.Control) error
 	ReportForwardingFault(circuitId string, ctrlId string)
+
+	// ReportCircuitEndpointFault reports that a circuit's ingress or egress endpoint on this
+	// router has gone away, so the controller can remove the circuit. It does not block and does
+	// not wait for the controller.
+	ReportCircuitEndpointFault(circuitId string, ctrlId string, subject ctrl_pb.FaultSubject)
 	RegisterDestination(circuitId string, address xgress.Address, destination Destination)
 	EndCircuit(circuitId string)
 }

--- a/router/forwarder/endpoint_faulter.go
+++ b/router/forwarder/endpoint_faulter.go
@@ -1,0 +1,276 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package forwarder
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/openziti/channel/v5/protobufs"
+	"github.com/openziti/metrics"
+	"github.com/openziti/ziti/v2/common/pb/ctrl_pb"
+	"github.com/openziti/ziti/v2/router/env"
+)
+
+// endpointFaultSweepInterval is how often a sender re-checks its pending set without being woken.
+// It paces two things: retrying faults a controller would not take, and releasing faults held past
+// the retention window. It is therefore well under the retention window, so a fault gets many
+// attempts before it is given up on, and expiry runs at a useful granularity.
+const endpointFaultSweepInterval = 15 * time.Second
+
+// endpointFaultKey identifies a pending fault. The subject is part of the key because one router
+// can hold both ends of a circuit, and those are two distinct faults for the same circuit.
+type endpointFaultKey struct {
+	circuitId string
+	subject   ctrl_pb.FaultSubject
+}
+
+// pendingEndpointFault is a fault waiting to be sent. queuedAt is when the fault was first
+// reported and is never advanced, so retention measures from when the circuit went away rather
+// than from the last attempt.
+type pendingEndpointFault struct {
+	key      endpointFaultKey
+	queuedAt time.Time
+}
+
+// endpointFaultSender delivers circuit endpoint faults to one controller.
+//
+// Faults are held in a set rather than a queue so that a controller which is unreachable
+// accumulates at most one entry per circuit, and so that reporting the same fault twice is free.
+// One goroutine per controller owns the sending, so a controller that stops reading costs only its
+// own sender; reporters never block and never wait for a controller.
+//
+// That goroutine also expires faults, so its sends are bounded rather than blocking: waiting
+// indefinitely on one controller would stop retention from running while new faults kept
+// arriving, which is the growth the retention window exists to stop.
+type endpointFaultSender struct {
+	ctrlId      string
+	ctrls       env.NetworkControllers
+	retention   time.Duration
+	sendTimeout time.Duration
+
+	lock    sync.Mutex
+	pending map[endpointFaultKey]*pendingEndpointFault
+
+	notify      chan struct{}
+	stop        chan struct{}
+	isStopped   atomic.Bool
+	closeNotify <-chan struct{}
+
+	sent    metrics.Meter
+	expired metrics.Meter
+}
+
+func newEndpointFaultSender(ctrlId string, f *Faulter) *endpointFaultSender {
+	result := &endpointFaultSender{
+		ctrlId:      ctrlId,
+		ctrls:       f.ctrls,
+		retention:   f.endpointFaultRetention,
+		sendTimeout: f.ctrls.DefaultRequestTimeout(),
+		pending:     map[endpointFaultKey]*pendingEndpointFault{},
+		notify:      make(chan struct{}, 1),
+		stop:        make(chan struct{}),
+		closeNotify: f.closeNotify,
+		sent:        f.endpointFaultsSent,
+		expired:     f.endpointFaultsExpired,
+	}
+
+	go result.run()
+
+	return result
+}
+
+// report adds a fault to the pending set and wakes the sender. It does not block.
+func (self *endpointFaultSender) report(key endpointFaultKey) {
+	self.lock.Lock()
+	if _, exists := self.pending[key]; !exists {
+		self.pending[key] = &pendingEndpointFault{key: key, queuedAt: time.Now()}
+	}
+	self.lock.Unlock()
+
+	self.wake()
+}
+
+func (self *endpointFaultSender) wake() {
+	select {
+	case self.notify <- struct{}{}:
+	default:
+	}
+}
+
+// shutdown stops the sender and abandons anything it still holds. Used when a controller is
+// removed from the cluster, whose circuits are gone with it.
+func (self *endpointFaultSender) shutdown() {
+	if self.isStopped.CompareAndSwap(false, true) {
+		close(self.stop)
+	}
+}
+
+// hasPending return true if there are pending faults
+func (self *endpointFaultSender) hasPending() bool {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+	return len(self.pending) > 0
+}
+
+func (self *endpointFaultSender) run() {
+	faultLog.Info("endpoint fault sender started", "ctrlId", self.ctrlId)
+	defer faultLog.Info("endpoint fault sender exited", "ctrlId", self.ctrlId)
+
+	ticker := time.NewTicker(endpointFaultSweepInterval)
+	defer ticker.Stop()
+
+	for {
+		self.expirePending()
+
+		// Only a completed drain justifies going straight round again, and then only because
+		// faults reported while it ran are already waiting. A drain cut short by a send failure
+		// must wait, or an undeliverable fault spins this goroutine retrying as fast as the
+		// failure comes back.
+		if self.sendPending() && self.hasPending() {
+			select {
+			case <-self.stop:
+				return
+			case <-self.closeNotify:
+				return
+			default:
+				continue
+			}
+		}
+
+		select {
+		case <-self.notify:
+		case <-ticker.C:
+		case <-self.stop:
+			return
+		case <-self.closeNotify:
+			return
+		}
+	}
+}
+
+// expirePending drops faults held longer than the retention window. Expiry means the controller
+// keeps a circuit this router no longer has, so it is reported as an error rather than logged
+// quietly.
+func (self *endpointFaultSender) expirePending() {
+	if self.retention <= 0 {
+		return
+	}
+
+	cutoff := time.Now().Add(-self.retention)
+
+	self.lock.Lock()
+	var expired []endpointFaultKey
+	for key, fault := range self.pending {
+		if fault.queuedAt.Before(cutoff) {
+			expired = append(expired, key)
+			delete(self.pending, key)
+		}
+	}
+	self.lock.Unlock()
+
+	for _, key := range expired {
+		self.expired.Mark(1)
+		faultLog.Error("giving up on circuit fault, controller may still hold the circuit",
+			"ctrlId", self.ctrlId,
+			"circuitId", key.circuitId,
+			"subject", key.subject.String(),
+			"retention", self.retention,
+		)
+	}
+}
+
+// sendPending delivers what it can and stops at the first failure, reporting whether it got
+// through the whole set. A failure means the channel is unavailable, so the rest would fail too;
+// they stay pending until the controller reconnects or the sweep comes round.
+//
+// Faults are removed as they are sent rather than taken out of the set up front, so the set
+// always reflects what is still owed. Draining into a local copy would hide in-flight faults from
+// expirePending, letting them age past the retention window unnoticed, and would make the set
+// briefly look empty to anything else reading it.
+func (self *endpointFaultSender) sendPending() bool {
+	for _, fault := range self.snapshotPending() {
+		select {
+		case <-self.stop:
+			return false
+		case <-self.closeNotify:
+			return false
+		default:
+		}
+
+		if !self.send(fault) {
+			return false
+		}
+
+		self.lock.Lock()
+		delete(self.pending, fault.key)
+		self.lock.Unlock()
+	}
+
+	return true
+}
+
+func (self *endpointFaultSender) snapshotPending() []*pendingEndpointFault {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+
+	result := make([]*pendingEndpointFault, 0, len(self.pending))
+	for _, fault := range self.pending {
+		result = append(result, fault)
+	}
+	return result
+}
+
+// send reports whether the fault was handed to the controller channel. A fault that could not be
+// sent is left pending for a later attempt.
+func (self *endpointFaultSender) send(fault *pendingEndpointFault) bool {
+	ctrlCh := self.ctrls.GetCtrlChannel(self.ctrlId)
+	if ctrlCh == nil {
+		// The controller is not connected yet, or is gone. If it was removed, shutdown clears
+		// this set; otherwise reconnecting wakes the sender.
+		return false
+	}
+
+	msg := &ctrl_pb.Fault{Subject: fault.key.subject, Id: fault.key.circuitId}
+
+	// Waits for the write rather than for the queue to accept it: the sender declines to retry a
+	// failed write, so treating queue acceptance as delivery would drop the fault while reporting
+	// success. The timeout bounds both stages, so a controller that is not draining delays this
+	// sender by at most one timeout before it expires and retries.
+	//
+	// A successful write still is not proof the controller processed it; faults carry no reply, so
+	// this is the strongest confirmation available.
+	envelope := protobufs.MarshalTyped(msg).WithTimeout(self.sendTimeout)
+	if err := envelope.SendAndWaitForWire(ctrlCh.GetDefaultSender()); err != nil {
+		faultLog.Debug("could not send circuit fault, will retry",
+			"error", err,
+			"ctrlId", self.ctrlId,
+			"circuitId", fault.key.circuitId,
+			"subject", fault.key.subject.String(),
+		)
+		return false
+	}
+
+	self.sent.Mark(1)
+	faultLog.Debug("reported circuit fault",
+		"ctrlId", self.ctrlId,
+		"circuitId", fault.key.circuitId,
+		"subject", fault.key.subject.String(),
+	)
+	return true
+}

--- a/router/forwarder/endpoint_faulter_test.go
+++ b/router/forwarder/endpoint_faulter_test.go
@@ -1,0 +1,327 @@
+package forwarder
+
+import (
+	"errors"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/openziti/channel/v5"
+	"github.com/openziti/metrics"
+	"github.com/openziti/ziti/v2/common/ctrlchan"
+	"github.com/openziti/ziti/v2/common/pb/ctrl_pb"
+	"github.com/openziti/ziti/v2/router/env"
+	cmap "github.com/orcaman/concurrent-map/v2"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// testCtrlChannel completes ctrlchan.CtrlChannel over BaseCtrlChannel and runs a goroutine in
+// place of an underlay, so that sends waiting for a write actually complete. Setting writeErr
+// makes those writes fail the way channel v5.0.27 reports it: NotifyErr, then NotifyAfterWrite.
+type testCtrlChannel struct {
+	*ctrlchan.BaseCtrlChannel
+	writeErr atomic.Pointer[error]
+	written  chan *ctrl_pb.Fault
+	attempts atomic.Int32
+	notifier *channel.CloseNotifier
+}
+
+func newTestCtrlChannel(t *testing.T) *testCtrlChannel {
+	result := &testCtrlChannel{
+		BaseCtrlChannel: ctrlchan.NewBaseCtrlChannel(),
+		written:         make(chan *ctrl_pb.Fault, 1024),
+		notifier:        channel.NewCloseNotifier(),
+	}
+
+	go result.runUnderlay()
+	t.Cleanup(result.notifier.NotifyClosed)
+
+	return result
+}
+
+func (self *testCtrlChannel) IsConnected() bool {
+	return true
+}
+
+func (self *testCtrlChannel) failWrites(err error) {
+	self.writeErr.Store(&err)
+}
+
+func (self *testCtrlChannel) succeedWrites() {
+	self.writeErr.Store(nil)
+}
+
+func (self *testCtrlChannel) runUnderlay() {
+	for {
+		sendable, err := self.GetNextMsgDefault(self.notifier)
+		if err != nil || sendable == nil {
+			return
+		}
+
+		listener := sendable.SendListener()
+		listener.NotifyBeforeWrite()
+		self.attempts.Add(1)
+
+		if writeErr := self.writeErr.Load(); writeErr != nil {
+			// how a failed underlay write is reported once HandleTxFailed declines a retry
+			listener.NotifyErr(*writeErr)
+			listener.NotifyAfterWrite()
+			continue
+		}
+
+		fault := &ctrl_pb.Fault{}
+		if err = proto.Unmarshal(sendable.Msg().Body, fault); err == nil {
+			self.written <- fault
+		}
+		listener.NotifyAfterWrite()
+	}
+}
+
+// testControllers hands out one controller channel, or none when unavailable is set, standing in
+// for a controller that is not connected.
+type testControllers struct {
+	env.MockNetworkControllers
+	ctrlCh *testCtrlChannel
+	// read by the sender goroutine while the test flips it
+	unavailable atomic.Bool
+}
+
+func (self *testControllers) GetCtrlChannel(string) ctrlchan.CtrlChannel {
+	if self.unavailable.Load() {
+		return nil
+	}
+	return self.ctrlCh
+}
+
+func newTestFaulter(t *testing.T, retention time.Duration) (*Faulter, *testControllers) {
+	registry := metrics.NewRegistry("test", nil)
+	ctrls := &testControllers{ctrlCh: newTestCtrlChannel(t)}
+
+	return &Faulter{
+		ctrls:                  ctrls,
+		closeNotify:            make(chan struct{}),
+		endpointFaultSenders:   cmap.New[*endpointFaultSender](),
+		endpointFaultRetention: retention,
+		circuitFaults:          registry.Meter("faults.circuit"),
+		endpointFaultsSent:     registry.Meter("faults.circuit.endpoint"),
+		endpointFaultsExpired:  registry.Meter("faults.circuit.endpoint.expired"),
+	}, ctrls
+}
+
+// takeFault waits for the next fault the underlay wrote.
+func takeFault(req *require.Assertions, ctrls *testControllers) *ctrl_pb.Fault {
+	select {
+	case fault := <-ctrls.ctrlCh.written:
+		return fault
+	case <-time.After(5 * time.Second):
+		req.Fail("no fault was written")
+		return nil
+	}
+}
+
+func pendingCount(f *Faulter, ctrlId string) int {
+	sender, found := f.endpointFaultSenders.Get(ctrlId)
+	if !found {
+		return 0
+	}
+	sender.lock.Lock()
+	defer sender.lock.Unlock()
+	return len(sender.pending)
+}
+
+func Test_EndpointFault_Delivered(t *testing.T) {
+	req := require.New(t)
+	f, ctrls := newTestFaulter(t, time.Minute)
+
+	f.ReportEndpointFault("circuit-1", "ctrl-1", ctrl_pb.FaultSubject_IngressFault)
+
+	fault := takeFault(req, ctrls)
+	req.Equal("circuit-1", fault.Id)
+	req.Equal(ctrl_pb.FaultSubject_IngressFault, fault.Subject)
+
+	req.Eventually(func() bool {
+		return pendingCount(f, "ctrl-1") == 0
+	}, 5*time.Second, time.Millisecond, "a delivered fault must not stay pending")
+}
+
+// Test_EndpointFault_RetainedWhileControllerUnavailable is the point of the change: a fault that
+// cannot be sent is kept rather than lost, since nothing else will report it again.
+func Test_EndpointFault_RetainedWhileControllerUnavailable(t *testing.T) {
+	req := require.New(t)
+	f, ctrls := newTestFaulter(t, time.Minute)
+	ctrls.unavailable.Store(true)
+
+	f.ReportEndpointFault("circuit-1", "ctrl-1", ctrl_pb.FaultSubject_IngressFault)
+
+	req.Eventually(func() bool {
+		return pendingCount(f, "ctrl-1") == 1
+	}, 5*time.Second, time.Millisecond, "an unsendable fault must be retained")
+
+	// the controller comes back and is announced; the retained fault goes out without waiting for
+	// the sweep
+	ctrls.unavailable.Store(false)
+	sender, _ := f.endpointFaultSenders.Get("ctrl-1")
+	sender.wake()
+
+	fault := takeFault(req, ctrls)
+	req.Equal("circuit-1", fault.Id)
+}
+
+func Test_EndpointFault_DuplicatesCollapse(t *testing.T) {
+	req := require.New(t)
+	f, ctrls := newTestFaulter(t, time.Minute)
+	ctrls.unavailable.Store(true)
+
+	for range 20 {
+		f.ReportEndpointFault("circuit-1", "ctrl-1", ctrl_pb.FaultSubject_IngressFault)
+	}
+
+	req.Eventually(func() bool {
+		return pendingCount(f, "ctrl-1") == 1
+	}, 5*time.Second, time.Millisecond, "repeat reports of one fault must collapse")
+}
+
+// Test_EndpointFault_SubjectIsPartOfTheKey covers a router holding both ends of a circuit: those
+// are two distinct faults and neither may displace the other.
+func Test_EndpointFault_SubjectIsPartOfTheKey(t *testing.T) {
+	req := require.New(t)
+	f, ctrls := newTestFaulter(t, time.Minute)
+	ctrls.unavailable.Store(true)
+
+	f.ReportEndpointFault("circuit-1", "ctrl-1", ctrl_pb.FaultSubject_IngressFault)
+	f.ReportEndpointFault("circuit-1", "ctrl-1", ctrl_pb.FaultSubject_EgressFault)
+
+	req.Eventually(func() bool {
+		return pendingCount(f, "ctrl-1") == 2
+	}, 5*time.Second, time.Millisecond, "ingress and egress faults for one circuit are distinct")
+}
+
+// Test_EndpointFault_ExpiresAfterRetention covers the memory bound: a fault outlives the circuit
+// it names, so a controller that stays unreachable would otherwise accumulate one entry per
+// teardown for the length of the outage.
+func Test_EndpointFault_ExpiresAfterRetention(t *testing.T) {
+	req := require.New(t)
+	f, ctrls := newTestFaulter(t, time.Millisecond)
+	ctrls.unavailable.Store(true)
+
+	f.ReportEndpointFault("circuit-1", "ctrl-1", ctrl_pb.FaultSubject_IngressFault)
+
+	sender, found := f.endpointFaultSenders.Get("ctrl-1")
+	req.True(found)
+
+	req.Eventually(func() bool {
+		sender.wake()
+		return pendingCount(f, "ctrl-1") == 0
+	}, 5*time.Second, time.Millisecond, "a fault held past retention must be given up")
+}
+
+func Test_EndpointFault_ReportDoesNotBlockOnUnavailableController(t *testing.T) {
+	req := require.New(t)
+	f, ctrls := newTestFaulter(t, time.Minute)
+	ctrls.unavailable.Store(true)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := range 500 {
+			f.ReportEndpointFault(circuitId(i), "ctrl-1", ctrl_pb.FaultSubject_IngressFault)
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		req.Fail("reporting a fault blocked on an unavailable controller")
+	}
+}
+
+func Test_EndpointFault_NoControllerIsReported(t *testing.T) {
+	req := require.New(t)
+	f, _ := newTestFaulter(t, time.Minute)
+
+	// nothing to send to and nothing to retry against; must not create a sender
+	f.ReportEndpointFault("circuit-1", "", ctrl_pb.FaultSubject_IngressFault)
+
+	req.Equal(0, f.endpointFaultSenders.Count())
+}
+
+func Test_EndpointFault_ShutdownAbandonsPending(t *testing.T) {
+	req := require.New(t)
+	f, ctrls := newTestFaulter(t, time.Minute)
+	ctrls.unavailable.Store(true)
+
+	f.ReportEndpointFault("circuit-1", "ctrl-1", ctrl_pb.FaultSubject_IngressFault)
+
+	sender, found := f.endpointFaultSenders.Get("ctrl-1")
+	req.True(found)
+
+	// a controller removed from the cluster has no circuits left to clean up
+	f.endpointFaultSenders.Remove("ctrl-1")
+	sender.shutdown()
+	sender.shutdown() // idempotent
+
+	req.Equal(0, f.endpointFaultSenders.Count())
+}
+
+func circuitId(i int) string {
+	return "circuit-" + strconv.Itoa(i)
+}
+
+// Test_EndpointFault_RetainedWhenWriteFails covers the difference between the queue accepting a
+// fault and the fault reaching the wire. The sender declines to retry a failed write, so treating
+// queue acceptance as delivery drops the fault while reporting success.
+func Test_EndpointFault_RetainedWhenWriteFails(t *testing.T) {
+	req := require.New(t)
+	f, ctrls := newTestFaulter(t, time.Minute)
+	ctrls.ctrlCh.failWrites(errors.New("underlay write failed"))
+
+	f.ReportEndpointFault("circuit-1", "ctrl-1", ctrl_pb.FaultSubject_IngressFault)
+
+	// wait for the write to have been attempted and failed, so that what is asserted below is the
+	// state after the attempt rather than the state before it
+	req.Eventually(func() bool {
+		return ctrls.ctrlCh.attempts.Load() > 0
+	}, 5*time.Second, time.Millisecond, "the fault was never written")
+
+	req.Equal(1, pendingCount(f, "ctrl-1"), "a fault whose write failed must be retained")
+	req.Equal(int64(0), f.endpointFaultsSent.Count(), "a failed write is not a delivery")
+
+	// writes recover, and the retained fault goes out
+	ctrls.ctrlCh.succeedWrites()
+	sender, found := f.endpointFaultSenders.Get("ctrl-1")
+	req.True(found)
+	sender.wake()
+
+	fault := takeFault(req, ctrls)
+	req.Equal("circuit-1", fault.Id)
+
+	req.Eventually(func() bool {
+		return pendingCount(f, "ctrl-1") == 0
+	}, 5*time.Second, time.Millisecond)
+	req.Equal(int64(1), f.endpointFaultsSent.Count())
+}
+
+// Test_EndpointFault_ExpiresWhileControllerNotDraining covers retention continuing to run while a
+// controller takes nothing. The sender both delivers and expires, so a send that waited
+// indefinitely would stop expiry while new faults kept arriving.
+func Test_EndpointFault_ExpiresWhileControllerNotDraining(t *testing.T) {
+	req := require.New(t)
+	f, ctrls := newTestFaulter(t, time.Millisecond)
+	ctrls.ctrlCh.failWrites(errors.New("underlay write failed"))
+
+	f.ReportEndpointFault("circuit-1", "ctrl-1", ctrl_pb.FaultSubject_IngressFault)
+
+	sender, found := f.endpointFaultSenders.Get("ctrl-1")
+	req.True(found)
+
+	// the fault must leave by expiring, not by being counted as sent
+	req.Eventually(func() bool {
+		sender.wake()
+		return f.endpointFaultsExpired.Count() > 0
+	}, 10*time.Second, 5*time.Millisecond, "retention must run even while sends are failing")
+
+	req.Equal(int64(0), f.endpointFaultsSent.Count())
+	req.Equal(0, pendingCount(f, "ctrl-1"))
+}

--- a/router/forwarder/faulter.go
+++ b/router/forwarder/faulter.go
@@ -45,11 +45,26 @@ type Faulter struct {
 	closeNotify   <-chan struct{}
 	linkFaults    metrics.Meter
 	circuitFaults metrics.Meter
+
+	// Endpoint faults are delivered per controller, separately from the batched forwarding
+	// faults above: they are reported when a circuit's endpoint goes away rather than when
+	// traffic arrives for an unknown circuit, so nothing re-reports them and each needs its own
+	// retry. Senders are created on demand, since a router does not necessarily hold circuits
+	// for every controller.
+	endpointFaultSenders   cmap.ConcurrentMap[string, *endpointFaultSender]
+	endpointFaultRetention time.Duration
+	endpointFaultsSent     metrics.Meter
+	endpointFaultsExpired  metrics.Meter
 }
 
 type FaultReceiver interface {
 	Report(circuitId string, ctrlId string)
 	NotifyInvalidLink(linkId string)
+
+	// ReportEndpointFault reports that a circuit's ingress or egress endpoint on this router has
+	// gone away, so the controller can remove the circuit. It does not block and does not wait
+	// for the controller; delivery, retry and eventual expiry are the faulter's.
+	ReportEndpointFault(circuitId string, ctrlId string, subject ctrl_pb.FaultSubject)
 }
 
 func NewFaulter(routerEnv env.RouterEnv, interval time.Duration) *Faulter {
@@ -60,13 +75,67 @@ func NewFaulter(routerEnv env.RouterEnv, interval time.Duration) *Faulter {
 		closeNotify:   routerEnv.GetCloseNotify(),
 		linkFaults:    routerEnv.GetMetricsRegistry().Meter("faults.link"),
 		circuitFaults: routerEnv.GetMetricsRegistry().Meter("faults.circuit"),
+
+		endpointFaultSenders:   cmap.New[*endpointFaultSender](),
+		endpointFaultRetention: routerEnv.GetConfig().Forwarder.EndpointFaultRetention,
+		endpointFaultsSent:     routerEnv.GetMetricsRegistry().Meter("faults.circuit.endpoint"),
+		endpointFaultsExpired:  routerEnv.GetMetricsRegistry().Meter("faults.circuit.endpoint.expired"),
 	}
+
+	// Endpoint faults are delivered regardless of the forwarding fault interval: unlike a
+	// forwarding fault, which the forwarder re-reports while traffic keeps arriving, an
+	// unreported endpoint fault leaves the controller holding a circuit forever.
+	routerEnv.GetNetworkControllers().AddChangeListener(env.CtrlEventListenerFunc(f.notifyOfCtrlEvent))
 
 	if interval > 0 {
 		go f.run()
 	}
 
 	return f
+}
+
+// notifyOfCtrlEvent keeps the per-controller endpoint fault senders in step with the cluster. A
+// reconnecting controller is woken so anything held for it goes out immediately rather than
+// waiting for the sweep; a removed controller's senders are shut down, abandoning what they hold,
+// since a controller that has left the cluster has no circuits to clean up.
+func (self *Faulter) notifyOfCtrlEvent(event env.CtrlEvent) {
+	if event.Controller == nil {
+		return
+	}
+
+	ctrlId := event.Controller.Channel().Id()
+
+	switch event.Type {
+	case env.ControllerReconnected, env.ControllerAdded:
+		if sender, found := self.endpointFaultSenders.Get(ctrlId); found {
+			sender.wake()
+		}
+	case env.ControllerRemoved:
+		if sender, found := self.endpointFaultSenders.Get(ctrlId); found {
+			self.endpointFaultSenders.Remove(ctrlId)
+			sender.shutdown()
+		}
+	}
+}
+
+func (self *Faulter) ReportEndpointFault(circuitId string, ctrlId string, subject ctrl_pb.FaultSubject) {
+	if ctrlId == "" {
+		faultLog.Error("cannot report circuit endpoint fault, no controller for circuit",
+			"circuitId", circuitId,
+			"subject", subject.String(),
+		)
+		return
+	}
+
+	sender := self.endpointFaultSenders.Upsert(ctrlId, nil, func(exists bool, current *endpointFaultSender, _ *endpointFaultSender) *endpointFaultSender {
+		if current != nil {
+			return current
+		}
+		return newEndpointFaultSender(ctrlId, self)
+	})
+
+	self.circuitFaults.Mark(1)
+	sender.report(endpointFaultKey{circuitId: circuitId, subject: subject})
 }
 
 func (self *Faulter) Report(circuitId string, ctrlId string) {

--- a/router/forwarder/forwarder.go
+++ b/router/forwarder/forwarder.go
@@ -320,6 +320,19 @@ func (forwarder *Forwarder) ForwardControl(srcAddr xgress.Address, control *xgre
 	return err
 }
 
+// ReportCircuitEndpointFault hands the fault to the faulter, which owns delivery, retry and
+// expiry. Like ReportForwardingFault it resolves the owning controller from the forward table when
+// the caller does not know it.
+func (forwarder *Forwarder) ReportCircuitEndpointFault(circuitId string, ctrlId string, subject ctrl_pb.FaultSubject) {
+	if ctrlId == "" {
+		if ct, _ := forwarder.circuits.getForwardTable(circuitId, false); ct != nil {
+			ctrlId = ct.ctrlId
+		}
+	}
+
+	forwarder.faulter.ReportEndpointFault(circuitId, ctrlId, subject)
+}
+
 func (forwarder *Forwarder) ReportForwardingFault(circuitId string, ctrlId string) {
 	if ctrlId == "" {
 		ct, _ := forwarder.circuits.getForwardTable(circuitId, false)

--- a/router/handler_xgress/close.go
+++ b/router/handler_xgress/close.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/michaelquigley/pfxlog"
-	"github.com/openziti/channel/v5/protobufs"
 	"github.com/openziti/sdk-golang/v2/xgress"
 	"github.com/openziti/ziti/v2/common/pb/ctrl_pb"
 	"github.com/openziti/ziti/v2/router/env"
@@ -56,20 +55,11 @@ func (txc *closeHandler) HandleXgressClose(x *xgress.Xgress) {
 	txc.forwarder.EndCircuit(x.CircuitId())
 
 	// Notify the controller of the xgress fault
-	fault := &ctrl_pb.Fault{Id: x.CircuitId()}
-	if x.Originator() == xgress.Initiator {
-		fault.Subject = ctrl_pb.FaultSubject_IngressFault
-	} else if x.Originator() == xgress.Terminator {
-		fault.Subject = ctrl_pb.FaultSubject_EgressFault
+	subject := ctrl_pb.FaultSubject_IngressFault
+	if x.Originator() == xgress.Terminator {
+		subject = ctrl_pb.FaultSubject_EgressFault
 	}
 
-	ch := txc.ctrls.GetChannel(x.CtrlId())
-	if ch == nil {
-		log.WithField("ctrlId", x.CtrlId()).Error("control channel not available")
-	} else {
-		log.Debug("notifying controller of fault")
-		if err := protobufs.MarshalTyped(fault).Send(ch); err != nil {
-			log.WithError(err).Error("error sending fault")
-		}
-	}
+	log.Debug("reporting circuit fault")
+	txc.forwarder.ReportCircuitEndpointFault(x.CircuitId(), x.CtrlId(), subject)
 }

--- a/router/posture/checks.go
+++ b/router/posture/checks.go
@@ -56,13 +56,7 @@ func (cache *Cache) onUpdate(data *InstanceData) {
 func (cache *Cache) AddResponses(identityId, apiSessionId string, responses *edge_client_pb.PostureResponses) {
 	instance := cache.getOrCreateInstance(identityId, apiSessionId)
 
-	updated := false
-	for _, response := range responses.Responses {
-		next := instance.Apply(response, cache.totpParser)
-		updated = updated || next
-	}
-
-	if updated {
+	if instance.ApplyBatch(responses.Responses, cache.totpParser) {
 		instance.emitUpdated()
 	}
 }
@@ -288,24 +282,64 @@ type TotpTokenParser interface {
 	ParseTotpToken(string) (*common.TotpClaims, error)
 }
 
-// Apply updates the posture instance with new device state information from a posture response.
-// This function merges the incoming posture data with existing data, only updating fields
-// that are present in the response. Changes are detected by comparing new values with
-// existing ones, and update listeners are notified only when actual changes occur.
-//
-// The function handles various types of posture data including OS information, domain
-// membership, MAC addresses, process lists, device lock status, and wake events.
-//
-// Parameters:
-//   - response: The posture response containing updated device state information
-//   - parser: A TOTP token parser implementation, used to verify ToTP tokens on posture response
-//
-// Returns:
-//   - bool: True if the posture instance was updated, false if no changes were detected
+// Apply updates the posture instance with the device state in a single posture response,
+// reporting whether anything changed. Equivalent to ApplyBatch with one response.
 func (instance *Instance) Apply(response *edge_client_pb.PostureResponse, parser TotpTokenParser) bool {
+	return instance.ApplyBatch([]*edge_client_pb.PostureResponse{response}, parser)
+}
+
+// ApplyBatch merges a batch of posture responses into the instance, reporting whether anything
+// changed. Each response carries one kind of device state (OS, domain, MAC addresses, a process
+// list delta, lock or wake events, or a TOTP token) and only that field is updated.
+//
+// The batch applies under a single lock hold, so a reader taking a Snapshot sees the state before
+// the batch or after all of it, never a partial batch. That matters because a batch is the unit a
+// client reports in: it may carry one process-list entry per watched process, or a MAC address
+// and a domain that change together, and evaluating an intermediate state can fail checks that
+// both the previous and the resulting state pass.
+//
+// TOTP tokens are verified before the lock is taken, since ParseTotpToken does signature
+// verification and reads public keys from the router data model, which does not belong inside this
+// lock. parser may be nil when no response carries a token.
+func (instance *Instance) ApplyBatch(responses []*edge_client_pb.PostureResponse, parser TotpTokenParser) bool {
+	totpClaims := make([]*common.TotpClaims, len(responses))
+	for i, response := range responses {
+		totpToken := response.GetTotpToken()
+		if totpToken == nil {
+			continue
+		}
+
+		if totpToken.Token == "" {
+			pfxlog.Logger().Error("received empty totp token for posture response")
+		}
+
+		claims, err := parser.ParseTotpToken(totpToken.Token)
+		if err != nil {
+			pfxlog.Logger().WithError(err).Error("error parsing totp token")
+		} else if claims.IssuedAt == nil {
+			pfxlog.Logger().Error("received totp token with no issued at time")
+		} else {
+			totpClaims[i] = claims
+		}
+	}
+
 	instance.lock.Lock()
 	defer instance.lock.Unlock()
 
+	updated := false
+	for i, response := range responses {
+		if instance.applyLocked(response, totpClaims[i]) {
+			updated = true
+		}
+	}
+
+	return updated
+}
+
+// applyLocked merges one response into the instance, reporting whether anything changed.
+// totpClaims carries the response's pre-verified TOTP claims, and is nil when the response is not
+// a TOTP token or its token failed verification. Caller must hold the instance lock.
+func (instance *Instance) applyLocked(response *edge_client_pb.PostureResponse, totpClaims *common.TotpClaims) bool {
 	updated := false
 
 	if os := response.GetOs(); os != nil {
@@ -343,28 +377,20 @@ func (instance *Instance) Apply(response *edge_client_pb.PostureResponse, parser
 		if instance.mergeProcessList(processList) {
 			updated = true
 		}
-	} else if totpToken := response.GetTotpToken(); totpToken != nil {
-		if totpToken.Token == "" {
-			pfxlog.Logger().Error("received empty totp token for posture response")
+	} else if response.GetTotpToken() != nil {
+		if totpClaims == nil {
+			// verification failed and was already logged
+			return false
 		}
 
-		totpClaims, err := parser.ParseTotpToken(totpToken.Token)
-
-		if err != nil {
-			pfxlog.Logger().WithError(err).Error("error parsing totp token")
-		} else if totpClaims.IssuedAt == nil {
-			pfxlog.Logger().Error("received totp token with no issued at time")
-		} else {
-
-			if totpClaims.ApiSessionId == instance.ApiSessionId {
-				passedAt := totpClaims.IssuedAt.Time
-				if instance.PassedMfaAt == nil || instance.PassedMfaAt.Before(passedAt) {
-					instance.PassedMfaAt = &passedAt
-					updated = true
-				}
-			} else {
-				pfxlog.Logger().Errorf("received totp token for api session %s, but instance is for %s", totpClaims.ApiSessionId, instance.ApiSessionId)
+		if totpClaims.ApiSessionId == instance.ApiSessionId {
+			passedAt := totpClaims.IssuedAt.Time
+			if instance.PassedMfaAt == nil || instance.PassedMfaAt.Before(passedAt) {
+				instance.PassedMfaAt = &passedAt
+				updated = true
 			}
+		} else {
+			pfxlog.Logger().Errorf("received totp token for api session %s, but instance is for %s", totpClaims.ApiSessionId, instance.ApiSessionId)
 		}
 	} else {
 		pfxlog.Logger().Warnf("received unknown posture response type: no fields updated, type: %T", response.GetType())

--- a/router/posture/checks_batch_test.go
+++ b/router/posture/checks_batch_test.go
@@ -1,0 +1,116 @@
+package posture
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/openziti/sdk-golang/v2/pb/edge_client_pb"
+	"github.com/stretchr/testify/require"
+)
+
+func procResponse(path, hash string) *edge_client_pb.PostureResponse {
+	return processListResponse(&edge_client_pb.PostureResponse_Process{
+		Path: path, IsRunning: true, Hash: hash,
+	})
+}
+
+func procBatch(hash string) []*edge_client_pb.PostureResponse {
+	return []*edge_client_pb.PostureResponse{
+		procResponse("/bin/a", hash), procResponse("/bin/b", hash), procResponse("/bin/c", hash),
+	}
+}
+
+// Test_ApplyBatch_ReaderNeverSeesMixedBatch covers the interleaving that revokes access from a
+// client that is in fact compliant. The Go SDK reports one process-list entry per watched process,
+// so a batch that updates several processes applies them one at a time. A reader must observe the
+// state before the batch or after all of it: a mix of old and new entries can fail an AllOf
+// process check that both the previous and the resulting state pass.
+func Test_ApplyBatch_ReaderNeverSeesMixedBatch(t *testing.T) {
+	req := require.New(t)
+
+	for range 500 {
+		instance := newInstance()
+		req.True(instance.ApplyBatch(procBatch("v1"), nil))
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			instance.ApplyBatch(procBatch("v2"), nil)
+		}()
+
+		var hashes []string
+		go func() {
+			defer wg.Done()
+			for _, proc := range instance.Snapshot().ProcessList.GetProcesses() {
+				hashes = append(hashes, proc.Hash)
+			}
+		}()
+
+		wg.Wait()
+
+		req.Len(hashes, 3)
+		for _, hash := range hashes {
+			req.Equal(hashes[0], hash,
+				"a reader must see the batch fully applied or not at all, got a mix: %v", hashes)
+		}
+	}
+}
+
+// Test_ApplyBatch_ReaderNeverSeesPartialGrowth is the same requirement for a batch that adds
+// processes rather than updating them: the set is empty or complete, never half built.
+func Test_ApplyBatch_ReaderNeverSeesPartialGrowth(t *testing.T) {
+	req := require.New(t)
+
+	for range 500 {
+		instance := newInstance()
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			instance.ApplyBatch(procBatch("v1"), nil)
+		}()
+
+		var observed int
+		go func() {
+			defer wg.Done()
+			observed = len(instance.Snapshot().ProcessList.GetProcesses())
+		}()
+
+		wg.Wait()
+		req.Contains([]int{0, 3}, observed, "a reader must not observe a partially applied batch")
+	}
+}
+
+func Test_ApplyBatch_AppliesEveryResponse(t *testing.T) {
+	req := require.New(t)
+	instance := newInstance()
+
+	req.True(instance.ApplyBatch([]*edge_client_pb.PostureResponse{
+		{Type: &edge_client_pb.PostureResponse_Domain_{
+			Domain: &edge_client_pb.PostureResponse_Domain{Name: "example.com"}}},
+		macResponse("00:11:22:33:44:55"),
+		procResponse("/bin/a", "abc"),
+	}, nil))
+
+	data := instance.Snapshot()
+	req.Equal("example.com", data.Domain.GetName())
+	req.Equal([]string{"001122334455"}, data.Macs.GetAddresses())
+	req.Len(data.ProcessList.GetProcesses(), 1)
+}
+
+func Test_ApplyBatch_UnchangedBatchReportsNoUpdate(t *testing.T) {
+	req := require.New(t)
+	instance := newInstance()
+
+	batch := []*edge_client_pb.PostureResponse{procResponse("/bin/a", "abc"), procResponse("/bin/b", "abc")}
+	req.True(instance.ApplyBatch(batch, nil))
+	req.False(instance.ApplyBatch(batch, nil), "re-reporting the same batch is not a change")
+}
+
+func Test_ApplyBatch_EmptyBatchReportsNoUpdate(t *testing.T) {
+	require.False(t, newInstance().ApplyBatch(nil, nil))
+}

--- a/router/state/manager.go
+++ b/router/state/manager.go
@@ -393,6 +393,28 @@ func NewManager(stateEnv env.RouterEnv) Manager {
 		panic(errors.Wrap(err, "error creating rdm goroutine pool"))
 	}
 
+	// Separate from the rdm pool, which is single-worker because data state events must apply in
+	// order. Posture re-evaluations are per api session and independent of each other, and must
+	// not queue behind an rdm sync.
+	postureEvalPoolConfig := goroutines.PoolConfig{
+		QueueSize:   uint32(1000),
+		MinWorkers:  0,
+		MaxWorkers:  uint32(8),
+		IdleTime:    30 * time.Second,
+		CloseNotify: stateEnv.GetCloseNotify(),
+		PanicHandler: func(err interface{}) {
+			pfxlog.Logger().
+				WithField(logrus.ErrorKey, err).
+				WithField("backtrace", string(debug.Stack())).Error("panic during posture re-evaluation")
+		},
+	}
+	servermetrics.ConfigureGoroutinesPoolMetrics(&postureEvalPoolConfig, stateEnv.GetMetricsRegistry(), "pool.posture.eval")
+
+	postureEvalPool, err := goroutines.NewPool(postureEvalPoolConfig)
+	if err != nil {
+		panic(errors.Wrap(err, "error creating posture evaluation goroutine pool"))
+	}
+
 	result := &ManagerImpl{
 		EventEmmiter:             events.New(),
 		legacyApiSessionsByToken: cmap.New[*ApiSessionToken](),
@@ -400,6 +422,7 @@ func NewManager(stateEnv env.RouterEnv) Manager {
 		certCache:                cmap.New[*x509.Certificate](),
 		env:                      stateEnv,
 		routerDataModelPool:      routerDataModelPool,
+		postureEvalPool:          postureEvalPool,
 		endpointsChanged:         make(chan env.CtrlEvent, 10),
 		modelChanged:             make(chan struct{}, 1),
 	}
@@ -426,20 +449,50 @@ func NewManager(stateEnv env.RouterEnv) Manager {
 	return result
 }
 
-// onPostureDataUpdate responds to changes in posture data by re-evaluating access policies
-// for all connections associated with the affected identity. When posture data changes
-// (such as OS updates, domain changes, or MFA status), this function ensures that all
-// active connections are still compliant with access policies.
-//
-// The function iterates through all channels for the identity, examines each connection,
-// and re-evaluates access using the updated posture data. Connections that no longer
-// meet policy requirements are automatically terminated with appropriate error messages.
-//
-// Parameters:
-//   - data: The updated posture instance data containing the current device state
+// onPostureDataUpdate schedules a re-evaluation of the api session whose posture data changed, so
+// that access no longer permitted by current posture is revoked and the SDK is told the new state.
+// It returns without waiting for that evaluation; see evaluatePostureChange.
 func (self *ManagerImpl) onPostureDataUpdate(data *posture.InstanceData) {
+	identityId := data.IdentityId
+	apiSessionId := data.ApiSessionId
+
+	// Handed to a worker so the caller, the connection's read loop, is not held while circuits are
+	// re-evaluated and state is pushed. If the workers are saturated, run it here instead: dropping
+	// it would leave access that posture no longer permits in place, and running it inline makes
+	// the connection producing the churn absorb the cost.
+	work := func() { self.evaluatePostureChange(identityId, apiSessionId) }
+	if err := self.postureEvalPool.QueueOrError(work); err != nil {
+		pfxlog.Logger().WithError(err).
+			WithField("identityId", identityId).
+			Debug("posture evaluation pool unavailable, re-evaluating inline")
+		work()
+	}
+}
+
+// evaluatePostureChange re-evaluates an api session's circuits and hosted terminators against the
+// identity's current posture, closing what no longer has access, and pushes the resulting state to
+// the SDK.
+//
+// It reads the posture data itself rather than taking it from the update that scheduled it: several
+// updates for one api session can be in flight, and evaluating the state an older update carried
+// could revoke access that the newer state allows. Reading current data makes a late evaluation
+// redundant instead of wrong.
+//
+// A consequence is that states between updates are not separately acted on: if an endpoint reports
+// non-compliance and then compliance again before this runs, nothing is revoked. Enforcement is
+// against current posture only. Anything that must observe every reported state, an audit trail or
+// posture events, belongs on the ingest path in posture.Instance.Apply, which sees every update in
+// the order it arrived.
+func (self *ManagerImpl) evaluatePostureChange(identityId, apiSessionId string) {
+	data := self.GetPostureData(apiSessionId)
+	if data == nil {
+		// the api session's posture data is gone (the session was evicted), so it has no
+		// connections left to re-evaluate
+		return
+	}
+
 	rdm := self.routerDataModel.Load()
-	channels := self.connectionTracker.GetChannelsByIdentityId(data.IdentityId)
+	channels := self.connectionTracker.GetChannelsByIdentityId(identityId)
 
 	for _, ch := range channels {
 		// Posture data is per-api-session. An identity may have several concurrent
@@ -449,7 +502,7 @@ func (self *ManagerImpl) onPostureDataUpdate(data *posture.InstanceData) {
 		// another's circuits. Every circuit and terminator on a channel shares the
 		// channel's api-session, so make this check once per channel.
 		apiSessionToken := GetApiSessionTokenFromCh(ch)
-		if apiSessionToken == nil || apiSessionToken.Id != data.ApiSessionId {
+		if apiSessionToken == nil || apiSessionToken.Id != apiSessionId {
 			continue
 		}
 
@@ -457,8 +510,6 @@ func (self *ManagerImpl) onPostureDataUpdate(data *posture.InstanceData) {
 		if edgeConn == nil {
 			continue
 		}
-
-		identityId := apiSessionToken.IdentityId
 
 		// Re-evaluate dial access (policy + posture) for every active dial
 		// circuit — both connId mux-sink conns and SDK-hosted xgress circuits.
@@ -626,6 +677,7 @@ type ManagerImpl struct {
 	ctrlRootCache       controllerRootCache
 	routerDataModel     atomic.Pointer[common.RouterDataModel]
 	routerDataModelPool goroutines.Pool
+	postureEvalPool     goroutines.Pool
 
 	resyncRouterDataModel atomic.Bool
 	endpointsChanged      chan env.CtrlEvent

--- a/router/state/manager_posture_eval_test.go
+++ b/router/state/manager_posture_eval_test.go
@@ -1,0 +1,135 @@
+package state
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/openziti/channel/v5"
+	"github.com/openziti/foundation/v2/goroutines"
+	"github.com/openziti/sdk-golang/v2/pb/edge_client_pb"
+	"github.com/openziti/ziti/v2/common"
+	"github.com/openziti/ziti/v2/router/posture"
+	"github.com/stretchr/testify/require"
+)
+
+// rejectingPool is a goroutines.Pool that accepts no work, standing in for a pool whose workers
+// and queue are saturated. Shutting a real pool down is not usable here: QueueOrError selects over
+// the queue and the close signal together, so a shut-down pool still accepts work about half the
+// time.
+type rejectingPool struct{}
+
+func (rejectingPool) Queue(func()) error                           { return errors.New("rejected") }
+func (rejectingPool) QueueWithTimeout(func(), time.Duration) error { return errors.New("rejected") }
+func (rejectingPool) QueueOrError(func()) error                    { return errors.New("rejected") }
+func (rejectingPool) GetWorkerCount() uint32                       { return 0 }
+func (rejectingPool) GetQueueSize() uint32                         { return 0 }
+func (rejectingPool) GetBusyWorkers() uint32                       { return 0 }
+func (rejectingPool) GetOutstanding() uint32                       { return 0 }
+func (rejectingPool) Shutdown()                                    {}
+func (rejectingPool) ShutdownAndWait(time.Duration) error          { return nil }
+func (rejectingPool) AwaitIdle(time.Duration) error                { return nil }
+
+// stubConnectionTracker records whether the posture evaluation reached the point of looking for
+// the identity's connections, which is the first thing it does once it has posture data.
+type stubConnectionTracker struct {
+	lookups atomic.Int32
+}
+
+func (self *stubConnectionTracker) GetChannels() map[string][]channel.Channel {
+	return nil
+}
+
+func (self *stubConnectionTracker) GetChannelsByIdentityId(string) []channel.Channel {
+	self.lookups.Add(1)
+	return nil
+}
+
+func newPostureEvalTestManager(t *testing.T, pool goroutines.Pool) (*ManagerImpl, *stubConnectionTracker) {
+	tracker := &stubConnectionTracker{}
+	mgr := &ManagerImpl{
+		postureCache:      posture.NewCache(nil),
+		postureEvalPool:   pool,
+		connectionTracker: tracker,
+	}
+	mgr.routerDataModel.Store(common.NewBareRouterDataModel(""))
+	t.Cleanup(func() {
+		if pool != nil {
+			pool.Shutdown()
+		}
+	})
+	return mgr, tracker
+}
+
+func newTestPool(t *testing.T, queueSize uint32) goroutines.Pool {
+	pool, err := goroutines.NewPool(goroutines.PoolConfig{
+		QueueSize:    queueSize,
+		MinWorkers:   0,
+		MaxWorkers:   1,
+		IdleTime:     time.Second,
+		CloseNotify:  make(chan struct{}),
+		PanicHandler: func(interface{}) {},
+	})
+	require.NoError(t, err)
+	return pool
+}
+
+func seedPosture(mgr *ManagerImpl, apiSessionId string) {
+	mgr.postureCache.AddResponses("identity-1", apiSessionId, &edge_client_pb.PostureResponses{
+		Responses: []*edge_client_pb.PostureResponse{
+			{
+				Type: &edge_client_pb.PostureResponse_Domain_{
+					Domain: &edge_client_pb.PostureResponse_Domain{Name: "example.com"},
+				},
+			},
+		},
+	})
+}
+
+func Test_EvaluatePostureChange_NoPostureDataIsANoop(t *testing.T) {
+	req := require.New(t)
+	mgr, tracker := newPostureEvalTestManager(t, newTestPool(t, 16))
+
+	// the api session's posture data has been evicted; there is nothing to re-evaluate and no
+	// connections to look for
+	mgr.evaluatePostureChange("identity-1", "evicted-session")
+
+	req.Equal(int32(0), tracker.lookups.Load())
+}
+
+func Test_EvaluatePostureChange_ReadsCurrentPostureData(t *testing.T) {
+	req := require.New(t)
+	mgr, tracker := newPostureEvalTestManager(t, newTestPool(t, 16))
+
+	seedPosture(mgr, "session-1")
+	mgr.evaluatePostureChange("identity-1", "session-1")
+
+	req.Equal(int32(1), tracker.lookups.Load(), "posture data present, so the evaluation proceeds")
+}
+
+// Test_OnPostureDataUpdate_RunsInlineWhenPoolRejects covers the fail-safe: an evaluation that
+// cannot be queued must still run, since dropping it would leave access in place that current
+// posture no longer permits.
+func Test_OnPostureDataUpdate_RunsInlineWhenPoolRejects(t *testing.T) {
+	req := require.New(t)
+
+	mgr, tracker := newPostureEvalTestManager(t, rejectingPool{})
+	seedPosture(mgr, "session-1")
+
+	mgr.onPostureDataUpdate(&posture.InstanceData{IdentityId: "identity-1", ApiSessionId: "session-1"})
+
+	req.Equal(int32(1), tracker.lookups.Load(), "a rejected evaluation must still run inline")
+}
+
+func Test_OnPostureDataUpdate_SchedulesOntoThePool(t *testing.T) {
+	req := require.New(t)
+	mgr, tracker := newPostureEvalTestManager(t, newTestPool(t, 16))
+	seedPosture(mgr, "session-1")
+
+	mgr.onPostureDataUpdate(&posture.InstanceData{IdentityId: "identity-1", ApiSessionId: "session-1"})
+
+	req.Eventually(func() bool {
+		return tracker.lookups.Load() == 1
+	}, 5*time.Second, time.Millisecond, "the scheduled evaluation must run")
+}

--- a/router/test/single_router_perf_test.go
+++ b/router/test/single_router_perf_test.go
@@ -127,6 +127,9 @@ func (t testFaultReceiver) Report(circuitId string, ctrlId string) {}
 
 func (t testFaultReceiver) NotifyInvalidLink(linkId string) {}
 
+func (t testFaultReceiver) ReportEndpointFault(circuitId string, ctrlId string, subject ctrl_pb.FaultSubject) {
+}
+
 type testXgCloseHandler struct{}
 
 func (t testXgCloseHandler) HandleXgressClose(x *xgress.Xgress) {

--- a/router/xgress_edge/accept.go
+++ b/router/xgress_edge/accept.go
@@ -112,12 +112,12 @@ func (self *Acceptor) BindChannel(binding channel.Binding) error {
 		},
 	})
 
-	channel.AddReceiveHandlers(binding, &channel.AsyncFunctionReceiveAdapter{
-		Type: sdkEdge.ContentTypePostureResponse,
-		Handler: func(m *channel.Message, ch channel.Channel) {
-			conn.processPostureResponse(m, ch)
-		},
-	})
+	// Handled on the receive loop rather than through an async adapter: posture responses must
+	// apply in the order the SDK sent them, and a dial or bind received behind one must observe it
+	// applied. An async adapter dispatches each message on its own goroutine, which lets an older
+	// response land after a newer one and lets a dial overtake the response it depends on. Only
+	// applying the reported state runs here; enforcement and the SDK notification are deferred.
+	binding.AddReceiveHandlerF(sdkEdge.ContentTypePostureResponse, conn.processPostureResponse)
 
 	channel.AddReceiveHandlers(binding, &channel.AsyncFunctionReceiveAdapter{
 		Type: sdkEdge.ContentTypeUpdateToken,
@@ -140,6 +140,8 @@ func (self *Acceptor) BindChannel(binding channel.Binding) error {
 		},
 	})
 
+	// Resync requests carry no ordering requirement and are rate limited per connection, so unlike
+	// posture responses above they stay on an async adapter.
 	channel.AddReceiveHandlers(binding, &channel.AsyncFunctionReceiveAdapter{
 		Type: sdkEdge.ContentTypeResyncPostureState,
 		Handler: func(m *channel.Message, ch channel.Channel) {

--- a/router/xgress_edge/listener.go
+++ b/router/xgress_edge/listener.go
@@ -408,6 +408,43 @@ func (listener *listener) Close() error {
 	return listener.underlayListener.Close()
 }
 
+// pendingPostureState is a posture state change waiting to be written to the SDK. seq is not
+// assigned here; the writer assigns it as it sends, so coalescing cannot leave gaps in the
+// sequence the SDK sees.
+type pendingPostureState struct {
+	rdm             *common.RouterDataModel
+	structuralIndex uint64
+	data            *posture.InstanceData
+}
+
+// posturePushState is a connection's posture push state: the queue of state changes to write to
+// the SDK, the sequence of those writes, and the rate limit for SDK-requested resyncs.
+type posturePushState struct {
+	// send holds the queued state change and whether a writer goroutine is draining it. Both are
+	// decided under the same lock so a producer cannot queue work just as the writer decides to
+	// exit, which would leave the state unsent with nothing to retrigger it.
+	send struct {
+		sync.Mutex
+		// pending is the state change to write, or nil when none is queued. A newer state
+		// replaces an older one rather than queueing behind it: PostureStateChange is a full
+		// state replacement, so only the newest is worth sending.
+		pending *pendingPostureState
+		writing bool
+	}
+
+	// seq is the per-connection PostureStateChange counter, assigned by the writer.
+	seq atomic.Uint64
+
+	// resync rate limits SDK-requested resyncs, each of which rebuilds the identity's full
+	// posture state. See processResyncPostureState. deferredSend is the pending send for a
+	// request that arrived inside the rate limit, and is nil when none is pending.
+	resync struct {
+		sync.Mutex
+		lastSentAt   time.Time
+		deferredSend *time.Timer
+	}
+}
+
 type edgeClientConn struct {
 	msgMux          sdkedge.ConnMux[*state.ConnState]
 	listener        *listener
@@ -429,11 +466,8 @@ type edgeClientConn struct {
 		lastRequired concurrenz.AtomicValue[time.Time]
 	}
 
-	// postureSeq is the per-connection PostureStateChange counter. postureSendMu serializes seq
-	// assignment with the channel send (see emitPostureStateChange): two concurrent emits must not
-	// enqueue out of seq order, since the SDK reads out-of-order seqs as gaps.
-	postureSeq    atomic.Uint64
-	postureSendMu sync.Mutex
+	// posture holds this connection's posture push state.
+	posture posturePushState
 
 	// svcSubscription tracks the per-connection service push subscription state.
 	svcSubscription struct {
@@ -858,6 +892,8 @@ func (self *edgeClientConn) HandleClose(ch channel.Channel) {
 	self.msgMux.Close()
 	self.cleanupXgressCircuits()
 	self.listener.factory.stateManager.RouterDataModel().UnsubscribeFromIdentityChanges(self.getIdentityId(), self)
+	self.cancelDeferredPostureResync()
+	self.discardPendingPostureState()
 	if self.removeApiSessionListener != nil {
 		self.removeApiSessionListener()
 	}
@@ -1831,8 +1867,11 @@ func (self *edgeClientConn) processPostureResponse(msg *channel.Message, ch chan
 			return
 		}
 
-		go self.listener.factory.stateManager.ProcessPostureResponses(ch, postureResponses)
-
+		// Applied on the read loop, not a goroutine: responses for one connection must apply in the
+		// order sent, and the SDK reports posture before it dials or binds, so a dial arriving
+		// behind a posture response must see that response already applied. The expensive part,
+		// re-evaluating access and pushing state, is handed off inside ProcessPostureResponses.
+		self.listener.factory.stateManager.ProcessPostureResponses(ch, postureResponses)
 	}
 }
 
@@ -2038,8 +2077,70 @@ func (self *edgeClientConn) sendFullSyncLocked(rdm *common.RouterDataModel) bool
 	return true
 }
 
+// minPostureResyncInterval is the shortest gap between honouring posture resync requests on one
+// connection. A conforming SDK asks at most once per detected gap and waits for the answer, so
+// this only bounds a client that asks faster than that.
+const minPostureResyncInterval = time.Second
+
 func (self *edgeClientConn) processResyncPostureState(_ *channel.Message, _ channel.Channel) {
 	if !self.isServiceSubscriptionActive() {
+		return
+	}
+
+	if !self.claimPostureResync() {
+		return
+	}
+
+	self.sendPostureState()
+}
+
+// claimPostureResync reports whether a resync should be sent now. Requests arriving inside the
+// rate limit are not answered immediately and not discarded either: one is deferred to the end of
+// the current interval, because an SDK that asked will not ask again until it is answered, and
+// dropping the request would leave it on stale posture state until some unrelated change happened
+// to push new state. Repeated requests inside one interval collapse into that single deferred send.
+func (self *edgeClientConn) claimPostureResync() bool {
+	self.posture.resync.Lock()
+	defer self.posture.resync.Unlock()
+
+	now := time.Now()
+	if elapsed := now.Sub(self.posture.resync.lastSentAt); elapsed >= minPostureResyncInterval {
+		self.posture.resync.lastSentAt = now
+		return true
+	} else if self.posture.resync.deferredSend == nil {
+		self.posture.resync.deferredSend = time.AfterFunc(minPostureResyncInterval-elapsed, self.sendDeferredPostureResync)
+	}
+
+	return false
+}
+
+// discardPendingPostureState drops any queued posture state change. The writer's send unblocks
+// when the channel closes; this keeps it from writing state nobody can receive on its way out.
+func (self *edgeClientConn) discardPendingPostureState() {
+	self.posture.send.Lock()
+	defer self.posture.send.Unlock()
+	self.posture.send.pending = nil
+}
+
+// cancelDeferredPostureResync stops a pending deferred resync, so a closing connection is not
+// kept alive by its timer.
+func (self *edgeClientConn) cancelDeferredPostureResync() {
+	self.posture.resync.Lock()
+	defer self.posture.resync.Unlock()
+
+	if self.posture.resync.deferredSend != nil {
+		self.posture.resync.deferredSend.Stop()
+		self.posture.resync.deferredSend = nil
+	}
+}
+
+func (self *edgeClientConn) sendDeferredPostureResync() {
+	self.posture.resync.Lock()
+	self.posture.resync.deferredSend = nil
+	self.posture.resync.lastSentAt = time.Now()
+	self.posture.resync.Unlock()
+
+	if self.ch.GetChannel().IsClosed() || !self.isServiceSubscriptionActive() {
 		return
 	}
 
@@ -2062,14 +2163,60 @@ func (self *edgeClientConn) sendPostureState() {
 	self.emitPostureStateChange(rdm, uint64(rdm.CurrentIndex()), data)
 }
 
-// emitPostureStateChange assigns the next posture seq and sends the state change through one
-// serialized per-connection path. All PostureStateChange emission funnels through here.
+// emitPostureStateChange queues a posture state change for delivery to the SDK and returns
+// without waiting for it to be written. All PostureStateChange emission funnels through here.
+//
+// It does not write to the channel itself because callers include the connection read loop and
+// the shared posture evaluation pool: a peer that stops reading would otherwise park the caller
+// on a full send queue, stalling that connection's reads or, worse, posture enforcement for every
+// other identity. A state change queued while an earlier one is still being written replaces it,
+// since the message is a full state replacement.
 func (self *edgeClientConn) emitPostureStateChange(rdm *common.RouterDataModel, structuralIndex uint64, data *posture.InstanceData) {
-	self.postureSendMu.Lock()
-	defer self.postureSendMu.Unlock()
+	self.posture.send.Lock()
+	self.posture.send.pending = &pendingPostureState{
+		rdm:             rdm,
+		structuralIndex: structuralIndex,
+		data:            data,
+	}
+	startWriter := !self.posture.send.writing
+	if startWriter {
+		self.posture.send.writing = true
+	}
+	self.posture.send.Unlock()
 
-	seq := self.postureSeq.Inc()
-	ps := buildPostureStateChange(seq, structuralIndex, rdm, self.getIdentityId(), data)
+	if startWriter {
+		go self.writePostureStateChanges()
+	}
+}
+
+// writePostureStateChanges drains queued posture state changes to the SDK, exiting once the queue
+// is empty. It is started on demand by emitPostureStateChange and is the only writer of
+// PostureStateChange messages on this connection, which is what keeps the sequence the SDK sees
+// contiguous.
+func (self *edgeClientConn) writePostureStateChanges() {
+	for {
+		self.posture.send.Lock()
+		next := self.posture.send.pending
+		self.posture.send.pending = nil
+		if next == nil {
+			// Released under the same lock a producer queues on, so a state change queued from
+			// here on starts a new writer rather than being dropped.
+			self.posture.send.writing = false
+			self.posture.send.Unlock()
+			return
+		}
+		self.posture.send.Unlock()
+
+		self.writePostureStateChange(next)
+	}
+}
+
+// writePostureStateChange assigns the next posture seq and writes one state change to the SDK.
+// Only writePostureStateChanges may call it: seq is assigned here rather than at queue time, so
+// concurrent writers would produce out-of-order seqs, which the SDK reads as gaps.
+func (self *edgeClientConn) writePostureStateChange(pending *pendingPostureState) {
+	seq := self.posture.seq.Inc()
+	ps := buildPostureStateChange(seq, pending.structuralIndex, pending.rdm, self.getIdentityId(), pending.data)
 
 	b, err := proto.Marshal(ps)
 	if err != nil {
@@ -2078,6 +2225,10 @@ func (self *edgeClientConn) emitPostureStateChange(rdm *common.RouterDataModel, 
 	}
 
 	msg := channel.NewMessage(sdkedge.ContentTypePostureStateChange, b)
+
+	// CH-S1 exception: this goroutine exists to drain the queue into the channel, so blocking here
+	// is the backpressure, and nothing else is behind it. A peer that stops reading parks this
+	// writer only; the send unblocks when the channel closes.
 	if err := self.ch.GetChannel().Send(msg); err != nil {
 		pfxlog.Logger().WithError(err).Error("failed to send PostureStateChange")
 	}

--- a/router/xgress_edge/listener.go
+++ b/router/xgress_edge/listener.go
@@ -956,25 +956,16 @@ func (self *edgeClientConn) cleanupXgressCircuit(edgeForwarder *xgEdgeForwarder)
 	self.forwarder.EndCircuit(circuitId)
 	self.xgCircuits.Remove(circuitId)
 
-	// Notify the controller of the xgress fault
-	fault := &ctrl_pb.Fault{Id: circuitId}
-	switch edgeForwarder.originator {
-	case xgress.Initiator:
-		fault.Subject = ctrl_pb.FaultSubject_IngressFault
-	case xgress.Terminator:
-		fault.Subject = ctrl_pb.FaultSubject_EgressFault
+	// Notify the controller of the xgress fault. Handed to the forwarder rather than sent here:
+	// this runs on the connection read loop and on the posture evaluation pool, neither of which
+	// may park on a controller that has stopped reading.
+	subject := ctrl_pb.FaultSubject_IngressFault
+	if edgeForwarder.originator == xgress.Terminator {
+		subject = ctrl_pb.FaultSubject_EgressFault
 	}
 
-	controllers := self.listener.factory.env.GetNetworkControllers()
-	ch := controllers.GetChannel(edgeForwarder.ctrlId)
-	if ch == nil {
-		log.WithField("ctrlId", edgeForwarder.ctrlId).Error("control channel not available")
-	} else {
-		log.Debug("notifying controller of fault")
-		if err := protobufs.MarshalTyped(fault).Send(ch); err != nil {
-			log.WithError(err).Error("error sending fault")
-		}
-	}
+	log.Debug("reporting circuit fault")
+	self.forwarder.ReportCircuitEndpointFault(circuitId, edgeForwarder.ctrlId, subject)
 }
 
 func (self *edgeClientConn) ContentType() int32 {

--- a/router/xgress_edge/listener_posture_push_test.go
+++ b/router/xgress_edge/listener_posture_push_test.go
@@ -1,0 +1,208 @@
+package xgress_edge
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openziti/channel/v5"
+	"github.com/openziti/sdk-golang/v2/pb/edge_client_pb"
+	sdkedge "github.com/openziti/sdk-golang/v2/ziti/edge"
+	"github.com/openziti/ziti/v2/common"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// blockingTestChannel holds each Send until released, standing in for an SDK that has stopped
+// draining its channel. It signals entry on entered before blocking, so a test can wait for the
+// writer to actually be inside Send rather than inferring it from producer-side state.
+type blockingTestChannel struct {
+	NoopTestChannel
+	entered     chan struct{}
+	release     chan struct{}
+	releaseOnce sync.Once
+	sent        chan *channel.Message
+}
+
+func newBlockingTestChannel(t *testing.T) *blockingTestChannel {
+	result := &blockingTestChannel{
+		entered: make(chan struct{}, 4096),
+		release: make(chan struct{}),
+		sent:    make(chan *channel.Message, 4096),
+	}
+	// a test that fails before releasing must not leave the writer parked
+	t.Cleanup(result.releaseSends)
+	return result
+}
+
+func (self *blockingTestChannel) releaseSends() {
+	self.releaseOnce.Do(func() { close(self.release) })
+}
+
+func (self *blockingTestChannel) Send(s channel.Sendable) error {
+	self.entered <- struct{}{}
+	<-self.release
+	self.sent <- s.Msg()
+	return nil
+}
+
+// awaitSendEntered blocks until a writer has entered Send.
+func (self *blockingTestChannel) awaitSendEntered(req *require.Assertions) {
+	select {
+	case <-self.entered:
+	case <-time.After(5 * time.Second):
+		req.Fail("no writer entered Send")
+	}
+}
+
+func (self *blockingTestChannel) IsClosed() bool {
+	return false
+}
+
+func (self *blockingTestChannel) ConnectionId() string {
+	return "blocking-test-conn"
+}
+
+func newPushTestConn(ch channel.Channel) *edgeClientConn {
+	conn := &edgeClientConn{ch: sdkedge.NewSingleSdkChannel(ch)}
+	conn.svcSubscription.Lock()
+	conn.svcSubscription.active = true
+	conn.svcSubscription.Unlock()
+	return conn
+}
+
+func emitTestPostureState(conn *edgeClientConn) {
+	conn.emitPostureStateChange(common.NewBareRouterDataModel(""), 1, nil)
+}
+
+// Test_PostureStatePush_DoesNotBlockCaller is the core of the fix: emission is called from the
+// connection read loop and from the shared posture evaluation pool, so it must not park on a peer
+// that has stopped reading. Parking a pool worker would stall posture enforcement for unrelated
+// identities.
+func Test_PostureStatePush_DoesNotBlockCaller(t *testing.T) {
+	req := require.New(t)
+
+	testCh := newBlockingTestChannel(t)
+	conn := newPushTestConn(testCh)
+
+	returned := make(chan struct{})
+	go func() {
+		defer close(returned)
+		for range 20 {
+			emitTestPostureState(conn)
+		}
+	}()
+
+	select {
+	case <-returned:
+	case <-time.After(5 * time.Second):
+		req.Fail("emitting posture state blocked on a peer that is not reading")
+	}
+
+	testCh.releaseSends()
+}
+
+// Test_PostureStatePush_CoalescesWhileBlocked covers the queue being a single slot: while one
+// write is in flight, further state changes replace each other rather than piling up, because the
+// message is a full state replacement and only the newest is worth sending.
+func Test_PostureStatePush_CoalescesWhileBlocked(t *testing.T) {
+	req := require.New(t)
+
+	testCh := newBlockingTestChannel(t)
+	conn := newPushTestConn(testCh)
+
+	// the first emit starts the writer; wait until it is actually inside Send, so the replacements
+	// below cannot coalesce with the state it is already carrying
+	emitTestPostureState(conn)
+	testCh.awaitSendEntered(req)
+
+	for range 50 {
+		emitTestPostureState(conn)
+	}
+
+	conn.posture.send.Lock()
+	pending := conn.posture.send.pending
+	conn.posture.send.Unlock()
+	req.NotNil(pending, "the newest state must be queued")
+
+	testCh.releaseSends()
+
+	// exactly two writes: the one that was in flight, and the coalesced newest
+	req.Eventually(func() bool {
+		conn.posture.send.Lock()
+		defer conn.posture.send.Unlock()
+		return !conn.posture.send.writing && conn.posture.send.pending == nil
+	}, 5*time.Second, time.Millisecond)
+
+	req.Equal(2, len(testCh.sent), "50 queued state changes must coalesce into one write")
+}
+
+// Test_PostureStatePush_WriterRestartsAfterDraining covers the exit-and-restart handoff: the
+// writer releases its slot under the same lock producers queue on, so a state change arriving
+// after it drains starts a new writer instead of being left unsent.
+func Test_PostureStatePush_WriterRestartsAfterDraining(t *testing.T) {
+	req := require.New(t)
+
+	testCh := newBlockingTestChannel(t)
+	testCh.releaseSends() // never block
+	conn := newPushTestConn(testCh)
+
+	for range 100 {
+		emitTestPostureState(conn)
+		req.Eventually(func() bool {
+			conn.posture.send.Lock()
+			defer conn.posture.send.Unlock()
+			return !conn.posture.send.writing
+		}, 5*time.Second, time.Millisecond, "writer must exit once the queue drains")
+	}
+
+	req.Equal(100, len(testCh.sent), "every state change must be written when nothing blocks")
+}
+
+// Test_PostureStatePush_SeqIsContiguous locks in that coalescing does not skip sequence numbers.
+// The SDK reads a gap as lost state and answers with a resync request.
+func Test_PostureStatePush_SeqIsContiguous(t *testing.T) {
+	req := require.New(t)
+
+	testCh := newBlockingTestChannel(t)
+	testCh.releaseSends()
+	conn := newPushTestConn(testCh)
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 25 {
+				emitTestPostureState(conn)
+			}
+		}()
+	}
+	wg.Wait()
+
+	req.Eventually(func() bool {
+		conn.posture.send.Lock()
+		defer conn.posture.send.Unlock()
+		return !conn.posture.send.writing && conn.posture.send.pending == nil
+	}, 5*time.Second, time.Millisecond)
+
+	seqs := map[uint64]struct{}{}
+	for len(testCh.sent) > 0 {
+		msg := <-testCh.sent
+		ps := decodePostureStateChange(req, msg)
+		_, dup := seqs[ps.Seq]
+		req.False(dup, "seq %d written twice", ps.Seq)
+		seqs[ps.Seq] = struct{}{}
+	}
+
+	// whatever coalescing did, the seqs written are 1..n with no gaps
+	for seq := uint64(1); seq <= uint64(len(seqs)); seq++ {
+		req.Contains(seqs, seq, "seq %d missing, the SDK reads that as a gap", seq)
+	}
+}
+
+func decodePostureStateChange(req *require.Assertions, msg *channel.Message) *edge_client_pb.PostureStateChange {
+	ps := &edge_client_pb.PostureStateChange{}
+	req.NoError(proto.Unmarshal(msg.Body, ps))
+	return ps
+}

--- a/router/xgress_edge/listener_posture_resync_test.go
+++ b/router/xgress_edge/listener_posture_resync_test.go
@@ -1,0 +1,122 @@
+package xgress_edge
+
+import (
+	"testing"
+	"time"
+
+	sdkedge "github.com/openziti/sdk-golang/v2/ziti/edge"
+	"github.com/stretchr/testify/require"
+)
+
+func (self *recordingTestChannel) IsClosed() bool {
+	return false
+}
+
+func newResyncTestConn() *edgeClientConn {
+	conn := &edgeClientConn{ch: sdkedge.NewSingleSdkChannel(&recordingTestChannel{})}
+	conn.svcSubscription.Lock()
+	conn.svcSubscription.active = true
+	conn.svcSubscription.Unlock()
+	return conn
+}
+
+func Test_PostureResync_FirstRequestIsAnswered(t *testing.T) {
+	req := require.New(t)
+	conn := newResyncTestConn()
+
+	req.True(conn.claimPostureResync(), "the first request on a connection must be answered")
+}
+
+func Test_PostureResync_RequestsInsideIntervalAreRateLimited(t *testing.T) {
+	req := require.New(t)
+	conn := newResyncTestConn()
+
+	req.True(conn.claimPostureResync())
+	req.False(conn.claimPostureResync(), "a second request inside the interval must not be answered immediately")
+	req.False(conn.claimPostureResync())
+}
+
+func Test_PostureResync_RateLimitedRequestIsDeferredNotDropped(t *testing.T) {
+	req := require.New(t)
+	conn := newResyncTestConn()
+
+	req.True(conn.claimPostureResync())
+	req.False(conn.claimPostureResync())
+
+	conn.posture.resync.Lock()
+	deferred := conn.posture.resync.deferredSend
+	conn.posture.resync.Unlock()
+
+	req.NotNil(deferred, "a request that is rate limited must be deferred, since the SDK will not ask again")
+}
+
+func Test_PostureResync_RepeatedRequestsCollapseIntoOneDeferredSend(t *testing.T) {
+	req := require.New(t)
+	conn := newResyncTestConn()
+
+	req.True(conn.claimPostureResync())
+	for range 50 {
+		req.False(conn.claimPostureResync())
+	}
+
+	// a burst inside one interval must leave a single pending send, not one per request
+	conn.posture.resync.Lock()
+	deferred := conn.posture.resync.deferredSend
+	conn.posture.resync.Unlock()
+	req.NotNil(deferred)
+}
+
+func Test_PostureResync_AnsweredAgainAfterInterval(t *testing.T) {
+	req := require.New(t)
+	conn := newResyncTestConn()
+
+	req.True(conn.claimPostureResync())
+
+	// simulate the interval having elapsed rather than sleeping through it
+	conn.posture.resync.Lock()
+	conn.posture.resync.lastSentAt = time.Now().Add(-minPostureResyncInterval)
+	conn.posture.resync.Unlock()
+
+	req.True(conn.claimPostureResync(), "a request after the interval must be answered")
+}
+
+func Test_PostureResync_DeferredSendClearsPendingState(t *testing.T) {
+	req := require.New(t)
+	conn := newResyncTestConn()
+
+	req.True(conn.claimPostureResync())
+	req.False(conn.claimPostureResync())
+
+	// the connection has no api session, so the send itself is a no-op; what matters is that the
+	// deferred flag is cleared so a later gap can be reported again
+	conn.sendDeferredPostureResync()
+
+	conn.posture.resync.Lock()
+	deferred := conn.posture.resync.deferredSend
+	conn.posture.resync.Unlock()
+	req.Nil(deferred)
+}
+
+func Test_PostureResync_CancelStopsPendingDeferredSend(t *testing.T) {
+	req := require.New(t)
+	conn := newResyncTestConn()
+
+	req.True(conn.claimPostureResync())
+	req.False(conn.claimPostureResync())
+
+	conn.cancelDeferredPostureResync()
+
+	conn.posture.resync.Lock()
+	deferred := conn.posture.resync.deferredSend
+	conn.posture.resync.Unlock()
+
+	req.Nil(deferred, "closing must not leave a timer holding the connection")
+}
+
+func Test_PostureResync_CancelWithNothingPendingIsSafe(t *testing.T) {
+	conn := newResyncTestConn()
+
+	// the common case: a connection closes having never been asked for a resync
+	conn.cancelDeferredPostureResync()
+	conn.cancelDeferredPostureResync()
+}


### PR DESCRIPTION
Fixes #4359, fixes #4377. Two commits, reviewable separately.

**Posture response ordering (#4359).** Posture responses were dispatched through an async receive adapter, one goroutine per message, so an older response could overwrite a newer one and a dial could be evaluated before the posture it depends on. The Go SDK submits posture synchronously before it dials or binds, so that ordering matters. Responses are now handled on the channel's receive loop, and a batch applies under a single lock hold so evaluation never sees a partly applied batch.

Only applying the reported state runs there. Re-evaluating access moved to a bounded pool, separate from the single-worker router data model pool, and re-reads current posture data so an evaluation overtaken by a newer update is redundant rather than acting on stale state. Pushing state to the SDK moved to a per-connection writer with a coalescing single-slot queue, so a client that stops reading cannot park a read loop or stall enforcement for other identities. SDK-requested resyncs are rate limited per connection, deferring rather than dropping a request that arrives inside the interval.

**Circuit endpoint faults (#4377).** Ingress and egress circuit faults were sent inline from whichever goroutine tore the circuit down, including the read loop and the posture evaluation pool, with an unbounded send. They were also lost on failure, with nothing to re-report them. They now go to the faulter, which delivers them from a goroutine per controller, retains what it could not send, retries on reconnect, and gives up after a configurable retention window rather than accumulating for the length of an outage.