### PR TITLE
[Backport-2.0] Apply posture responses in order and against a stable snapshot

### DIFF
--- a/router/posture/checks.go
+++ b/router/posture/checks.go
@@ -68,13 +68,7 @@ func (cache *Cache) AddResponses(identityId, apiSessionId string, responses *edg
 		return valueInMap
 	})
 
-	updated := false
-	for _, response := range responses.Responses {
-		next := instance.Apply(response, cache.totpParser)
-		updated = updated || next
-	}
-
-	if updated {
+	if instance.ApplyBatch(responses.Responses, cache.totpParser) {
 		instance.emitUpdated()
 	}
 }
@@ -257,24 +251,64 @@ type TotpTokenParser interface {
 	ParseTotpToken(string) (*common.TotpClaims, error)
 }
 
-// Apply updates the posture instance with new device state information from a posture response.
-// This function merges the incoming posture data with existing data, only updating fields
-// that are present in the response. Changes are detected by comparing new values with
-// existing ones, and update listeners are notified only when actual changes occur.
-//
-// The function handles various types of posture data including OS information, domain
-// membership, MAC addresses, process lists, device lock status, and wake events.
-//
-// Parameters:
-//   - response: The posture response containing updated device state information
-//   - parser: A TOTP token parser implementation, used to verify ToTP tokens on posture response
-//
-// Returns:
-//   - bool: True if the posture instance was updated, false if no changes were detected
+// Apply updates the posture instance with the device state in a single posture response,
+// reporting whether anything changed. Equivalent to ApplyBatch with one response.
 func (instance *Instance) Apply(response *edge_client_pb.PostureResponse, parser TotpTokenParser) bool {
+	return instance.ApplyBatch([]*edge_client_pb.PostureResponse{response}, parser)
+}
+
+// ApplyBatch merges a batch of posture responses into the instance, reporting whether anything
+// changed. Each response carries one kind of device state (OS, domain, MAC addresses, a process
+// list, lock or wake events, or a TOTP token) and only that field is updated.
+//
+// The batch applies under a single lock hold, so a reader taking a Snapshot sees the state before
+// the batch or after all of it, never a partial batch. That matters because a batch is the unit a
+// client reports in: it may carry one process-list entry per watched process, or a MAC address
+// and a domain that change together, and evaluating an intermediate state can fail checks that
+// both the previous and the resulting state pass.
+//
+// TOTP tokens are verified before the lock is taken, since ParseTotpToken does signature
+// verification and reads public keys from the router data model, which does not belong inside this
+// lock. parser may be nil when no response carries a token.
+func (instance *Instance) ApplyBatch(responses []*edge_client_pb.PostureResponse, parser TotpTokenParser) bool {
+	totpClaims := make([]*common.TotpClaims, len(responses))
+	for i, response := range responses {
+		totpToken := response.GetTotpToken()
+		if totpToken == nil {
+			continue
+		}
+
+		if totpToken.Token == "" {
+			pfxlog.Logger().Error("received empty totp token for posture response")
+		}
+
+		claims, err := parser.ParseTotpToken(totpToken.Token)
+		if err != nil {
+			pfxlog.Logger().WithError(err).Error("error parsing totp token")
+		} else if claims.IssuedAt == nil {
+			pfxlog.Logger().Error("received totp token with no issued at time")
+		} else {
+			totpClaims[i] = claims
+		}
+	}
+
 	instance.lock.Lock()
 	defer instance.lock.Unlock()
 
+	updated := false
+	for i, response := range responses {
+		if instance.applyLocked(response, totpClaims[i]) {
+			updated = true
+		}
+	}
+
+	return updated
+}
+
+// applyLocked merges one response into the instance, reporting whether anything changed.
+// totpClaims carries the response's pre-verified TOTP claims, and is nil when the response is not
+// a TOTP token or its token failed verification. Caller must hold the instance lock.
+func (instance *Instance) applyLocked(response *edge_client_pb.PostureResponse, totpClaims *common.TotpClaims) bool {
 	updated := false
 
 	if os := response.GetOs(); os != nil {
@@ -312,28 +346,20 @@ func (instance *Instance) Apply(response *edge_client_pb.PostureResponse, parser
 		if instance.mergeProcessList(processList) {
 			updated = true
 		}
-	} else if totpToken := response.GetTotpToken(); totpToken != nil {
-		if totpToken.Token == "" {
-			pfxlog.Logger().Error("received empty totp token for posture response")
+	} else if response.GetTotpToken() != nil {
+		if totpClaims == nil {
+			// verification failed and was already logged
+			return false
 		}
 
-		totpClaims, err := parser.ParseTotpToken(totpToken.Token)
-
-		if err != nil {
-			pfxlog.Logger().WithError(err).Error("error parsing totp token")
-		} else if totpClaims.IssuedAt == nil {
-			pfxlog.Logger().Error("received totp token with no issued at time")
-		} else {
-
-			if totpClaims.ApiSessionId == instance.ApiSessionId {
-				passedAt := totpClaims.IssuedAt.Time
-				if instance.PassedMfaAt == nil || instance.PassedMfaAt.Before(passedAt) {
-					instance.PassedMfaAt = &passedAt
-					updated = true
-				}
-			} else {
-				pfxlog.Logger().Errorf("received totp token for api session %s, but instance is for %s", totpClaims.ApiSessionId, instance.ApiSessionId)
+		if totpClaims.ApiSessionId == instance.ApiSessionId {
+			passedAt := totpClaims.IssuedAt.Time
+			if instance.PassedMfaAt == nil || instance.PassedMfaAt.Before(passedAt) {
+				instance.PassedMfaAt = &passedAt
+				updated = true
 			}
+		} else {
+			pfxlog.Logger().Errorf("received totp token for api session %s, but instance is for %s", totpClaims.ApiSessionId, instance.ApiSessionId)
 		}
 	} else {
 		pfxlog.Logger().Warnf("received unknown posture response type: no fields updated, type: %T", response.GetType())
@@ -423,10 +449,22 @@ func isOsDifferent(old *edge_client_pb.PostureResponse_Os, new *edge_client_pb.P
 	return false
 }
 
-func (instance *Instance) emitUpdated() {
-	instance.Time = time.Now()
+// Snapshot returns a copy of the instance's posture data taken under the instance lock, so
+// readers evaluating posture checks never race the writers applying posture responses.
+func (instance *Instance) Snapshot() InstanceData {
+	instance.lock.Lock()
+	defer instance.lock.Unlock()
+	return instance.InstanceData
+}
 
+// emitUpdated stamps the update time and hands listeners a copy of the posture data, both under
+// the instance lock, so it does not race a reader taking a Snapshot or a writer applying a batch.
+// Listeners are called outside the lock: they re-enter the cache and evaluate access.
+func (instance *Instance) emitUpdated() {
+	instance.lock.Lock()
+	instance.Time = time.Now()
 	instanceFieldCopy := instance.InstanceData
+	instance.lock.Unlock()
 
 	for _, listener := range instance.updatedListeners {
 		listener(&instanceFieldCopy)

--- a/router/posture/checks_batch_test.go
+++ b/router/posture/checks_batch_test.go
@@ -1,0 +1,116 @@
+package posture
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/openziti/sdk-golang/pb/edge_client_pb"
+	"github.com/stretchr/testify/require"
+)
+
+func procResponse(path, hash string) *edge_client_pb.PostureResponse {
+	return processListResponse(&edge_client_pb.PostureResponse_Process{
+		Path: path, IsRunning: true, Hash: hash,
+	})
+}
+
+func procBatch(hash string) []*edge_client_pb.PostureResponse {
+	return []*edge_client_pb.PostureResponse{
+		procResponse("/bin/a", hash), procResponse("/bin/b", hash), procResponse("/bin/c", hash),
+	}
+}
+
+// Test_ApplyBatch_ReaderNeverSeesMixedBatch covers the interleaving that revokes access from a
+// client that is in fact compliant. The Go SDK reports one process-list entry per watched process,
+// so a batch that updates several processes applies them one at a time. A reader must observe the
+// state before the batch or after all of it: a mix of old and new entries can fail an AllOf
+// process check that both the previous and the resulting state pass.
+func Test_ApplyBatch_ReaderNeverSeesMixedBatch(t *testing.T) {
+	req := require.New(t)
+
+	for range 500 {
+		instance := newInstance()
+		req.True(instance.ApplyBatch(procBatch("v1"), nil))
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			instance.ApplyBatch(procBatch("v2"), nil)
+		}()
+
+		var hashes []string
+		go func() {
+			defer wg.Done()
+			for _, proc := range instance.Snapshot().ProcessList.GetProcesses() {
+				hashes = append(hashes, proc.Hash)
+			}
+		}()
+
+		wg.Wait()
+
+		req.Len(hashes, 3)
+		for _, hash := range hashes {
+			req.Equal(hashes[0], hash,
+				"a reader must see the batch fully applied or not at all, got a mix: %v", hashes)
+		}
+	}
+}
+
+// Test_ApplyBatch_ReaderNeverSeesPartialGrowth is the same requirement for a batch that adds
+// processes rather than updating them: the set is empty or complete, never half built.
+func Test_ApplyBatch_ReaderNeverSeesPartialGrowth(t *testing.T) {
+	req := require.New(t)
+
+	for range 500 {
+		instance := newInstance()
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			instance.ApplyBatch(procBatch("v1"), nil)
+		}()
+
+		var observed int
+		go func() {
+			defer wg.Done()
+			observed = len(instance.Snapshot().ProcessList.GetProcesses())
+		}()
+
+		wg.Wait()
+		req.Contains([]int{0, 3}, observed, "a reader must not observe a partially applied batch")
+	}
+}
+
+func Test_ApplyBatch_AppliesEveryResponse(t *testing.T) {
+	req := require.New(t)
+	instance := newInstance()
+
+	req.True(instance.ApplyBatch([]*edge_client_pb.PostureResponse{
+		{Type: &edge_client_pb.PostureResponse_Domain_{
+			Domain: &edge_client_pb.PostureResponse_Domain{Name: "example.com"}}},
+		macResponse("00:11:22:33:44:55"),
+		procResponse("/bin/a", "abc"),
+	}, nil))
+
+	data := instance.Snapshot()
+	req.Equal("example.com", data.Domain.GetName())
+	req.Equal([]string{"001122334455"}, data.Macs.GetAddresses())
+	req.Len(data.ProcessList.GetProcesses(), 1)
+}
+
+func Test_ApplyBatch_UnchangedBatchReportsNoUpdate(t *testing.T) {
+	req := require.New(t)
+	instance := newInstance()
+
+	batch := []*edge_client_pb.PostureResponse{procResponse("/bin/a", "abc"), procResponse("/bin/b", "abc")}
+	req.True(instance.ApplyBatch(batch, nil))
+	req.False(instance.ApplyBatch(batch, nil), "re-reporting the same batch is not a change")
+}
+
+func Test_ApplyBatch_EmptyBatchReportsNoUpdate(t *testing.T) {
+	require.False(t, newInstance().ApplyBatch(nil, nil))
+}

--- a/router/state/manager.go
+++ b/router/state/manager.go
@@ -355,6 +355,28 @@ func NewManager(stateEnv env.RouterEnv) Manager {
 		panic(errors.Wrap(err, "error creating rdm goroutine pool"))
 	}
 
+	// Separate from the rdm pool, which is single-worker because data state events must apply in
+	// order. Posture re-evaluations are per api session and independent of each other, and must
+	// not queue behind an rdm sync.
+	postureEvalPoolConfig := goroutines.PoolConfig{
+		QueueSize:   uint32(1000),
+		MinWorkers:  0,
+		MaxWorkers:  uint32(8),
+		IdleTime:    30 * time.Second,
+		CloseNotify: stateEnv.GetCloseNotify(),
+		PanicHandler: func(err interface{}) {
+			pfxlog.Logger().
+				WithField(logrus.ErrorKey, err).
+				WithField("backtrace", string(debug.Stack())).Error("panic during posture re-evaluation")
+		},
+	}
+	metrics.ConfigureGoroutinesPoolMetrics(&postureEvalPoolConfig, stateEnv.GetMetricsRegistry(), "pool.posture.eval")
+
+	postureEvalPool, err := goroutines.NewPool(postureEvalPoolConfig)
+	if err != nil {
+		panic(errors.Wrap(err, "error creating posture evaluation goroutine pool"))
+	}
+
 	result := &ManagerImpl{
 		EventEmmiter:             events.New(),
 		legacyApiSessionsByToken: cmap.New[*ApiSessionToken](),
@@ -362,6 +384,7 @@ func NewManager(stateEnv env.RouterEnv) Manager {
 		certCache:                cmap.New[*x509.Certificate](),
 		env:                      stateEnv,
 		routerDataModelPool:      routerDataModelPool,
+		postureEvalPool:          postureEvalPool,
 		endpointsChanged:         make(chan env.CtrlEvent, 10),
 		modelChanged:             make(chan struct{}, 1),
 	}
@@ -400,8 +423,46 @@ func NewManager(stateEnv env.RouterEnv) Manager {
 // Parameters:
 //   - data: The updated posture instance data containing the current device state
 func (self *ManagerImpl) onPostureDataUpdate(data *posture.InstanceData) {
+	identityId := data.IdentityId
+	apiSessionId := data.ApiSessionId
+
+	// Handed to a worker so the caller, the connection's read loop, is not held while circuits are
+	// re-evaluated. If the workers are saturated, run it here instead: dropping it would leave
+	// access that posture no longer permits in place, and running it inline makes the connection
+	// producing the churn absorb the cost.
+	work := func() { self.evaluatePostureChange(identityId, apiSessionId) }
+	if err := self.postureEvalPool.QueueOrError(work); err != nil {
+		pfxlog.Logger().WithError(err).
+			WithField("identityId", identityId).
+			Debug("posture evaluation pool unavailable, re-evaluating inline")
+		work()
+	}
+}
+
+// evaluatePostureChange re-evaluates an api session's circuits and hosted terminators against the
+// identity's current posture, closing what no longer has access.
+//
+// It reads the posture data itself rather than taking it from the update that scheduled it: several
+// updates for one api session can be in flight, and evaluating the state an older update carried
+// could revoke access that the newer state allows. Reading current data makes a late evaluation
+// redundant instead of wrong.
+//
+// A consequence is that states between updates are not separately acted on: if an endpoint reports
+// non-compliance and then compliance again before this runs, nothing is revoked. Enforcement is
+// against current posture only. Anything that must observe every reported state belongs on the
+// ingest path in posture.Instance.ApplyBatch, which sees every update in the order it arrived.
+func (self *ManagerImpl) evaluatePostureChange(identityId, apiSessionId string) {
+	instance := self.postureCache.GetInstance(apiSessionId)
+	if instance == nil {
+		// the api session's posture data is gone (the session was evicted), so it has no
+		// connections left to re-evaluate
+		return
+	}
+	snapshot := instance.Snapshot()
+	data := &snapshot
+
 	rdm := self.routerDataModel.Load()
-	channels := self.connectionTracker.GetChannelsByIdentityId(data.IdentityId)
+	channels := self.connectionTracker.GetChannelsByIdentityId(identityId)
 
 	for _, ch := range channels {
 		// Posture data is per-api-session. An identity may have several concurrent
@@ -411,7 +472,7 @@ func (self *ManagerImpl) onPostureDataUpdate(data *posture.InstanceData) {
 		// another's circuits. Every circuit and terminator on a channel shares the
 		// channel's api-session, so make this check once per channel.
 		apiSessionToken := GetApiSessionTokenFromCh(ch)
-		if apiSessionToken == nil || apiSessionToken.Id != data.ApiSessionId {
+		if apiSessionToken == nil || apiSessionToken.Id != apiSessionId {
 			continue
 		}
 
@@ -419,8 +480,6 @@ func (self *ManagerImpl) onPostureDataUpdate(data *posture.InstanceData) {
 		if edgeConn == nil {
 			continue
 		}
-
-		identityId := apiSessionToken.IdentityId
 
 		// Re-evaluate dial access (policy + posture) for every active dial
 		// circuit — both connId mux-sink conns and SDK-hosted xgress circuits.
@@ -482,7 +541,8 @@ func (self *ManagerImpl) HasAccess(identityId, apiSessionId, serviceId string, p
 	instance := self.postureCache.GetInstance(apiSessionId)
 
 	if instance != nil {
-		data = &instance.InstanceData
+		snapshot := instance.Snapshot()
+		data = &snapshot
 	}
 
 	return posture.HasAccess(rdm, identityId, serviceId, data, policyType)
@@ -561,6 +621,7 @@ type ManagerImpl struct {
 	ctrlRootCache       controllerRootCache
 	routerDataModel     atomic.Pointer[common.RouterDataModel]
 	routerDataModelPool goroutines.Pool
+	postureEvalPool     goroutines.Pool
 
 	resyncRouterDataModel atomic.Bool
 	endpointsChanged      chan env.CtrlEvent

--- a/router/state/manager_posture_eval_test.go
+++ b/router/state/manager_posture_eval_test.go
@@ -1,0 +1,241 @@
+package state
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/openziti/channel/v4"
+	"github.com/openziti/foundation/v2/goroutines"
+	"github.com/openziti/sdk-golang/pb/edge_client_pb"
+	"github.com/openziti/ziti/v2/common"
+	"github.com/openziti/ziti/v2/common/pb/edge_ctrl_pb"
+	"github.com/openziti/ziti/v2/router/posture"
+	"github.com/stretchr/testify/require"
+)
+
+// rejectingPool is a goroutines.Pool that accepts no work, standing in for a pool whose workers
+// and queue are saturated. Shutting a real pool down is not usable here: QueueOrError selects over
+// the queue and the close signal together, so a shut-down pool still accepts work about half the
+// time.
+type rejectingPool struct{}
+
+func (rejectingPool) Queue(func()) error                           { return errors.New("rejected") }
+func (rejectingPool) QueueWithTimeout(func(), time.Duration) error { return errors.New("rejected") }
+func (rejectingPool) QueueOrError(func()) error                    { return errors.New("rejected") }
+func (rejectingPool) GetWorkerCount() uint32                       { return 0 }
+func (rejectingPool) GetQueueSize() uint32                         { return 0 }
+func (rejectingPool) GetBusyWorkers() uint32                       { return 0 }
+func (rejectingPool) GetOutstanding() uint32                       { return 0 }
+func (rejectingPool) Shutdown()                                    {}
+func (rejectingPool) ShutdownAndWait(time.Duration) error          { return nil }
+func (rejectingPool) AwaitIdle(time.Duration) error                { return nil }
+
+// stubConnectionTracker records whether the posture evaluation reached the point of looking for
+// the identity's connections, which is the first thing it does once it has posture data.
+type stubConnectionTracker struct {
+	lookups atomic.Int32
+}
+
+func (self *stubConnectionTracker) GetChannels() map[string][]channel.Channel {
+	return nil
+}
+
+func (self *stubConnectionTracker) GetChannelsByIdentityId(string) []channel.Channel {
+	self.lookups.Add(1)
+	return nil
+}
+
+func newPostureEvalTestManager(t *testing.T, pool goroutines.Pool) (*ManagerImpl, *stubConnectionTracker) {
+	tracker := &stubConnectionTracker{}
+	mgr := &ManagerImpl{
+		postureCache:      posture.NewCache(nil),
+		postureEvalPool:   pool,
+		connectionTracker: tracker,
+	}
+	mgr.routerDataModel.Store(common.NewBareRouterDataModel())
+	t.Cleanup(func() {
+		if pool != nil {
+			pool.Shutdown()
+		}
+	})
+	return mgr, tracker
+}
+
+func newTestPool(t *testing.T, queueSize uint32) goroutines.Pool {
+	pool, err := goroutines.NewPool(goroutines.PoolConfig{
+		QueueSize:    queueSize,
+		MinWorkers:   0,
+		MaxWorkers:   1,
+		IdleTime:     time.Second,
+		CloseNotify:  make(chan struct{}),
+		PanicHandler: func(interface{}) {},
+	})
+	require.NoError(t, err)
+	return pool
+}
+
+func seedPosture(mgr *ManagerImpl, apiSessionId string) {
+	mgr.postureCache.AddResponses("identity-1", apiSessionId, &edge_client_pb.PostureResponses{
+		Responses: []*edge_client_pb.PostureResponse{
+			{
+				Type: &edge_client_pb.PostureResponse_Domain_{
+					Domain: &edge_client_pb.PostureResponse_Domain{Name: "example.com"},
+				},
+			},
+		},
+	})
+}
+
+func Test_EvaluatePostureChange_NoPostureDataIsANoop(t *testing.T) {
+	req := require.New(t)
+	mgr, tracker := newPostureEvalTestManager(t, newTestPool(t, 16))
+
+	// the api session's posture data has been evicted; there is nothing to re-evaluate and no
+	// connections to look for
+	mgr.evaluatePostureChange("identity-1", "evicted-session")
+
+	req.Equal(int32(0), tracker.lookups.Load())
+}
+
+func Test_EvaluatePostureChange_ReadsCurrentPostureData(t *testing.T) {
+	req := require.New(t)
+	mgr, tracker := newPostureEvalTestManager(t, newTestPool(t, 16))
+
+	seedPosture(mgr, "session-1")
+	mgr.evaluatePostureChange("identity-1", "session-1")
+
+	req.Equal(int32(1), tracker.lookups.Load(), "posture data present, so the evaluation proceeds")
+}
+
+// Test_OnPostureDataUpdate_RunsInlineWhenPoolRejects covers the fail-safe: an evaluation that
+// cannot be queued must still run, since dropping it would leave access in place that current
+// posture no longer permits.
+func Test_OnPostureDataUpdate_RunsInlineWhenPoolRejects(t *testing.T) {
+	req := require.New(t)
+
+	mgr, tracker := newPostureEvalTestManager(t, rejectingPool{})
+	seedPosture(mgr, "session-1")
+
+	mgr.onPostureDataUpdate(&posture.InstanceData{IdentityId: "identity-1", ApiSessionId: "session-1"})
+
+	req.Equal(int32(1), tracker.lookups.Load(), "a rejected evaluation must still run inline")
+}
+
+func Test_OnPostureDataUpdate_SchedulesOntoThePool(t *testing.T) {
+	req := require.New(t)
+	mgr, tracker := newPostureEvalTestManager(t, newTestPool(t, 16))
+	seedPosture(mgr, "session-1")
+
+	mgr.onPostureDataUpdate(&posture.InstanceData{IdentityId: "identity-1", ApiSessionId: "session-1"})
+
+	req.Eventually(func() bool {
+		return tracker.lookups.Load() == 1
+	}, 5*time.Second, time.Millisecond, "the scheduled evaluation must run")
+}
+
+// postureCheckedRdm builds the smallest data model in which an access check actually evaluates
+// posture: an identity, a service, and a dial policy joining them that carries a MAC check.
+// Without the policy the check short-circuits before it reads any posture data.
+func postureCheckedRdm(req *require.Assertions) *common.RouterDataModel {
+	rdm := common.NewBareRouterDataModel()
+
+	rdm.HandleIdentityEvent(1, &edge_ctrl_pb.DataState_Event{Action: edge_ctrl_pb.DataState_Create},
+		&edge_ctrl_pb.DataState_Event_Identity{Identity: &edge_ctrl_pb.DataState_Identity{Id: "identity-1", Name: "identity-1"}})
+
+	rdm.HandleServiceEvent(2, &edge_ctrl_pb.DataState_Event{Action: edge_ctrl_pb.DataState_Create},
+		&edge_ctrl_pb.DataState_Event_Service{Service: &edge_ctrl_pb.DataState_Service{Id: "service-1", Name: "service-1"}})
+
+	// A domain check, so evaluation reads the same field the posture responses below write. A check
+	// on some other field would never touch the memory being mutated.
+	rdm.HandlePostureCheckEvent(3, &edge_ctrl_pb.DataState_Event{Action: edge_ctrl_pb.DataState_Create},
+		&edge_ctrl_pb.DataState_Event_PostureCheck{PostureCheck: &edge_ctrl_pb.DataState_PostureCheck{
+			Id: "check-1", Name: "domain-check", TypeId: "DOMAIN",
+			Subtype: &edge_ctrl_pb.DataState_PostureCheck_Domains_{
+				Domains: &edge_ctrl_pb.DataState_PostureCheck_Domains{Domains: []string{"example.com"}},
+			},
+		}})
+
+	rdm.HandleServicePolicyEvent(4, &edge_ctrl_pb.DataState_Event{Action: edge_ctrl_pb.DataState_Create},
+		&edge_ctrl_pb.DataState_Event_ServicePolicy{ServicePolicy: &edge_ctrl_pb.DataState_ServicePolicy{
+			Id: "policy-1", Name: "policy-1", PolicyType: edge_ctrl_pb.PolicyType_DialPolicy,
+		}})
+
+	link := func(index uint64, entityType edge_ctrl_pb.ServicePolicyRelatedEntityType, id string) {
+		rdm.Handle(index, &edge_ctrl_pb.DataState_Event{
+			Action: edge_ctrl_pb.DataState_Create,
+			Model: &edge_ctrl_pb.DataState_Event_ServicePolicyChange{
+				ServicePolicyChange: &edge_ctrl_pb.DataState_ServicePolicyChange{
+					PolicyId:          "policy-1",
+					RelatedEntityIds:  []string{id},
+					RelatedEntityType: entityType,
+					Add:               true,
+				},
+			},
+		})
+	}
+
+	link(5, edge_ctrl_pb.ServicePolicyRelatedEntityType_RelatedIdentity, "identity-1")
+	link(6, edge_ctrl_pb.ServicePolicyRelatedEntityType_RelatedService, "service-1")
+	link(7, edge_ctrl_pb.ServicePolicyRelatedEntityType_RelatedPostureCheck, "check-1")
+
+	rdm.SetCurrentIndex(8)
+
+	policies, err := rdm.GetServiceAccessPolicies("identity-1", "service-1", edge_ctrl_pb.PolicyType_DialPolicy)
+	req.NoError(err, "the model must actually resolve a policy, or the check never reads posture data")
+	req.NotEmpty(policies.PostureChecks, "the policy must carry a posture check")
+
+	return rdm
+}
+
+// Test_HasAccess_DoesNotRacePostureResponses covers the access-check path reading posture data
+// while responses are applied to it. Handing the evaluator a pointer into the live instance is an
+// unsynchronized read of fields the response path writes under the instance lock. Run under -race.
+func Test_HasAccess_DoesNotRacePostureResponses(t *testing.T) {
+	req := require.New(t)
+	mgr, _ := newPostureEvalTestManager(t, newTestPool(t, 16))
+	mgr.routerDataModel.Store(postureCheckedRdm(req))
+
+	const apiSessionId = "session-1"
+
+	// Alternating values, because Apply skips a response that reports what it already holds: a
+	// writer that never writes cannot race a reader.
+	reportDomain := func(domain string) {
+		mgr.postureCache.AddResponses("identity-1", apiSessionId, &edge_client_pb.PostureResponses{
+			Responses: []*edge_client_pb.PostureResponse{
+				{
+					Type: &edge_client_pb.PostureResponse_Domain_{
+						Domain: &edge_client_pb.PostureResponse_Domain{Name: domain},
+					},
+				},
+			},
+		})
+	}
+	reportDomain("example.com")
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := range 500 {
+			if i%2 == 0 {
+				reportDomain("example.com")
+			} else {
+				reportDomain("other.example.com")
+			}
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for range 500 {
+			_, _ = mgr.HasAccess("identity-1", apiSessionId, "service-1", edge_ctrl_pb.PolicyType_DialPolicy)
+		}
+	}()
+
+	wg.Wait()
+	req.NotNil(mgr.postureCache.GetInstance(apiSessionId))
+}

--- a/router/xgress_edge/accept.go
+++ b/router/xgress_edge/accept.go
@@ -106,12 +106,12 @@ func (self *Acceptor) BindChannel(binding channel.Binding) error {
 		},
 	})
 
-	binding.AddTypedReceiveHandler(&channel.AsyncFunctionReceiveAdapter{
-		Type: sdkEdge.ContentTypePostureResponse,
-		Handler: func(m *channel.Message, ch channel.Channel) {
-			conn.processPostureResponse(m, ch)
-		},
-	})
+	// Handled on the receive loop rather than through an async adapter: posture responses must
+	// apply in the order the SDK sent them, and a dial or bind received behind one must observe it
+	// applied. An async adapter dispatches each message on its own goroutine, which lets an older
+	// response land after a newer one and lets a dial overtake the response it depends on. Only
+	// applying the reported state runs here; re-evaluating access is deferred.
+	binding.AddReceiveHandlerF(sdkEdge.ContentTypePostureResponse, conn.processPostureResponse)
 
 	binding.AddTypedReceiveHandler(&channel.AsyncFunctionReceiveAdapter{
 		Type: sdkEdge.ContentTypeUpdateToken,

--- a/router/xgress_edge/listener.go
+++ b/router/xgress_edge/listener.go
@@ -1468,8 +1468,11 @@ func (self *edgeClientConn) processPostureResponse(msg *channel.Message, ch chan
 			return
 		}
 
-		go self.listener.factory.stateManager.ProcessPostureResponses(ch, postureResponses)
-
+		// Applied on the read loop, not a goroutine: responses for one connection must apply in the
+		// order sent, and the SDK reports posture before it dials or binds, so a dial arriving
+		// behind a posture response must see that response already applied. The expensive part,
+		// re-evaluating access, is handed off inside ProcessPostureResponses.
+		self.listener.factory.stateManager.ProcessPostureResponses(ch, postureResponses)
 	}
 }
 


### PR DESCRIPTION
Fixes #4389, fixes #4392. Stacked on #4391, so review that first; this PR's diff is only the posture work.

Adapted from #4388 rather than cherry-picked, because roughly half of that change does not apply here. This branch has no service subscription and no posture state push to the SDK, so the per-connection push writer and the resync rate limit have no bug to fix: `processResyncPostureState` exists but is never registered. What carries over is the ordering fix, the batch-atomic apply, and the pooled re-evaluation.

**Two problems that are specific to this branch, tracked as #4392.** `HasAccess` handed the evaluator `&instance.InstanceData`, a pointer into the live instance, while the response path wrote those same fields under the instance lock. Main does not have this because its `HasAccess` takes a copy; `Instance.Snapshot` did not exist here, so this adds it.

Writing the test for that turned up a second unsynchronized write on the same path: `emitUpdated` stamped `instance.Time` and copied `InstanceData` without holding the lock. Both are fixed, and the new test detects each one independently — reverting either fix on its own produces a race report.

Worth knowing for review: the test needed a data model that actually resolves a policy carrying a posture check, and a writer that actually changes the reported value, or it passes without exercising anything. It asserts the policy resolves up front so it cannot quietly go vacuous again.

Two pre-existing failures on this branch, unchanged by this PR and verified against pristine `release-v2.0.x`: `go vet -tags=perf ./router/test/` fails to build on an unrelated interface mismatch, and `TestDataFlowAndCloseLogic` in `router/xgress_validation` fails under `-race` while passing without it.