### PR TITLE
[Backport-2.0] Deliver circuit endpoint faults through the faulter

### DIFF
--- a/router/env/config.go
+++ b/router/env/config.go
@@ -151,9 +151,9 @@ type Config struct {
 		Listeners             []*CtrlListenerConfig
 	}
 	Link struct {
-		Listeners          []map[interface{}]interface{}
-		Dialers            []map[interface{}]interface{}
-		Heartbeats         channel.HeartbeatOptions
+		Listeners              []map[interface{}]interface{}
+		Dialers                []map[interface{}]interface{}
+		Heartbeats             channel.HeartbeatOptions
 		PayloadSenderQueueSize int
 		AckSenderQueueSize     int
 	}

--- a/router/env/config_forwarder.go
+++ b/router/env/config_forwarder.go
@@ -23,9 +23,16 @@ import (
 )
 
 const (
-	DefaultXgressCloseCheckInterval    = 5 * time.Second
-	DefaultXgressDialDwellTime         = 0
-	DefaultFaultTxInterval             = 15 * time.Second
+	DefaultXgressCloseCheckInterval = 5 * time.Second
+	DefaultXgressDialDwellTime      = 0
+	DefaultFaultTxInterval          = 15 * time.Second
+
+	// DefaultEndpointFaultRetention is how long the router keeps retrying an unsent circuit
+	// endpoint fault before giving up on it. Configured as a duration, such as '5m'. Retention bounds the memory held while a controller
+	// is unreachable, since a fault outlives the circuit it refers to: the set grows with the
+	// teardown rate for as long as the outage lasts. Giving up leaves the controller holding a
+	// circuit the router no longer has, until the controller reconciles circuits on reconnect.
+	DefaultEndpointFaultRetention      = 5 * time.Minute
 	DefaultIdleTxInterval              = 60 * time.Second
 	DefaultIdleCircuitTimeout          = 60 * time.Second
 	DefaultXgressDialWorkerQueueLength = 1000
@@ -54,6 +61,7 @@ const (
 )
 
 type ForwarderOptions struct {
+	EndpointFaultRetention   time.Duration
 	FaultTxInterval          time.Duration
 	IdleCircuitTimeout       time.Duration
 	IdleTxInterval           time.Duration
@@ -72,9 +80,10 @@ type WorkerPoolOptions struct {
 
 func DefaultForwarderOptions() *ForwarderOptions {
 	return &ForwarderOptions{
-		FaultTxInterval:    DefaultFaultTxInterval,
-		IdleCircuitTimeout: DefaultIdleCircuitTimeout,
-		IdleTxInterval:     DefaultIdleTxInterval,
+		EndpointFaultRetention: DefaultEndpointFaultRetention,
+		FaultTxInterval:        DefaultFaultTxInterval,
+		IdleCircuitTimeout:     DefaultIdleCircuitTimeout,
+		IdleTxInterval:         DefaultIdleTxInterval,
 		LinkDial: WorkerPoolOptions{
 			QueueLength: DefaultLinkDialQueueLength,
 			WorkerCount: DefaultLinkDialWorkerCount,
@@ -95,6 +104,18 @@ func DefaultForwarderOptions() *ForwarderOptions {
 
 func LoadForwarderOptions(src map[interface{}]interface{}) (*ForwarderOptions, error) {
 	options := DefaultForwarderOptions()
+
+	if value, found := src["endpointFaultRetention"]; found {
+		val, ok := value.(string)
+		if !ok {
+			return nil, errors.New("invalid value for 'endpointFaultRetention', expected a duration, such as '5m'")
+		}
+
+		var err error
+		if options.EndpointFaultRetention, err = time.ParseDuration(val); err != nil {
+			return nil, errors.Wrap(err, "invalid value for 'endpointFaultRetention'")
+		}
+	}
 
 	if value, found := src["faultTxInterval"]; found {
 		if val, ok := value.(int); ok {

--- a/router/env/config_forwarder_test.go
+++ b/router/env/config_forwarder_test.go
@@ -1,0 +1,41 @@
+package env
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_LoadForwarderOptions_EndpointFaultRetentionDefaults(t *testing.T) {
+	options, err := LoadForwarderOptions(map[interface{}]interface{}{})
+	require.NoError(t, err)
+	require.Equal(t, DefaultEndpointFaultRetention, options.EndpointFaultRetention)
+}
+
+func Test_LoadForwarderOptions_EndpointFaultRetentionParsesDuration(t *testing.T) {
+	options, err := LoadForwarderOptions(map[interface{}]interface{}{
+		"endpointFaultRetention": "90s",
+	})
+	require.NoError(t, err)
+	require.Equal(t, 90*time.Second, options.EndpointFaultRetention)
+}
+
+func Test_LoadForwarderOptions_EndpointFaultRetentionRejectsNonDuration(t *testing.T) {
+	_, err := LoadForwarderOptions(map[interface{}]interface{}{
+		"endpointFaultRetention": "not-a-duration",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "endpointFaultRetention")
+}
+
+// Test_LoadForwarderOptions_EndpointFaultRetentionRejectsNumber guards the convention: durations
+// are configured as strings, and a bare number must be rejected rather than silently read as some
+// unit.
+func Test_LoadForwarderOptions_EndpointFaultRetentionRejectsNumber(t *testing.T) {
+	_, err := LoadForwarderOptions(map[interface{}]interface{}{
+		"endpointFaultRetention": 300000,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duration")
+}

--- a/router/env/env.go
+++ b/router/env/env.go
@@ -84,6 +84,11 @@ type Forwarder interface {
 	ForwardAcknowledgement(srcAddr xgress.Address, acknowledgement *xgress.Acknowledgement) error
 	ForwardControl(srcAddr xgress.Address, control *xgress.Control) error
 	ReportForwardingFault(circuitId string, ctrlId string)
+
+	// ReportCircuitEndpointFault reports that a circuit's ingress or egress endpoint on this
+	// router has gone away, so the controller can remove the circuit. It does not block and does
+	// not wait for the controller.
+	ReportCircuitEndpointFault(circuitId string, ctrlId string, subject ctrl_pb.FaultSubject)
 	RegisterDestination(circuitId string, address xgress.Address, destination Destination)
 	EndCircuit(circuitId string)
 }

--- a/router/forwarder/endpoint_faulter.go
+++ b/router/forwarder/endpoint_faulter.go
@@ -1,0 +1,278 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package forwarder
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/michaelquigley/pfxlog"
+	"github.com/openziti/channel/v4/protobufs"
+	"github.com/openziti/metrics"
+	"github.com/openziti/ziti/v2/common/pb/ctrl_pb"
+	"github.com/openziti/ziti/v2/router/env"
+)
+
+// endpointFaultSweepInterval is how often a sender re-checks its pending set without being woken.
+// It paces two things: retrying faults a controller would not take, and releasing faults held past
+// the retention window. It is therefore well under the retention window, so a fault gets many
+// attempts before it is given up on, and expiry runs at a useful granularity.
+const endpointFaultSweepInterval = 15 * time.Second
+
+// endpointFaultKey identifies a pending fault. The subject is part of the key because one router
+// can hold both ends of a circuit, and those are two distinct faults for the same circuit.
+type endpointFaultKey struct {
+	circuitId string
+	subject   ctrl_pb.FaultSubject
+}
+
+// pendingEndpointFault is a fault waiting to be sent. queuedAt is when the fault was first
+// reported and is never advanced, so retention measures from when the circuit went away rather
+// than from the last attempt.
+type pendingEndpointFault struct {
+	key      endpointFaultKey
+	queuedAt time.Time
+}
+
+// endpointFaultSender delivers circuit endpoint faults to one controller.
+//
+// Faults are held in a set rather than a queue so that a controller which is unreachable
+// accumulates at most one entry per circuit, and so that reporting the same fault twice is free.
+// One goroutine per controller owns the sending, so a controller that stops reading costs only its
+// own sender; reporters never block and never wait for a controller.
+//
+// That goroutine also expires faults, so its sends are bounded rather than blocking: waiting
+// indefinitely on one controller would stop retention from running while new faults kept
+// arriving, which is the growth the retention window exists to stop.
+type endpointFaultSender struct {
+	ctrlId      string
+	ctrls       env.NetworkControllers
+	retention   time.Duration
+	sendTimeout time.Duration
+
+	lock    sync.Mutex
+	pending map[endpointFaultKey]*pendingEndpointFault
+
+	notify      chan struct{}
+	stop        chan struct{}
+	isStopped   atomic.Bool
+	closeNotify <-chan struct{}
+
+	sent    metrics.Meter
+	expired metrics.Meter
+}
+
+func newEndpointFaultSender(ctrlId string, f *Faulter) *endpointFaultSender {
+	result := &endpointFaultSender{
+		ctrlId:      ctrlId,
+		ctrls:       f.ctrls,
+		retention:   f.endpointFaultRetention,
+		sendTimeout: f.ctrls.DefaultRequestTimeout(),
+		pending:     map[endpointFaultKey]*pendingEndpointFault{},
+		notify:      make(chan struct{}, 1),
+		stop:        make(chan struct{}),
+		closeNotify: f.closeNotify,
+		sent:        f.endpointFaultsSent,
+		expired:     f.endpointFaultsExpired,
+	}
+
+	go result.run()
+
+	return result
+}
+
+// report adds a fault to the pending set and wakes the sender. It does not block.
+func (self *endpointFaultSender) report(key endpointFaultKey) {
+	self.lock.Lock()
+	if _, exists := self.pending[key]; !exists {
+		self.pending[key] = &pendingEndpointFault{key: key, queuedAt: time.Now()}
+	}
+	self.lock.Unlock()
+
+	self.wake()
+}
+
+func (self *endpointFaultSender) wake() {
+	select {
+	case self.notify <- struct{}{}:
+	default:
+	}
+}
+
+// shutdown stops the sender and abandons anything it still holds. Used when a controller is
+// removed from the cluster, whose circuits are gone with it.
+func (self *endpointFaultSender) shutdown() {
+	if self.isStopped.CompareAndSwap(false, true) {
+		close(self.stop)
+	}
+}
+
+// hasPending return true if there are pending faults
+func (self *endpointFaultSender) hasPending() bool {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+	return len(self.pending) > 0
+}
+
+func (self *endpointFaultSender) run() {
+	log := pfxlog.Logger().WithField("ctrlId", self.ctrlId)
+	log.Info("endpoint fault sender started")
+	defer log.Info("endpoint fault sender exited")
+
+	ticker := time.NewTicker(endpointFaultSweepInterval)
+	defer ticker.Stop()
+
+	for {
+		self.expirePending()
+
+		// Only a completed drain justifies going straight round again, and then only because
+		// faults reported while it ran are already waiting. A drain cut short by a send failure
+		// must wait, or an undeliverable fault spins this goroutine retrying as fast as the
+		// failure comes back.
+		if self.sendPending() && self.hasPending() {
+			select {
+			case <-self.stop:
+				return
+			case <-self.closeNotify:
+				return
+			default:
+				continue
+			}
+		}
+
+		select {
+		case <-self.notify:
+		case <-ticker.C:
+		case <-self.stop:
+			return
+		case <-self.closeNotify:
+			return
+		}
+	}
+}
+
+// expirePending drops faults held longer than the retention window. Expiry means the controller
+// keeps a circuit this router no longer has, so it is reported as an error rather than logged
+// quietly.
+func (self *endpointFaultSender) expirePending() {
+	if self.retention <= 0 {
+		return
+	}
+
+	cutoff := time.Now().Add(-self.retention)
+
+	self.lock.Lock()
+	var expired []endpointFaultKey
+	for key, fault := range self.pending {
+		if fault.queuedAt.Before(cutoff) {
+			expired = append(expired, key)
+			delete(self.pending, key)
+		}
+	}
+	self.lock.Unlock()
+
+	for _, key := range expired {
+		self.expired.Mark(1)
+		pfxlog.Logger().
+			WithField("ctrlId", self.ctrlId).
+			WithField("circuitId", key.circuitId).
+			WithField("subject", key.subject.String()).
+			WithField("retention", self.retention).
+			Error("giving up on circuit fault, controller may still hold the circuit")
+	}
+}
+
+// sendPending delivers what it can and stops at the first failure, reporting whether it got
+// through the whole set. A failure means the channel is unavailable, so the rest would fail too;
+// they stay pending until the controller reconnects or the sweep comes round.
+//
+// Faults are removed as they are sent rather than taken out of the set up front, so the set
+// always reflects what is still owed. Draining into a local copy would hide in-flight faults from
+// expirePending, letting them age past the retention window unnoticed, and would make the set
+// briefly look empty to anything else reading it.
+func (self *endpointFaultSender) sendPending() bool {
+	for _, fault := range self.snapshotPending() {
+		select {
+		case <-self.stop:
+			return false
+		case <-self.closeNotify:
+			return false
+		default:
+		}
+
+		if !self.send(fault) {
+			return false
+		}
+
+		self.lock.Lock()
+		delete(self.pending, fault.key)
+		self.lock.Unlock()
+	}
+
+	return true
+}
+
+func (self *endpointFaultSender) snapshotPending() []*pendingEndpointFault {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+
+	result := make([]*pendingEndpointFault, 0, len(self.pending))
+	for _, fault := range self.pending {
+		result = append(result, fault)
+	}
+	return result
+}
+
+// send reports whether the fault was handed to the controller channel. A fault that could not be
+// sent is left pending for a later attempt.
+func (self *endpointFaultSender) send(fault *pendingEndpointFault) bool {
+	ctrlCh := self.ctrls.GetCtrlChannel(self.ctrlId)
+	if ctrlCh == nil {
+		// The controller is not connected yet, or is gone. If it was removed, shutdown clears
+		// this set; otherwise reconnecting wakes the sender.
+		return false
+	}
+
+	msg := &ctrl_pb.Fault{Subject: fault.key.subject, Id: fault.key.circuitId}
+
+	// Waits for the write rather than for the queue to accept it: the sender declines to retry a
+	// failed write, so treating queue acceptance as delivery would drop the fault while reporting
+	// success. The timeout bounds both stages, so a controller that is not draining delays this
+	// sender by at most one timeout before it expires and retries.
+	//
+	// A successful write still is not proof the controller processed it; faults carry no reply, so
+	// this is the strongest confirmation available.
+	envelope := protobufs.MarshalTyped(msg).WithTimeout(self.sendTimeout)
+	if err := envelope.SendAndWaitForWire(ctrlCh.GetDefaultSender()); err != nil {
+		pfxlog.Logger().
+			WithError(err).
+			WithField("ctrlId", self.ctrlId).
+			WithField("circuitId", fault.key.circuitId).
+			WithField("subject", fault.key.subject.String()).
+			Debug("could not send circuit fault, will retry")
+		return false
+	}
+
+	self.sent.Mark(1)
+	pfxlog.Logger().
+		WithField("ctrlId", self.ctrlId).
+		WithField("circuitId", fault.key.circuitId).
+		WithField("subject", fault.key.subject.String()).
+		Debug("reported circuit fault")
+	return true
+}

--- a/router/forwarder/endpoint_faulter_test.go
+++ b/router/forwarder/endpoint_faulter_test.go
@@ -1,0 +1,327 @@
+package forwarder
+
+import (
+	"errors"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/openziti/channel/v4"
+	"github.com/openziti/metrics"
+	"github.com/openziti/ziti/v2/common/ctrlchan"
+	"github.com/openziti/ziti/v2/common/pb/ctrl_pb"
+	"github.com/openziti/ziti/v2/router/env"
+	cmap "github.com/orcaman/concurrent-map/v2"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// testCtrlChannel completes ctrlchan.CtrlChannel over BaseCtrlChannel and runs a goroutine in
+// place of an underlay, so that sends waiting for a write actually complete. Setting writeErr
+// makes those writes fail the way channel v5.0.27 reports it: NotifyErr, then NotifyAfterWrite.
+type testCtrlChannel struct {
+	*ctrlchan.BaseCtrlChannel
+	writeErr atomic.Pointer[error]
+	written  chan *ctrl_pb.Fault
+	attempts atomic.Int32
+	notifier *channel.CloseNotifier
+}
+
+func newTestCtrlChannel(t *testing.T) *testCtrlChannel {
+	result := &testCtrlChannel{
+		BaseCtrlChannel: ctrlchan.NewBaseCtrlChannel(),
+		written:         make(chan *ctrl_pb.Fault, 1024),
+		notifier:        channel.NewCloseNotifier(),
+	}
+
+	go result.runUnderlay()
+	t.Cleanup(result.notifier.NotifyClosed)
+
+	return result
+}
+
+func (self *testCtrlChannel) IsConnected() bool {
+	return true
+}
+
+func (self *testCtrlChannel) failWrites(err error) {
+	self.writeErr.Store(&err)
+}
+
+func (self *testCtrlChannel) succeedWrites() {
+	self.writeErr.Store(nil)
+}
+
+func (self *testCtrlChannel) runUnderlay() {
+	for {
+		sendable, err := self.GetNextMsgDefault(self.notifier)
+		if err != nil || sendable == nil {
+			return
+		}
+
+		listener := sendable.SendListener()
+		listener.NotifyBeforeWrite()
+		self.attempts.Add(1)
+
+		if writeErr := self.writeErr.Load(); writeErr != nil {
+			// how a failed underlay write is reported once HandleTxFailed declines a retry
+			listener.NotifyErr(*writeErr)
+			listener.NotifyAfterWrite()
+			continue
+		}
+
+		fault := &ctrl_pb.Fault{}
+		if err = proto.Unmarshal(sendable.Msg().Body, fault); err == nil {
+			self.written <- fault
+		}
+		listener.NotifyAfterWrite()
+	}
+}
+
+// testControllers hands out one controller channel, or none when unavailable is set, standing in
+// for a controller that is not connected.
+type testControllers struct {
+	env.MockNetworkControllers
+	ctrlCh *testCtrlChannel
+	// read by the sender goroutine while the test flips it
+	unavailable atomic.Bool
+}
+
+func (self *testControllers) GetCtrlChannel(string) ctrlchan.CtrlChannel {
+	if self.unavailable.Load() {
+		return nil
+	}
+	return self.ctrlCh
+}
+
+func newTestFaulter(t *testing.T, retention time.Duration) (*Faulter, *testControllers) {
+	registry := metrics.NewRegistry("test", nil)
+	ctrls := &testControllers{ctrlCh: newTestCtrlChannel(t)}
+
+	return &Faulter{
+		ctrls:                  ctrls,
+		closeNotify:            make(chan struct{}),
+		endpointFaultSenders:   cmap.New[*endpointFaultSender](),
+		endpointFaultRetention: retention,
+		circuitFaults:          registry.Meter("faults.circuit"),
+		endpointFaultsSent:     registry.Meter("faults.circuit.endpoint"),
+		endpointFaultsExpired:  registry.Meter("faults.circuit.endpoint.expired"),
+	}, ctrls
+}
+
+// takeFault waits for the next fault the underlay wrote.
+func takeFault(req *require.Assertions, ctrls *testControllers) *ctrl_pb.Fault {
+	select {
+	case fault := <-ctrls.ctrlCh.written:
+		return fault
+	case <-time.After(5 * time.Second):
+		req.Fail("no fault was written")
+		return nil
+	}
+}
+
+func pendingCount(f *Faulter, ctrlId string) int {
+	sender, found := f.endpointFaultSenders.Get(ctrlId)
+	if !found {
+		return 0
+	}
+	sender.lock.Lock()
+	defer sender.lock.Unlock()
+	return len(sender.pending)
+}
+
+func Test_EndpointFault_Delivered(t *testing.T) {
+	req := require.New(t)
+	f, ctrls := newTestFaulter(t, time.Minute)
+
+	f.ReportEndpointFault("circuit-1", "ctrl-1", ctrl_pb.FaultSubject_IngressFault)
+
+	fault := takeFault(req, ctrls)
+	req.Equal("circuit-1", fault.Id)
+	req.Equal(ctrl_pb.FaultSubject_IngressFault, fault.Subject)
+
+	req.Eventually(func() bool {
+		return pendingCount(f, "ctrl-1") == 0
+	}, 5*time.Second, time.Millisecond, "a delivered fault must not stay pending")
+}
+
+// Test_EndpointFault_RetainedWhileControllerUnavailable is the point of the change: a fault that
+// cannot be sent is kept rather than lost, since nothing else will report it again.
+func Test_EndpointFault_RetainedWhileControllerUnavailable(t *testing.T) {
+	req := require.New(t)
+	f, ctrls := newTestFaulter(t, time.Minute)
+	ctrls.unavailable.Store(true)
+
+	f.ReportEndpointFault("circuit-1", "ctrl-1", ctrl_pb.FaultSubject_IngressFault)
+
+	req.Eventually(func() bool {
+		return pendingCount(f, "ctrl-1") == 1
+	}, 5*time.Second, time.Millisecond, "an unsendable fault must be retained")
+
+	// the controller comes back and is announced; the retained fault goes out without waiting for
+	// the sweep
+	ctrls.unavailable.Store(false)
+	sender, _ := f.endpointFaultSenders.Get("ctrl-1")
+	sender.wake()
+
+	fault := takeFault(req, ctrls)
+	req.Equal("circuit-1", fault.Id)
+}
+
+func Test_EndpointFault_DuplicatesCollapse(t *testing.T) {
+	req := require.New(t)
+	f, ctrls := newTestFaulter(t, time.Minute)
+	ctrls.unavailable.Store(true)
+
+	for range 20 {
+		f.ReportEndpointFault("circuit-1", "ctrl-1", ctrl_pb.FaultSubject_IngressFault)
+	}
+
+	req.Eventually(func() bool {
+		return pendingCount(f, "ctrl-1") == 1
+	}, 5*time.Second, time.Millisecond, "repeat reports of one fault must collapse")
+}
+
+// Test_EndpointFault_SubjectIsPartOfTheKey covers a router holding both ends of a circuit: those
+// are two distinct faults and neither may displace the other.
+func Test_EndpointFault_SubjectIsPartOfTheKey(t *testing.T) {
+	req := require.New(t)
+	f, ctrls := newTestFaulter(t, time.Minute)
+	ctrls.unavailable.Store(true)
+
+	f.ReportEndpointFault("circuit-1", "ctrl-1", ctrl_pb.FaultSubject_IngressFault)
+	f.ReportEndpointFault("circuit-1", "ctrl-1", ctrl_pb.FaultSubject_EgressFault)
+
+	req.Eventually(func() bool {
+		return pendingCount(f, "ctrl-1") == 2
+	}, 5*time.Second, time.Millisecond, "ingress and egress faults for one circuit are distinct")
+}
+
+// Test_EndpointFault_ExpiresAfterRetention covers the memory bound: a fault outlives the circuit
+// it names, so a controller that stays unreachable would otherwise accumulate one entry per
+// teardown for the length of the outage.
+func Test_EndpointFault_ExpiresAfterRetention(t *testing.T) {
+	req := require.New(t)
+	f, ctrls := newTestFaulter(t, time.Millisecond)
+	ctrls.unavailable.Store(true)
+
+	f.ReportEndpointFault("circuit-1", "ctrl-1", ctrl_pb.FaultSubject_IngressFault)
+
+	sender, found := f.endpointFaultSenders.Get("ctrl-1")
+	req.True(found)
+
+	req.Eventually(func() bool {
+		sender.wake()
+		return pendingCount(f, "ctrl-1") == 0
+	}, 5*time.Second, time.Millisecond, "a fault held past retention must be given up")
+}
+
+func Test_EndpointFault_ReportDoesNotBlockOnUnavailableController(t *testing.T) {
+	req := require.New(t)
+	f, ctrls := newTestFaulter(t, time.Minute)
+	ctrls.unavailable.Store(true)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := range 500 {
+			f.ReportEndpointFault(circuitId(i), "ctrl-1", ctrl_pb.FaultSubject_IngressFault)
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		req.Fail("reporting a fault blocked on an unavailable controller")
+	}
+}
+
+func Test_EndpointFault_NoControllerIsReported(t *testing.T) {
+	req := require.New(t)
+	f, _ := newTestFaulter(t, time.Minute)
+
+	// nothing to send to and nothing to retry against; must not create a sender
+	f.ReportEndpointFault("circuit-1", "", ctrl_pb.FaultSubject_IngressFault)
+
+	req.Equal(0, f.endpointFaultSenders.Count())
+}
+
+func Test_EndpointFault_ShutdownAbandonsPending(t *testing.T) {
+	req := require.New(t)
+	f, ctrls := newTestFaulter(t, time.Minute)
+	ctrls.unavailable.Store(true)
+
+	f.ReportEndpointFault("circuit-1", "ctrl-1", ctrl_pb.FaultSubject_IngressFault)
+
+	sender, found := f.endpointFaultSenders.Get("ctrl-1")
+	req.True(found)
+
+	// a controller removed from the cluster has no circuits left to clean up
+	f.endpointFaultSenders.Remove("ctrl-1")
+	sender.shutdown()
+	sender.shutdown() // idempotent
+
+	req.Equal(0, f.endpointFaultSenders.Count())
+}
+
+func circuitId(i int) string {
+	return "circuit-" + strconv.Itoa(i)
+}
+
+// Test_EndpointFault_RetainedWhenWriteFails covers the difference between the queue accepting a
+// fault and the fault reaching the wire. The sender declines to retry a failed write, so treating
+// queue acceptance as delivery drops the fault while reporting success.
+func Test_EndpointFault_RetainedWhenWriteFails(t *testing.T) {
+	req := require.New(t)
+	f, ctrls := newTestFaulter(t, time.Minute)
+	ctrls.ctrlCh.failWrites(errors.New("underlay write failed"))
+
+	f.ReportEndpointFault("circuit-1", "ctrl-1", ctrl_pb.FaultSubject_IngressFault)
+
+	// wait for the write to have been attempted and failed, so that what is asserted below is the
+	// state after the attempt rather than the state before it
+	req.Eventually(func() bool {
+		return ctrls.ctrlCh.attempts.Load() > 0
+	}, 5*time.Second, time.Millisecond, "the fault was never written")
+
+	req.Equal(1, pendingCount(f, "ctrl-1"), "a fault whose write failed must be retained")
+	req.Equal(int64(0), f.endpointFaultsSent.Count(), "a failed write is not a delivery")
+
+	// writes recover, and the retained fault goes out
+	ctrls.ctrlCh.succeedWrites()
+	sender, found := f.endpointFaultSenders.Get("ctrl-1")
+	req.True(found)
+	sender.wake()
+
+	fault := takeFault(req, ctrls)
+	req.Equal("circuit-1", fault.Id)
+
+	req.Eventually(func() bool {
+		return pendingCount(f, "ctrl-1") == 0
+	}, 5*time.Second, time.Millisecond)
+	req.Equal(int64(1), f.endpointFaultsSent.Count())
+}
+
+// Test_EndpointFault_ExpiresWhileControllerNotDraining covers retention continuing to run while a
+// controller takes nothing. The sender both delivers and expires, so a send that waited
+// indefinitely would stop expiry while new faults kept arriving.
+func Test_EndpointFault_ExpiresWhileControllerNotDraining(t *testing.T) {
+	req := require.New(t)
+	f, ctrls := newTestFaulter(t, time.Millisecond)
+	ctrls.ctrlCh.failWrites(errors.New("underlay write failed"))
+
+	f.ReportEndpointFault("circuit-1", "ctrl-1", ctrl_pb.FaultSubject_IngressFault)
+
+	sender, found := f.endpointFaultSenders.Get("ctrl-1")
+	req.True(found)
+
+	// the fault must leave by expiring, not by being counted as sent
+	req.Eventually(func() bool {
+		sender.wake()
+		return f.endpointFaultsExpired.Count() > 0
+	}, 10*time.Second, 5*time.Millisecond, "retention must run even while sends are failing")
+
+	req.Equal(int64(0), f.endpointFaultsSent.Count())
+	req.Equal(0, pendingCount(f, "ctrl-1"))
+}

--- a/router/forwarder/faulter.go
+++ b/router/forwarder/faulter.go
@@ -37,11 +37,26 @@ type Faulter struct {
 	closeNotify   <-chan struct{}
 	linkFaults    metrics.Meter
 	circuitFaults metrics.Meter
+
+	// Endpoint faults are delivered per controller, separately from the batched forwarding
+	// faults above: they are reported when a circuit's endpoint goes away rather than when
+	// traffic arrives for an unknown circuit, so nothing re-reports them and each needs its own
+	// retry. Senders are created on demand, since a router does not necessarily hold circuits
+	// for every controller.
+	endpointFaultSenders   cmap.ConcurrentMap[string, *endpointFaultSender]
+	endpointFaultRetention time.Duration
+	endpointFaultsSent     metrics.Meter
+	endpointFaultsExpired  metrics.Meter
 }
 
 type FaultReceiver interface {
 	Report(circuitId string, ctrlId string)
 	NotifyInvalidLink(linkId string)
+
+	// ReportEndpointFault reports that a circuit's ingress or egress endpoint on this router has
+	// gone away, so the controller can remove the circuit. It does not block and does not wait
+	// for the controller; delivery, retry and eventual expiry are the faulter's.
+	ReportEndpointFault(circuitId string, ctrlId string, subject ctrl_pb.FaultSubject)
 }
 
 func NewFaulter(routerEnv env.RouterEnv, interval time.Duration) *Faulter {
@@ -52,13 +67,67 @@ func NewFaulter(routerEnv env.RouterEnv, interval time.Duration) *Faulter {
 		closeNotify:   routerEnv.GetCloseNotify(),
 		linkFaults:    routerEnv.GetMetricsRegistry().Meter("faults.link"),
 		circuitFaults: routerEnv.GetMetricsRegistry().Meter("faults.circuit"),
+
+		endpointFaultSenders:   cmap.New[*endpointFaultSender](),
+		endpointFaultRetention: routerEnv.GetConfig().Forwarder.EndpointFaultRetention,
+		endpointFaultsSent:     routerEnv.GetMetricsRegistry().Meter("faults.circuit.endpoint"),
+		endpointFaultsExpired:  routerEnv.GetMetricsRegistry().Meter("faults.circuit.endpoint.expired"),
 	}
+
+	// Endpoint faults are delivered regardless of the forwarding fault interval: unlike a
+	// forwarding fault, which the forwarder re-reports while traffic keeps arriving, an
+	// unreported endpoint fault leaves the controller holding a circuit forever.
+	routerEnv.GetNetworkControllers().AddChangeListener(env.CtrlEventListenerFunc(f.notifyOfCtrlEvent))
 
 	if interval > 0 {
 		go f.run()
 	}
 
 	return f
+}
+
+// notifyOfCtrlEvent keeps the per-controller endpoint fault senders in step with the cluster. A
+// reconnecting controller is woken so anything held for it goes out immediately rather than
+// waiting for the sweep; a removed controller's senders are shut down, abandoning what they hold,
+// since a controller that has left the cluster has no circuits to clean up.
+func (self *Faulter) notifyOfCtrlEvent(event env.CtrlEvent) {
+	if event.Controller == nil {
+		return
+	}
+
+	ctrlId := event.Controller.Channel().Id()
+
+	switch event.Type {
+	case env.ControllerReconnected, env.ControllerAdded:
+		if sender, found := self.endpointFaultSenders.Get(ctrlId); found {
+			sender.wake()
+		}
+	case env.ControllerRemoved:
+		if sender, found := self.endpointFaultSenders.Get(ctrlId); found {
+			self.endpointFaultSenders.Remove(ctrlId)
+			sender.shutdown()
+		}
+	}
+}
+
+func (self *Faulter) ReportEndpointFault(circuitId string, ctrlId string, subject ctrl_pb.FaultSubject) {
+	if ctrlId == "" {
+		pfxlog.Logger().
+			WithField("circuitId", circuitId).
+			WithField("subject", subject.String()).
+			Error("cannot report circuit endpoint fault, no controller for circuit")
+		return
+	}
+
+	sender := self.endpointFaultSenders.Upsert(ctrlId, nil, func(exists bool, current *endpointFaultSender, _ *endpointFaultSender) *endpointFaultSender {
+		if current != nil {
+			return current
+		}
+		return newEndpointFaultSender(ctrlId, self)
+	})
+
+	self.circuitFaults.Mark(1)
+	sender.report(endpointFaultKey{circuitId: circuitId, subject: subject})
 }
 
 func (self *Faulter) Report(circuitId string, ctrlId string) {

--- a/router/forwarder/forwarder.go
+++ b/router/forwarder/forwarder.go
@@ -289,6 +289,19 @@ func (forwarder *Forwarder) ForwardControl(srcAddr xgress.Address, control *xgre
 	return err
 }
 
+// ReportCircuitEndpointFault hands the fault to the faulter, which owns delivery, retry and
+// expiry. Like ReportForwardingFault it resolves the owning controller from the forward table when
+// the caller does not know it.
+func (forwarder *Forwarder) ReportCircuitEndpointFault(circuitId string, ctrlId string, subject ctrl_pb.FaultSubject) {
+	if ctrlId == "" {
+		if ct, _ := forwarder.circuits.getForwardTable(circuitId, false); ct != nil {
+			ctrlId = ct.ctrlId
+		}
+	}
+
+	forwarder.faulter.ReportEndpointFault(circuitId, ctrlId, subject)
+}
+
 func (forwarder *Forwarder) ReportForwardingFault(circuitId string, ctrlId string) {
 	if ctrlId == "" {
 		ct, _ := forwarder.circuits.getForwardTable(circuitId, false)

--- a/router/forwarder/tables.go
+++ b/router/forwarder/tables.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/openziti/sdk-golang/xgress"
 	"github.com/openziti/ziti/v2/router/env"
-	"github.com/orcaman/concurrent-map/v2"
+	cmap "github.com/orcaman/concurrent-map/v2"
 )
 
 // circuitTable implements a directory of forwardTables, keyed by circuitId.

--- a/router/handler_xgress/close.go
+++ b/router/handler_xgress/close.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/michaelquigley/pfxlog"
-	"github.com/openziti/channel/v4/protobufs"
 	"github.com/openziti/sdk-golang/xgress"
 	"github.com/openziti/ziti/v2/common/pb/ctrl_pb"
 	"github.com/openziti/ziti/v2/router/env"
@@ -56,20 +55,11 @@ func (txc *closeHandler) HandleXgressClose(x *xgress.Xgress) {
 	txc.forwarder.EndCircuit(x.CircuitId())
 
 	// Notify the controller of the xgress fault
-	fault := &ctrl_pb.Fault{Id: x.CircuitId()}
-	if x.Originator() == xgress.Initiator {
-		fault.Subject = ctrl_pb.FaultSubject_IngressFault
-	} else if x.Originator() == xgress.Terminator {
-		fault.Subject = ctrl_pb.FaultSubject_EgressFault
+	subject := ctrl_pb.FaultSubject_IngressFault
+	if x.Originator() == xgress.Terminator {
+		subject = ctrl_pb.FaultSubject_EgressFault
 	}
 
-	ch := txc.ctrls.GetChannel(x.CtrlId())
-	if ch == nil {
-		log.WithField("ctrlId", x.CtrlId()).Error("control channel not available")
-	} else {
-		log.Debug("notifying controller of fault")
-		if err := protobufs.MarshalTyped(fault).Send(ch); err != nil {
-			log.WithError(err).Error("error sending fault")
-		}
-	}
+	log.Debug("reporting circuit fault")
+	txc.forwarder.ReportCircuitEndpointFault(x.CircuitId(), x.CtrlId(), subject)
 }

--- a/router/test/single_router_perf_test.go
+++ b/router/test/single_router_perf_test.go
@@ -126,6 +126,9 @@ func (t testFaultReceiver) Report(circuitId string, ctrlId string) {}
 
 func (t testFaultReceiver) NotifyInvalidLink(linkId string) {}
 
+func (t testFaultReceiver) ReportEndpointFault(circuitId string, ctrlId string, subject ctrl_pb.FaultSubject) {
+}
+
 type testXgCloseHandler struct{}
 
 func (t testXgCloseHandler) HandleXgressClose(x *xgress.Xgress) {

--- a/router/xgress_edge/listener.go
+++ b/router/xgress_edge/listener.go
@@ -774,25 +774,16 @@ func (self *edgeClientConn) cleanupXgressCircuit(edgeForwarder *xgEdgeForwarder)
 	self.forwarder.EndCircuit(circuitId)
 	self.xgCircuits.Remove(circuitId)
 
-	// Notify the controller of the xgress fault
-	fault := &ctrl_pb.Fault{Id: circuitId}
-	switch edgeForwarder.originator {
-	case xgress.Initiator:
-		fault.Subject = ctrl_pb.FaultSubject_IngressFault
-	case xgress.Terminator:
-		fault.Subject = ctrl_pb.FaultSubject_EgressFault
+	// Notify the controller of the xgress fault. Handed to the forwarder rather than sent here:
+	// this runs on the connection read loop and on the posture evaluation pool, neither of which
+	// may park on a controller that has stopped reading.
+	subject := ctrl_pb.FaultSubject_IngressFault
+	if edgeForwarder.originator == xgress.Terminator {
+		subject = ctrl_pb.FaultSubject_EgressFault
 	}
 
-	controllers := self.listener.factory.env.GetNetworkControllers()
-	ch := controllers.GetChannel(edgeForwarder.ctrlId)
-	if ch == nil {
-		log.WithField("ctrlId", edgeForwarder.ctrlId).Error("control channel not available")
-	} else {
-		log.Debug("notifying controller of fault")
-		if err := protobufs.MarshalTyped(fault).Send(ch); err != nil {
-			log.WithError(err).Error("error sending fault")
-		}
-	}
+	log.Debug("reporting circuit fault")
+	self.forwarder.ReportCircuitEndpointFault(circuitId, edgeForwarder.ctrlId, subject)
 }
 
 func (self *edgeClientConn) ContentType() int32 {


### PR DESCRIPTION
Fixes #4390. Backport of #4388 (#4377) to release-v2.0.x.

Cherry-pick of 6c7d07876 with three adaptations for this branch:

- `channel/v4` and non-`/v2` sdk-golang import paths. All the APIs the change needs exist on channel/v4 v4.3.12: `AddReceiveHandlerF`, `SendAndWaitForWire` with the same `NotifyErr` buffering, and the same `DefaultOutQueueSize` of 4. `common/ctrlchan` with its priority senders, `GetCtrlChannel`, and the `ControllerRemoved`/`ControllerReconnected` events are all present here too.
- `pfxlog` in place of the structured `faultLog` logging channel, which is main-only.
- `handler_xgress/close.go` drops its `protobufs` import, now unused once the fault send moves to the faulter.

Two pre-existing failures on this branch, neither caused by this change, both verified against pristine `release-v2.0.x` in a clean worktree:

- `go vet -tags=perf ./router/test/` already fails to build, on `dataPlaneAdapter` not satisfying `env.RouterEnv`. This change shifts the reported line from 162 to 165 because the test double gains a method, but the error is the same one. The double is updated for the new interface method so no second breakage is added.
- `TestDataFlowAndCloseLogic` in `router/xgress_validation` fails under `-race` (consistently, ~15.7s, so a timeout), and passes without it. Same on pristine.